### PR TITLE
bugfix: hy3 support FP8 KV cache and Marlin.

### DIFF
--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -112,9 +112,6 @@ def test_dense_attention_layer_installs_hcu_runtime_and_preserves_fallback(
     runtime = _module(
         "vllm_hcu.model_executor.layers.attention_runtime",
         FusedQkvSplitRmsNormRopeAttention=FusedQkvSplitRmsNormRopeAttention,
-        init_kv_cache_quant_e5m2=lambda *args: (
-            calls.append(("hcu-init", *args)) or "hcu-init"
-        ),
         attention_forward=lambda *args: (
             calls.append(("hcu-forward", *args)) or "hcu-forward"
         ),
@@ -142,15 +139,12 @@ def test_dense_attention_layer_installs_hcu_runtime_and_preserves_fallback(
     instance = Attention()
     assert instance.forward("q", "k", "v") == "official-forward"
 
-    layer.kv_cache_dtype = "fp8_e5m2"
-    assert module._init_kv_cache_quant(layer, "quant", "prefix") == "hcu-init"
-    instance.kv_cache_dtype = "fp8_e5m2"
-    assert instance.forward("q", "k", "v") == "hcu-forward"
+    layer.kv_cache_dtype = "fp8_e4m3"
+    assert module._init_kv_cache_quant(layer, "quant", "prefix") == "official-init"
     assert [call[0] for call in calls] == [
         "official-init",
         "official-forward",
-        "hcu-init",
-        "hcu-forward",
+        "official-init",
     ]
 
 
@@ -325,6 +319,82 @@ def test_attention_direct_forward_preserves_cpu_values_and_query_device():
     )
     assert output.dtype is torch.float64
     assert calls["dummy_device"] == query.device
+
+
+def test_fused_attention_quantizes_query_for_fp8_kv_cache(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    try:
+        runtime = importlib.import_module(
+            "vllm_hcu.model_executor.layers.attention_runtime"
+        )
+    except (ImportError, RuntimeError):
+        pytest.skip("vLLM custom-op registry is unavailable in this environment")
+
+    num_tokens, num_heads, num_kv_heads, head_size = 2, 2, 1, 2
+    q_size = num_heads * head_size
+    kv_size = num_kv_heads * head_size
+    qkv = torch.zeros(
+        num_tokens,
+        q_size + 2 * kv_size,
+        dtype=torch.bfloat16,
+    )
+    captured: dict[str, torch.dtype] = {}
+
+    def fused_qkv(**kwargs):
+        source = kwargs["qkv"]
+        return (
+            torch.zeros(num_tokens, num_heads, head_size, dtype=source.dtype),
+            torch.zeros(num_tokens, num_kv_heads, head_size, dtype=source.dtype),
+            torch.zeros(num_tokens, num_kv_heads, head_size, dtype=source.dtype),
+        )
+
+    def unified_attention(query, key, value, output, layer_name, **kwargs):
+        del key, value, layer_name, kwargs
+        captured["query"] = query.dtype
+        captured["output"] = output.dtype
+
+    monkeypatch.setattr(
+        torch.ops.vllm,
+        "fused_qkv_split_rmsnorm_rope_kv_store",
+        fused_qkv,
+    )
+    monkeypatch.setattr(
+        torch.ops.vllm,
+        "unified_attention_with_output",
+        unified_attention,
+    )
+
+    layer = object.__new__(runtime.FusedQkvSplitRmsNormRopeAttention)
+    torch.nn.Module.__init__(layer)
+    layer.num_heads = num_heads
+    layer.num_kv_heads = num_kv_heads
+    layer.head_size = head_size
+    layer.head_size_v = head_size
+    layer.layer_name = "layer"
+    layer.kv_cache_dtype = "fp8_e4m3"
+    layer.block_size = 16
+    layer.impl = SimpleNamespace(supports_quant_query_input=True)
+    layer._q_scale = torch.tensor(1.0)
+    layer.query_quant = lambda query, scale: (
+        query.to(torch.float8_e4m3fn),
+        scale,
+    )
+
+    output = layer.forward(
+        qkv,
+        torch.arange(num_tokens),
+        torch.empty(1, dtype=torch.bfloat16),
+        torch.ones(head_size, dtype=torch.bfloat16),
+        torch.ones(head_size, dtype=torch.bfloat16),
+        1e-5,
+    )
+
+    assert captured == {
+        "query": torch.float8_e4m3fn,
+        "output": torch.bfloat16,
+    }
+    assert output.dtype == torch.bfloat16
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime_patch/test_flash_attention_and_pp.py
+++ b/tests/runtime_patch/test_flash_attention_and_pp.py
@@ -122,6 +122,12 @@ def test_platform_flash_attention_mode_rejects_invalid_sidecar(
         hcu_module.get_hcu_flash_attn_mode()
 
 
+def test_hcu_platform_allows_explicit_fp8_e4m3_kv_cache() -> None:
+    from vllm_hcu.platforms.hcu import _validate_hcu_kv_cache_dtype
+
+    _validate_hcu_kv_cache_dtype("fp8_e4m3")
+
+
 @pytest.mark.parametrize(
     ("mode", "expected_shape", "expected_block_dim"),
     [
@@ -148,6 +154,40 @@ def test_flash_attention_kv_cache_contract_follows_resolved_mode(
     assert backend.get_kv_cache_stride_order(True) == (1, 0, 2, 3, 4, 5)
 
 
+def test_flash_attention_maps_explicit_fp8_e4m3_on_gfx938(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flash_attn = _load_hcu_flash_attention_module(monkeypatch)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda device: SimpleNamespace(gcnArchName="gfx938:sramecc+:xnack-"),
+    )
+    backend = flash_attn.HcuFlashAttentionBackend
+
+    assert backend.supports_kv_cache_dtype("fp8_e4m3") is True
+    assert (
+        backend.get_fp8_dtype_for_flashattn("fp8_e4m3")
+        == torch.float8_e4m3fn
+    )
+
+
+def test_flash_attention_does_not_remap_explicit_fp8_e4m3_on_gfx936(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flash_attn = _load_hcu_flash_attention_module(monkeypatch)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda device: SimpleNamespace(gcnArchName="gfx936:sramecc+:xnack-"),
+    )
+
+    with pytest.raises(ValueError, match="fp8_e4m3 only supported on gfx938"):
+        flash_attn.HcuFlashAttentionBackend.get_fp8_dtype_for_flashattn(
+            "fp8_e4m3"
+        )
+
+
 def test_cutlass_block_first_hnd_stride_contract(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -165,12 +205,18 @@ def test_cutlass_block_first_hnd_stride_contract(
 
 
 @pytest.mark.parametrize(
-    ("layout", "expected_writer"),
-    [("NHD", "aiter"), ("HND", "triton")],
+    ("layout", "kv_cache_dtype", "expected_writer"),
+    [
+        ("NHD", "auto", "aiter"),
+        ("HND", "auto", "triton"),
+        ("NHD", "fp8_e4m3", "triton"),
+        ("HND", "fp8_e4m3", "triton"),
+    ],
 )
 def test_flash_cache_writer_dispatches_by_physical_layout(
     monkeypatch: pytest.MonkeyPatch,
     layout: str,
+    kv_cache_dtype: str,
     expected_writer: str,
 ) -> None:
     fa_utils = importlib.import_module(
@@ -208,7 +254,7 @@ def test_flash_cache_writer_dispatches_by_physical_layout(
         key_cache,
         value_cache,
         slots,
-        "auto",
+        kv_cache_dtype,
         scale,
         scale,
     )
@@ -454,6 +500,86 @@ def test_hcu_flash_attention_forward_uses_metadata_window_with_fallback(
     )
 
     assert calls[0]["window_size"] == expected_window
+
+
+def test_cutlass_fp8_attention_passes_per_query_head_descales(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flash_attn = _load_hcu_flash_attention_module(monkeypatch)
+    impl = object.__new__(flash_attn.FlashAttentionImpl)
+    impl.vllm_flash_attn_version = 3
+    impl.attn_type = flash_attn.AttentionType.DECODER
+    impl.kv_cache_dtype = "fp8_e4m3"
+    impl.num_heads = 4
+    impl.num_kv_heads = 2
+    impl.supports_quant_query_input = True
+    impl.dcp_world_size = 1
+    impl.scale = 1.0
+    impl.alibi_slopes = None
+    impl.logits_soft_cap = 0.0
+    impl.sinks = None
+    impl.sliding_window = (-1, -1)
+
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(flash_attn, "_get_flash_attn_mode", lambda: "cutlass")
+    monkeypatch.setattr(
+        flash_attn,
+        "canonicalize_singleton_dim_strides",
+        lambda tensor: tensor,
+    )
+    monkeypatch.setattr(
+        flash_attn.HcuFlashAttentionBackend,
+        "get_fp8_dtype_for_flashattn",
+        staticmethod(lambda cache_dtype: torch.float8_e4m3fn),
+    )
+    monkeypatch.setattr(
+        flash_attn,
+        "varlen_fwd_unified",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    metadata = SimpleNamespace(
+        num_actual_tokens=1,
+        use_cascade=False,
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=torch.tensor([1], dtype=torch.int32),
+        max_query_len=1,
+        max_seq_len=1,
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+        scheduler_metadata=None,
+        causal=True,
+        sliding_window=None,
+    )
+    layer = SimpleNamespace(
+        _q_scale=torch.tensor([2.0, 3.0]),
+        _k_scale=torch.tensor([5.0, 7.0]),
+        _v_scale=torch.tensor([11.0, 13.0]),
+    )
+    query = torch.zeros(1, 4, 2).to(torch.float8_e4m3fn)
+    cache = torch.empty(1, 2, 1, 2, 2, dtype=torch.uint8)
+
+    impl.forward(
+        layer,
+        query,
+        torch.empty(1, 2, 2, dtype=torch.bfloat16),
+        torch.empty(1, 2, 2, dtype=torch.bfloat16),
+        cache,
+        metadata,
+        torch.empty(1, 4, 2, dtype=torch.bfloat16),
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["q"].dtype == torch.float8_e4m3fn
+    torch.testing.assert_close(
+        calls[0]["q_descale"],
+        torch.tensor([[2.0, 2.0, 3.0, 3.0]]),
+    )
+    torch.testing.assert_close(
+        calls[0]["k_descale"], torch.tensor([[5.0, 7.0]])
+    )
+    torch.testing.assert_close(
+        calls[0]["v_descale"], torch.tensor([[11.0, 13.0]])
+    )
 
 
 def test_block_first_kv_update_passes_axis_one_views_to_aiter(

--- a/tests/runtime_patch/test_hcu_model_runner_spec_decode_contract.py
+++ b/tests/runtime_patch/test_hcu_model_runner_spec_decode_contract.py
@@ -5,7 +5,12 @@
 from __future__ import annotations
 
 import ast
+import importlib
 from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import torch
 
 
 SOURCE_PATH = (
@@ -27,6 +32,19 @@ def _propose_draft_method(tree: ast.Module) -> ast.FunctionDef:
         for node in runner_class.body
         if isinstance(node, ast.FunctionDef)
         and node.name == "propose_draft_token_ids"
+    )
+
+
+def _runner_method(tree: ast.Module, name: str) -> ast.FunctionDef:
+    runner_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "GPUModelRunner"
+    )
+    return next(
+        node
+        for node in runner_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
     )
 
 
@@ -78,3 +96,63 @@ def test_runner_forwards_scheduler_dynamic_speculative_token_count() -> None:
 
     assert positional_calls == 3
     assert keyword_calls == 3
+
+
+def test_runner_clamps_speculative_placeholders_at_embedding_boundary() -> None:
+    """Keep scheduler placeholders out of the embedding lookup."""
+
+    source = SOURCE_PATH.read_text(encoding="utf-8")
+    method_source = ast.get_source_segment(
+        source,
+        _runner_method(ast.parse(source), "_preprocess"),
+    )
+
+    assert method_source is not None
+    assert "if self.speculative_config is not None:" in method_source
+    assert "self.input_ids.gpu[:num_input_tokens].clamp_(min=0)" in method_source
+
+
+def test_runner_uses_upstream_spec_metadata_h2d_contract() -> None:
+    """Do not revive the dynamic fused staging-buffer implementation."""
+
+    source = SOURCE_PATH.read_text(encoding="utf-8")
+    method = _runner_method(ast.parse(source), "_calc_spec_decode_metadata")
+    method_source = ast.get_source_segment(source, method)
+
+    assert method_source is not None
+    assert method_source.count("async_tensor_h2d(") == 5
+    assert "fused_meta_data" not in method_source
+    assert "draft_token_ids[target_logits_indices + 1]" in method_source
+
+
+def test_invalid_draft_suffixes_remain_rejected_in_metadata(monkeypatch) -> None:
+    """The embedding clamp must not erase -1 from rejection metadata."""
+
+    import vllm.v1.attention.backend as target_attention_backend
+
+    # Some target wheels predate this HCU-only metadata alias.
+    monkeypatch.setattr(
+        target_attention_backend,
+        "CpCommonAttentionMetadata",
+        object,
+        raising=False,
+    )
+    runner_module = importlib.import_module("vllm_hcu.v1.hcu_model_runner")
+    runner = object.__new__(runner_module.GPUModelRunner)
+    runner.device = torch.device("cpu")
+    runner.arange_np = np.arange(64, dtype=np.int64)
+    runner._arange_scratch = np.empty(64, dtype=np.int64)
+    runner.input_ids = SimpleNamespace(
+        gpu=torch.tensor(
+            [99, 10, -1, 99, 12, 99, 13, -1],
+            dtype=torch.int32,
+        )
+    )
+
+    metadata = runner_module.GPUModelRunner._calc_spec_decode_metadata(
+        runner,
+        np.array([2, 1, 2], dtype=np.int32),
+        np.array([3, 5, 8], dtype=np.int32),
+    )
+
+    assert metadata.draft_token_ids.tolist() == [10, -1, 12, 13, -1]

--- a/tests/runtime_patch/test_hcu_platform_kernel_imports.py
+++ b/tests/runtime_patch/test_hcu_platform_kernel_imports.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_hcu_platform_imports_stable_libtorch_kernels() -> None:
+    source = (ROOT / "vllm_hcu/platforms/hcu.py").read_text(encoding="utf-8")
+    module = ast.parse(source)
+    hcu_platform = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "HCUPlatform"
+    )
+    method = next(
+        node
+        for node in hcu_platform.body
+        if isinstance(node, ast.FunctionDef) and node.name == "import_kernels"
+    )
+    imported_modules = {
+        alias.name
+        for node in ast.walk(method)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+
+    assert "vllm._C_stable_libtorch" in imported_modules

--- a/tests/runtime_patch/test_hy_v3_eplb_source.py
+++ b/tests/runtime_patch/test_hy_v3_eplb_source.py
@@ -40,6 +40,60 @@ def test_hy_v3_decoder_layer_passes_enable_eplb_to_moe() -> None:
     assert ast.unparse(enable_eplb_kw.value) == "parallel_config.enable_eplb"
 
 
+def test_hy_v3_uses_v0251_expert_mapping_function() -> None:
+    for relative_path in (
+        "vllm_hcu/models/hy_v3.py",
+        "vllm_hcu/models/hy_v3_mtp.py",
+    ):
+        source = (ROOT / relative_path).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        imported_names = {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+            and node.module == "vllm.model_executor.layers.fused_moe"
+            for alias in node.names
+        }
+        assert "fused_moe_make_expert_params_mapping" in imported_names
+
+        obsolete_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "FusedMoE"
+            and node.func.attr == "make_expert_params_mapping"
+        ]
+        assert obsolete_calls == []
+
+
+def test_hy_v3_uses_v0251_cache_scale_mapper_api() -> None:
+    sources = {
+        relative_path: (ROOT / relative_path).read_text(encoding="utf-8")
+        for relative_path in (
+            "vllm_hcu/models/hy_v3.py",
+            "vllm_hcu/models/hy_v3_mtp.py",
+        )
+    }
+
+    for source in sources.values():
+        tree = ast.parse(source)
+        obsolete_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get_cache_scale"
+        ]
+        assert obsolete_calls == []
+
+    assert "get_cache_scale_mapper()" in sources[
+        "vllm_hcu/models/hy_v3_mtp.py"
+    ]
+
+
 def test_fp8_marlin_moe_method_allows_eplb() -> None:
     source = (
         ROOT

--- a/tests/runtime_patch/test_hy_v3_marlin_contract.py
+++ b/tests/runtime_patch/test_hy_v3_marlin_contract.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+from pathlib import Path
+
+import pytest
+import torch
+
+from vllm_hcu.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe_marlin import (
+    get_w8a8_int8_marlin_weights,
+)
+
+
+SOURCE = Path(
+    "vllm_hcu/model_executor/layers/quantization/compressed_tensors/"
+    "compressed_tensors_moe_marlin.py"
+)
+
+
+def test_marlin_packs_all_experts_like_individual_experts() -> None:
+    weights = torch.arange(3 * 5 * 128, dtype=torch.int16).to(torch.int8)
+    weights = weights.reshape(3, 5, 128)
+
+    packed = get_w8a8_int8_marlin_weights(weights)
+    reference = torch.stack(
+        [get_w8a8_int8_marlin_weights(weight) for weight in weights]
+    )
+
+    assert packed.shape == (3, 2, 5 * 64)
+    assert torch.equal(packed, reference)
+
+
+def test_marlin_rejects_unaligned_source_k() -> None:
+    with pytest.raises(ValueError, match=r"K \(65\).+k_tile \(64\)"):
+        get_w8a8_int8_marlin_weights(torch.empty(2, 3, 65, dtype=torch.int8))
+
+
+def test_fp8_marlin_returns_distinct_output_for_shared_experts() -> None:
+    """HY3 aliases x as shared_experts_input, so Marlin must not mutate x."""
+    tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+    method = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "CompressedTensorsW8A8FP8MarlinMoEMethod"
+    )
+    forward = next(
+        node
+        for node in method.body
+        if isinstance(node, ast.FunctionDef) and node.name == "fused_moe_forward"
+    )
+    calls = [
+        node
+        for node in ast.walk(forward)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "fused_experts_impl_fp8_marlin"
+    ]
+
+    assert len(calls) == 1
+    inplace = next(
+        keyword.value for keyword in calls[0].keywords if keyword.arg == "inplace"
+    )
+    assert isinstance(inplace, ast.Constant)
+    assert inplace.value is False
+
+
+def test_fp8_marlin_weight_packing_does_not_requantize_checkpoint() -> None:
+    source = SOURCE.read_text(encoding="utf-8")
+    assert "fp32_to_fp8_e4m3fn" not in source

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -706,6 +706,9 @@ def test_workspace_aiter_rope_and_cache_composes_public_ops(
     def cache_flash(*args, **kwargs):
         calls.append(("cache_flash", args, kwargs))
 
+    def triton_cache_flash(*args, **kwargs):
+        calls.append(("triton_cache_flash", args, kwargs))
+
     def cache(*args, **kwargs):
         calls.append(("cache", args, kwargs))
 
@@ -726,6 +729,15 @@ def test_workspace_aiter_rope_and_cache_composes_public_ops(
     monkeypatch.setitem(sys.modules, "aiter.ops.triton", triton)
     monkeypatch.setitem(sys.modules, "aiter.ops.cache", cache_module)
     monkeypatch.setitem(sys.modules, "aiter.ops.triton.rope", rope_module)
+    triton_cache_module = _module(
+        "vllm.v1.attention.ops.triton_reshape_and_cache_flash",
+        triton_reshape_and_cache_flash=triton_cache_flash,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.v1.attention.ops.triton_reshape_and_cache_flash",
+        triton_cache_module,
+    )
 
     query = torch.zeros(2, 8)
     key = torch.zeros(2, 4)
@@ -753,7 +765,7 @@ def test_workspace_aiter_rope_and_cache_composes_public_ops(
         True,
         True,
     )
-    assert [call[0] for call in calls] == ["rope", "cache_flash"]
+    assert [call[0] for call in calls] == ["rope", "triton_cache_flash"]
     assert calls[0][1][0].shape == (2, 2, 4)
     assert calls[0][1][1].shape == (2, 1, 4)
     assert calls[0][1][5] == 0

--- a/tests/runtime_patch/test_worker_framework_opt.py
+++ b/tests/runtime_patch/test_worker_framework_opt.py
@@ -800,10 +800,11 @@ def test_proposer_sidecar_init_cplb_fix_rocm_preservation_and_custom_sp_padding(
     assert prepared.num_kv_actual_tokens == 5
 
 
-def test_proposer_registers_flashmla_sparse_metadata_once() -> None:
+def test_proposer_registers_hcu_multistep_metadata_once() -> None:
     from vllm.v1.attention.backends.mla.flashmla_sparse import (
         FlashMLASparseMetadata,
     )
+    from vllm_hcu.v1.attention.backends.flash_attn import FlashAttentionMetadata
     from vllm_hcu.v1.spec_decode import proposer_runtime
 
     proposer = SimpleNamespace(allowed_attn_types=(str,))
@@ -816,7 +817,13 @@ def test_proposer_registers_flashmla_sparse_metadata_once() -> None:
         SimpleNamespace(), proposer, config, "cpu", None
     )
 
-    assert proposer.allowed_attn_types == (str, FlashMLASparseMetadata)
+    assert proposer.allowed_attn_types == (
+        str,
+        FlashAttentionMetadata,
+        FlashMLASparseMetadata,
+    )
+    hcu_metadata = object.__new__(FlashAttentionMetadata)
+    assert isinstance(hcu_metadata, proposer.allowed_attn_types)
 
 
 def test_proposer_lightly_cp_atomic_metadata_and_forward_context_chain(

--- a/vllm_hcu/model_executor/layers/attention_forward_runtime.py
+++ b/vllm_hcu/model_executor/layers/attention_forward_runtime.py
@@ -15,6 +15,26 @@ from typing import Any
 import torch
 
 
+def quantize_attention_query(self: Any, query: torch.Tensor) -> torch.Tensor:
+    """Match the query dtype to a quantized KV cache when supported."""
+
+    if self.query_quant is None:
+        return query
+    if self.kv_cache_dtype not in {
+        "fp8",
+        "fp8_e4m3",
+        "fp8_e5m2",
+        "nvfp4",
+    }:
+        raise ValueError(
+            "unsupported HCU quantized attention KV-cache dtype "
+            f"{self.kv_cache_dtype!r}"
+        )
+    if self.impl.supports_quant_query_input:
+        query, _ = self.query_quant(query, self._q_scale)
+    return query
+
+
 def attention_forward(
     upstream: ModuleType,
     self: Any,
@@ -35,14 +55,7 @@ def attention_forward(
         )
     if output_dtype is None:
         output_dtype = query.dtype
-    if self.query_quant is not None:
-        if self.kv_cache_dtype not in {"fp8", "fp8_e4m3", "fp8_e5m2", "nvfp4"}:
-            raise ValueError(
-                "unsupported HCU quantized attention KV-cache dtype "
-                f"{self.kv_cache_dtype!r}"
-            )
-        if self.impl.supports_quant_query_input:
-            query, _ = self.query_quant(query, self._q_scale)
+    query = quantize_attention_query(self, query)
 
     if output_shape is None:
         num_tokens = query.shape[0]
@@ -87,4 +100,4 @@ def attention_forward(
     return output.view(-1, hidden_size)
 
 
-__all__ = ["attention_forward"]
+__all__ = ["attention_forward", "quantize_attention_query"]

--- a/vllm_hcu/model_executor/layers/attention_runtime.py
+++ b/vllm_hcu/model_executor/layers/attention_runtime.py
@@ -19,7 +19,10 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backend import AttentionBackend, AttentionType
 
-from vllm_hcu.model_executor.layers.attention_forward_runtime import attention_forward
+from vllm_hcu.model_executor.layers.attention_forward_runtime import (
+    attention_forward,
+    quantize_attention_query,
+)
 from vllm_hcu.model_executor.layers.kv_cache_utils import split_kv_cache
 from vllm_hcu.platforms import envs as henvs
 
@@ -30,7 +33,7 @@ def init_kv_cache_quant_e5m2(
     quant_config: QuantizationConfig | None,
     prefix: str,
 ) -> None:
-    """v0.25.1 target ``_init_kv_cache_quant`` plus the HCU E5M2 delta."""
+    """Initialize the HCU E5M2 KV cache without the CUDA FP8 restriction."""
 
     upstream.set_default_quant_scales(layer, register_buffer=True)
     layer._o_scale_float = None
@@ -127,6 +130,9 @@ class FusedQkvSplitRmsNormRopeAttention(Attention):
             block_size=self.block_size,
             is_neox=is_neox,
         )
+        query_shape = query.shape
+        query = quantize_attention_query(self, query.reshape(num_tokens, -1))
+        query = query.view(query_shape)
         torch.ops.vllm.unified_attention_with_output(
             query,
             key,

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
@@ -101,15 +101,39 @@ def _is_hcu_aiter_w8a8_moe_requested() -> bool:
 def get_w8a8_int8_marlin_weights(
          weight,
          k_tile=64):
-    # 7168, 512
-    weight = weight.T
-    size_k, size_n = weight.shape
-    assert size_k // k_tile
-    weight = weight.reshape(size_k // k_tile, k_tile, size_n)
-    weight = weight.transpose(1, 2)
-    weight = weight.reshape(size_k // k_tile, size_n * k_tile)
+    if weight.dim() == 2:
+        # [N, K] -> [K // k_tile, N * k_tile]
+        weight = weight.T
+        size_k, size_n = weight.shape
+        if size_k % k_tile != 0:
+            raise ValueError(
+                f"Marlin requires K ({size_k}) to be divisible by "
+                f"k_tile ({k_tile})"
+            )
+        weight = weight.reshape(size_k // k_tile, k_tile, size_n)
+        weight = weight.transpose(1, 2)
+        return weight.reshape(size_k // k_tile, size_n * k_tile)
 
-    return weight
+    if weight.dim() == 3:
+        # [E, N, K] -> [E, K // k_tile, N * k_tile].  Packing the full
+        # expert tensor avoids retaining one FP32 copy per expert while loading
+        # large models such as HY3.
+        num_experts, size_n, size_k = weight.shape
+        if size_k % k_tile != 0:
+            raise ValueError(
+                f"Marlin requires K ({size_k}) to be divisible by "
+                f"k_tile ({k_tile})"
+            )
+        weight = weight.transpose(1, 2)
+        weight = weight.reshape(
+            num_experts, size_k // k_tile, k_tile, size_n
+        )
+        weight = weight.transpose(2, 3)
+        return weight.reshape(
+            num_experts, size_k // k_tile, size_n * k_tile
+        )
+
+    raise ValueError(f"Expected a 2D or 3D weight, got {weight.dim()}D")
 
 
 def w8a8_nt_kpack2_marlin_weight(w8a8_w, # [size_n, size_k// 2 ]
@@ -123,17 +147,6 @@ def w8a8_nt_kpack2_marlin_weight(w8a8_w, # [size_n, size_k// 2 ]
     w8a8_w = w8a8_w.permute((0, 2, 1, 3)).contiguous()
     w8a8_w = w8a8_w.reshape((size_n // k_tile, size_k * k_tile))
     return w8a8_w
-
-def fp32_to_fp8_e4m3fn(t: torch.Tensor) -> torch.Tensor:
-    """更合理的FP32到Float8_e4m3fn转换，使用最近值而不是简单舍弃尾数"""
-    # torch.float8_e4m3fn的数值范围约[-448, 448]
-    fp8_min, fp8_max = -448.0, 448.0
-    t_clamped = t.clamp(min=fp8_min, max=fp8_max)
-    # 保证不会下溢到0
-    # 转换前到float16再转fp8可能提升精度（float8实现本身通常通过float16做rounding）
-    t_fp16 = t_clamped.to(torch.float16)
-    return t_fp16.to(torch.float8_e4m3fn)
-
 
 def w8a8_fp8_nt_kpack2_marlin_weight(w8a8_w,  # [size_n, size_k// 2 ]
                                      k_tile=16,
@@ -297,20 +310,22 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
             layer.w2_weight = Parameter(w2_marlin, requires_grad=False)
             return
 
-        w1_marlin_list = []
-        for ii in range(layer.w13_weight.shape[0]):
-            w1_marlin_in = get_w8a8_int8_marlin_weights(layer.w13_weight[ii])
-            w1_marlin_list.append(w1_marlin_in.float() if w1_marlin_in.dtype == torch.float8_e4m3fn else w1_marlin_in)
-        w1_marlin = torch.stack(w1_marlin_list, dim=0)
-        w1_marlin = fp32_to_fp8_e4m3fn(w1_marlin)
+        if layer.w13_weight.dtype != torch.float8_e4m3fn:
+            raise TypeError(
+                "FP8 W8A8 MoE expects w13_weight to be "
+                f"torch.float8_e4m3fn, got {layer.w13_weight.dtype}"
+            )
+        if layer.w2_weight.dtype != torch.float8_e4m3fn:
+            raise TypeError(
+                "FP8 W8A8 MoE expects w2_weight to be "
+                f"torch.float8_e4m3fn, got {layer.w2_weight.dtype}"
+            )
 
-        del w1_marlin_list
-        w2_marlin_list = []
-        for ii in range(layer.w2_weight.shape[0]):
-            w2_marlin_in = get_w8a8_int8_marlin_weights(layer.w2_weight[ii])
-            w2_marlin_list.append(w2_marlin_in.float() if w2_marlin_in.dtype == torch.float8_e4m3fn else w2_marlin_in)
-        w2_marlin = torch.stack(w2_marlin_list, dim=0)
-        w2_marlin = fp32_to_fp8_e4m3fn(w2_marlin)
+        # The checkpoint is already FP8.  Marlin only needs a layout change;
+        # converting every expert through FP32/FP16 is both unnecessary and a
+        # large temporary-memory spike for HY3's 192 experts.
+        w1_marlin = get_w8a8_int8_marlin_weights(layer.w13_weight)
+        w2_marlin = get_w8a8_int8_marlin_weights(layer.w2_weight)
         layer.w13_weight = Parameter(w1_marlin, requires_grad=False)
         layer.w2_weight = Parameter(w2_marlin, requires_grad=False)
 
@@ -336,7 +351,11 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
             w2=layer.w2_weight,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
-            inplace=True,
+            # vLLM v0.25.1 removed the fused-MoE in-place output contract.
+            # More importantly, HY3 aliases x as the shared-expert input.  An
+            # in-place routed result makes the shared expert consume corrupted
+            # input (or races it when the auxiliary stream launches early).
+            inplace=False,
             activation=activation,
             apply_router_weight_on_input=apply_router_weight_on_input,
             use_fp8_w8a8=True,

--- a/vllm_hcu/models/hy_v3.py
+++ b/vllm_hcu/models/hy_v3.py
@@ -45,7 +45,11 @@ from vllm.distributed import (
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.attention import Attention, FusedQkvSplitRmsNormRopeAttention
-from vllm.model_executor.layers.fused_moe import FusedMoE, GateLinear
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoE,
+    GateLinear,
+    fused_moe_make_expert_params_mapping,
+)
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
@@ -652,7 +656,7 @@ class HYV3Model(nn.Module):
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
-        return FusedMoE.make_expert_params_mapping(
+        return fused_moe_make_expert_params_mapping(
             self,
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
@@ -710,17 +714,6 @@ class HYV3Model(nn.Module):
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
             if self.config.tie_word_embeddings and "lm_head.weight" in name:
-                continue
-            if self.quant_config is not None and (
-                scale_name := self.quant_config.get_cache_scale(name)
-            ):
-                param = params_dict[scale_name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                loaded_weight = (
-                    loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
-                )
-                weight_loader(param, loaded_weight)
-                loaded_params.add(scale_name)
                 continue
             if "scale" in name:
                 # Remapping the name of FP8 kv-scale.

--- a/vllm_hcu/models/hy_v3_mtp.py
+++ b/vllm_hcu/models/hy_v3_mtp.py
@@ -34,7 +34,10 @@ from torch import nn
 from transformers import PretrainedConfig
 
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
-from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoE,
+    fused_moe_make_expert_params_mapping,
+)
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
@@ -373,6 +376,10 @@ class HYV3MTP(nn.Module, SupportsPP):
         return torch.concat((q, k, v))
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        if self.quant_config is not None and (
+            cache_scale_mapper := self.quant_config.get_cache_scale_mapper()
+        ):
+            weights = cache_scale_mapper.apply(weights)
         cla_factor = _get_cla_factor(self.config)
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
@@ -399,7 +406,7 @@ class HYV3MTP(nn.Module, SupportsPP):
         ]
 
         if _is_moe(self.config):
-            expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            expert_params_mapping = fused_moe_make_expert_params_mapping(
                 self,
                 ckpt_gate_proj_name="gate_proj",
                 ckpt_down_proj_name="down_proj",
@@ -444,14 +451,6 @@ class HYV3MTP(nn.Module, SupportsPP):
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
                 continue
             if self.config.tie_word_embeddings and "lm_head.weight" in name:
-                continue
-            if self.quant_config is not None and (
-                scale_name := self.quant_config.get_cache_scale(name)
-            ):
-                param = params_dict[scale_name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                loaded_weight = loaded_weight[0]
-                weight_loader(param, loaded_weight)
                 continue
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
             if spec_layer is None:

--- a/vllm_hcu/platforms/hcu.py
+++ b/vllm_hcu/platforms/hcu.py
@@ -29,6 +29,26 @@ logger = init_logger(__name__)
 _ensure_platform_plugin_ready()
 
 
+# Recognition here only prevents an invalid format from reaching backend
+# selection. It does not claim that every backend/device pair is complete.
+_HCU_RECOGNIZED_FP8_KV_CACHE_DTYPES = frozenset(
+    {"fp8", "fp8_e4m3", "fp8_e5m2", "fp8_ds_mla"}
+)
+
+
+def _validate_hcu_kv_cache_dtype(cache_dtype: str) -> None:
+    """Reject unknown FP8 KV-cache formats before backend selection."""
+
+    if (
+        cache_dtype.startswith("fp8")
+        and cache_dtype not in _HCU_RECOGNIZED_FP8_KV_CACHE_DTYPES
+    ):
+        raise ValueError(
+            f"HCU does not recognize FP8 KV cache dtype {cache_dtype!r}; use "
+            "--kv-cache-dtype fp8, fp8_e4m3, fp8_e5m2, or fp8_ds_mla"
+        )
+
+
 def get_hcu_flash_attn_mode() -> str:
     """Resolve the HCU flash-attention sub-mode from serialized config."""
 
@@ -230,10 +250,22 @@ class HCUPlatform(Platform):
     
     @classmethod
     def import_kernels(cls) -> None:
-        """Import ROCm-specific kernels."""
+        """Import the vLLM and optional ROCm kernel extensions used by HCU."""
         super().import_kernels()
 
         import contextlib
+
+        # HCU derives directly from Platform rather than CudaPlatformBase, so
+        # the base implementation only imports vllm._C.  Cache operators such
+        # as ``_C_cache_ops::reshape_and_cache_flash`` live in the stable
+        # libtorch extension and must be imported explicitly to register their
+        # torch.ops schemas and CUDA/HIP implementations.
+        try:
+            import vllm._C_stable_libtorch  # noqa: F401
+        except ImportError as exc:
+            logger.warning_once(
+                "Failed to import vLLM stable-libtorch kernels: %r", exc
+            )
 
         # Import ROCm-specific extension
         with contextlib.suppress(ImportError):
@@ -526,6 +558,10 @@ class HCUPlatform(Platform):
 
     @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+        cache_config = vllm_config.cache_config
+        if cache_config is not None:
+            _validate_hcu_kv_cache_dtype(cache_config.cache_dtype)
+
         from vllm.config.compilation import CUDAGraphMode
         from vllm_hcu.patch.import_coordinator import IMPORT_COORDINATOR
         from vllm_hcu.patch.platform.core_fix.patch_vllm_config import (
@@ -548,7 +584,6 @@ class HCUPlatform(Platform):
         select_hcu_scheduler(vllm_config)
         select_hcu_multiproc_executor(vllm_config)
 
-        cache_config = vllm_config.cache_config
         compilation_config = vllm_config.compilation_config
         parallel_config = vllm_config.parallel_config
         # if cache_config and cache_config.block_size is None:

--- a/vllm_hcu/v1/attention/backends/fa_utils.py
+++ b/vllm_hcu/v1/attention/backends/fa_utils.py
@@ -41,7 +41,15 @@ def reshape_and_cache_flash(
     # Logical cache views remain [block, token, head, dim] in both layouts.
     # HND is distinguishable by a token stride smaller than the head stride.
     # If either dimension is one, selecting NHD is also address-equivalent.
-    if key_cache.ndim == 4 and key_cache.stride(1) < key_cache.stride(2):
+    #
+    # AITER's flash cache writer corrupts FP8 E4M3 pages on HCU (including
+    # NaN bit patterns).  vLLM's Triton writer explicitly casts through the
+    # platform FP8 dtype and is stride-aware, so use it for FP8 caches as well
+    # as for HND storage. Keep other quantization formats on their existing
+    # route until they have an explicit HCU cache contract.
+    if kv_cache_dtype.startswith("fp8") or (
+        key_cache.ndim == 4 and key_cache.stride(1) < key_cache.stride(2)
+    ):
         from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
             triton_reshape_and_cache_flash,
         )

--- a/vllm_hcu/v1/attention/backends/flash_attn.py
+++ b/vllm_hcu/v1/attention/backends/flash_attn.py
@@ -228,14 +228,15 @@ class HcuFlashAttentionBackend(AttentionBackend):
     @staticmethod
     def get_fp8_dtype_for_flashattn(kv_cache_dtype: str) -> torch.dtype:
         if kv_cache_dtype in ("fp8", "fp8_e4m3"):
-            if torch.cuda.get_device_properties("cuda").gcnArchName.split(':')[0] == "gfx938":
+            arch = torch.cuda.get_device_properties("cuda").gcnArchName.split(":")[0]
+            if arch == "gfx938":
                 return torch.float8_e4m3fn
-            else:
-                raise ValueError(f"{kv_cache_dtype} only supported on nmz")
-        elif kv_cache_dtype in ("fp8_e5m2"):
+            raise ValueError(f"{kv_cache_dtype} only supported on gfx938")
+        if kv_cache_dtype == "fp8_e5m2":
+            # E5M2 is retained for gfx936. Do not impose a strict
+            # device/backend gate until CUTLASS FP8 coverage there is complete.
             return torch.float8_e5m2
-        else:
-            raise ValueError(f"Unrecognized FP8 dtype: {kv_cache_dtype}")
+        raise ValueError(f"Unrecognized FP8 dtype: {kv_cache_dtype}")
 
     @classmethod
     def supports_head_size(cls, head_size: int) -> bool:
@@ -898,6 +899,13 @@ class FlashAttentionImpl(AttentionImpl):
             )
             key_cache = key_cache.view(dtype)
             value_cache = value_cache.view(dtype)
+            mode = _get_flash_attn_mode()
+            if (
+                mode == "cutlass"
+                and self.dcp_world_size <= 1
+                and query.dtype == torch.float8_e4m3fn
+            ):
+                query = query.view(dtype)
 
         if not attn_metadata.use_cascade:
             cu_seqlens_q = attn_metadata.query_start_loc
@@ -976,23 +984,45 @@ class FlashAttentionImpl(AttentionImpl):
                         "[HCU FLASH_ATTN PATH] unified_flash_attn",
                         scope="local",
                     )
+                    if (
+                        self.kv_cache_dtype.startswith("fp8")
+                        and query.dtype == torch.float8_e4m3fn
+                    ):
+                        num_seqs = cu_seqlens_q.shape[0] - 1
+                        if (
+                            layer._q_scale.numel() == self.num_kv_heads
+                            and self.num_heads % self.num_kv_heads == 0
+                        ):
+                            q_descale = layer._q_scale.reshape(
+                                1, self.num_kv_heads
+                            ).expand(num_seqs, self.num_kv_heads)
+                            q_descale = q_descale.repeat_interleave(
+                                self.num_heads // self.num_kv_heads, dim=-1
+                            )
+                        else:
+                            q_descale = layer._q_scale.expand(
+                                (num_seqs, self.num_heads)
+                            )
                     varlen_fwd_unified(
-                    q=query[:num_actual_tokens],
-                    k=key_cache,
-                    v=value_cache,
-                    cu_seqlens_q=cu_seqlens_q,
-                    seqused_k=seqused_k,
-                    block_table=block_table,
-                    max_seqlen_q=max_seqlen_q,
-                    max_seqlen_k=max_seqlen_k,
-                    softmax_scale=self.scale,
-                    causal=attn_metadata.causal,
-                    softcap=self.logits_soft_cap,
-                    window_size=sliding_window_size,
-                    alibi_slopes=self.alibi_slopes,
-                    s_aux=self.sinks,
-                    out=output[:num_actual_tokens],
-                    )   
+                        q=query[:num_actual_tokens],
+                        k=key_cache,
+                        v=value_cache,
+                        cu_seqlens_q=cu_seqlens_q,
+                        seqused_k=seqused_k,
+                        block_table=block_table,
+                        max_seqlen_q=max_seqlen_q,
+                        max_seqlen_k=max_seqlen_k,
+                        softmax_scale=self.scale,
+                        causal=attn_metadata.causal,
+                        softcap=self.logits_soft_cap,
+                        window_size=sliding_window_size,
+                        alibi_slopes=self.alibi_slopes,
+                        s_aux=self.sinks,
+                        out=output[:num_actual_tokens],
+                        q_descale=q_descale,
+                        k_descale=k_descale,
+                        v_descale=v_descale,
+                    )
 
                 else:
                     logger.info_once(

--- a/vllm_hcu/v1/hcu_model_runner.py
+++ b/vllm_hcu/v1/hcu_model_runner.py
@@ -113,6 +113,7 @@ from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
 from vllm.utils.nvtx_pytorch_hooks import PytHooks
 from vllm.utils.platform_utils import is_pin_memory_available, num_compute_units
 from vllm.utils.torch_utils import (
+    async_tensor_h2d,
     get_dtype_size,
     is_quantized_kv_cache,
     kv_cache_dtype_str_to_dtype,
@@ -2793,53 +2794,22 @@ class GPUModelRunner(
         # [0, 1, 2, 5, 6, 9]
         target_logits_indices += self._arange_scratch[: cu_num_draft_tokens[-1]]
 
-        # TODO: Optimize the CPU -> GPU copy.
-        # cu_num_draft_tokens = torch.from_numpy(cu_num_draft_tokens).to(
-        #     self.device, non_blocking=True
-        # )
-        # cu_num_sampled_tokens = torch.from_numpy(cu_num_sampled_tokens).to(
-        #     self.device, non_blocking=True
-        # )
-        # logits_indices = torch.from_numpy(logits_indices).to(
-        #     self.device, non_blocking=True
-        # )
-        # target_logits_indices = torch.from_numpy(target_logits_indices).to(
-        #     self.device, non_blocking=True
-        # )
-        # bonus_logits_indices = torch.from_numpy(bonus_logits_indices).to(
-        #     self.device, non_blocking=True
-        # )
-
-        # # Compute the draft token ids.
-        # # draft_token_indices:      [  1,   2,   3, 105, 106, 208]
-        # draft_token_ids = self.input_ids.gpu[logits_indices]
-        # draft_token_ids = draft_token_ids[target_logits_indices + 1]
-
-        draft_token_indices = target_logits_indices + 1
-        # Optimize the H2D in the process of creating spec decode metadata
-        fused_meta_data = cu_num_draft_tokens.tolist() + cu_num_sampled_tokens.tolist()\
-              + logits_indices.tolist() + target_logits_indices.tolist() + bonus_logits_indices.tolist()\
-              + draft_token_indices.tolist()
-
-        fused_meta_data_len = np.array([len(cu_num_draft_tokens), len(cu_num_sampled_tokens),\
-                                        len(logits_indices), len(target_logits_indices),\
-                                            len(bonus_logits_indices), len(draft_token_indices)], dtype=np.int32)
-        cu_fused_meta_data_len = np.cumsum(fused_meta_data_len, dtype=np.int32)
-        fused_meta_data = torch.tensor(
-            fused_meta_data, dtype=torch.int32, pin_memory=self.pin_memory
-        ).to(self.device, non_blocking=True)
-
-        cu_num_draft_tokens = fused_meta_data[:cu_fused_meta_data_len[0]]
-        cu_num_sampled_tokens = fused_meta_data[cu_fused_meta_data_len[0]:cu_fused_meta_data_len[1]]
-        logits_indices = fused_meta_data[cu_fused_meta_data_len[1]:cu_fused_meta_data_len[2]]
-        target_logits_indices = fused_meta_data[cu_fused_meta_data_len[2]:cu_fused_meta_data_len[3]]
-        bonus_logits_indices = fused_meta_data[cu_fused_meta_data_len[3]:cu_fused_meta_data_len[4]]
-        draft_token_indices = fused_meta_data[cu_fused_meta_data_len[4]:cu_fused_meta_data_len[5]]
+        cu_num_draft_tokens = async_tensor_h2d(cu_num_draft_tokens, device=self.device)
+        cu_num_sampled_tokens = async_tensor_h2d(
+            cu_num_sampled_tokens, device=self.device
+        )
+        logits_indices = async_tensor_h2d(logits_indices, device=self.device)
+        target_logits_indices = async_tensor_h2d(
+            target_logits_indices, device=self.device
+        )
+        bonus_logits_indices = async_tensor_h2d(
+            bonus_logits_indices, device=self.device
+        )
 
         # Compute the draft token ids.
         # draft_token_indices:      [  1,   2,   3, 105, 106, 208]
         draft_token_ids = self.input_ids.gpu[logits_indices]
-        draft_token_ids = draft_token_ids[draft_token_indices]
+        draft_token_ids = draft_token_ids[target_logits_indices + 1]
 
         return SpecDecodeMetadata(
             draft_token_ids=draft_token_ids,
@@ -3444,6 +3414,13 @@ class GPUModelRunner(
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         is_first_rank = get_pp_group().is_first_rank
         is_encoder_decoder = self.model_config.is_encoder_decoder
+
+        # The async speculative scheduler may use -1 as a placeholder for
+        # requests that were not in the previous worker batch. Keep -1 in the
+        # speculative metadata so rejection sampling rejects those positions,
+        # but clamp it before the embedding lookup.
+        if self.speculative_config is not None:
+            self.input_ids.gpu[:num_input_tokens].clamp_(min=0)
 
         # _prepare_inputs may reorder the batch, so we must gather multi
         # modal outputs after that to ensure the correct order

--- a/vllm_hcu/v1/spec_decode/proposer_runtime.py
+++ b/vllm_hcu/v1/spec_decode/proposer_runtime.py
@@ -22,10 +22,13 @@ def initialize_proposer(
     proposer._hcu_feature_config = config
     proposer.runner = runner
 
-    # HCU FlashMLA sparse explicitly supports speculative tokens as decode
-    # queries, but target vLLM v0.25.1 does not include its metadata class in
-    # the ROCm multi-step drafting allowlist.  Keep the target proposer and
-    # extend only the HCU-owned backend capability registration.
+    # HCU FlashAttention and FlashMLA sparse both support speculative tokens as
+    # decode queries, but target vLLM v0.25.1 does not include their metadata
+    # classes in the ROCm multi-step drafting allowlist. Keep the target
+    # proposer and extend only the HCU-owned backend capability registration.
+    from vllm_hcu.v1.attention.backends.flash_attn import FlashAttentionMetadata
+
+    hcu_attn_types = [FlashAttentionMetadata]
     try:
         from vllm.v1.attention.backends.mla.flashmla_sparse import (
             FlashMLASparseMetadata,
@@ -34,12 +37,15 @@ def initialize_proposer(
         if exc.name != "vllm.v1.attention.backends.mla.flashmla_sparse":
             raise
     else:
-        allowed_attn_types = getattr(proposer, "allowed_attn_types", None)
-        if (
-            allowed_attn_types is not None
-            and FlashMLASparseMetadata not in allowed_attn_types
-        ):
-            proposer.allowed_attn_types += (FlashMLASparseMetadata,)
+        hcu_attn_types.append(FlashMLASparseMetadata)
+
+    allowed_attn_types = getattr(proposer, "allowed_attn_types", None)
+    if allowed_attn_types is not None:
+        proposer.allowed_attn_types += tuple(
+            metadata_type
+            for metadata_type in hcu_attn_types
+            if metadata_type not in proposer.allowed_attn_types
+        )
 
     proposer.enable_multi_layers_mtp = config.enable_multi_layers_mtp
     proposer.enable_lightly_cp = config.enable_lightly_cp


### PR DESCRIPTION
### bugfix: HY3 FP8 KV cache and Marlin runtime compatibility with vLLM v0.25.1
 - Align HY3/MTP expert mapping and KV-scale loading with v0.25.1 contracts.
 - Fix FP8 Marlin MoE packing, avoid redundant requantization, and preserve shared-expert inputs.
 - Correct FP8 E4M3 cache writes, fused-query quantization, and CUTLASS per-head descales.
 - Enable multi-step MTP decoding for HCU FlashAttention metadata and register stable cache kernels.

unit test: added coverage for HY3/MTP loading contracts, Marlin expert packing and out-of-place execution, FP8 E4M3 device mapping/cache dispatch/query quantization, CUTLASS descales, kernel registration, and multi-step metadata support.

### model test
| model | gsm8k-100 | humaneval-100 |
|:------------|:---------:|:-------------:|
| Hy3 fp8 (mtp=2) | 0.98 | 0.97 | 
| Hy3 fp8 (mtp=3) | - | 0.96 | 

**serve**

`
export GPU_MAX_HW_QUEUES=4
export HIP_VISIBLE_DEVICES=0,1,2,3
vllm serve /models2/Hy3-Channel-FP8-w8a8 \
  -q slimquant_marlin \
  --trust-remote-code \
  --tensor-parallel-size 4 \
  --enable-prefix-caching \
  --speculative-config.method mtp \
  --speculative-config.num_speculative_tokens 2 \
  --speculative-config.quantization "slimquant_marlin" \
  --tool-call-parser hy_v3 \
  --reasoning-parser hy_v3 \
  --kv_cache_dtype fp8_e4m3 \
  --gpu-memory-utilization 0.92 \
  --enable-auto-tool-choice \
  --served-model-name hy3-fp8 \
  --port 8001
`

**eval humaneval**

`
evalscope eval   --model hy3-fp8 \
  --api-url http://127.0.0.1:8001/v1 \
  --api-key EMPTY \
  --eval-type openai_api \
  --limit 100 \
  --eval-batch-size 32 \
  --datasets humaneval \
  --dataset-args '{"humaneval":{"few_shot_random":false,"metrics_list":["Pass@1"]}}' \
  --generation-config '{"temperature":0,"top_p":0.95,"max_tokens":5120,"timeout":600,"stream":true,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}'   \
  --work-dir /tmp/hy3_humaneval-100
`

**eval gsm8k**

`
evalscope eval   --model hy3-fp8 \
  --api-url http://127.0.0.1:8001/v1 \
  --api-key EMPTY \
  --eval-type openai_api \
  --limit 100 \
  --eval-batch-size 32 \
  --datasets gsm8k \
  --dataset-args '{"gsm8k":{"few_shot_random":false}}' \
  --generation-config '{"temperature":0,"top_p":0.95,"max_tokens":5120,"timeout":600,"stream":true,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}' \
  --work-dir /tmp/hy3_gsm8k-100
`
