### PR TITLE
feat(hcu): support GLM-5.2 PCP with model runner v2

### DIFF
--- a/.superpowers/sdd/2026-08-19-glm52-pcp-hcu/task-7-report.md
+++ b/.superpowers/sdd/2026-08-19-glm52-pcp-hcu/task-7-report.md
@@ -88,3 +88,105 @@ also completed successfully. `ruff` is not installed in this environment.
 - Peak device memory is sampled from aggregate live device usage during each
   request, so Task 8 should run on an otherwise idle eight-HCU host for a clean
   measurement.
+
+## Fix Round 1
+
+Review identified two integration gaps: EvalScope addressed the checkpoint
+path while the server advertised a basename, and post-request liveness relied
+only on the parent process plus deterministic output parity.
+
+### RED: served/request model identity
+
+The new builder contract executed both consumers with the default checkpoint
+and an overridden `VLLM_HCU_GLM52_MODEL`:
+
+```text
+pytest -q tests/integration/server/test_evalscope_glm52_pcp_humaneval.py \
+  -k 'request_model_matches_served_model'
+
+2 failed, 4 deselected
+```
+
+The default case emitted `/models/GLM-5___1-Channel-FP8-w8a8` to EvalScope
+while advertising `GLM-5___1-Channel-FP8-w8a8`; the override case emitted the
+override checkpoint path while retaining that advertised basename.
+
+### GREEN: stable served/request model identity
+
+`server.served_model_name` is now the single stable request-facing identity.
+The server builder adds `--served-model-name` from it and the EvalScope builder
+uses the same value, while `VLLM_HCU_GLM52_MODEL` continues to select the
+checkpoint loaded by `vllm serve`.
+
+```text
+pytest -q tests/integration/server/test_evalscope_glm52_pcp_humaneval.py \
+  -k 'command_request_model_matches_served_model'
+
+2 passed, 4 deselected
+```
+
+### RED: acceptance-path worker-group health check
+
+A CPU integration test started a real loopback SSE completion endpoint and a
+real local `/health` endpoint. With the acceptance path's health call absent,
+the completion succeeded but the health endpoint was never reached:
+
+```text
+pytest -q tests/integration/models/test_glm52_pcp_mrv2.py \
+  -k 'health'
+
+1 failed, 4 deselected
+AssertionError: assert 0 == 1
+```
+
+### GREEN: post-request `/health`
+
+`_stream_completion` now requires an HTTP 200 from the existing OpenAI server
+`/health` endpoint after every smoke and 32K/64K completion. Deterministic token
+parity remains separately asserted; it is not represented as individual-rank
+telemetry.
+
+```text
+pytest -q tests/integration/models/test_glm52_pcp_mrv2.py \
+  -k 'health'
+
+1 passed, 4 deselected
+```
+
+The loopback test declares `NO_PROXY` so the environment's configured HTTP
+proxy cannot intercept the local health contract.
+
+Individual-rank failure evidence remains a Task 8 hardware-log check.
+
+### Fix Round 1 verification
+
+```text
+VLLM_HCU_GLM52_MODEL=/models/GLM-5___1-Channel-FP8-w8a8 \
+pytest --collect-only -q \
+  tests/integration/models/test_glm52_pcp_mrv2.py \
+  tests/integration/server/test_evalscope_glm52_pcp_humaneval.py
+
+11 tests collected
+```
+
+```text
+pytest -q \
+  tests/integration/models/test_glm52_pcp_mrv2.py \
+  tests/integration/server/test_evalscope_report_threshold.py \
+  tests/integration/server/test_evalscope_glm52_pcp_humaneval.py \
+  -k 'command or payload or config or health'
+
+7 passed, 7 deselected
+```
+
+```text
+pytest -q -m 'not hcu' \
+  tests/integration/models/test_glm52_pcp_mrv2.py \
+  tests/integration/server/test_evalscope_report_threshold.py \
+  tests/integration/server/test_evalscope_glm52_pcp_humaneval.py
+
+10 passed, 4 deselected
+```
+
+The modified Python files compile successfully and `git diff --check` is
+clean. No hardware or model server was started.

--- a/.superpowers/sdd/2026-08-19-glm52-pcp-hcu/task-7-report.md
+++ b/.superpowers/sdd/2026-08-19-glm52-pcp-hcu/task-7-report.md
@@ -1,0 +1,90 @@
+# Task 7 Report: Reproducible GLM-5.2 PCP Acceptance Coverage
+
+## Status
+
+Implemented CPU-verifiable launch, configuration, and payload contracts plus
+the marked eight-HCU smoke, 32K/64K long-context, and EvalScope HumanEval
+acceptance cases. No server or accelerator workload was started in this task.
+
+## Delivered contracts
+
+- The default model is `/models/GLM-5___1-Channel-FP8-w8a8`, with
+  `VLLM_HCU_GLM52_MODEL` consumed by the server command builder as an override.
+- The launch environment sets `VLLM_USE_V2_MODEL_RUNNER=1` through the shared
+  EvalScope server harness.
+- The candidate server uses TP=4, PCP=2, EP, eager execution, Triton MoE, and
+  `max_model_len=69632`, with thinking disabled by default.
+- The command contract rejects speculative decoding, PP, DCP, compilation,
+  and explicit quantization flags (including `slimquant_marlin`).
+- Fixed-ID OpenAI-compatible smoke requests use `temperature=0`, return token
+  IDs, and pass `chat_template_kwargs.enable_thinking=false`.
+- The 32K and 64K cases submit exact token-count prompts, require at least one
+  decode token, and require the server worker group to remain live. JSON
+  artifacts contain token IDs, latency, TTFT, throughput, and peak observed
+  device-memory fields.
+- EvalScope uses OpenAI API evaluation, HumanEval limit 32, batch size 1,
+  `temperature=0`, `do_sample=false`, `max_tokens=2048`, and a request-level
+  thinking-off option.
+- All real acceptance cases carry `hcu_count(8)`, `multi_hcu`, `slow`, and
+  `nightly`; the EvalScope case also carries `external_service("evalscope")`.
+
+## TDD evidence
+
+RED was captured before creating the YAML configuration or extending the
+launch environment consumer:
+
+```text
+pytest -q tests/integration/server/test_evalscope_report_threshold.py \
+  tests/integration/server/test_evalscope_glm52_pcp_humaneval.py \
+  -k 'command or payload or config'
+
+3 failed, 4 deselected
+```
+
+All three failures were the expected `FileNotFoundError` for the not-yet-added
+`tests/models/glm52_pcp_humaneval_evalscope.yaml`; they demonstrated that the
+command, config, and payload consumers could not satisfy the new contract.
+After adding the YAML and the smallest required shared-harness extension, the
+same focused command passed.
+
+## Verification
+
+```text
+VLLM_HCU_GLM52_MODEL=/models/GLM-5___1-Channel-FP8-w8a8 \
+pytest --collect-only -q \
+  tests/integration/models/test_glm52_pcp_mrv2.py \
+  tests/integration/server/test_evalscope_glm52_pcp_humaneval.py
+
+8 tests collected
+```
+
+```text
+pytest -q tests/integration/server/test_evalscope_report_threshold.py \
+  tests/integration/server/test_evalscope_glm52_pcp_humaneval.py \
+  -k 'command or payload or config'
+
+3 passed, 4 deselected
+```
+
+Additional CPU-safe verification before commit:
+
+```text
+pytest -q -m 'not hcu' \
+  tests/integration/models/test_glm52_pcp_mrv2.py \
+  tests/integration/server/test_evalscope_report_threshold.py \
+  tests/integration/server/test_evalscope_glm52_pcp_humaneval.py
+
+7 passed, 4 deselected
+```
+
+`python -m compileall` for the modified Python files and `git diff --check`
+also completed successfully. `ruff` is not installed in this environment.
+
+## Concerns and deferred evidence
+
+- The real GLM-5.2 server, long-context requests, rank convergence, HumanEval
+  results, and runtime metrics remain unexecuted; they require the Task 8
+  eight-HCU run.
+- Peak device memory is sampled from aggregate live device usage during each
+  request, so Task 8 should run on an otherwise idle eight-HCU host for a clean
+  measurement.

--- a/docs/superpowers/plans/2026-08-19-glm52-pcp-hcu.md
+++ b/docs/superpowers/plans/2026-08-19-glm52-pcp-hcu.md
@@ -1,0 +1,831 @@
+# GLM-5.2 HCU Prefill Context Parallel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add plugin-owned Model Runner V2 PCP support for `/models/GLM-5___1-Channel-FP8-w8a8`, accepting the eight-HCU topology `TP=4 + PCP=2 + EP` in eager mode without modifying vLLM v0.25.1.
+
+**Architecture:** Selectively backport vLLM PR #46570 into the HCU plugin. A fail-closed config adapter enables only the approved MLA PCP scope; `HcuPCPManager` partitions global MRV2 batches into DualChunkSwap virtual rows and restores them before sampling; exact-name adapters make KV ownership DCP-only and gather MLA/indexer cache inputs; the plugin-owned MoE runner performs one PCP dispatch/combine path. Every PCP branch is conditional on `prefill_context_parallel_size > 1`, so PCP=1 keeps the existing runtime.
+
+**Tech Stack:** Python 3, vLLM v0.25.1, PyTorch distributed, HCU FlashMLA/sparse MLA, Triton MoE, pytest, EvalScope.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-glm52-pcp-hcu-design.md`
+
+## Global Constraints
+
+- Change only `/models/zb/vllm_025_hcu/vllm-plugin-das`; do not edit or commit `/models/zb/vllm_025/vllm`.
+- Target exactly vLLM v0.25.1 and validate every runtime-patch symbol and signature before installation.
+- Support MRV2, MLA/sparse MLA, PP=1, DCP=1, DP=1, eager execution, and EP. Reject V1, PP, DCP, DP, speculative decoding/MTP, graphs, LoRA, multimodal input, KV offload, P/D disaggregation, and HCU lightly-CP.
+- Keep `--prefill-context-parallel-size` as the only PCP flag. PCP=1 must not construct a manager, change cache sizing, invoke a PCP collective, or change MoE routing.
+- PCP partitions prefill work but does not shard KV ownership. DCP alone controls KV block sizes, slot ownership, and per-rank KV capacity.
+- Preserve Apache-2.0 notices and name vLLM PR #46570 / commit `b6ff8a2f50` in upstream-derived modules.
+- Acceptance topology is eight HCU devices: baseline `TP=8, PCP=1, EP`; candidate `TP=4, PCP=2, EP`; both MRV2, eager, `--moe-backend triton`, deterministic sampling.
+
+---
+
+### Task 1: Add the Fail-Closed MRV2 PCP Configuration Gate
+
+**Files:**
+- Modify: `vllm_hcu/patch/platform/core_fix/patch_vllm_config.py`
+- Modify: `tests/runtime_patch/test_platform_hcu_config.py`
+- Create: `tests/runtime_patch/test_glm52_pcp_config.py`
+
+**Interfaces:**
+- Add: `_validate_hcu_pcp_scope(vllm_config: object) -> bool`.
+- Wrap: `vllm.config.vllm.VllmConfig._get_v2_model_runner_unsupported_features`.
+- Wrap: `vllm.config.vllm.VllmConfig._validate_v2_model_runner`.
+- Preserve: the original v0.25.1 rejection for every configuration outside the approved HCU PCP scope.
+
+- [ ] **Step 1: Write the failing supported-scope and rejection-matrix tests**
+
+Build CPU-safe fake `VllmConfig` objects and prove one valid configuration is
+accepted while every unsupported dimension fails independently:
+
+```python
+def test_glm52_mrv2_mla_pcp2_eager_is_allowed(make_pcp_config):
+    config = make_pcp_config(
+        architecture="GlmMoeDsaForCausalLM",
+        use_mla=True,
+        pcp=2,
+        tp=4,
+        enable_expert_parallel=True,
+        enforce_eager=True,
+    )
+    assert patch_vllm_config._validate_hcu_pcp_scope(config) is True
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"use_v2": False}, "Model Runner V2"),
+        ({"use_mla": False}, "MLA"),
+        ({"pp": 2}, "pipeline parallel"),
+        ({"dcp": 2}, "decode context parallel"),
+        ({"dp": 2}, "data parallel"),
+        ({"speculative": True}, "speculative decoding"),
+        ({"enforce_eager": False}, "eager"),
+        ({"lora": True}, "LoRA"),
+        ({"multimodal": True}, "multimodal"),
+        ({"kv_offload": True}, "KV offload"),
+        ({"kv_transfer": True}, "P/D disaggregation"),
+        ({"enable_lightly_cp": True}, "lightly-CP"),
+    ],
+)
+def test_glm52_pcp_scope_rejects_unsupported_combinations(
+    make_pcp_config, override, message
+):
+    with pytest.raises(ValueError, match=message):
+        patch_vllm_config._validate_hcu_pcp_scope(
+            make_pcp_config(pcp=2, **override)
+        )
+```
+
+Add PCP=1 assertions proving the upstream unsupported-feature list and
+validation result are unchanged.
+
+- [ ] **Step 2: Run the focused tests and verify red**
+
+Run:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/zb/vllm_025/vllm \
+pytest -q tests/runtime_patch/test_glm52_pcp_config.py \
+          tests/runtime_patch/test_platform_hcu_config.py
+```
+
+Expected: the new test fails because `_validate_hcu_pcp_scope` and both PCP
+gate wrappers do not exist; existing platform tests still pass.
+
+- [ ] **Step 3: Implement validation before removing the generic MRV2 PCP gate**
+
+Extend `TARGETS`, exact signature checks, marker validation, and wrappers in
+`patch_vllm_config.py`. The core decision must remain explicit:
+
+```python
+pcp_size = parallel_config.prefill_context_parallel_size
+if pcp_size <= 1:
+    return False
+
+_require_mrv2_mla_eager_pcp_contract(vllm_config)
+return True
+```
+
+The unsupported-feature wrapper may remove only the PCP feature emitted by
+v0.25.1 and only after `_validate_hcu_pcp_scope(self)` returns `True`. The
+validation wrapper calls the original method for PCP=1 and for any invalid PCP
+configuration. Each invalid dimension gets its own actionable `ValueError`.
+
+- [ ] **Step 4: Verify config and lifecycle behavior**
+
+Run:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/zb/vllm_025/vllm \
+pytest -q tests/runtime_patch/test_glm52_pcp_config.py \
+          tests/runtime_patch/test_platform_hcu_config.py \
+          tests/patch/test_plugin_lifecycle.py
+```
+
+Expected: all selected tests pass, repeated patch application is idempotent,
+and a signature mismatch raises `PatchCompatibilityError`.
+
+- [ ] **Step 5: Commit the configuration gate**
+
+```bash
+git add vllm_hcu/patch/platform/core_fix/patch_vllm_config.py \
+        tests/runtime_patch/test_glm52_pcp_config.py \
+        tests/runtime_patch/test_platform_hcu_config.py
+git commit -m "feat(hcu): validate model runner v2 PCP scope"
+```
+
+### Task 2: Add the DualChunkSwap Virtual-Batch PCP Manager
+
+**Files:**
+- Create: `vllm_hcu/v1/pcp_manager.py`
+- Create: `tests/runtime_patch/test_glm52_pcp_manager.py`
+
+**Interfaces:**
+- Add: `RankSegment` value object.
+- Add: `HcuPCPManager.partition_batch(input_batch) -> InputBatch`.
+- Add: `HcuPCPManager.prepare_attn(input_batch)` and `get_dummy_slot_mappings(num_tokens)`.
+- Add: `HcuPCPManager.restore_hidden_states(hidden_states)` and `restore_for_sampling(hidden_states)`.
+- Add no-op helpers: `maybe_build_pcp_manager`, `maybe_partition_pcp_batch`, and `maybe_restore_pcp_for_sampling`.
+
+- [ ] **Step 1: Write pure partition/restore tests with a fake PCP group**
+
+Cover even and uneven request lengths, zero-length rank segments, two local
+rows per request, mixed prefill/decode batches, padding, logits indices, and
+decode replication. For each prefill request, concatenate all ranks' segments
+and assert every global token occurs once:
+
+```python
+@pytest.mark.parametrize("length", [1, 2, 7, 8, 9, 31])
+def test_dual_chunk_swap_covers_each_prefill_token_once(length):
+    segments = [
+        HcuPCPManager.rank_segments(length, pcp_rank=rank, pcp_size=2)
+        for rank in range(2)
+    ]
+    covered = sorted(
+        token
+        for rank_segments in segments
+        for segment in rank_segments
+        for token in range(segment.start, segment.stop)
+    )
+    assert covered == list(range(length))
+```
+
+Use an in-memory collective double to assert restoration returns global token
+order and request order without requiring HCU hardware.
+
+- [ ] **Step 2: Run the manager tests and verify red**
+
+Run:
+
+```bash
+pytest -q tests/runtime_patch/test_glm52_pcp_manager.py
+```
+
+Expected: import failure because `vllm_hcu.v1.pcp_manager` does not exist.
+
+- [ ] **Step 3: Implement the manager as a narrow attributed backport**
+
+Adapt the batch-layout algorithm from `vllm/v1/worker/gpu/pcp_manager.py` at
+commit `b6ff8a2f50`. Keep the license header and upstream reference. Allocate
+separate local buffers for `idx_mapping`, request/token counts, positions,
+sequence lengths, query starts, block tables, slot mappings, logits indices,
+and phase flags. Do not mutate the saved global `InputBatch`.
+
+The build helper must return `None` for PCP=1 and assert the approved runtime
+contract before constructing a manager:
+
+```python
+def maybe_build_pcp_manager(vllm_config, device, req_states, block_tables):
+    if vllm_config.parallel_config.prefill_context_parallel_size == 1:
+        return None
+    return HcuPCPManager(vllm_config, device, req_states, block_tables)
+```
+
+- [ ] **Step 4: Verify manager invariants and attribution**
+
+Run:
+
+```bash
+pytest -q tests/runtime_patch/test_glm52_pcp_manager.py
+python -m compileall -q vllm_hcu/v1/pcp_manager.py
+rg -n "b6ff8a2f50|#46570|Apache-2.0" vllm_hcu/v1/pcp_manager.py
+```
+
+Expected: tests pass, compilation succeeds, and all three provenance markers
+are present.
+
+- [ ] **Step 5: Commit the virtual-batch manager**
+
+```bash
+git add vllm_hcu/v1/pcp_manager.py \
+        tests/runtime_patch/test_glm52_pcp_manager.py
+git commit -m "feat(hcu): add virtual batch PCP manager"
+```
+
+### Task 3: Make KV-Cache Ownership Depend on DCP, Not PCP
+
+**Files:**
+- Create: `vllm_hcu/patch/platform/framework_opt/patch_pcp_kv_cache_utils.py`
+- Create: `vllm_hcu/patch/platform/framework_opt/patch_pcp_kv_cache_interface.py`
+- Create: `vllm_hcu/patch/platform/framework_opt/patch_pcp_single_type_kv_cache_manager.py`
+- Create: `vllm_hcu/patch/platform/framework_opt/patch_pcp_kv_cache_coordinator.py`
+- Modify: `vllm_hcu/patch/platform/__init__.py`
+- Create: `tests/runtime_patch/test_glm52_pcp_kv_cache.py`
+- Modify: `tests/patch/test_plugin_lifecycle.py`
+
+**Interfaces:**
+- Adapt: `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`.
+- Adapt: `vllm.v1.kv_cache_interface.AttentionSpec.max_num_blocks_per_req`.
+- Adapt: `vllm.v1.kv_cache_interface.FullAttentionSpec.max_memory_usage_bytes`.
+- Adapt: `vllm.v1.core.single_type_kv_cache_manager.SingleTypeKVCacheManager.__init__`.
+- Adapt: `vllm.v1.core.single_type_kv_cache_manager.FullAttentionManager.__init__`.
+- Adapt: `vllm.v1.core.kv_cache_coordinator.UnitaryKVCacheCoordinator.__init__`.
+
+- [ ] **Step 1: Write PCP1/PCP2/DCP2 cache-sizing truth-table tests**
+
+Assert the supported PCP path never divides or multiplies capacity by PCP:
+
+```python
+@pytest.mark.parametrize(
+    ("dcp", "pcp", "expected_effective_block_size"),
+    [(1, 1, 64), (1, 2, 64), (2, 1, 128)],
+)
+def test_attention_kv_ownership_is_dcp_only(
+    patched_cache_modules, make_cache_config, dcp, pcp, expected_effective_block_size
+):
+    scheduler_size, hash_size = patched_cache_modules.resolve(
+        make_cache_config(block_size=64, dcp=dcp, pcp=pcp)
+    )
+    assert scheduler_size == expected_effective_block_size
+    assert hash_size == expected_effective_block_size
+```
+
+Also cover multi-group LCM, full-attention hash resolution, per-request block
+count, max memory, and the unitary coordinator. Prove PCP=1 delegates to the
+original functions and DCP=2 retains v0.25.1 behavior.
+
+- [ ] **Step 2: Run the cache tests and verify red**
+
+Run:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/zb/vllm_025/vllm \
+pytest -q tests/runtime_patch/test_glm52_pcp_kv_cache.py
+```
+
+Expected: PCP=2 cases observe `block_size * pcp` or capacity divided by PCP.
+
+- [ ] **Step 3: Implement exact-name conditional adapters**
+
+Create one adapter per exact target module, each with `TARGET_MODULE`,
+`PATCH_ID`, `TARGETS`, marker/wrapper attributes, complete signature checks,
+and an early PCP=1 call to the original implementation. For PCP>1, reproduce
+the DCP-only formulas from upstream commit `b6ff8a2f50`:
+
+```python
+effective_block_size = kv_cache_spec.block_size * dcp_world_size
+max_blocks = cdiv(max_len, attention_spec.block_size * dcp_world_size)
+```
+
+Register the four adapters in `_ORDERED_FRAMEWORK_ADAPTERS` before the existing
+MTP coordinator patch so ordering is deterministic and reviewable.
+
+- [ ] **Step 4: Verify sizing, patch inventory, and lifecycle safety**
+
+Run:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/zb/vllm_025/vllm \
+pytest -q tests/runtime_patch/test_glm52_pcp_kv_cache.py \
+          tests/runtime_patch/test_mtp_kv_cache_coordinator.py \
+          tests/patch/test_plugin_lifecycle.py
+```
+
+Expected: all selected tests pass; inventory includes all four stable patch
+IDs; double registration is idempotent; signature drift fails closed.
+
+- [ ] **Step 5: Commit DCP-only cache ownership**
+
+```bash
+git add vllm_hcu/patch/platform/__init__.py \
+        vllm_hcu/patch/platform/framework_opt/patch_pcp_*.py \
+        tests/runtime_patch/test_glm52_pcp_kv_cache.py \
+        tests/patch/test_plugin_lifecycle.py
+git commit -m "fix(hcu): keep PCP KV cache ownership unsharded"
+```
+
+### Task 4: Integrate PCP with MRV2 Input, Attention, and Sampling State
+
+**Files:**
+- Modify: `vllm_hcu/v1/hcu_model_runner_v2.py`
+- Create: `vllm_hcu/patch/worker/framework_opt/patch_pcp_block_tables.py`
+- Create: `vllm_hcu/patch/worker/framework_opt/patch_pcp_model_state.py`
+- Modify: `vllm_hcu/patch/worker/__init__.py`
+- Create: `tests/runtime_patch/test_glm52_pcp_runner.py`
+- Modify: `tests/patch/test_worker_dispatcher.py`
+
+**Interfaces:**
+- Override: `HcuGPUModelRunnerV2.__init__`, `initialize_kv_cache`, `prepare_inputs`, `prepare_attn`, `prepare_dummy_attn`, and `sample_tokens`.
+- Extend: `BlockTables.gather_block_tables(idx_mapping, num_reqs_padded, out=None, out_ptrs=None)`.
+- Extend: `BlockTables.compute_slot_mappings(idx_mapping, query_start_loc, positions, num_tokens_padded, out=None)`.
+- Adapt: `vllm.v1.worker.gpu.model_states.default.DefaultModelState.prepare_attn` metadata slicing and `is_prefilling` propagation.
+
+- [ ] **Step 1: Write runner call-order and state-restoration tests**
+
+Use a fake upstream MRV2 base and manager to assert this order:
+
+```python
+assert events == [
+    "super.initialize_kv_cache",
+    "build_pcp_manager",
+    "super.prepare_inputs",
+    "partition_batch",
+    "pcp.prepare_attn",
+    "restore_for_sampling",
+    "super.sample_tokens",
+]
+```
+
+Assert `sample_tokens` replaces both
+`execute_model_state.hidden_states` and `execute_model_state.input_batch`
+before calling the existing PP/MTP-aware superclass path. Add PCP=1 tests that
+observe exactly the old event list.
+
+- [ ] **Step 2: Write block-table and metadata adapter tests**
+
+Prove caller-provided output tensors are used without overwriting global
+buffers, at most two virtual rows are emitted per original request,
+`query_start_loc` is sliced to `num_reqs + 1`, and `is_prefilling` reaches MLA
+metadata. Add exact-signature and idempotence cases.
+
+- [ ] **Step 3: Run focused tests and verify red**
+
+Run:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/zb/vllm_025/vllm \
+pytest -q tests/runtime_patch/test_glm52_pcp_runner.py \
+          tests/patch/test_worker_dispatcher.py -k 'pcp or dispatcher_inventory'
+```
+
+Expected: runner lacks PCP lifecycle hooks and worker dispatcher lacks both
+new adapters.
+
+- [ ] **Step 4: Implement the MRV2 lifecycle and exact worker adapters**
+
+Construct the manager only after upstream block-table allocation. Partition
+only after upstream input preparation. Route attention preparation and dummy
+slot mappings through the manager when non-`None`. Restore saved global state
+before the existing `sample_tokens` implementation:
+
+```python
+def sample_tokens(self, grammar_output):
+    state = self.execute_model_state
+    if self.pcp_manager is not None and state is not None:
+        state.hidden_states, state.input_batch = (
+            self.pcp_manager.restore_for_sampling(
+                state.hidden_states
+            )
+        )
+    input_batch = None if state is None else state.input_batch
+    output = super().sample_tokens(grammar_output)
+    if input_batch is not None:
+        synchronize_pp_spec_draft_tokens(self, input_batch)
+    return output
+```
+
+Register both worker callbacks with feature `always`; their wrappers inspect
+PCP size at runtime and preserve the exact PCP=1 call path.
+
+- [ ] **Step 5: Verify runner, dispatcher, and existing PP/MTP behavior**
+
+Run:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/zb/vllm_025/vllm \
+pytest -q tests/runtime_patch/test_glm52_pcp_runner.py \
+          tests/runtime_patch/test_hcu_model_runner_spec_decode_contract.py \
+          tests/runtime_patch/test_glm51_mtp_contract.py \
+          tests/patch/test_worker_dispatcher.py
+```
+
+Expected: all selected tests pass; PCP state restores before logits/prompt
+logprobs; existing PP+MTP broadcast tests remain green.
+
+- [ ] **Step 6: Commit MRV2 integration**
+
+```bash
+git add vllm_hcu/v1/hcu_model_runner_v2.py \
+        vllm_hcu/patch/worker/framework_opt/patch_pcp_block_tables.py \
+        vllm_hcu/patch/worker/framework_opt/patch_pcp_model_state.py \
+        vllm_hcu/patch/worker/__init__.py \
+        tests/runtime_patch/test_glm52_pcp_runner.py \
+        tests/patch/test_worker_dispatcher.py
+git commit -m "feat(hcu): integrate PCP with model runner v2"
+```
+
+### Task 5: Gather MLA and GLM DSA Cache Inputs Before Cache Writes
+
+**Files:**
+- Create: `vllm_hcu/model_executor/layers/attention/pcp.py`
+- Modify: `vllm_hcu/patch/worker/op_opt/patch_mla_attention.py`
+- Modify: `vllm_hcu/patch/worker/op_opt/patch_mla_indexer.py`
+- Modify: `vllm_hcu/patch/worker/op_opt/patch_flashmla_sparse.py`
+- Modify: `vllm_hcu/model_executor/layers/sparse_attn_indexer.py`
+- Modify: `vllm_hcu/v1/attention/backends/mla/flashmla.py`
+- Modify: `vllm_hcu/v1/attention/backends/mla/flashmla_sparse.py`
+- Create: `tests/runtime_patch/test_glm52_pcp_mla.py`
+- Modify: `tests/runtime_patch/test_mla_target_ownership.py`
+- Modify: `tests/runtime_patch/test_sparse_indexer_loading.py`
+
+**Interfaces:**
+- Add: `maybe_gather_mla_latent_cache_inputs(kv, rope_k, slot_mapping, metadata)`.
+- Add: `maybe_gather_indexer_k(k, slot_mapping, metadata)`.
+- Add: `finalize_mla_pcp_decode(output, metadata)` if decode output requires rank selection.
+- Wrap: `MLAAttention.forward` in addition to the existing `forward_impl` adapter.
+- Advertise: `supports_pcp = True` only on HCU dense/sparse MLA implementations used by GLM-5.2.
+
+- [ ] **Step 1: Write collective-order and tensor-shape tests**
+
+With a fake PCP group, assert prefill gathers latent KV, RoPE K, indexer K,
+and their slot mappings in identical rank order while Q remains local. Assert
+decode-only and PCP=1 calls return the original tensor identities and perform
+zero collectives. Cover mixed prefill/decode metadata and uneven local token
+counts.
+
+```python
+gathered_kv, gathered_rope, gathered_slots = (
+    maybe_gather_mla_latent_cache_inputs(kv, rope_k, slots, metadata)
+)
+assert gathered_kv.shape[0] == sum(metadata.pcp_token_counts)
+assert gathered_rope.shape[0] == gathered_kv.shape[0]
+assert gathered_slots.shape[0] == gathered_kv.shape[0]
+assert fake_group.calls == ["kv", "rope_k", "slot_mapping"]
+```
+
+- [ ] **Step 2: Write direct-attention and backend capability tests**
+
+Assert PCP sets `MLAAttention.use_direct_call = True`, invokes the gather
+helper before `forward_impl`, and never enters the opaque custom-op route.
+Assert PCP=1 keeps the current opaque behavior. Assert dense HCU FlashMLA and
+sparse HCU FlashMLA implementations report `supports_pcp=True`, while an
+unrelated attention backend remains false.
+
+- [ ] **Step 3: Run focused tests and verify red**
+
+Run:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/zb/vllm_025/vllm \
+pytest -q tests/runtime_patch/test_glm52_pcp_mla.py \
+          tests/runtime_patch/test_mla_target_ownership.py \
+          tests/runtime_patch/test_sparse_indexer_loading.py
+```
+
+Expected: helper import and capability assertions fail; PCP cannot safely
+insert complete cache data.
+
+- [ ] **Step 4: Implement attributed gather helpers and direct eager path**
+
+Adapt `vllm/model_executor/layers/attention/pcp.py` from commit
+`b6ff8a2f50`, retaining attribution. Extend the strict MLA adapter to validate
+and wrap `MLAAttention.forward`. In `hcu_init`, enable direct calls only when
+PCP>1. The full-forward wrapper gathers cache inputs and delegates to the
+already-patched `forward_impl`; PCP=1 invokes the original full-forward path.
+
+Update the plugin-owned sparse indexer so its K cache write receives gathered
+K and gathered slots before invoking `hcu_sparse_attn_indexer`. Preserve local
+Q/index selection and existing FP8/index-topk behavior.
+
+- [ ] **Step 5: Verify MLA, sparse indexer, and existing lightly-CP isolation**
+
+Run:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/zb/vllm_025/vllm \
+pytest -q tests/runtime_patch/test_glm52_pcp_mla.py \
+          tests/runtime_patch/test_mla_target_ownership.py \
+          tests/runtime_patch/test_sparse_indexer_loading.py \
+          tests/runtime_patch/test_attention_mla_fla_mamba.py
+```
+
+Expected: all selected tests pass; PCP and lightly-CP branches are mutually
+exclusive; PCP=1 retains existing custom-op ownership.
+
+- [ ] **Step 6: Commit PCP-aware MLA and indexer cache insertion**
+
+```bash
+git add vllm_hcu/model_executor/layers/attention/pcp.py \
+        vllm_hcu/model_executor/layers/sparse_attn_indexer.py \
+        vllm_hcu/v1/attention/backends/mla/flashmla.py \
+        vllm_hcu/v1/attention/backends/mla/flashmla_sparse.py \
+        vllm_hcu/patch/worker/op_opt/patch_mla_attention.py \
+        vllm_hcu/patch/worker/op_opt/patch_mla_indexer.py \
+        vllm_hcu/patch/worker/op_opt/patch_flashmla_sparse.py \
+        tests/runtime_patch/test_glm52_pcp_mla.py \
+        tests/runtime_patch/test_mla_target_ownership.py \
+        tests/runtime_patch/test_sparse_indexer_loading.py
+git commit -m "feat(hcu): gather MLA cache inputs for PCP"
+```
+
+### Task 6: Make Triton MoE Dispatch PCP-Aware Without Double Collectives
+
+**Files:**
+- Modify: `vllm_hcu/model_executor/layers/fused_moe/moe_runner.py`
+- Create: `tests/runtime_patch/test_glm52_pcp_moe.py`
+- Modify: `tests/runtime_patch/test_moe_deepep.py`
+
+**Interfaces:**
+- Modify: `MoERunner._maybe_dispatch`.
+- Modify: `MoERunner._maybe_combine`.
+- Preserve: existing naive DP/EP behavior and shared-expert output ordering.
+
+- [ ] **Step 1: Write the all-to-all/fallback collective matrix**
+
+Test PCP=1, PCP=2 fallback, and PCP=2 all-to-all-kernel configurations:
+
+```python
+@pytest.mark.parametrize(
+    ("pcp", "use_all2all_kernels", "gathers", "reduce_scatters"),
+    [(1, False, 0, 0), (2, False, 2, 1), (2, True, 0, 0)],
+)
+def test_moe_uses_exactly_one_pcp_dispatch_path(
+    make_runner, pcp, use_all2all_kernels, gathers, reduce_scatters
+):
+    runner, group = make_runner(pcp, use_all2all_kernels)
+    hidden, logits = runner._maybe_dispatch(make_hidden(), make_logits())
+    runner._maybe_combine(None, hidden)
+    assert group.all_gather_count == gathers
+    assert group.reduce_scatter_count == reduce_scatters
+```
+
+Add a shared-expert case asserting routed and shared outputs have the same
+token order before addition, plus the existing missing-router-logits error.
+
+- [ ] **Step 2: Run MoE tests and verify red**
+
+Run:
+
+```bash
+pytest -q tests/runtime_patch/test_glm52_pcp_moe.py \
+          tests/runtime_patch/test_moe_deepep.py
+```
+
+Expected: the `use_all2all_kernels=True` case observes an unnecessary PCP
+all-gather and reduce-scatter.
+
+- [ ] **Step 3: Gate fallback collectives on the MoE parallel config**
+
+Use the same predicate in dispatch and combine:
+
+```python
+needs_fallback_pcp_collective = (
+    self.moe_config.pcp_size > 1
+    and not self.moe_config.moe_parallel_config.use_all2all_kernels
+)
+```
+
+When true, gather hidden states and router logits before expert execution and
+reduce-scatter the combined routed result afterwards. When false, let the
+selected all-to-all kernel consume PCP-local shards. Do not change PCP=1.
+
+- [ ] **Step 4: Verify Triton, DeepEP, and shared experts**
+
+Run:
+
+```bash
+pytest -q tests/runtime_patch/test_glm52_pcp_moe.py \
+          tests/runtime_patch/test_moe_deepep.py \
+          tests/runtime_patch/test_quant_gemm_aiter.py -k 'moe_backend or triton'
+```
+
+Expected: all selected tests pass and exactly one PCP dispatch/combine path is
+active for each backend family.
+
+- [ ] **Step 5: Commit PCP-aware MoE dispatch**
+
+```bash
+git add vllm_hcu/model_executor/layers/fused_moe/moe_runner.py \
+        tests/runtime_patch/test_glm52_pcp_moe.py \
+        tests/runtime_patch/test_moe_deepep.py
+git commit -m "fix(hcu): avoid duplicate PCP MoE collectives"
+```
+
+### Task 7: Add Reproducible GLM-5.2 PCP Server and EvalScope Coverage
+
+**Files:**
+- Create: `tests/models/glm52_pcp_humaneval_evalscope.yaml`
+- Create: `tests/integration/server/test_evalscope_glm52_pcp_humaneval.py`
+- Create: `tests/integration/models/test_glm52_pcp_mrv2.py`
+- Modify: `tests/integration/server/README.md`
+- Modify: `tests/integration/models/README.md`
+- Modify: `tests/models/README.md`
+
+**Interfaces:**
+- Consume model override: `VLLM_HCU_GLM52_MODEL`, defaulting to `/models/GLM-5___1-Channel-FP8-w8a8`.
+- Produce eight-HCU smoke/long-context tests and an EvalScope HumanEval 32-sample test.
+- Use OpenAI-compatible requests with `temperature=0` and thinking disabled in request/template arguments.
+
+- [ ] **Step 1: Write resource-routing and command-construction tests**
+
+Add collection-safe tests that assert the candidate server command contains:
+
+```text
+VLLM_USE_V2_MODEL_RUNNER=1
+--tensor-parallel-size 4
+--prefill-context-parallel-size 2
+--enable-expert-parallel
+--enforce-eager
+--moe-backend triton
+--max-model-len 69632
+--default-chat-template-kwargs '{"enable_thinking":false}'
+```
+
+Assert it does not contain speculative decoding, PP, DCP, graph compilation,
+or `--quantization slimquant_marlin`. The model already carries its FP8 W8A8
+quantization metadata.
+
+- [ ] **Step 2: Add deterministic smoke and 32K/64K cases**
+
+Create fixed prompts and assert non-empty generated token IDs, no rank
+divergence, and at least one decode token after 32K and 64K prefill. Mark the
+test `hcu_count(8)`, `multi_hcu`, `slow`, and `nightly`. Emit latency, TTFT,
+throughput, and peak-memory fields to the test artifact directory.
+
+- [ ] **Step 3: Add EvalScope HumanEval 32 configuration**
+
+Configure dataset `humaneval`, limit 32, OpenAI API evaluation, batch size 1,
+and deterministic generation:
+
+```yaml
+evalscope:
+  datasets: [humaneval]
+  limit: 32
+  generation_config:
+    temperature: 0
+    do_sample: false
+    max_tokens: 2048
+```
+
+Pass the GLM chat-template option that disables thinking and assert the emitted
+request payload retains both thinking-off and `temperature: 0`.
+
+- [ ] **Step 4: Collect tests and verify command contracts without HCU work**
+
+Run:
+
+```bash
+VLLM_HCU_GLM52_MODEL=/models/GLM-5___1-Channel-FP8-w8a8 \
+pytest --collect-only -q \
+  tests/integration/models/test_glm52_pcp_mrv2.py \
+  tests/integration/server/test_evalscope_glm52_pcp_humaneval.py
+
+pytest -q tests/integration/server/test_evalscope_report_threshold.py \
+          tests/integration/server/test_evalscope_glm52_pcp_humaneval.py \
+          -k 'command or payload or config'
+```
+
+Expected: tests collect without accelerator initialization and all CPU command
+contract cases pass.
+
+- [ ] **Step 5: Commit reproducible acceptance coverage**
+
+```bash
+git add tests/models/glm52_pcp_humaneval_evalscope.yaml \
+        tests/integration/server/test_evalscope_glm52_pcp_humaneval.py \
+        tests/integration/models/test_glm52_pcp_mrv2.py \
+        tests/integration/server/README.md \
+        tests/integration/models/README.md \
+        tests/models/README.md
+git commit -m "test(hcu): cover GLM-5.2 PCP acceptance"
+```
+
+### Task 8: Run Full Regression and Eight-HCU Acceptance
+
+**Files:**
+- Modify only when a failing test demonstrates a scoped PCP defect.
+- Record: test logs under the existing pytest/EvalScope artifact directories; do not commit generated logs.
+
+**Interfaces:**
+- Produce proof that PCP=1 is unchanged and `TP=4 + PCP=2 + EP` serves GLM-5.2 correctly.
+- Produce baseline/candidate HumanEval, correctness, memory, TTFT, ITL, and throughput records.
+
+- [ ] **Step 1: Run static and focused CPU verification**
+
+Run:
+
+```bash
+python -m compileall -q vllm_hcu tests
+git diff --check
+VLLM_V0251_SOURCE_ROOT=/models/zb/vllm_025/vllm \
+pytest -q \
+  tests/runtime_patch/test_glm52_pcp_config.py \
+  tests/runtime_patch/test_glm52_pcp_manager.py \
+  tests/runtime_patch/test_glm52_pcp_kv_cache.py \
+  tests/runtime_patch/test_glm52_pcp_runner.py \
+  tests/runtime_patch/test_glm52_pcp_mla.py \
+  tests/runtime_patch/test_glm52_pcp_moe.py \
+  tests/runtime_patch/test_platform_hcu_config.py \
+  tests/runtime_patch/test_mla_target_ownership.py \
+  tests/runtime_patch/test_sparse_indexer_loading.py \
+  tests/patch/test_plugin_lifecycle.py \
+  tests/patch/test_worker_dispatcher.py
+```
+
+Expected: compile and diff checks exit zero; every selected test passes.
+
+- [ ] **Step 2: Run the pre-change 80-test regression set**
+
+Run:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/zb/vllm_025/vllm \
+pytest -q \
+  tests/runtime_patch/test_platform_hcu_config.py \
+  tests/runtime_patch/test_mla_target_ownership.py \
+  tests/runtime_patch/test_sparse_indexer_loading.py \
+  tests/patch/test_plugin_lifecycle.py
+```
+
+Expected: at least the original 80 cases remain green, plus any newly added
+cases in those files.
+
+- [ ] **Step 3: Start the PCP=1 baseline on eight HCU devices**
+
+Run from the plugin environment:
+
+```bash
+HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+VLLM_USE_V2_MODEL_RUNNER=1 \
+vllm serve /models/GLM-5___1-Channel-FP8-w8a8 \
+  --served-model-name glm52-baseline \
+  --tensor-parallel-size 8 \
+  --prefill-context-parallel-size 1 \
+  --enable-expert-parallel \
+  --moe-backend triton \
+  --enforce-eager \
+  --max-model-len 69632 \
+  --default-chat-template-kwargs '{"enable_thinking":false}' \
+  --port 8000
+```
+
+Expected: all eight workers become healthy, logs say Model Runner V2, and no
+PCP manager/collective is created.
+
+- [ ] **Step 4: Run baseline deterministic prompts, long context, and HumanEval**
+
+Submit the fixed smoke prompt set with `temperature=0` and thinking disabled,
+then the 32K and 64K prompts, then run the 32-sample EvalScope configuration.
+Save generated token IDs, pass count, memory, TTFT, ITL, and throughput.
+
+- [ ] **Step 5: Start the PCP=2 candidate on eight HCU devices**
+
+Stop the baseline cleanly, confirm all eight devices are free, then run:
+
+```bash
+HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+VLLM_USE_V2_MODEL_RUNNER=1 \
+vllm serve /models/GLM-5___1-Channel-FP8-w8a8 \
+  --served-model-name glm52-pcp2 \
+  --tensor-parallel-size 4 \
+  --prefill-context-parallel-size 2 \
+  --enable-expert-parallel \
+  --moe-backend triton \
+  --enforce-eager \
+  --max-model-len 69632 \
+  --default-chat-template-kwargs '{"enable_thinking":false}' \
+  --port 8000
+```
+
+Expected: all eight workers become healthy with MRV2 and no fallback,
+capability error, collective mismatch, cache-write error, or worker crash.
+
+- [ ] **Step 6: Run candidate correctness and EvalScope acceptance**
+
+Run the exact same prompt and EvalScope payloads. Acceptance requires fixed
+smoke token IDs to match the baseline, 32K and 64K prefill plus one decode
+token to complete, and HumanEval passed count not below baseline. Record
+performance metrics without imposing a first-release speed threshold.
+
+- [ ] **Step 7: Verify the vLLM checkout is unchanged**
+
+Run:
+
+```bash
+git -C /models/zb/vllm_025/vllm status --short
+git status --short
+git log --oneline --decorate -8
+```
+
+Expected: no change caused by this feature appears in the vLLM checkout; the
+plugin worktree contains only intended commits and no generated artifacts.
+
+- [ ] **Step 8: Close acceptance without an empty commit**
+
+If hardware acceptance exposes a defect, return to the owning task, add its
+focused regression test, implement the minimal fix, rerun that task's listed
+verification, and use that task's explicit file list for the fix commit. If no
+fix is required, create no empty verification commit.

--- a/docs/superpowers/specs/2026-08-19-glm52-pcp-hcu-design.md
+++ b/docs/superpowers/specs/2026-08-19-glm52-pcp-hcu-design.md
@@ -26,6 +26,8 @@ The first release supports only this configuration family:
 - No LoRA, multimodal inputs, P/D disaggregation, KV offload, or data
   parallelism. Expert parallelism is supported and required by the acceptance
   topology.
+- HCU lightly-CP is disabled; it is a separate context-parallel algorithm and
+  cannot be combined with PCP in this release.
 
 The public interface remains vLLM's existing
 `--prefill-context-parallel-size`; the plugin does not add a second PCP flag.
@@ -248,7 +250,7 @@ separate designs and are explicitly outside this work.
 ## Out of Scope
 
 - PCP combined with PP, MTP, DCP, DP, CUDA/HIP graphs, LoRA, multimodal input,
-  P/D disaggregation, or KV offload.
+  P/D disaggregation, KV offload, or HCU lightly-CP.
 - PCP support for GQA, MHA, hybrid attention, sliding-window attention, Mamba,
   or non-causal models.
 - Multi-node PCP.

--- a/docs/superpowers/specs/2026-08-19-glm52-pcp-hcu-design.md
+++ b/docs/superpowers/specs/2026-08-19-glm52-pcp-hcu-design.md
@@ -1,0 +1,256 @@
+# GLM-5.2 HCU Prefill Context Parallel Design
+
+## Goal
+
+Add plugin-owned Prefill Context Parallelism (PCP) support for
+`/models/GLM-5___1-Channel-FP8-w8a8` while keeping the vLLM dependency fixed at
+v0.25.1. The first accepted deployment is eight HCU devices using Model Runner
+V2, `TP=4`, `PCP=2`, expert parallelism, and eager execution.
+
+The implementation is a focused HCU backport of vLLM pull request #46570
+(`b6ff8a2f50`, "Add MRV2 virtual-batch PCP for MLA"). It must live entirely in
+`vllm-plugin-das`; `/models/zb/vllm_025/vllm` must remain unchanged.
+
+## Scope
+
+The first release supports only this configuration family:
+
+- Model Runner V2 selected with `VLLM_USE_V2_MODEL_RUNNER=1`.
+- An MLA or sparse-MLA causal language model. The acceptance model uses
+  `GlmMoeDsaForCausalLM` with `index_topk=2048`.
+- `pipeline_parallel_size=1`.
+- `prefill_context_parallel_size>1` and
+  `decode_context_parallel_size=1`.
+- No speculative configuration, including MTP.
+- Eager execution with CUDA/HIP graph mode disabled.
+- No LoRA, multimodal inputs, P/D disaggregation, KV offload, or data
+  parallelism. Expert parallelism is supported and required by the acceptance
+  topology.
+
+The public interface remains vLLM's existing
+`--prefill-context-parallel-size`; the plugin does not add a second PCP flag.
+`PCP=1` must retain the current runner, attention, KV-cache, and MoE behavior.
+
+## Chosen Approach
+
+Use a selective plugin-side backport rather than copying the upstream runner or
+upgrading the vLLM checkout. The plugin will add an HCU PCP manager and extend
+the existing MRV2 subclass and exact-name runtime patch framework at the narrow
+points required by PCP.
+
+This approach preserves the v0.25.1 deployment contract and the existing
+PP+MTP fixes. It also keeps upstream-derived PCP behavior recognizable: copied
+algorithms retain their Apache license headers and name pull request #46570 in
+their module documentation.
+
+The alternatives were rejected for these reasons:
+
+- Copying all 39 files changed by #46570 would fork large parts of vLLM inside
+  the plugin and make future compatibility checks ambiguous.
+- Updating the vLLM baseline would pull hundreds of unrelated upstream commits
+  into an HCU compatibility change and violate the plugin-only delivery
+  boundary.
+
+## Runtime Architecture
+
+### Configuration and fail-closed validation
+
+The platform-side `VllmConfig` adapter will permit MRV2 PCP only for MLA models
+and validate the restricted scope before worker startup. It will produce one
+specific error for each unsupported combination: V1 runner, PP, DCP, DP,
+speculative decoding/MTP, non-eager graph mode, LoRA, multimodal input, KV
+offload, or non-MLA attention.
+
+Validation must run before the plugin removes v0.25.1's generic
+"Model Runner V2 does not yet support prefill context parallelism" gate. The
+gate is removed only when all HCU PCP invariants pass; otherwise the original
+configuration remains rejected.
+
+### Virtual-batch partitioning
+
+`HcuGPUModelRunnerV2` will own an `HcuPCPManager` adapted from upstream
+#46570. The scheduler continues to create a global batch. Immediately after
+the upstream runner prepares its `InputBatch`, the manager converts every
+prefill request into rank-local virtual rows using DualChunkSwap partitioning.
+
+For PCP size `P`, a request is split into `2P` contiguous chunks. PCP rank `r`
+receives chunks `r` and `2P-1-r`. Pairing an early and late causal chunk keeps
+the attention work more balanced than assigning one contiguous range per
+rank. Decode rows are replicated across PCP ranks so request state stays
+synchronized.
+
+The manager keeps the global `InputBatch` private until sampling. Rank-local
+buffers are separately allocated for request mappings, positions, sequence
+lengths, block tables, slot mappings, logits indices, and padding state. This
+avoids overwriting the global batch while allowing up to two local rows for
+each global request.
+
+### KV-cache ownership
+
+PCP partitions prefill computation; it does not shard decode KV ownership.
+With the first-release requirement `DCP=1`, every PCP rank owns a complete KV
+cache for each request.
+
+The plugin will patch the v0.25.1 scheduler/cache calculations that currently
+multiply effective block size by `PCP`. PCP must be excluded from:
+
+- scheduler and hash block-size resolution;
+- per-request block counts and maximum KV memory calculations;
+- full-attention cache-manager alignment;
+- unitary KV-cache coordinator block sizing; and
+- slot-mapping context-parallel rank calculations.
+
+These patches are conditional on HCU PCP and retain the original behavior for
+`PCP=1`. DCP behavior is not redesigned in this release.
+
+### MLA and GLM DSA attention
+
+During prefill, each PCP rank computes only its local Q rows but requires the
+complete latent KV sequence. Before cache insertion, the attention adapter
+all-gathers rank-local `kv_c_normed` and RoPE K tensors across the PCP group,
+aligns them with the gathered slot mappings, and writes the complete cache on
+every rank.
+
+The acceptance model uses sparse DSA/MLA. Its indexer follows the same rule:
+the indexer K values and their slot mappings are gathered before cache
+insertion, while Q/index selection remains rank-local. Prefill metadata must
+use explicit request-phase information so short prefill continuations are not
+misclassified as decode rows.
+
+Because this release is eager-only, the HCU MLA adapter will use the direct
+Python attention path for PCP. This avoids changing v0.25.1's already
+registered opaque custom-op graph and makes the cache-gather side effect
+explicit. Existing opaque/custom-op behavior remains unchanged for `PCP=1`.
+
+The HCU backend selector will advertise PCP only for the MLA, sparse MLA, and
+DeepSeek-v3.2-style indexer backends exercised by this design. Other attention
+backends continue to fail capability validation.
+
+### MoE and expert parallelism
+
+After attention, hidden states and router logits contain only the local PCP
+token shard. The plugin-owned MoE runner must perform PCP-aware dispatch:
+
+- When the selected EP all-to-all implementation consumes PCP-local token
+  shards directly, it must not perform an extra PCP all-gather.
+- For the non-all-to-all fallback, hidden states and router logits are
+  all-gathered before expert execution and reduce-scattered after combine.
+
+The acceptance topology uses one EP group spanning all eight TP/PCP ranks.
+Shared-expert output must follow the same token ordering as the routed expert
+output before the reduce-scatter result is returned to attention order.
+
+### Global restoration and sampling
+
+Before logits, prompt logprobs, sampling, or postprocessing, the manager
+all-gathers local hidden states and restores the original global request and
+token order. `HcuGPUModelRunnerV2.sample_tokens` will replace the saved execute
+state with the restored hidden states and global `InputBatch` before delegating
+to upstream sampling.
+
+This placement ensures logits indices, request IDs, prompt logprobs, and
+request-state updates all observe the scheduler's original batch rather than
+PCP virtual rows.
+
+## Plugin Structure
+
+PCP code will be split by ownership rather than collected in one broad patch:
+
+- `vllm_hcu/v1/pcp_manager.py`: virtual-batch partition and restore logic.
+- `vllm_hcu/v1/hcu_model_runner_v2.py`: MRV2 lifecycle integration.
+- `vllm_hcu/model_executor/layers/attention/pcp.py`: latent KV and indexer K
+  gather helpers.
+- Platform config adapters: capability gate and restricted-scope validation.
+- Worker callbacks: block-table, cache-sizing, attention metadata, MLA, and
+  indexer compatibility patches.
+- Plugin-owned sparse indexer and MoE runner: HCU kernel-facing PCP behavior.
+
+Every runtime patch must validate the exact v0.25.1 target signature before
+installation and register a stable patch ID in the existing lifecycle
+registry. A missing or changed target is a startup error, not a silent skip.
+
+## Error Handling
+
+- Unsupported PCP combinations fail during configuration with the incompatible
+  feature named in the message.
+- Missing PCP process groups, mismatched tensor counts, invalid virtual-batch
+  slices, and restore-index inconsistencies use assertions with rank and shape
+  context because they indicate internal contract violations.
+- Backend capability failures name the selected backend and the required PCP
+  capability.
+- Collective or HCU kernel failures retain their original traceback; the
+  plugin does not fall back to PCP=1 or Model Runner V1.
+- `PCP=1` never constructs `HcuPCPManager` and never executes a PCP collective.
+
+## Testing Strategy
+
+Implementation follows test-driven development. Each production behavior is
+preceded by a focused failing test.
+
+### CPU and contract tests
+
+1. Configuration permits MRV2+MLA+PCP+eager and rejects each unsupported
+   combination independently.
+2. DualChunkSwap partitions multiple requests, preserves every token exactly
+   once per prefill, handles uneven lengths, and restores global order.
+3. Decode-only rows remain replicated and mixed prefill/decode batches restore
+   correct logits indices and request mappings.
+4. KV-cache sizing depends on DCP but not PCP when HCU PCP is active.
+5. Block-table and slot-mapping helpers accept PCP-local output buffers without
+   mutating the global batch buffers.
+6. MLA latent KV and indexer K gather helpers preserve decode writes and order
+   gathered prefill writes by PCP rank.
+7. Backend selection accepts only the intended HCU MLA/indexer backends.
+8. MoE dispatch executes exactly one PCP gather/combine path for both all-to-all
+   and fallback configurations.
+9. MRV2 integration partitions after input preparation and restores before
+   sampling and prompt-logprob computation.
+10. Patch lifecycle tests verify exact targets, idempotence, and fail-closed
+    behavior.
+
+The pre-change baseline is the focused configuration, lifecycle, MLA, and
+sparse-indexer suite: 80 tests passing.
+
+### Eight-HCU acceptance
+
+Run both deployments with the same model, tokenizer, KV-cache dtype, maximum
+length, deterministic sampling parameters, and HCU MoE backend:
+
+- Baseline: `TP=8`, `PCP=1`, EP enabled, MRV2, eager.
+- Candidate: `TP=4`, `PCP=2`, EP enabled, MRV2, eager.
+
+Acceptance requires:
+
+1. The candidate server reaches healthy state on all eight ranks.
+2. Fixed smoke prompts with `temperature=0` complete without rank divergence;
+   generated token IDs match the baseline for the deterministic comparison
+   set.
+3. One 32K and one 64K input complete prefill and at least one decode token.
+4. EvalScope HumanEval runs 32 samples with thinking disabled and
+   `temperature=0`; its passed count is not below the PCP=1 baseline.
+5. Logs contain no Model Runner V1 fallback, PCP capability assertion,
+   collective shape mismatch, KV-cache write error, or worker crash.
+6. Peak memory, TTFT, inter-token latency, and throughput are recorded for both
+   deployments. The first release has no mandatory performance-improvement
+   threshold.
+
+## Rollback and Compatibility
+
+`--prefill-context-parallel-size 1` is the rollback path and must select the
+current implementation without PCP patches affecting runtime behavior. The
+existing `VLLM_USE_V2_MODEL_RUNNER=0` V1 fallback remains available for
+non-PCP deployments.
+
+The change must not alter the existing GLM PP+MTP+graph command because PCP is
+not part of that configuration. PP, MTP, and graph support for PCP require
+separate designs and are explicitly outside this work.
+
+## Out of Scope
+
+- PCP combined with PP, MTP, DCP, DP, CUDA/HIP graphs, LoRA, multimodal input,
+  P/D disaggregation, or KV offload.
+- PCP support for GQA, MHA, hybrid attention, sliding-window attention, Mamba,
+  or non-causal models.
+- Multi-node PCP.
+- A new ring-attention algorithm or a performance rewrite of HCU collectives.
+- Changing, committing, or opening a merge request against the vLLM checkout.

--- a/tests/integration/models/README.md
+++ b/tests/integration/models/README.md
@@ -28,3 +28,11 @@ Override these paths with `VLLM_HCU_QWEN25_15B_MODEL`,
 `VLLM_HCU_QWEN3_RERANKER_06B_MODEL`.
 
 The real Mamba path can be overridden through `VLLM_HCU_FALCON_MAMBA_MODEL`.
+
+`test_glm52_pcp_mrv2.py` provides the eight-HCU GLM-5.2 PCP acceptance
+workload. It makes two fixed-ID deterministic smoke requests and verifies
+32K- and 64K-token prefills each produce decode token IDs while the server's
+worker group remains live. Per-case JSON artifacts include generated token
+IDs, latency, TTFT, aggregate token throughput, and peak observed device
+memory. Set `VLLM_HCU_TEST_ARTIFACT_DIR` to select the output directory; the
+default is `/tmp/vllm-hcu-integration/glm52-pcp`.

--- a/tests/integration/models/README.md
+++ b/tests/integration/models/README.md
@@ -32,7 +32,8 @@ The real Mamba path can be overridden through `VLLM_HCU_FALCON_MAMBA_MODEL`.
 `test_glm52_pcp_mrv2.py` provides the eight-HCU GLM-5.2 PCP acceptance
 workload. It makes two fixed-ID deterministic smoke requests and verifies
 32K- and 64K-token prefills each produce decode token IDs while the server's
-worker group remains live. Per-case JSON artifacts include generated token
-IDs, latency, TTFT, aggregate token throughput, and peak observed device
+`/health` endpoint continues to report a healthy worker group. Per-case JSON
+artifacts include generated token IDs, latency, TTFT, aggregate token
+throughput, and peak observed device
 memory. Set `VLLM_HCU_TEST_ARTIFACT_DIR` to select the output directory; the
 default is `/tmp/vllm-hcu-integration/glm52-pcp`.

--- a/tests/integration/models/test_glm52_pcp_mrv2.py
+++ b/tests/integration/models/test_glm52_pcp_mrv2.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Eight-HCU GLM-5.2 model-runner-v2 PCP acceptance coverage."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.request import Request, urlopen
+
+import pytest
+
+from tests.fixtures.resources import TestResources as HcuTestResources
+from tests.integration.model_runtime import require_model_runtime
+from tests.integration.server.evalscope_server import (
+    ROOT,
+    _open_log,
+    _server_environment,
+    _terminate_process_group,
+    _wait_for_server,
+    load_config,
+    server_command,
+)
+from tests.integration.server.openai_server import OpenAIServer
+
+
+DEFAULT_MODEL = "/models/GLM-5___1-Channel-FP8-w8a8"
+MODEL_ENV = "VLLM_HCU_GLM52_MODEL"
+DEFAULT_CONFIG = ROOT / "tests/models/glm52_pcp_humaneval_evalscope.yaml"
+
+
+@dataclass(frozen=True)
+class CandidateServer:
+    api: OpenAIServer
+    process: subprocess.Popen[bytes]
+    artifact_dir: Path
+
+
+def _chat_payload(request_id: str) -> dict[str, Any]:
+    return {
+        "model": "GLM-5___1-Channel-FP8-w8a8",
+        "request_id": request_id,
+        "messages": [
+            {
+                "role": "user",
+                "content": "Reply with exactly one word naming Earth's satellite.",
+            }
+        ],
+        "temperature": 0,
+        "max_tokens": 8,
+        "return_token_ids": True,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+
+def _completion_payload(
+    prompt_token_ids: list[int], request_id: str
+) -> dict[str, Any]:
+    return {
+        "model": "GLM-5___1-Channel-FP8-w8a8",
+        "request_id": request_id,
+        "prompt": prompt_token_ids,
+        "temperature": 0,
+        "max_tokens": 8,
+        "return_token_ids": True,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+
+
+def test_glm52_smoke_payload_contract() -> None:
+    payload = _chat_payload("glm52-pcp-smoke-01")
+
+    assert payload["request_id"] == "glm52-pcp-smoke-01"
+    assert payload["temperature"] == 0
+    assert payload["chat_template_kwargs"] == {"enable_thinking": False}
+    assert payload["return_token_ids"] is True
+
+
+@contextmanager
+def _serve_candidate(
+    resources: HcuTestResources,
+) -> Iterator[CandidateServer]:
+    require_model_runtime(
+        resources,
+        env_name=MODEL_ENV,
+        relative_path=DEFAULT_MODEL,
+        label="GLM-5.2 TP4+PCP2+EP",
+        hcu_count=8,
+    )
+    config = load_config(DEFAULT_CONFIG, "VLLM_HCU_GLM52_HUMANEVAL_CONFIG")
+    command, host, port = server_command(config, model_env=MODEL_ENV)
+    environment = _server_environment(config)
+    artifact_dir = Path(
+        os.environ.get(
+            "VLLM_HCU_TEST_ARTIFACT_DIR",
+            "/tmp/vllm-hcu-integration/glm52-pcp",
+        )
+    )
+    server_log_path = artifact_dir / "vllm_server.log"
+    with _open_log(server_log_path) as server_log:
+        process = subprocess.Popen(
+            command,
+            cwd=ROOT,
+            env=environment,
+            stdout=server_log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        try:
+            _wait_for_server(
+                process,
+                f"http://{host}:{port}/health",
+                int(config["server"]["startup_timeout_s"]),
+            )
+            yield CandidateServer(
+                api=OpenAIServer(
+                    base_url=f"http://{host}:{port}",
+                    model_name="GLM-5___1-Channel-FP8-w8a8",
+                    log_path=server_log_path,
+                ),
+                process=process,
+                artifact_dir=artifact_dir,
+            )
+        finally:
+            _terminate_process_group(
+                process,
+                int(config["server"]["shutdown_timeout_s"]),
+            )
+
+
+@pytest.fixture(scope="module")
+def glm52_candidate_server(
+    hcu_test_resources: HcuTestResources,
+) -> Iterator[CandidateServer]:
+    with _serve_candidate(hcu_test_resources) as candidate:
+        yield candidate
+
+
+def _peak_device_memory_sampler(stop: threading.Event, samples: list[int]) -> None:
+    import torch
+
+    while not stop.wait(0.05):
+        usage = 0
+        for device_index in range(torch.cuda.device_count()):
+            free_bytes, total_bytes = torch.cuda.mem_get_info(device_index)
+            usage += total_bytes - free_bytes
+        samples.append(usage)
+
+
+def _stream_completion(
+    candidate: CandidateServer,
+    path: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    request = Request(
+        candidate.api.base_url + path,
+        data=json.dumps(payload).encode(),
+        headers={
+            "Authorization": "Bearer EMPTY",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    samples: list[int] = []
+    stop = threading.Event()
+    sampler = threading.Thread(
+        target=_peak_device_memory_sampler,
+        args=(stop, samples),
+        daemon=True,
+    )
+    started = time.perf_counter()
+    sampler.start()
+    token_ids: list[int] = []
+    prompt_token_ids: list[int] | None = None
+    first_token_at: float | None = None
+    usage: dict[str, Any] = {}
+    response_id: str | None = None
+    try:
+        with urlopen(request, timeout=7200) as response:
+            assert response.status == 200
+            for raw_line in response:
+                line = raw_line.decode(errors="replace").strip()
+                if not line.startswith("data:"):
+                    continue
+                data = line.removeprefix("data:").strip()
+                if data == "[DONE]":
+                    break
+                chunk = json.loads(data)
+                response_id = response_id or chunk.get("id")
+                if prompt_token_ids is None and chunk.get("prompt_token_ids"):
+                    prompt_token_ids = list(chunk["prompt_token_ids"])
+                chunk_usage = chunk.get("usage")
+                if isinstance(chunk_usage, dict):
+                    usage = chunk_usage
+                for choice in chunk.get("choices", []):
+                    if prompt_token_ids is None and choice.get("prompt_token_ids"):
+                        prompt_token_ids = list(choice["prompt_token_ids"])
+                    delta = list(choice.get("token_ids") or [])
+                    if delta and first_token_at is None:
+                        first_token_at = time.perf_counter()
+                    token_ids.extend(delta)
+    finally:
+        finished = time.perf_counter()
+        stop.set()
+        sampler.join(timeout=5)
+
+    assert response_id is not None
+    assert response_id.endswith(payload["request_id"])
+    assert token_ids, "the request must decode at least one token"
+    assert first_token_at is not None
+    assert candidate.process.poll() is None, "a PCP worker rank exited during decode"
+    latency = finished - started
+    prompt_count = int(usage.get("prompt_tokens", len(prompt_token_ids or [])))
+    completion_count = int(usage.get("completion_tokens", len(token_ids)))
+    return {
+        "request_id": payload["request_id"],
+        "prompt_token_count": prompt_count,
+        "completion_token_count": completion_count,
+        "token_ids": token_ids,
+        "latency_seconds": latency,
+        "ttft_seconds": first_token_at - started,
+        "throughput_tokens_per_second": (prompt_count + completion_count) / latency,
+        "peak_memory_bytes": max(samples, default=0),
+    }
+
+
+def _write_metrics(candidate: CandidateServer, case_id: str, record: dict) -> None:
+    candidate.artifact_dir.mkdir(parents=True, exist_ok=True)
+    (candidate.artifact_dir / f"{case_id}.json").write_text(
+        json.dumps(record, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize("request_id", ["glm52-pcp-smoke-01"])
+@pytest.mark.hcu
+@pytest.mark.model
+@pytest.mark.multi_hcu
+@pytest.mark.hcu_count(8)
+@pytest.mark.slow
+@pytest.mark.nightly
+def test_glm52_pcp_deterministic_smoke(
+    glm52_candidate_server: CandidateServer,
+    request_id: str,
+) -> None:
+    payload = _chat_payload(request_id)
+    payload["stream"] = True
+    payload["stream_options"] = {"include_usage": True}
+    first = _stream_completion(
+        glm52_candidate_server,
+        "/v1/chat/completions",
+        payload,
+    )
+    second_payload = {**payload, "request_id": "glm52-pcp-smoke-02"}
+    second = _stream_completion(
+        glm52_candidate_server,
+        "/v1/chat/completions",
+        second_payload,
+    )
+
+    rank_converged = (
+        glm52_candidate_server.process.poll() is None
+        and first["token_ids"] == second["token_ids"]
+    )
+    assert rank_converged
+    _write_metrics(
+        glm52_candidate_server,
+        request_id,
+        {
+            "first": first,
+            "second": second,
+            "rank_divergence": not rank_converged,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("prompt_tokens", "request_id"),
+    [
+        pytest.param(32768, "glm52-pcp-context-32k", id="32k-prefill"),
+        pytest.param(65536, "glm52-pcp-context-64k", id="64k-prefill"),
+    ],
+)
+@pytest.mark.hcu
+@pytest.mark.model
+@pytest.mark.multi_hcu
+@pytest.mark.hcu_count(8)
+@pytest.mark.slow
+@pytest.mark.nightly
+def test_glm52_pcp_long_context_decodes_after_prefill(
+    glm52_candidate_server: CandidateServer,
+    prompt_tokens: int,
+    request_id: str,
+) -> None:
+    tokenized = glm52_candidate_server.api.post(
+        "/tokenize",
+        {
+            "model": glm52_candidate_server.api.model_name,
+            "prompt": "GLM PCP deterministic long-context token.",
+        },
+    )
+    assert tokenized.status == 200
+    seed_token_ids = tokenized.body["tokens"]
+    assert seed_token_ids
+    repeated = (seed_token_ids * (prompt_tokens // len(seed_token_ids) + 1))[
+        :prompt_tokens
+    ]
+
+    record = _stream_completion(
+        glm52_candidate_server,
+        "/v1/completions",
+        _completion_payload(repeated, request_id),
+    )
+
+    assert record["prompt_token_count"] == prompt_tokens
+    assert record["completion_token_count"] >= 1
+    assert record["peak_memory_bytes"] > 0
+    _write_metrics(glm52_candidate_server, request_id, record)

--- a/tests/integration/models/test_glm52_pcp_mrv2.py
+++ b/tests/integration/models/test_glm52_pcp_mrv2.py
@@ -7,11 +7,13 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 from urllib.request import Request, urlopen
@@ -33,6 +35,7 @@ from tests.integration.server.openai_server import OpenAIServer
 
 
 DEFAULT_MODEL = "/models/GLM-5___1-Channel-FP8-w8a8"
+DEFAULT_SERVED_MODEL = "GLM-5___1-Channel-FP8-w8a8"
 MODEL_ENV = "VLLM_HCU_GLM52_MODEL"
 DEFAULT_CONFIG = ROOT / "tests/models/glm52_pcp_humaneval_evalscope.yaml"
 
@@ -44,9 +47,57 @@ class CandidateServer:
     artifact_dir: Path
 
 
-def _chat_payload(request_id: str) -> dict[str, Any]:
+class _HealthHandler(BaseHTTPRequestHandler):
+    health_request_count = 0
+    completion_request_count = 0
+
+    def do_GET(self) -> None:
+        if self.path != "/health":
+            self.send_error(404)
+            return
+        type(self).health_request_count += 1
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def do_POST(self) -> None:
+        if self.path != "/v1/completions":
+            self.send_error(404)
+            return
+        type(self).completion_request_count += 1
+        content_length = int(self.headers["Content-Length"])
+        payload = json.loads(self.rfile.read(content_length))
+        response_id = f"cmpl-{payload['request_id']}"
+        chunks = [
+            {
+                "id": response_id,
+                "choices": [{"index": 0, "text": "ok", "token_ids": [17]}],
+            },
+            {
+                "id": response_id,
+                "choices": [],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            },
+        ]
+        body = "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks)
+        body += "data: [DONE]\n\n"
+        encoded = body.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, format: str, *args: object) -> None:
+        del format, args
+
+
+def _chat_payload(
+    request_id: str,
+    model: str = DEFAULT_SERVED_MODEL,
+) -> dict[str, Any]:
     return {
-        "model": "GLM-5___1-Channel-FP8-w8a8",
+        "model": model,
         "request_id": request_id,
         "messages": [
             {
@@ -62,10 +113,12 @@ def _chat_payload(request_id: str) -> dict[str, Any]:
 
 
 def _completion_payload(
-    prompt_token_ids: list[int], request_id: str
+    prompt_token_ids: list[int],
+    request_id: str,
+    model: str = DEFAULT_SERVED_MODEL,
 ) -> dict[str, Any]:
     return {
-        "model": "GLM-5___1-Channel-FP8-w8a8",
+        "model": model,
         "request_id": request_id,
         "prompt": prompt_token_ids,
         "temperature": 0,
@@ -85,6 +138,56 @@ def test_glm52_smoke_payload_contract() -> None:
     assert payload["return_token_ids"] is True
 
 
+def test_stream_completion_checks_worker_group_health_after_request(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1,localhost")
+    _HealthHandler.health_request_count = 0
+    _HealthHandler.completion_request_count = 0
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _HealthHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    process = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        start_new_session=True,
+    )
+    try:
+        host, port = server.server_address
+        candidate = CandidateServer(
+            api=OpenAIServer(
+                base_url=f"http://{host}:{port}",
+                model_name=DEFAULT_SERVED_MODEL,
+                log_path=tmp_path / "unused.log",
+            ),
+            process=process,
+            artifact_dir=tmp_path,
+        )
+
+        record = _stream_completion(
+            candidate,
+            "/v1/completions",
+            _completion_payload([11], "health-contract"),
+        )
+
+        assert record["token_ids"] == [17]
+        assert _HealthHandler.completion_request_count == 1
+        assert _HealthHandler.health_request_count == 1
+    finally:
+        _terminate_process_group(process, timeout_s=1)
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _assert_worker_group_healthy(api: OpenAIServer) -> None:
+    response = api.get_text("/health", timeout_s=30)
+    assert response.status == 200, (
+        f"worker-group health check failed with status={response.status}: "
+        f"{response.text[:1000]!r}; server_log={api.log_path}"
+    )
+
+
 @contextmanager
 def _serve_candidate(
     resources: HcuTestResources,
@@ -97,6 +200,7 @@ def _serve_candidate(
         hcu_count=8,
     )
     config = load_config(DEFAULT_CONFIG, "VLLM_HCU_GLM52_HUMANEVAL_CONFIG")
+    served_model_name = str(config["server"]["served_model_name"])
     command, host, port = server_command(config, model_env=MODEL_ENV)
     environment = _server_environment(config)
     artifact_dir = Path(
@@ -124,7 +228,7 @@ def _serve_candidate(
             yield CandidateServer(
                 api=OpenAIServer(
                     base_url=f"http://{host}:{port}",
-                    model_name="GLM-5___1-Channel-FP8-w8a8",
+                    model_name=served_model_name,
                     log_path=server_log_path,
                 ),
                 process=process,
@@ -217,7 +321,8 @@ def _stream_completion(
     assert response_id.endswith(payload["request_id"])
     assert token_ids, "the request must decode at least one token"
     assert first_token_at is not None
-    assert candidate.process.poll() is None, "a PCP worker rank exited during decode"
+    assert candidate.process.poll() is None, "the server process exited during decode"
+    _assert_worker_group_healthy(candidate.api)
     latency = finished - started
     prompt_count = int(usage.get("prompt_tokens", len(prompt_token_ids or [])))
     completion_count = int(usage.get("completion_tokens", len(token_ids)))
@@ -252,7 +357,7 @@ def test_glm52_pcp_deterministic_smoke(
     glm52_candidate_server: CandidateServer,
     request_id: str,
 ) -> None:
-    payload = _chat_payload(request_id)
+    payload = _chat_payload(request_id, glm52_candidate_server.api.model_name)
     payload["stream"] = True
     payload["stream_options"] = {"include_usage": True}
     first = _stream_completion(
@@ -267,18 +372,19 @@ def test_glm52_pcp_deterministic_smoke(
         second_payload,
     )
 
-    rank_converged = (
+    deterministic_token_parity = (
         glm52_candidate_server.process.poll() is None
         and first["token_ids"] == second["token_ids"]
     )
-    assert rank_converged
+    assert deterministic_token_parity
     _write_metrics(
         glm52_candidate_server,
         request_id,
         {
             "first": first,
             "second": second,
-            "rank_divergence": not rank_converged,
+            "deterministic_token_parity": deterministic_token_parity,
+            "worker_group_healthy": True,
         },
     )
 
@@ -318,7 +424,11 @@ def test_glm52_pcp_long_context_decodes_after_prefill(
     record = _stream_completion(
         glm52_candidate_server,
         "/v1/completions",
-        _completion_payload(repeated, request_id),
+        _completion_payload(
+            repeated,
+            request_id,
+            glm52_candidate_server.api.model_name,
+        ),
     )
 
     assert record["prompt_token_count"] == prompt_tokens

--- a/tests/integration/server/README.md
+++ b/tests/integration/server/README.md
@@ -23,6 +23,9 @@ Current coverage:
 - `test_evalscope_deepseek_r1_gsm8k.py` starts `vllm serve` for
   DeepSeek-R1 Channel-FP8 W8A8 with TP=8, waits for `/health`, then runs
   EvalScope on GSM8K through the OpenAI API.
+- `test_evalscope_glm52_pcp_humaneval.py` checks the collection-safe
+  GLM-5.2 model-runner-v2 TP=4, PCP=2, EP, eager, Triton-MoE launch contract,
+  then runs 32 deterministic HumanEval samples through the OpenAI API.
 
 The Qwen3-8B smoke test needs one local HCU device, the checkpoint at
 `/models/llm-models/qwen3/Qwen3-8B`, `vllm`, and `evalscope`. Select it with
@@ -47,3 +50,10 @@ The DeepSeek-R1 test needs eight local HCU devices, the local model path,
 `vllm`, and `evalscope`. It is marked `hcu`, `model`, `multi_hcu`,
 `hcu_count(8)`, `slow`, `nightly`, and `external_service("evalscope")`, so it
 is excluded from `integration-smoke`.
+
+The GLM-5.2 acceptance server defaults to
+`/models/GLM-5___1-Channel-FP8-w8a8`; override it with
+`VLLM_HCU_GLM52_MODEL`. The EvalScope configuration itself can be replaced
+with `VLLM_HCU_GLM52_HUMANEVAL_CONFIG`. It requires eight HCU devices and
+EvalScope, and intentionally uses model-runner v2 with `TP=4`, `PCP=2`, EP,
+eager execution, and the Triton MoE backend.

--- a/tests/integration/server/evalscope_server.py
+++ b/tests/integration/server/evalscope_server.py
@@ -172,11 +172,16 @@ def _terminate_process_group(proc: subprocess.Popen, timeout_s: int) -> None:
         proc.wait(timeout=10)
 
 
-def _server_environment() -> dict[str, str]:
+def _server_environment(config: dict[str, Any] | None = None) -> dict[str, str]:
     env = os.environ.copy()
     env.pop("VLLM_PLUGINS", None)
     env["VLLM_HCU_USE_FLASH_ATTN_UNIFIED"] = "1"
     env.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+    if config is not None:
+        configured = config.get("server", {}).get("environment", {})
+        if not isinstance(configured, dict):
+            raise TypeError("server.environment must be a mapping")
+        env.update({str(name): str(value) for name, value in configured.items()})
     return env
 
 
@@ -297,7 +302,7 @@ def run_evalscope_server_test(
     server_log_path = log_dir / "vllm_server.log"
     eval_log_path = log_dir / "evalscope.log"
 
-    env = _server_environment()
+    env = _server_environment(config)
 
     with _open_log(server_log_path) as server_log:
         server_log.write(("server command: " + " ".join(command) + "\n").encode())

--- a/tests/integration/server/evalscope_server.py
+++ b/tests/integration/server/evalscope_server.py
@@ -82,6 +82,9 @@ def server_command(
     host = os.environ.get("VLLM_HCU_SERVER_HOST", str(server.get("host", "127.0.0.1")))
     port = _maybe_int_env("VLLM_HCU_SERVER_PORT", int(server.get("port", 10128)))
     args = [str(item) for item in server.get("args", [])]
+    served_model_name = server.get("served_model_name")
+    if served_model_name is not None and "--served-model-name" not in args:
+        args.extend(["--served-model-name", str(served_model_name)])
     if "--port" not in args and "-p" not in args:
         args.extend(["--port", str(port)])
     return ["vllm", "serve", model, *args], host, port
@@ -96,7 +99,12 @@ def evalscope_command(
     work_dir: Path,
 ) -> list[str]:
     evalscope = config["evalscope"]
-    model = _model_path(config, model_env)
+    model = str(
+        config.get("server", {}).get(
+            "served_model_name",
+            _model_path(config, model_env),
+        )
+    )
     generation = evalscope["generation_config"]
     dataset_args = json.dumps(evalscope["dataset_args"], separators=(",", ":"))
     command = [

--- a/tests/integration/server/test_evalscope_glm52_pcp_humaneval.py
+++ b/tests/integration/server/test_evalscope_glm52_pcp_humaneval.py
@@ -121,6 +121,38 @@ def test_glm52_humaneval_request_payload_is_deterministic(
     assert _option_value(command, "--datasets") == "humaneval"
 
 
+@pytest.mark.parametrize(
+    "model_override",
+    [None, "/models/overrides/GLM-5.2-FP8"],
+    ids=["default-model-path", "overridden-model-path"],
+)
+def test_glm52_evalscope_command_request_model_matches_served_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    model_override: str | None,
+) -> None:
+    monkeypatch.delenv("VLLM_HCU_GLM52_HUMANEVAL_CONFIG", raising=False)
+    if model_override is None:
+        monkeypatch.delenv(MODEL_ENV, raising=False)
+    else:
+        monkeypatch.setenv(MODEL_ENV, model_override)
+    config = load_config(DEFAULT_CONFIG, "VLLM_HCU_GLM52_HUMANEVAL_CONFIG")
+
+    server, host, port = server_command(config, model_env=MODEL_ENV)
+    evaluation = evalscope_command(
+        config,
+        model_env=MODEL_ENV,
+        host=host,
+        port=port,
+        work_dir=tmp_path,
+    )
+
+    assert _option_value(evaluation, "--model") == _option_value(
+        server,
+        "--served-model-name",
+    )
+
+
 @pytest.mark.hcu
 @pytest.mark.model
 @pytest.mark.multi_hcu

--- a/tests/integration/server/test_evalscope_glm52_pcp_humaneval.py
+++ b/tests/integration/server/test_evalscope_glm52_pcp_humaneval.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""GLM-5.2 TP4+PCP2+EP OpenAI server and HumanEval acceptance."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.integration.server.evalscope_server import (
+    _server_environment,
+    evalscope_command,
+    load_config,
+    run_evalscope_server_test,
+    server_command,
+)
+
+
+ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_CONFIG = ROOT / "tests/models/glm52_pcp_humaneval_evalscope.yaml"
+MODEL_ENV = "VLLM_HCU_GLM52_MODEL"
+
+
+def _option_value(command: list[str], option: str) -> str:
+    index = command.index(option)
+    return command[index + 1]
+
+
+def test_glm52_pcp_server_command_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(MODEL_ENV, raising=False)
+    monkeypatch.delenv("VLLM_HCU_GLM52_HUMANEVAL_CONFIG", raising=False)
+    config = load_config(DEFAULT_CONFIG, "VLLM_HCU_GLM52_HUMANEVAL_CONFIG")
+
+    command, host, port = server_command(config, model_env=MODEL_ENV)
+    environment = _server_environment(config)
+
+    assert command[:3] == [
+        "vllm",
+        "serve",
+        "/models/GLM-5___1-Channel-FP8-w8a8",
+    ]
+    assert host == "127.0.0.1"
+    assert port == 10132
+    assert environment["VLLM_USE_V2_MODEL_RUNNER"] == "1"
+    assert _option_value(command, "--tensor-parallel-size") == "4"
+    assert _option_value(command, "--prefill-context-parallel-size") == "2"
+    assert "--enable-expert-parallel" in command
+    assert "--enforce-eager" in command
+    assert _option_value(command, "--moe-backend") == "triton"
+    assert _option_value(command, "--max-model-len") == "69632"
+    assert (
+        _option_value(command, "--served-model-name")
+        == "GLM-5___1-Channel-FP8-w8a8"
+    )
+    assert json.loads(
+        _option_value(command, "--default-chat-template-kwargs")
+    ) == {"enable_thinking": False}
+
+    forbidden_options = {
+        "--speculative-config",
+        "--speculative-model",
+        "--num-speculative-tokens",
+        "--pipeline-parallel-size",
+        "--decode-context-parallel-size",
+        "--compilation-config",
+        "--quantization",
+    }
+    assert forbidden_options.isdisjoint(command)
+
+    monkeypatch.setenv(MODEL_ENV, "/models/overrides/glm52")
+    override_command, _, _ = server_command(config, model_env=MODEL_ENV)
+    assert override_command[2] == "/models/overrides/glm52"
+
+
+def test_glm52_humaneval_config_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_HCU_GLM52_HUMANEVAL_CONFIG", raising=False)
+    config = load_config(DEFAULT_CONFIG, "VLLM_HCU_GLM52_HUMANEVAL_CONFIG")
+    evalscope = config["evalscope"]
+
+    assert evalscope["datasets"] == ["humaneval"]
+    assert evalscope["limit"] == 32
+    assert evalscope["eval_type"] == "openai_api"
+    assert evalscope["eval_batch_size"] == 1
+    assert evalscope["generation_config"] == {
+        "temperature": 0,
+        "do_sample": False,
+        "max_tokens": 2048,
+        "extra_body": {
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+    }
+
+
+def test_glm52_humaneval_request_payload_is_deterministic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_HCU_GLM52_HUMANEVAL_CONFIG", raising=False)
+    config = load_config(DEFAULT_CONFIG, "VLLM_HCU_GLM52_HUMANEVAL_CONFIG")
+
+    command = evalscope_command(
+        config,
+        model_env=MODEL_ENV,
+        host="127.0.0.1",
+        port=10132,
+        work_dir=tmp_path,
+    )
+    generation = json.loads(_option_value(command, "--generation-config"))
+
+    assert generation["temperature"] == 0
+    assert generation["do_sample"] is False
+    assert generation["extra_body"]["chat_template_kwargs"] == {
+        "enable_thinking": False
+    }
+    assert _option_value(command, "--limit") == "32"
+    assert _option_value(command, "--eval-batch-size") == "1"
+    assert _option_value(command, "--datasets") == "humaneval"
+
+
+@pytest.mark.hcu
+@pytest.mark.model
+@pytest.mark.multi_hcu
+@pytest.mark.hcu_count(8)
+@pytest.mark.slow
+@pytest.mark.nightly
+@pytest.mark.external_service("evalscope")
+def test_glm52_pcp_humaneval_evalscope_server() -> None:
+    config = load_config(DEFAULT_CONFIG, "VLLM_HCU_GLM52_HUMANEVAL_CONFIG")
+    run_evalscope_server_test(
+        config,
+        model_env=MODEL_ENV,
+        model_label="GLM-5.2 TP4+PCP2+EP",
+        required_hcu_count=8,
+    )

--- a/tests/models/README.md
+++ b/tests/models/README.md
@@ -17,6 +17,9 @@ Available local configurations:
 
 - `deepseek_r1_gsm8k_evalscope.yaml`: DeepSeek-R1 Channel-FP8 W8A8 server
   plus EvalScope GSM8K.
+- `glm52_pcp_humaneval_evalscope.yaml`: GLM-5.2 Channel-FP8 W8A8
+  model-runner-v2 server with TP=4, PCP=2, EP, and EvalScope HumanEval (32
+  deterministic samples).
 - `qwen3_8b_gsm8k_evalscope.yaml`: Qwen3-8B server plus EvalScope GSM8K.
 - `qwen35_9b_gsm8k_evalscope.yaml`: Qwen3.5-9B server plus EvalScope GSM8K.
 - `qwen3_vl_8b_mmmu_evalscope.yaml`: Qwen3-VL-8B-Instruct server plus

--- a/tests/models/glm52_pcp_humaneval_evalscope.yaml
+++ b/tests/models/glm52_pcp_humaneval_evalscope.yaml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+
+name: glm52_pcp_humaneval_evalscope
+model: /models/GLM-5___1-Channel-FP8-w8a8
+
+server:
+  host: 127.0.0.1
+  port: 10132
+  startup_timeout_s: 7200
+  shutdown_timeout_s: 120
+  environment:
+    VLLM_USE_V2_MODEL_RUNNER: "1"
+  args:
+    - --served-model-name
+    - GLM-5___1-Channel-FP8-w8a8
+    - --trust-remote-code
+    - --tensor-parallel-size
+    - "4"
+    - --prefill-context-parallel-size
+    - "2"
+    - --enable-expert-parallel
+    - --enforce-eager
+    - --moe-backend
+    - triton
+    - --max-model-len
+    - "69632"
+    - --default-chat-template-kwargs
+    - '{"enable_thinking":false}'
+
+evalscope:
+  work_dir: /tmp/vllm-hcu-evalscope/glm52_pcp_humaneval
+  api_key: EMPTY
+  eval_type: openai_api
+  generation_config:
+    temperature: 0
+    do_sample: false
+    max_tokens: 2048
+    extra_body:
+      chat_template_kwargs:
+        enable_thinking: false
+  stream: true
+  eval_batch_size: 1
+  timeout: 7200
+  limit: 32
+  datasets:
+    - humaneval
+  dataset_args:
+    humaneval: {}
+  no_timestamp: true

--- a/tests/models/glm52_pcp_humaneval_evalscope.yaml
+++ b/tests/models/glm52_pcp_humaneval_evalscope.yaml
@@ -9,11 +9,10 @@ server:
   port: 10132
   startup_timeout_s: 7200
   shutdown_timeout_s: 120
+  served_model_name: GLM-5___1-Channel-FP8-w8a8
   environment:
     VLLM_USE_V2_MODEL_RUNNER: "1"
   args:
-    - --served-model-name
-    - GLM-5___1-Channel-FP8-w8a8
     - --trust-remote-code
     - --tensor-parallel-size
     - "4"

--- a/tests/patch/test_platform_dispatcher.py
+++ b/tests/patch/test_platform_dispatcher.py
@@ -102,6 +102,22 @@ def test_platform_framework_inventory_is_explicit_and_dependency_ordered():
             "vllm.distributed.parallel_state",
         ),
         (
+            "platform.framework_opt.pcp_kv_cache_utils",
+            "vllm.v1.core.kv_cache_utils",
+        ),
+        (
+            "platform.framework_opt.pcp_kv_cache_interface",
+            "vllm.v1.kv_cache_interface",
+        ),
+        (
+            "platform.framework_opt.pcp_single_type_kv_cache_manager",
+            "vllm.v1.core.single_type_kv_cache_manager",
+        ),
+        (
+            "platform.framework_opt.pcp_kv_cache_coordinator",
+            "vllm.v1.core.kv_cache_coordinator",
+        ),
+        (
             "platform.framework_opt.mtp_indexer_kv_cache_coordinator",
             "vllm.v1.core.kv_cache_coordinator",
         ),
@@ -245,9 +261,9 @@ def test_apply_platform_patches_is_idempotent_narrow_and_reported():
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout.strip().splitlines()[-1])
     assert payload == {
-        "count": 37,
+        "count": 41,
         "replacements": 11,
-        "callbacks": 26,
+        "callbacks": 30,
         "failed": [],
         "builtins_same": True,
         "role": "Main",

--- a/tests/patch/test_plugin_lifecycle.py
+++ b/tests/patch/test_plugin_lifecycle.py
@@ -510,6 +510,9 @@ def test_hcu_model_runner_v2_is_thin_upstream_adapter(monkeypatch):
     upstream_module = ModuleType(upstream_name)
 
     class UpstreamGPUModelRunner:
+        def __init__(self, vllm_config, device):
+            self.upstream_init = (vllm_config, device)
+
         def execute_model(self):
             return "upstream"
 
@@ -519,9 +522,14 @@ def test_hcu_model_runner_v2_is_thin_upstream_adapter(monkeypatch):
 
     adapter_module = importlib.import_module(adapter_name)
     adapter = adapter_module.HcuGPUModelRunnerV2
+    config = object()
+    device = object()
+    runner = adapter(config, device)
 
     assert issubclass(adapter, UpstreamGPUModelRunner)
-    assert adapter().execute_model() == "upstream"
+    assert runner.upstream_init == (config, device)
+    assert runner.pcp_manager is None
+    assert runner.execute_model() == "upstream"
     assert "execute_model" not in adapter.__dict__
 
 

--- a/tests/patch/test_plugin_lifecycle.py
+++ b/tests/patch/test_plugin_lifecycle.py
@@ -231,6 +231,36 @@ def test_platform_reentry_preserves_an_authoritative_role(monkeypatch):
     assert PATCH_REGISTRY.process_role() is ProcessRole.ENGINE_CORE
 
 
+def test_pcp_kv_cache_callbacks_precede_mtp_coordinator_deterministically():
+    from vllm_hcu.patch.platform import platform_framework_callback_names
+
+    inventory = platform_framework_callback_names()
+    mtp_index = inventory.index(
+        (
+            "platform.framework_opt.mtp_indexer_kv_cache_coordinator",
+            "vllm.v1.core.kv_cache_coordinator",
+        )
+    )
+    assert inventory[mtp_index - 4 : mtp_index] == (
+        (
+            "platform.framework_opt.pcp_kv_cache_utils",
+            "vllm.v1.core.kv_cache_utils",
+        ),
+        (
+            "platform.framework_opt.pcp_kv_cache_interface",
+            "vllm.v1.kv_cache_interface",
+        ),
+        (
+            "platform.framework_opt.pcp_single_type_kv_cache_manager",
+            "vllm.v1.core.single_type_kv_cache_manager",
+        ),
+        (
+            "platform.framework_opt.pcp_kv_cache_coordinator",
+            "vllm.v1.core.kv_cache_coordinator",
+        ),
+    )
+
+
 def test_platform_probe_failure_is_exposed_on_vllm_second_invocation(monkeypatch):
     calls: list[str] = []
     monkeypatch.setattr(plugin, "_PLATFORM_INIT_FAILURE", None)

--- a/tests/patch/test_worker_dispatcher.py
+++ b/tests/patch/test_worker_dispatcher.py
@@ -144,6 +144,15 @@ def test_worker_inventory_is_complete_explicit_and_dependency_ordered():
     assert "os.walk(" not in source
 
 
+def test_pcp_model_state_dispatcher_inventory_is_always_enabled():
+    patch_id = "worker.framework_opt.pcp.default_model_state_metadata"
+    assert (
+        patch_id,
+        "vllm.v1.worker.gpu.model_states.default",
+    ) in worker_dispatcher.worker_callback_names()
+    assert worker_dispatcher._patch_features()[patch_id] == "always"
+
+
 def test_cold_replacement_metadata_matches_lazy_adapter_contracts():
     for spec in worker_dispatcher._COLD_REPLACEMENTS:
         adapter = importlib.import_module(spec.adapter)
@@ -677,3 +686,33 @@ def test_invalid_spawned_sidecar_fails_before_worker_registration():
     )
     assert result.returncode != 0
     assert "enable_lightly_cplb requires enable_lightly_cp" in result.stderr
+
+
+def test_pcp_model_state_adapter_matches_exact_v0251_target():
+    result = _run_fresh(
+        """
+import inspect
+import json
+
+from vllm.v1.worker.gpu.model_states import default
+from vllm_hcu.patch.worker.framework_opt import patch_pcp_model_state
+
+before = str(inspect.signature(default.DefaultModelState.prepare_attn))
+first = patch_pcp_model_state.apply_to_module(default)
+second = patch_pcp_model_state.apply_to_module(default)
+after = str(inspect.signature(default.DefaultModelState.prepare_attn))
+print(json.dumps({
+    "first": first,
+    "second": second,
+    "signature_preserved": before == after,
+}))
+""",
+        timeout=180,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload == {
+        "first": True,
+        "second": False,
+        "signature_preserved": True,
+    }

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -230,6 +230,20 @@ def test_flashmla_sparse_bf16_preserves_v0251_topk_length(monkeypatch):
         calls.append(("hcu", q, cache, indices, softmax_scale, topk_length))
         return torch.ones(q.shape[0], 4, q.shape[-1]), None
 
+    def split_decodes_and_prefills(
+        common_attn_metadata,
+        decode_threshold=1,
+        require_uniform=False,
+        treat_short_extends_as_decodes=True,
+    ):
+        del (
+            common_attn_metadata,
+            decode_threshold,
+            require_uniform,
+            treat_short_extends_as_decodes,
+        )
+        return 0, 0, 0, 0
+
     import vllm_hcu.v1.attention.ops.flashmla as hcu_flashmla
 
     monkeypatch.setattr(hcu_flashmla, "FlashMLASchedMeta", object)
@@ -247,6 +261,7 @@ def test_flashmla_sparse_bf16_preserves_v0251_topk_length(monkeypatch):
         FlashMLASparseMetadataBuilder=FlashMLASparseMetadataBuilder,
         FlashMLASparseImpl=FlashMLASparseImpl,
         current_platform=platform,
+        split_decodes_and_prefills=split_decodes_and_prefills,
         torch=torch,
     )
     assert adapter.apply_to_module(module)
@@ -270,6 +285,103 @@ def test_flashmla_sparse_bf16_preserves_v0251_topk_length(monkeypatch):
         == "official-bf16"
     )
     assert calls[-1][-1] is topk_length
+
+
+def test_flashmla_sparse_mixed_metadata_exposes_pcp_cache_phase(monkeypatch):
+    """PCP cache gathers need phase counts even in mixed FP8 mode."""
+
+    adapter = _adapter("patch_flashmla_sparse")
+    split_calls: list[tuple[object, ...]] = []
+
+    class FlashMLASparseMetadataBuilder:
+        reorder_batch_threshold = 7
+
+        def build(
+            self,
+            common_prefix_len,
+            common_attn_metadata,
+            fast_build=False,
+        ):
+            del self, common_prefix_len, common_attn_metadata, fast_build
+            return SimpleNamespace(
+                fp8_use_mixed_batch=True,
+                fp8_extra_metadata=SimpleNamespace(),
+            )
+
+    class FlashMLASparseImpl:
+        def _fp8_flash_mla_kernel(
+            self,
+            q,
+            kv_c_and_k_pe_cache,
+            topk_indices,
+            kernel_metadata,
+        ):
+            del self, q, kv_c_and_k_pe_cache, topk_indices, kernel_metadata
+
+        def _bf16_flash_mla_kernel(
+            self,
+            q,
+            kv_c_and_k_pe_cache,
+            topk_indices,
+            topk_length=None,
+        ):
+            del self, q, kv_c_and_k_pe_cache, topk_indices, topk_length
+
+    def split_decodes_and_prefills(
+        common_attn_metadata,
+        decode_threshold=1,
+        require_uniform=False,
+        treat_short_extends_as_decodes=True,
+    ):
+        split_calls.append(
+            (
+                common_attn_metadata,
+                decode_threshold,
+                require_uniform,
+                treat_short_extends_as_decodes,
+            )
+        )
+        return 3, 2, 3, 5
+
+    import vllm_hcu.v1.attention.ops.flashmla as hcu_flashmla
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(hcu_flashmla, "FlashMLASchedMeta", object)
+    monkeypatch.setattr(hcu_flashmla, "flash_mla_sparse_fwd", lambda *a, **k: None)
+    monkeypatch.setattr(
+        hcu_flashmla,
+        "flash_mla_with_kvcache",
+        lambda **kwargs: (kwargs, None),
+    )
+    monkeypatch.setattr(hcu_flashmla, "get_mla_metadata", lambda *a, **k: None)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_FP8_MIXED_BATCH",
+        True,
+        raising=False,
+    )
+    module = _module(
+        adapter.TARGET_MODULE,
+        FlashMLASparseMetadataBuilder=FlashMLASparseMetadataBuilder,
+        FlashMLASparseImpl=FlashMLASparseImpl,
+        current_platform=SimpleNamespace(is_rocm=lambda: False),
+        split_decodes_and_prefills=split_decodes_and_prefills,
+        torch=torch,
+    )
+    assert adapter.apply_to_module(module)
+    builder = FlashMLASparseMetadataBuilder()
+    builder.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(prefill_context_parallel_size=2)
+    )
+    common = SimpleNamespace(num_actual_tokens=8)
+
+    metadata = builder.build(0, common)
+
+    assert metadata.fp8_use_mixed_batch is True
+    assert metadata.num_decodes == 3
+    assert metadata.num_prefills == 2
+    assert metadata.num_decode_tokens == 3
+    assert split_calls == [(common, 7, True, False)]
 
 
 def test_attention_direct_forward_preserves_cpu_values_and_query_device():

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -14,25 +14,22 @@ import pytest
 import torch
 
 
-def split_decodes_and_prefills(
-    common_attn_metadata,
-    decode_threshold=1,
-    require_uniform=False,
-    treat_short_extends_as_decodes=True,
+def _install_flashmla_sparse_separate_builder(
+    module,
+    builder_cls,
+    *,
+    indirect_split=False,
 ):
-    del decode_threshold, require_uniform, treat_short_extends_as_decodes
-    return 0, 1, 0, common_attn_metadata.num_actual_tokens
-
-
-def _make_flashmla_sparse_separate_builder(splitter):
-    namespace = {
-        "SimpleNamespace": SimpleNamespace,
-        "split_decodes_and_prefills": splitter,
-    }
+    module.SimpleNamespace = SimpleNamespace
+    split_expression = (
+        "utils.split_decodes_and_prefills"
+        if indirect_split
+        else "split_decodes_and_prefills"
+    )
     exec(
-        """
+        f"""
 def _build_fp8_separate_prefill_decode(self, common_attn_metadata):
-    counts = split_decodes_and_prefills(
+    counts = {split_expression}(
         common_attn_metadata,
         decode_threshold=self.reorder_batch_threshold or 1,
         require_uniform=True,
@@ -42,11 +39,15 @@ def _build_fp8_separate_prefill_decode(self, common_attn_metadata):
         num_prefills=counts[1],
         num_decode_tokens=counts[2],
         num_prefill_tokens=counts[3],
+        decode_metadata=(get_mla_metadata() if counts[0] else None),
     )
 """,
-        namespace,
+        module.__dict__,
     )
-    return namespace["_build_fp8_separate_prefill_decode"]
+    builder_cls._build_fp8_separate_prefill_decode = (
+        module._build_fp8_separate_prefill_decode
+    )
+    return builder_cls._build_fp8_separate_prefill_decode
 
 
 def _adapter(name: str):
@@ -279,10 +280,6 @@ def test_flashmla_sparse_bf16_preserves_v0251_topk_length(monkeypatch):
         )
         return 0, 0, 0, 0
 
-    FlashMLASparseMetadataBuilder._build_fp8_separate_prefill_decode = (
-        _make_flashmla_sparse_separate_builder(split_decodes_and_prefills)
-    )
-
     import vllm_hcu.v1.attention.ops.flashmla as hcu_flashmla
 
     monkeypatch.setattr(hcu_flashmla, "FlashMLASchedMeta", object)
@@ -292,7 +289,13 @@ def test_flashmla_sparse_bf16_preserves_v0251_topk_length(monkeypatch):
         "flash_mla_with_kvcache",
         lambda **kwargs: (kwargs, None),
     )
-    monkeypatch.setattr(hcu_flashmla, "get_mla_metadata", lambda *a, **k: None)
+    monkeypatch.setattr(
+        hcu_flashmla,
+        "get_mla_metadata",
+        lambda *a, **k: pytest.fail(
+            "BF16 kernel test built separate decode metadata"
+        ),
+    )
 
     platform = SimpleNamespace(is_rocm=lambda: True)
     module = _module(
@@ -302,6 +305,9 @@ def test_flashmla_sparse_bf16_preserves_v0251_topk_length(monkeypatch):
         current_platform=platform,
         split_decodes_and_prefills=split_decodes_and_prefills,
         torch=torch,
+    )
+    _install_flashmla_sparse_separate_builder(
+        module, FlashMLASparseMetadataBuilder
     )
     assert adapter.apply_to_module(module)
     impl = FlashMLASparseImpl()
@@ -382,10 +388,6 @@ def test_flashmla_sparse_mixed_metadata_exposes_pcp_cache_phase(monkeypatch):
         )
         return 3, 2, 3, 5
 
-    FlashMLASparseMetadataBuilder._build_fp8_separate_prefill_decode = (
-        _make_flashmla_sparse_separate_builder(split_decodes_and_prefills)
-    )
-
     import vllm_hcu.v1.attention.ops.flashmla as hcu_flashmla
     from vllm_hcu.platforms import envs as henvs
 
@@ -396,7 +398,13 @@ def test_flashmla_sparse_mixed_metadata_exposes_pcp_cache_phase(monkeypatch):
         "flash_mla_with_kvcache",
         lambda **kwargs: (kwargs, None),
     )
-    monkeypatch.setattr(hcu_flashmla, "get_mla_metadata", lambda *a, **k: None)
+    monkeypatch.setattr(
+        hcu_flashmla,
+        "get_mla_metadata",
+        lambda *a, **k: pytest.fail(
+            "mixed FP8 metadata built separate decode metadata"
+        ),
+    )
     monkeypatch.setattr(
         henvs,
         "VLLM_HCU_USE_FP8_MIXED_BATCH",
@@ -410,6 +418,9 @@ def test_flashmla_sparse_mixed_metadata_exposes_pcp_cache_phase(monkeypatch):
         current_platform=SimpleNamespace(is_rocm=lambda: False),
         split_decodes_and_prefills=split_decodes_and_prefills,
         torch=torch,
+    )
+    _install_flashmla_sparse_separate_builder(
+        module, FlashMLASparseMetadataBuilder
     )
     assert adapter.apply_to_module(module)
     builder = FlashMLASparseMetadataBuilder()
@@ -427,7 +438,13 @@ def test_flashmla_sparse_mixed_metadata_exposes_pcp_cache_phase(monkeypatch):
     assert split_calls == [(common, 7, True, False)]
 
 
-def _make_flashmla_sparse_separate_metadata_module(adapter, split_calls):
+def _make_flashmla_sparse_separate_metadata_module(
+    adapter,
+    split_calls,
+    *,
+    get_mla_metadata=lambda: None,
+    indirect_split=False,
+):
     from vllm.v1.attention.backends.utils import (
         split_decodes_and_prefills as upstream_split_decodes_and_prefills,
     )
@@ -486,10 +503,17 @@ def _make_flashmla_sparse_separate_metadata_module(adapter, split_calls):
         FlashMLASparseImpl=FlashMLASparseImpl,
         current_platform=SimpleNamespace(is_rocm=lambda: False),
         split_decodes_and_prefills=split_decodes_and_prefills,
+        get_mla_metadata=get_mla_metadata,
         torch=torch,
     )
-    FlashMLASparseMetadataBuilder._build_fp8_separate_prefill_decode = (
-        _make_flashmla_sparse_separate_builder(split_decodes_and_prefills)
+    if indirect_split:
+        module.utils = SimpleNamespace(
+            split_decodes_and_prefills=split_decodes_and_prefills
+        )
+    _install_flashmla_sparse_separate_builder(
+        module,
+        FlashMLASparseMetadataBuilder,
+        indirect_split=indirect_split,
     )
     return module, FlashMLASparseMetadataBuilder
 
@@ -500,17 +524,66 @@ def test_flashmla_sparse_rejects_separate_builder_splitter_drift():
         adapter, []
     )
 
-    def incompatible_helper(self, common_attn_metadata):
-        del self, common_attn_metadata
-        return SimpleNamespace()
-
-    builder_cls._build_fp8_separate_prefill_decode = incompatible_helper
+    exec(
+        """
+def incompatible_helper(self, common_attn_metadata):
+    return SimpleNamespace()
+""",
+        module.__dict__,
+    )
+    builder_cls._build_fp8_separate_prefill_decode = module.incompatible_helper
 
     with pytest.raises(
         adapter.PatchCompatibilityError,
         match="_build_fp8_separate_prefill_decode.*split_decodes_and_prefills",
     ):
         adapter.apply_to_module(module)
+
+
+def test_flashmla_sparse_rejects_indirect_splitter_before_mutation():
+    adapter = _adapter("patch_flashmla_sparse")
+    module, builder_cls = _make_flashmla_sparse_separate_metadata_module(
+        adapter,
+        [],
+        indirect_split=True,
+    )
+    original_build = builder_cls.build
+    original_get_mla_metadata = module.get_mla_metadata
+
+    with pytest.raises(
+        adapter.PatchCompatibilityError,
+        match="direct LOAD_GLOBAL.*split_decodes_and_prefills",
+    ):
+        adapter.apply_to_module(module)
+
+    assert builder_cls.build is original_build
+    assert module.get_mla_metadata is original_get_mla_metadata
+    assert not hasattr(module, adapter._MARKER)
+
+
+def test_flashmla_sparse_rejects_helper_from_different_module_globals():
+    adapter = _adapter("patch_flashmla_sparse")
+    module, builder_cls = _make_flashmla_sparse_separate_metadata_module(
+        adapter, []
+    )
+    decoy_module = _module(
+        "decoy_flashmla_sparse",
+        split_decodes_and_prefills=module.split_decodes_and_prefills,
+        get_mla_metadata=module.get_mla_metadata,
+    )
+    _install_flashmla_sparse_separate_builder(decoy_module, builder_cls)
+    original_build = builder_cls.build
+    original_get_mla_metadata = module.get_mla_metadata
+
+    with pytest.raises(
+        adapter.PatchCompatibilityError,
+        match="globals.*target module",
+    ):
+        adapter.apply_to_module(module)
+
+    assert builder_cls.build is original_build
+    assert module.get_mla_metadata is original_get_mla_metadata
+    assert not hasattr(module, adapter._MARKER)
 
 
 def test_flashmla_sparse_pcp_separate_metadata_keeps_short_extend_as_prefill(
@@ -520,8 +593,20 @@ def test_flashmla_sparse_pcp_separate_metadata_keeps_short_extend_as_prefill(
 
     adapter = _adapter("patch_flashmla_sparse")
     split_calls: list[bool] = []
+    metadata_calls: list[str] = []
+
+    def cuda_get_mla_metadata():
+        metadata_calls.append("cuda")
+        return "cuda-metadata"
+
+    def hcu_get_mla_metadata():
+        metadata_calls.append("hcu")
+        return "hcu-metadata"
+
     module, builder_cls = _make_flashmla_sparse_separate_metadata_module(
-        adapter, split_calls
+        adapter,
+        split_calls,
+        get_mla_metadata=cuda_get_mla_metadata,
     )
     import vllm_hcu.v1.attention.ops.flashmla as hcu_flashmla
     from vllm_hcu.platforms import envs as henvs
@@ -533,7 +618,9 @@ def test_flashmla_sparse_pcp_separate_metadata_keeps_short_extend_as_prefill(
         "flash_mla_with_kvcache",
         lambda **kwargs: (kwargs, None),
     )
-    monkeypatch.setattr(hcu_flashmla, "get_mla_metadata", lambda *a, **k: None)
+    monkeypatch.setattr(
+        hcu_flashmla, "get_mla_metadata", hcu_get_mla_metadata
+    )
     monkeypatch.setattr(
         henvs,
         "VLLM_HCU_USE_FP8_MIXED_BATCH",
@@ -547,10 +634,10 @@ def test_flashmla_sparse_pcp_separate_metadata_keeps_short_extend_as_prefill(
     )
     common = SimpleNamespace(
         num_actual_tokens=4,
-        num_reqs=3,
+        num_reqs=4,
         max_query_len=2,
-        query_start_loc_cpu=torch.tensor([0, 1, 2, 4]),
-        is_prefilling=torch.tensor([False, True, True]),
+        query_start_loc_cpu=torch.tensor([0, 1, 2, 4, 4]),
+        is_prefilling=torch.tensor([False, True, True, False]),
     )
 
     metadata = builder.build(0, common)
@@ -567,15 +654,32 @@ def test_flashmla_sparse_pcp_separate_metadata_keeps_short_extend_as_prefill(
         nested.num_prefills,
         nested.num_decode_tokens,
         nested.num_prefill_tokens,
-    ) == (1, 2, 1, 3)
+    ) == (1, 3, 1, 3)
+    assert nested.decode_metadata == "hcu-metadata"
+    assert metadata_calls == ["hcu"]
     assert split_calls == [False, False]
 
 
 def test_flashmla_sparse_pcp_one_preserves_separate_phase_default(monkeypatch):
     adapter = _adapter("patch_flashmla_sparse")
     split_calls: list[bool] = []
+    metadata_calls: list[str] = []
+
+    def cuda_get_mla_metadata():
+        metadata_calls.append("cuda")
+        return "cuda-metadata"
+
+    def hcu_get_mla_metadata():
+        metadata_calls.append("hcu")
+        return "hcu-metadata"
+
     module, builder_cls = _make_flashmla_sparse_separate_metadata_module(
-        adapter, split_calls
+        adapter,
+        split_calls,
+        get_mla_metadata=cuda_get_mla_metadata,
+    )
+    original_separate_builder = (
+        builder_cls._build_fp8_separate_prefill_decode
     )
     import vllm_hcu.v1.attention.ops.flashmla as hcu_flashmla
     from vllm_hcu.platforms import envs as henvs
@@ -587,7 +691,9 @@ def test_flashmla_sparse_pcp_one_preserves_separate_phase_default(monkeypatch):
         "flash_mla_with_kvcache",
         lambda **kwargs: (kwargs, None),
     )
-    monkeypatch.setattr(hcu_flashmla, "get_mla_metadata", lambda *a, **k: None)
+    monkeypatch.setattr(
+        hcu_flashmla, "get_mla_metadata", hcu_get_mla_metadata
+    )
     monkeypatch.setattr(
         henvs,
         "VLLM_HCU_USE_FP8_MIXED_BATCH",
@@ -595,6 +701,10 @@ def test_flashmla_sparse_pcp_one_preserves_separate_phase_default(monkeypatch):
         raising=False,
     )
     assert adapter.apply_to_module(module)
+    assert (
+        builder_cls._build_fp8_separate_prefill_decode
+        is original_separate_builder
+    )
     builder = builder_cls()
     builder.vllm_config = SimpleNamespace(
         parallel_config=SimpleNamespace(prefill_context_parallel_size=1)
@@ -614,6 +724,8 @@ def test_flashmla_sparse_pcp_one_preserves_separate_phase_default(monkeypatch):
     assert metadata.fp8_use_mixed_batch is False
     assert metadata.fp8_extra_metadata.num_decodes == 2
     assert metadata.fp8_extra_metadata.num_prefills == 0
+    assert metadata.fp8_extra_metadata.decode_metadata == "hcu-metadata"
+    assert metadata_calls == ["hcu"]
     assert split_calls == [True]
 
 

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -14,6 +14,41 @@ import pytest
 import torch
 
 
+def split_decodes_and_prefills(
+    common_attn_metadata,
+    decode_threshold=1,
+    require_uniform=False,
+    treat_short_extends_as_decodes=True,
+):
+    del decode_threshold, require_uniform, treat_short_extends_as_decodes
+    return 0, 1, 0, common_attn_metadata.num_actual_tokens
+
+
+def _make_flashmla_sparse_separate_builder(splitter):
+    namespace = {
+        "SimpleNamespace": SimpleNamespace,
+        "split_decodes_and_prefills": splitter,
+    }
+    exec(
+        """
+def _build_fp8_separate_prefill_decode(self, common_attn_metadata):
+    counts = split_decodes_and_prefills(
+        common_attn_metadata,
+        decode_threshold=self.reorder_batch_threshold or 1,
+        require_uniform=True,
+    )
+    return SimpleNamespace(
+        num_decodes=counts[0],
+        num_prefills=counts[1],
+        num_decode_tokens=counts[2],
+        num_prefill_tokens=counts[3],
+    )
+""",
+        namespace,
+    )
+    return namespace["_build_fp8_separate_prefill_decode"]
+
+
 def _adapter(name: str):
     return importlib.import_module(f"vllm_hcu.patch.worker.op_opt.{name}")
 
@@ -244,6 +279,10 @@ def test_flashmla_sparse_bf16_preserves_v0251_topk_length(monkeypatch):
         )
         return 0, 0, 0, 0
 
+    FlashMLASparseMetadataBuilder._build_fp8_separate_prefill_decode = (
+        _make_flashmla_sparse_separate_builder(split_decodes_and_prefills)
+    )
+
     import vllm_hcu.v1.attention.ops.flashmla as hcu_flashmla
 
     monkeypatch.setattr(hcu_flashmla, "FlashMLASchedMeta", object)
@@ -343,6 +382,10 @@ def test_flashmla_sparse_mixed_metadata_exposes_pcp_cache_phase(monkeypatch):
         )
         return 3, 2, 3, 5
 
+    FlashMLASparseMetadataBuilder._build_fp8_separate_prefill_decode = (
+        _make_flashmla_sparse_separate_builder(split_decodes_and_prefills)
+    )
+
     import vllm_hcu.v1.attention.ops.flashmla as hcu_flashmla
     from vllm_hcu.platforms import envs as henvs
 
@@ -382,6 +425,196 @@ def test_flashmla_sparse_mixed_metadata_exposes_pcp_cache_phase(monkeypatch):
     assert metadata.num_prefills == 2
     assert metadata.num_decode_tokens == 3
     assert split_calls == [(common, 7, True, False)]
+
+
+def _make_flashmla_sparse_separate_metadata_module(adapter, split_calls):
+    from vllm.v1.attention.backends.utils import (
+        split_decodes_and_prefills as upstream_split_decodes_and_prefills,
+    )
+
+    class FlashMLASparseMetadataBuilder:
+        reorder_batch_threshold = 1
+
+        def build(
+            self,
+            common_prefix_len,
+            common_attn_metadata,
+            fast_build=False,
+        ):
+            del self, common_prefix_len, common_attn_metadata, fast_build
+            return SimpleNamespace(
+                fp8_use_mixed_batch=True,
+                fp8_extra_metadata=None,
+            )
+
+    class FlashMLASparseImpl:
+        def _fp8_flash_mla_kernel(
+            self,
+            q,
+            kv_c_and_k_pe_cache,
+            topk_indices,
+            kernel_metadata,
+        ):
+            del self, q, kv_c_and_k_pe_cache, topk_indices, kernel_metadata
+
+        def _bf16_flash_mla_kernel(
+            self,
+            q,
+            kv_c_and_k_pe_cache,
+            topk_indices,
+            topk_length=None,
+        ):
+            del self, q, kv_c_and_k_pe_cache, topk_indices, topk_length
+
+    def split_decodes_and_prefills(
+        common_attn_metadata,
+        decode_threshold=1,
+        require_uniform=False,
+        treat_short_extends_as_decodes=True,
+    ):
+        split_calls.append(treat_short_extends_as_decodes)
+        return upstream_split_decodes_and_prefills(
+            common_attn_metadata,
+            decode_threshold=decode_threshold,
+            require_uniform=require_uniform,
+            treat_short_extends_as_decodes=treat_short_extends_as_decodes,
+        )
+
+    module = _module(
+        adapter.TARGET_MODULE,
+        FlashMLASparseMetadataBuilder=FlashMLASparseMetadataBuilder,
+        FlashMLASparseImpl=FlashMLASparseImpl,
+        current_platform=SimpleNamespace(is_rocm=lambda: False),
+        split_decodes_and_prefills=split_decodes_and_prefills,
+        torch=torch,
+    )
+    FlashMLASparseMetadataBuilder._build_fp8_separate_prefill_decode = (
+        _make_flashmla_sparse_separate_builder(split_decodes_and_prefills)
+    )
+    return module, FlashMLASparseMetadataBuilder
+
+
+def test_flashmla_sparse_rejects_separate_builder_splitter_drift():
+    adapter = _adapter("patch_flashmla_sparse")
+    module, builder_cls = _make_flashmla_sparse_separate_metadata_module(
+        adapter, []
+    )
+
+    def incompatible_helper(self, common_attn_metadata):
+        del self, common_attn_metadata
+        return SimpleNamespace()
+
+    builder_cls._build_fp8_separate_prefill_decode = incompatible_helper
+
+    with pytest.raises(
+        adapter.PatchCompatibilityError,
+        match="_build_fp8_separate_prefill_decode.*split_decodes_and_prefills",
+    ):
+        adapter.apply_to_module(module)
+
+
+def test_flashmla_sparse_pcp_separate_metadata_keeps_short_extend_as_prefill(
+    monkeypatch,
+):
+    """Nested FP8 metadata must use the same PCP phase split as its parent."""
+
+    adapter = _adapter("patch_flashmla_sparse")
+    split_calls: list[bool] = []
+    module, builder_cls = _make_flashmla_sparse_separate_metadata_module(
+        adapter, split_calls
+    )
+    import vllm_hcu.v1.attention.ops.flashmla as hcu_flashmla
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(hcu_flashmla, "FlashMLASchedMeta", object)
+    monkeypatch.setattr(hcu_flashmla, "flash_mla_sparse_fwd", lambda *a, **k: None)
+    monkeypatch.setattr(
+        hcu_flashmla,
+        "flash_mla_with_kvcache",
+        lambda **kwargs: (kwargs, None),
+    )
+    monkeypatch.setattr(hcu_flashmla, "get_mla_metadata", lambda *a, **k: None)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_FP8_MIXED_BATCH",
+        False,
+        raising=False,
+    )
+    assert adapter.apply_to_module(module)
+    builder = builder_cls()
+    builder.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(prefill_context_parallel_size=2)
+    )
+    common = SimpleNamespace(
+        num_actual_tokens=4,
+        num_reqs=3,
+        max_query_len=2,
+        query_start_loc_cpu=torch.tensor([0, 1, 2, 4]),
+        is_prefilling=torch.tensor([False, True, True]),
+    )
+
+    metadata = builder.build(0, common)
+    nested = metadata.fp8_extra_metadata
+
+    assert metadata.fp8_use_mixed_batch is False
+    assert (
+        metadata.num_decodes,
+        metadata.num_prefills,
+        metadata.num_decode_tokens,
+    ) == (nested.num_decodes, nested.num_prefills, nested.num_decode_tokens)
+    assert (
+        nested.num_decodes,
+        nested.num_prefills,
+        nested.num_decode_tokens,
+        nested.num_prefill_tokens,
+    ) == (1, 2, 1, 3)
+    assert split_calls == [False, False]
+
+
+def test_flashmla_sparse_pcp_one_preserves_separate_phase_default(monkeypatch):
+    adapter = _adapter("patch_flashmla_sparse")
+    split_calls: list[bool] = []
+    module, builder_cls = _make_flashmla_sparse_separate_metadata_module(
+        adapter, split_calls
+    )
+    import vllm_hcu.v1.attention.ops.flashmla as hcu_flashmla
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(hcu_flashmla, "FlashMLASchedMeta", object)
+    monkeypatch.setattr(hcu_flashmla, "flash_mla_sparse_fwd", lambda *a, **k: None)
+    monkeypatch.setattr(
+        hcu_flashmla,
+        "flash_mla_with_kvcache",
+        lambda **kwargs: (kwargs, None),
+    )
+    monkeypatch.setattr(hcu_flashmla, "get_mla_metadata", lambda *a, **k: None)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_FP8_MIXED_BATCH",
+        False,
+        raising=False,
+    )
+    assert adapter.apply_to_module(module)
+    builder = builder_cls()
+    builder.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(prefill_context_parallel_size=1)
+    )
+
+    metadata = builder.build(
+        0,
+        SimpleNamespace(
+            num_actual_tokens=2,
+            num_reqs=2,
+            max_query_len=1,
+            query_start_loc_cpu=torch.tensor([0, 1, 2]),
+            is_prefilling=torch.tensor([False, True]),
+        ),
+    )
+
+    assert metadata.fp8_use_mixed_batch is False
+    assert metadata.fp8_extra_metadata.num_decodes == 2
+    assert metadata.fp8_extra_metadata.num_prefills == 0
+    assert split_calls == [True]
 
 
 def test_attention_direct_forward_preserves_cpu_values_and_query_device():

--- a/tests/runtime_patch/test_glm52_pcp_config.py
+++ b/tests/runtime_patch/test_glm52_pcp_config.py
@@ -8,6 +8,7 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
+from vllm.config.vllm import VllmConfig
 from vllm_hcu.patch.config import HcuFeatureConfig
 from vllm_hcu.patch.platform.core_fix import patch_vllm_config
 from vllm_hcu.patch.platform.core_fix._common import PatchCompatibilityError
@@ -207,3 +208,45 @@ def test_pcp_patch_rejects_v0251_wrapper_signature_drift() -> None:
     )
     with pytest.raises(PatchCompatibilityError, match="incompatible signature"):
         patch_vllm_config.apply_to_module(module)
+
+
+class _LifecycleCompilationConfig:
+    def __init__(self) -> None:
+        self.cudagraph_mode = SimpleNamespace(has_full_cudagraphs=lambda: False)
+
+
+def test_forced_v1_pcp_is_rejected_during_platform_config_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+    make_pcp_config,
+) -> None:
+    """Removing the platform gate would let forced V1 PCP finish validation."""
+
+    import torch
+
+    assert VllmConfig.__module__ == "vllm.config.vllm"
+
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda device: SimpleNamespace(gcnArchName="gfx936"),
+    )
+    from vllm_hcu.patch.platform.framework_opt import (
+        patch_multiproc_executor,
+        patch_scheduler,
+    )
+    from vllm_hcu.platforms.hcu import HCUPlatform
+
+    monkeypatch.setattr(
+        patch_scheduler, "select_hcu_scheduler", lambda config: False
+    )
+    monkeypatch.setattr(
+        patch_multiproc_executor, "select_hcu_multiproc_executor", lambda config: False
+    )
+    config = make_pcp_config(use_v2=False, pcp=2)
+    config.compilation_config = _LifecycleCompilationConfig()
+    config.kernel_config = SimpleNamespace(moe_backend="auto")
+    config.cache_config.user_specified_block_size = True
+    config.parallel_config.worker_cls = "auto"
+
+    with pytest.raises(ValueError, match="Model Runner V2"):
+        HCUPlatform.check_and_update_config(config)

--- a/tests/runtime_patch/test_glm52_pcp_config.py
+++ b/tests/runtime_patch/test_glm52_pcp_config.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Fail-closed Model Runner V2 PCP configuration contracts."""
+
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from vllm_hcu.patch.config import HcuFeatureConfig
+from vllm_hcu.patch.platform.core_fix import patch_vllm_config
+from vllm_hcu.patch.platform.core_fix._common import PatchCompatibilityError
+
+
+def _make_pcp_config(**overrides: object) -> object:
+    """Build a CPU-safe object matching vLLM 0.25.1 config field names."""
+
+    architecture = overrides.pop("architecture", "GlmMoeDsaForCausalLM")
+    use_v2 = overrides.pop("use_v2", True)
+    use_mla = overrides.pop("use_mla", True)
+    pcp = overrides.pop("pcp", 2)
+    tp = overrides.pop("tp", 4)
+    pp = overrides.pop("pp", 1)
+    dcp = overrides.pop("dcp", 1)
+    dp = overrides.pop("dp", 1)
+    enable_expert_parallel = overrides.pop("enable_expert_parallel", True)
+    enforce_eager = overrides.pop("enforce_eager", True)
+    speculative = overrides.pop("speculative", False)
+    lora = overrides.pop("lora", False)
+    multimodal = overrides.pop("multimodal", False)
+    kv_offload = overrides.pop("kv_offload", False)
+    kv_transfer = overrides.pop("kv_transfer", False)
+    enable_lightly_cp = overrides.pop("enable_lightly_cp", False)
+    if overrides:
+        raise AssertionError(f"unknown PCP fixture override(s): {sorted(overrides)}")
+
+    return SimpleNamespace(
+        use_v2_model_runner=use_v2,
+        model_config=SimpleNamespace(
+            architectures=[architecture],
+            use_mla=use_mla,
+            enforce_eager=enforce_eager,
+            is_multimodal_model=multimodal,
+        ),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=tp,
+            prefill_context_parallel_size=pcp,
+            pipeline_parallel_size=pp,
+            decode_context_parallel_size=dcp,
+            data_parallel_size=dp,
+            enable_expert_parallel=enable_expert_parallel,
+        ),
+        speculative_config=(SimpleNamespace(method="mtp") if speculative else None),
+        lora_config=(SimpleNamespace() if lora else None),
+        cache_config=SimpleNamespace(kv_offloading_size=(1.0 if kv_offload else None)),
+        kv_transfer_config=(
+            SimpleNamespace(kv_connector="MooncakeConnector") if kv_transfer else None
+        ),
+        additional_config={
+            "hcu": HcuFeatureConfig(enable_lightly_cp=enable_lightly_cp).to_dict()
+        },
+    )
+
+
+@pytest.fixture
+def make_pcp_config():
+    return _make_pcp_config
+
+
+def test_glm52_mrv2_mla_pcp2_eager_is_allowed(make_pcp_config) -> None:
+    """Removing the accepted GLM PCP branch must reject this configuration."""
+
+    config = make_pcp_config(
+        architecture="GlmMoeDsaForCausalLM",
+        use_mla=True,
+        pcp=2,
+        tp=4,
+        enable_expert_parallel=True,
+        enforce_eager=True,
+    )
+    assert patch_vllm_config._validate_hcu_pcp_scope(config) is True
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"use_v2": False}, "Model Runner V2"),
+        ({"architecture": "DeepseekV2ForCausalLM"}, "GLM-5.2"),
+        ({"use_mla": False}, "MLA"),
+        ({"pp": 2}, "pipeline parallel"),
+        ({"dcp": 2}, "decode context parallel"),
+        ({"dp": 2}, "data parallel"),
+        ({"enable_expert_parallel": False}, "expert parallel"),
+        ({"speculative": True}, "speculative decoding"),
+        ({"enforce_eager": False}, "eager"),
+        ({"lora": True}, "LoRA"),
+        ({"multimodal": True}, "multimodal"),
+        ({"kv_offload": True}, "KV offload"),
+        ({"kv_transfer": True}, "P/D disaggregation"),
+        ({"enable_lightly_cp": True}, "lightly-CP"),
+    ],
+)
+def test_glm52_pcp_scope_rejects_unsupported_combinations(
+    make_pcp_config, override, message
+) -> None:
+    """Each unsupported PCP dimension must fail closed with its own reason."""
+
+    with pytest.raises(ValueError, match=message):
+        patch_vllm_config._validate_hcu_pcp_scope(
+            make_pcp_config(pcp=2, **override)
+        )
+
+
+def _make_vllm_module() -> ModuleType:
+    module = ModuleType(patch_vllm_config.TARGET_MODULE)
+
+    class ModelConfig:
+        def get_model_arch_config(self) -> object:
+            return None
+
+    class VllmConfig:
+        def with_hf_config(self, hf_config: object, architectures=None):
+            del hf_config, architectures
+            return self
+
+        def _set_cudagraph_sizes(self) -> None:
+            return None
+
+        def _get_v2_model_runner_unsupported_features(self) -> list[str]:
+            if self.parallel_config.prefill_context_parallel_size > 1:
+                return ["prefill context parallelism"]
+            return ["upstream feature"]
+
+        def _validate_v2_model_runner(self) -> None:
+            unsupported = self._get_v2_model_runner_unsupported_features()
+            if unsupported:
+                raise ValueError(
+                    f"Model Runner V2 does not yet support: {', '.join(unsupported)}"
+                )
+
+    module.ModelConfig = ModelConfig
+    module.VllmConfig = VllmConfig
+    return module
+
+
+def _as_fake_vllm_config(module: ModuleType, config: object) -> object:
+    patched_config = object.__new__(module.VllmConfig)
+    patched_config.__dict__.update(vars(config))
+    return patched_config
+
+
+def test_valid_glm52_pcp_removes_only_the_upstream_pcp_rejection(
+    make_pcp_config,
+) -> None:
+    """Restoring the original unsupported list must reject valid GLM PCP."""
+
+    module = _make_vllm_module()
+    assert patch_vllm_config.apply_to_module(module) is True
+    config = _as_fake_vllm_config(module, make_pcp_config(pcp=2))
+
+    assert config._get_v2_model_runner_unsupported_features() == []
+    config._validate_v2_model_runner()
+
+
+def test_pcp1_preserves_upstream_v2_unsupported_feature_and_validation(
+    make_pcp_config,
+) -> None:
+    """Accidentally bypassing non-PCP V2 validation must fail this test."""
+
+    module = _make_vllm_module()
+    assert patch_vllm_config.apply_to_module(module) is True
+    config = _as_fake_vllm_config(module, make_pcp_config(pcp=1))
+
+    assert config._get_v2_model_runner_unsupported_features() == ["upstream feature"]
+    with pytest.raises(ValueError, match="upstream feature"):
+        config._validate_v2_model_runner()
+
+
+def test_invalid_pcp_preserves_upstream_pcp_rejection(make_pcp_config) -> None:
+    """Relaxing PCP before its HCU scope passes must remain impossible."""
+
+    module = _make_vllm_module()
+    assert patch_vllm_config.apply_to_module(module) is True
+    config = _as_fake_vllm_config(
+        module, make_pcp_config(pcp=2, use_mla=False)
+    )
+
+    assert config._get_v2_model_runner_unsupported_features() == [
+        "prefill context parallelism"
+    ]
+    with pytest.raises(ValueError, match="prefill context parallelism"):
+        config._validate_v2_model_runner()
+
+
+def test_pcp_patch_rejects_v0251_wrapper_signature_drift() -> None:
+    """Changing either v0.25.1 wrapper boundary must fail patch installation."""
+
+    module = _make_vllm_module()
+
+    def incompatible_unsupported(self, feature: object) -> list[str]:
+        del self, feature
+        return []
+
+    module.VllmConfig._get_v2_model_runner_unsupported_features = (
+        incompatible_unsupported
+    )
+    with pytest.raises(PatchCompatibilityError, match="incompatible signature"):
+        patch_vllm_config.apply_to_module(module)

--- a/tests/runtime_patch/test_glm52_pcp_config.py
+++ b/tests/runtime_patch/test_glm52_pcp_config.py
@@ -210,6 +210,22 @@ def test_pcp_patch_rejects_v0251_wrapper_signature_drift() -> None:
         patch_vllm_config.apply_to_module(module)
 
 
+def test_model_arch_config_signature_drift_names_exact_target() -> None:
+    module = _make_vllm_module()
+
+    def incompatible_model_arch_config(self, feature: object) -> object:
+        del self, feature
+        return None
+
+    module.ModelConfig.get_model_arch_config = incompatible_model_arch_config
+
+    with pytest.raises(PatchCompatibilityError) as error:
+        patch_vllm_config.apply_to_module(module)
+
+    assert patch_vllm_config.TARGETS[4] in str(error.value)
+    assert patch_vllm_config.TARGETS[2] not in str(error.value)
+
+
 class _LifecycleCompilationConfig:
     def __init__(self) -> None:
         self.cudagraph_mode = SimpleNamespace(has_full_cudagraphs=lambda: False)

--- a/tests/runtime_patch/test_glm52_pcp_kv_cache.py
+++ b/tests/runtime_patch/test_glm52_pcp_kv_cache.py
@@ -1,0 +1,549 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""GLM-5.2 PCP keeps complete per-rank KV cache ownership."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+os.environ.setdefault("VLLM_PLUGINS", "__disabled__")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TARGET_VLLM_ROOT = Path(
+    os.environ.get("VLLM_V0251_SOURCE_ROOT", REPO_ROOT.parent / "vllm_0251")
+).resolve()
+if not (TARGET_VLLM_ROOT / "vllm/__init__.py").is_file():
+    raise RuntimeError(
+        f"VLLM_V0251_SOURCE_ROOT does not contain vllm: {TARGET_VLLM_ROOT}"
+    )
+if str(TARGET_VLLM_ROOT) not in sys.path:
+    sys.path.insert(0, str(TARGET_VLLM_ROOT))
+
+
+def _full_attention_spec(block_size: int):
+    from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+    return FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=8,
+        dtype=torch.float16,
+    )
+
+
+def _kv_cache_config(*block_sizes: int, num_blocks: int = 32):
+    from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec
+
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                layer_names=[f"model.layers.{index}.self_attn"],
+                kv_cache_spec=_full_attention_spec(block_size),
+            )
+            for index, block_size in enumerate(block_sizes)
+        ],
+    )
+
+
+def _vllm_config(
+    *,
+    block_size: int,
+    dcp: int,
+    pcp: int,
+    max_model_len: int = 4096,
+    enable_prefix_caching: bool = True,
+    hash_block_size: int | None = None,
+):
+    return SimpleNamespace(
+        cache_config=SimpleNamespace(
+            block_size=block_size,
+            enable_prefix_caching=enable_prefix_caching,
+            hash_block_size=hash_block_size,
+        ),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp,
+            prefill_context_parallel_size=pcp,
+        ),
+        model_config=SimpleNamespace(max_model_len=max_model_len),
+        kv_transfer_config=None,
+    )
+
+
+@pytest.fixture(scope="module")
+def patched_cache_modules():
+    from vllm_hcu.patch.platform import apply_platform_patches
+
+    apply_platform_patches()
+
+    from vllm.v1 import kv_cache_interface
+    from vllm.v1.core import (
+        kv_cache_coordinator,
+        kv_cache_utils,
+        single_type_kv_cache_manager,
+    )
+
+    return SimpleNamespace(
+        interface=kv_cache_interface,
+        coordinator=kv_cache_coordinator,
+        resolve=kv_cache_utils.resolve_kv_cache_block_sizes,
+        manager=single_type_kv_cache_manager,
+    )
+
+
+@pytest.mark.parametrize(
+    ("dcp", "pcp", "expected_effective_block_size"),
+    [(1, 1, 64), (1, 2, 64), (2, 1, 128)],
+)
+def test_attention_kv_ownership_is_dcp_only(
+    patched_cache_modules, dcp, pcp, expected_effective_block_size
+):
+    scheduler_size, hash_size = patched_cache_modules.resolve(
+        _kv_cache_config(64),
+        _vllm_config(block_size=64, dcp=dcp, pcp=pcp),
+    )
+
+    assert scheduler_size == expected_effective_block_size
+    assert hash_size == expected_effective_block_size
+
+
+@pytest.mark.parametrize(
+    ("dcp", "pcp", "expected_scheduler", "expected_hash"),
+    [(1, 1, 48, 8), (1, 2, 48, 8), (2, 2, 96, 16)],
+)
+def test_multi_group_resolution_scales_attention_groups_by_dcp_only(
+    patched_cache_modules, dcp, pcp, expected_scheduler, expected_hash
+):
+    scheduler_size, hash_size = patched_cache_modules.resolve(
+        _kv_cache_config(16, 24),
+        _vllm_config(block_size=16, dcp=dcp, pcp=pcp),
+    )
+
+    assert scheduler_size == expected_scheduler
+    assert hash_size == expected_hash
+
+
+@pytest.mark.parametrize(
+    ("dcp", "pcp", "expected_blocks"),
+    [(1, 1, 5), (1, 2, 5), (2, 1, 3)],
+)
+def test_full_attention_memory_capacity_is_not_divided_by_pcp(
+    patched_cache_modules, dcp, pcp, expected_blocks
+):
+    spec = _full_attention_spec(16)
+    config = _vllm_config(
+        block_size=16,
+        dcp=dcp,
+        pcp=pcp,
+        max_model_len=65,
+    )
+
+    assert spec.max_memory_usage_bytes(config) == expected_blocks * 512
+
+
+@pytest.mark.parametrize(
+    ("dcp", "pcp", "expected_block_size"),
+    [(1, 1, 16), (1, 2, 16), (2, 1, 32)],
+)
+def test_single_type_manager_allocation_granularity_is_dcp_only(
+    patched_cache_modules, dcp, pcp, expected_block_size
+):
+    pool = SimpleNamespace(null_block=object())
+    manager = patched_cache_modules.manager.FullAttentionManager(
+        kv_cache_spec=_full_attention_spec(16),
+        block_pool=pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=expected_block_size,
+        dcp_world_size=dcp,
+        pcp_world_size=pcp,
+    )
+
+    assert manager.block_size == expected_block_size
+    assert manager.dcp_world_size == dcp
+    assert manager.pcp_world_size == pcp
+
+
+@pytest.mark.parametrize(
+    ("dcp", "pcp", "expected_hits"),
+    [(1, 1, 2), (1, 2, 2), (2, 1, 1)],
+)
+def test_full_attention_hash_lookup_uses_dcp_only(
+    patched_cache_modules, dcp, pcp, expected_hits
+):
+    cached = [object(), object()]
+
+    class BlockPool:
+        def get_cached_block(self, block_hash, kv_cache_group_ids):
+            del kv_cache_group_ids
+            return [cached[int(block_hash)]]
+
+    hits = patched_cache_modules.manager.FullAttentionManager.find_longest_cache_hit(
+        block_hashes=[0, 1],
+        max_length=32,
+        kv_cache_group_ids=[0],
+        block_pool=BlockPool(),
+        kv_cache_spec=_full_attention_spec(16),
+        drop_eagle_block=False,
+        alignment_tokens=16 * dcp,
+        dcp_world_size=dcp,
+        pcp_world_size=pcp,
+    )
+
+    assert len(hits[0]) == expected_hits
+
+
+@pytest.mark.parametrize(
+    ("dcp", "pcp", "expected_block_size"),
+    [(1, 1, 16), (1, 2, 16), (2, 1, 32)],
+)
+def test_unitary_coordinator_block_size_is_dcp_only(
+    monkeypatch, patched_cache_modules, dcp, pcp, expected_block_size
+):
+    coordinator_module = patched_cache_modules.coordinator
+    base_calls: list[tuple[int, int]] = []
+
+    def base_init(
+        self,
+        kv_cache_config,
+        max_model_len,
+        max_num_batched_tokens,
+        use_eagle,
+        enable_caching,
+        enable_kv_cache_events,
+        dcp_world_size,
+        pcp_world_size,
+        scheduler_block_size,
+        hash_block_size,
+        metrics_collector=None,
+    ):
+        del (
+            max_model_len,
+            max_num_batched_tokens,
+            use_eagle,
+            enable_caching,
+            enable_kv_cache_events,
+            scheduler_block_size,
+            hash_block_size,
+            metrics_collector,
+        )
+        base_calls.append((dcp_world_size, pcp_world_size))
+        self.kv_cache_config = kv_cache_config
+        self.eagle_group_ids = set()
+        self.single_type_managers = [SimpleNamespace(use_eagle=False)]
+
+    monkeypatch.setattr(coordinator_module.KVCacheCoordinator, "__init__", base_init)
+    coordinator = coordinator_module.UnitaryKVCacheCoordinator(
+        _kv_cache_config(16),
+        4096,
+        256,
+        False,
+        False,
+        False,
+        dcp,
+        pcp,
+        expected_block_size,
+        expected_block_size,
+    )
+
+    assert coordinator.block_size == expected_block_size
+    assert coordinator.dcp_world_size == dcp
+    assert coordinator.pcp_world_size == pcp
+    assert base_calls == [(dcp, pcp)]
+
+
+@pytest.mark.parametrize(
+    ("dcp", "pcp", "expected_max_blocks"),
+    [(1, 1, 16), (1, 4, 16), (2, 4, 8)],
+)
+def test_mrv2_block_table_capacity_already_depends_on_dcp_only(
+    monkeypatch, dcp, pcp, expected_max_blocks
+):
+    from vllm.v1.worker.gpu import model_runner
+
+    captured: dict[str, object] = {}
+
+    class StopAfterBlockTables(RuntimeError):
+        pass
+
+    class BlockTables:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            raise StopAfterBlockTables
+
+    monkeypatch.setattr(
+        model_runner,
+        "init_attn_backend",
+        lambda *args, **kwargs: (
+            [],
+            SimpleNamespace(min_cg_support=None, min_cg_attn_backend=None),
+            [64],
+        ),
+    )
+    monkeypatch.setattr(model_runner, "BlockTables", BlockTables)
+
+    runner = object.__new__(model_runner.GPUModelRunner)
+    runner.max_model_len = 1024
+    runner.is_encoder_decoder = False
+    runner.max_num_reqs = 4
+    runner.max_num_tokens = 256
+    runner.device = torch.device("cpu")
+    runner.dcp_size = dcp
+    runner.dcp_rank = 0
+    runner.cp_interleave = 1
+    runner.parallel_config = SimpleNamespace(
+        decode_context_parallel_size=dcp,
+        prefill_context_parallel_size=pcp,
+    )
+    runner.vllm_config = SimpleNamespace()
+
+    with pytest.raises(StopAfterBlockTables):
+        model_runner.GPUModelRunner.initialize_kv_cache(
+            runner, _kv_cache_config(64)
+        )
+
+    assert captured["max_num_blocks_per_group"] == [expected_max_blocks]
+    assert captured["cp_size"] == dcp
+
+
+def test_cache_adapters_are_idempotent_after_platform_registration(
+    patched_cache_modules,
+):
+    del patched_cache_modules
+    from vllm_hcu.patch.platform.framework_opt import (
+        patch_pcp_kv_cache_coordinator,
+        patch_pcp_kv_cache_interface,
+        patch_pcp_kv_cache_utils,
+        patch_pcp_single_type_kv_cache_manager,
+    )
+
+    assert patch_pcp_kv_cache_utils.apply() is False
+    assert patch_pcp_kv_cache_interface.apply() is False
+    assert patch_pcp_single_type_kv_cache_manager.apply() is False
+    assert patch_pcp_kv_cache_coordinator.apply() is False
+
+
+def test_cache_adapters_fail_closed_on_signature_drift():
+    from vllm_hcu.patch.platform.framework_opt import (
+        patch_pcp_kv_cache_coordinator,
+        patch_pcp_kv_cache_interface,
+        patch_pcp_kv_cache_utils,
+        patch_pcp_single_type_kv_cache_manager,
+    )
+    from vllm_hcu.patch.platform.framework_opt._common import (
+        PatchCompatibilityError,
+    )
+
+    utils = ModuleType(patch_pcp_kv_cache_utils.TARGET_MODULE)
+    utils.resolve_kv_cache_block_sizes = lambda config: config
+    with pytest.raises(PatchCompatibilityError, match="incompatible signature"):
+        patch_pcp_kv_cache_utils.apply_to_module(utils)
+
+    interface = ModuleType(patch_pcp_kv_cache_interface.TARGET_MODULE)
+
+    class FullAttentionSpec:
+        def max_memory_usage_bytes(self, config, extra):
+            del self, config, extra
+
+    interface.FullAttentionSpec = FullAttentionSpec
+    with pytest.raises(PatchCompatibilityError, match="incompatible signature"):
+        patch_pcp_kv_cache_interface.apply_to_module(interface)
+
+    managers = ModuleType(patch_pcp_single_type_kv_cache_manager.TARGET_MODULE)
+
+    class SingleTypeKVCacheManager:
+        def __init__(self, kv_cache_spec):
+            del self, kv_cache_spec
+
+    class FullAttentionManager(SingleTypeKVCacheManager):
+        @classmethod
+        def find_longest_cache_hit(cls):
+            del cls
+
+    managers.SingleTypeKVCacheManager = SingleTypeKVCacheManager
+    managers.FullAttentionManager = FullAttentionManager
+    with pytest.raises(PatchCompatibilityError, match="incompatible signature"):
+        patch_pcp_single_type_kv_cache_manager.apply_to_module(managers)
+
+    coordinator = ModuleType(patch_pcp_kv_cache_coordinator.TARGET_MODULE)
+
+    class UnitaryKVCacheCoordinator:
+        def __init__(self, kv_cache_config):
+            del self, kv_cache_config
+
+    coordinator.UnitaryKVCacheCoordinator = UnitaryKVCacheCoordinator
+    with pytest.raises(PatchCompatibilityError, match="incompatible signature"):
+        patch_pcp_kv_cache_coordinator.apply_to_module(coordinator)
+
+
+def test_pcp1_cache_adapters_delegate_to_original_implementations():
+    from vllm_hcu.patch.platform.framework_opt import (
+        patch_pcp_kv_cache_coordinator,
+        patch_pcp_kv_cache_interface,
+        patch_pcp_kv_cache_utils,
+        patch_pcp_single_type_kv_cache_manager,
+    )
+
+    calls: list[tuple[str, int]] = []
+    config = _vllm_config(block_size=16, dcp=1, pcp=1)
+
+    utils = ModuleType(patch_pcp_kv_cache_utils.TARGET_MODULE)
+
+    class AttentionSpec:
+        pass
+
+    class MambaSpec:
+        pass
+
+    def resolve(kv_cache_config, vllm_config):
+        del kv_cache_config
+        calls.append(
+            (
+                "resolve",
+                vllm_config.parallel_config.prefill_context_parallel_size,
+            )
+        )
+        return 7, 11
+
+    utils.AttentionSpec = AttentionSpec
+    utils.MambaSpec = MambaSpec
+    utils.resolve_kv_cache_block_sizes = resolve
+    assert patch_pcp_kv_cache_utils.apply_to_module(utils) is True
+    assert utils.resolve_kv_cache_block_sizes(SimpleNamespace(), config) == (7, 11)
+
+    interface = ModuleType(patch_pcp_kv_cache_interface.TARGET_MODULE)
+
+    class FullAttentionSpec:
+        def max_memory_usage_bytes(self, vllm_config):
+            calls.append(
+                (
+                    "memory",
+                    vllm_config.parallel_config.prefill_context_parallel_size,
+                )
+            )
+            return 13
+
+    interface.FullAttentionSpec = FullAttentionSpec
+    interface.cdiv = lambda numerator, denominator: (
+        numerator + denominator - 1
+    ) // denominator
+    assert patch_pcp_kv_cache_interface.apply_to_module(interface) is True
+    assert FullAttentionSpec().max_memory_usage_bytes(config) == 13
+
+    managers = ModuleType(patch_pcp_single_type_kv_cache_manager.TARGET_MODULE)
+
+    class SingleTypeKVCacheManager:
+        def __init__(
+            self,
+            kv_cache_spec,
+            block_pool,
+            enable_caching,
+            kv_cache_group_id,
+            scheduler_block_size,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            max_admission_blocks_per_request=None,
+        ):
+            del (
+                kv_cache_spec,
+                block_pool,
+                enable_caching,
+                kv_cache_group_id,
+                scheduler_block_size,
+                dcp_world_size,
+                max_admission_blocks_per_request,
+            )
+            calls.append(("manager", pcp_world_size))
+
+    class FullAttentionManager(SingleTypeKVCacheManager):
+        @classmethod
+        def find_longest_cache_hit(
+            cls,
+            block_hashes,
+            max_length,
+            kv_cache_group_ids,
+            block_pool,
+            kv_cache_spec,
+            drop_eagle_block,
+            alignment_tokens,
+            dcp_world_size=1,
+            pcp_world_size=1,
+        ):
+            del (
+                cls,
+                block_hashes,
+                max_length,
+                kv_cache_group_ids,
+                block_pool,
+                kv_cache_spec,
+                drop_eagle_block,
+                alignment_tokens,
+                dcp_world_size,
+            )
+            calls.append(("hash", pcp_world_size))
+            return (["original"],)
+
+    managers.SingleTypeKVCacheManager = SingleTypeKVCacheManager
+    managers.FullAttentionManager = FullAttentionManager
+    assert patch_pcp_single_type_kv_cache_manager.apply_to_module(managers) is True
+    FullAttentionManager(None, None, False, 0, 16, pcp_world_size=1)
+    assert FullAttentionManager.find_longest_cache_hit(
+        [], 0, [0], None, None, False, 16, pcp_world_size=1
+    ) == (["original"],)
+
+    coordinator = ModuleType(patch_pcp_kv_cache_coordinator.TARGET_MODULE)
+
+    class KVCacheCoordinator:
+        pass
+
+    class UnitaryKVCacheCoordinator(KVCacheCoordinator):
+        def __init__(
+            self,
+            kv_cache_config,
+            max_model_len,
+            max_num_batched_tokens,
+            use_eagle,
+            enable_caching,
+            enable_kv_cache_events,
+            dcp_world_size,
+            pcp_world_size,
+            scheduler_block_size,
+            hash_block_size,
+            metrics_collector=None,
+        ):
+            del (
+                self,
+                kv_cache_config,
+                max_model_len,
+                max_num_batched_tokens,
+                use_eagle,
+                enable_caching,
+                enable_kv_cache_events,
+                dcp_world_size,
+                scheduler_block_size,
+                hash_block_size,
+                metrics_collector,
+            )
+            calls.append(("coordinator", pcp_world_size))
+
+    coordinator.KVCacheCoordinator = KVCacheCoordinator
+    coordinator.UnitaryKVCacheCoordinator = UnitaryKVCacheCoordinator
+    assert patch_pcp_kv_cache_coordinator.apply_to_module(coordinator) is True
+    UnitaryKVCacheCoordinator(None, 1, 1, False, False, False, 1, 1, 16, 16)
+
+    assert calls == [
+        ("resolve", 1),
+        ("memory", 1),
+        ("manager", 1),
+        ("hash", 1),
+        ("coordinator", 1),
+    ]

--- a/tests/runtime_patch/test_glm52_pcp_manager.py
+++ b/tests/runtime_patch/test_glm52_pcp_manager.py
@@ -281,6 +281,45 @@ def test_dual_chunk_swap_uses_symmetric_segments_and_keeps_empty_rows() -> None:
     assert any(segment.start == segment.stop for segment in segments)
 
 
+def test_two_token_warmup_prefill_drops_empty_runtime_rows() -> None:
+    """Zero-token chunks must not become bogus sparse-indexer decodes."""
+
+    global_batch = _make_batch(
+        [("warmup-prefill", [10, 11], 2, True)]
+    )
+    managers, _ = _make_managers()
+
+    for manager in managers:
+        local = manager.partition_batch(global_batch)
+        assert local.req_ids == ["warmup-prefill"]
+        assert local.num_reqs == 1
+        assert local.num_scheduled_tokens.tolist() == [1]
+        assert local.query_start_loc_np.tolist() == [0, 1]
+        assert local.is_prefilling_np.tolist() == [True]
+
+
+def test_one_token_prefill_keeps_one_dummy_row_on_the_empty_rank() -> None:
+    """An empty PCP rank still needs a valid prefill metadata row."""
+
+    global_batch = _make_batch(
+        [("one-token-prefill", [10], 1, True)]
+    )
+    managers, _ = _make_managers()
+    local_batches = [
+        manager.partition_batch(global_batch) for manager in managers
+    ]
+
+    assert local_batches[0].num_scheduled_tokens.tolist() == [1]
+    empty_rank = local_batches[1]
+    assert empty_rank.req_ids == ["one-token-prefill"]
+    assert empty_rank.num_reqs == 1
+    assert empty_rank.num_tokens == 0
+    assert empty_rank.num_tokens_after_padding == 1
+    assert empty_rank.num_scheduled_tokens.tolist() == [0]
+    assert empty_rank.query_start_loc_np.tolist() == [0, 0]
+    assert empty_rank.is_prefilling_np.tolist() == [True]
+
+
 def test_partition_creates_two_prefill_rows_and_replicates_decode() -> None:
     """Treating decode like prefill must desynchronize decode request rows."""
 

--- a/tests/runtime_patch/test_glm52_pcp_manager.py
+++ b/tests/runtime_patch/test_glm52_pcp_manager.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""CPU-only contracts for the GLM-5.2 virtual-batch PCP manager."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm_hcu.patch.config import HcuFeatureConfig
+from vllm_hcu.v1.pcp_manager import (
+    HcuPCPManager,
+    RankSegment,
+    maybe_build_pcp_manager,
+    maybe_partition_pcp_batch,
+    maybe_restore_pcp_for_sampling,
+)
+
+
+class _InMemoryPCPGroup:
+    """Deterministic all-gather double; no accelerator process group needed."""
+
+    def __init__(self, rank: int, world_size: int) -> None:
+        self.rank_in_group = rank
+        self.world_size = world_size
+        self.gathered: list[torch.Tensor] | None = None
+        self.collective_calls = 0
+
+    def all_gather(self, tensor: torch.Tensor, dim: int = 0) -> torch.Tensor:
+        self.collective_calls += 1
+        assert dim == 0
+        assert self.gathered is not None
+        assert torch.equal(tensor, self.gathered[self.rank_in_group])
+        return torch.cat(self.gathered, dim=dim)
+
+
+class _InMemoryBlockTables:
+    """Block/slot table double that performs real tensor indexing on CPU."""
+
+    def __init__(self) -> None:
+        canonical = torch.arange(32 * 4, dtype=torch.int32).reshape(32, 4)
+        self.block_tables = [SimpleNamespace(gpu=canonical)]
+        self.input_block_tables = [torch.full_like(canonical, -77)]
+        self.num_kv_cache_groups = 1
+        self.slot_mappings = torch.empty((1, 128), dtype=torch.int64)
+
+    def gather_block_tables(
+        self,
+        idx_mapping: torch.Tensor,
+        num_reqs: int,
+    ) -> tuple[torch.Tensor, ...]:
+        raise AssertionError(
+            "PCP must not gather into runner-owned v0.25.1 input block tables"
+        )
+
+    def compute_slot_mappings(
+        self,
+        idx_mapping: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        positions: torch.Tensor,
+        num_tokens: int,
+    ) -> torch.Tensor:
+        for req_idx in range(idx_mapping.numel()):
+            start = int(query_start_loc[req_idx])
+            stop = int(query_start_loc[req_idx + 1])
+            self.slot_mappings[0, start:stop] = (
+                idx_mapping[req_idx] * 100 + positions[start:stop]
+            )
+        return self.slot_mappings[:, :num_tokens]
+
+
+def _make_config(pcp_size: int = 2, **overrides: object) -> object:
+    values = {
+        "architecture": "GlmMoeDsaForCausalLM",
+        "use_v2": True,
+        "use_mla": True,
+        "pp": 1,
+        "dcp": 1,
+        "dp": 1,
+        "enable_expert_parallel": True,
+        "enforce_eager": True,
+    }
+    values.update(overrides)
+    return SimpleNamespace(
+        use_v2_model_runner=values["use_v2"],
+        model_config=SimpleNamespace(
+            architectures=[values["architecture"]],
+            use_mla=values["use_mla"],
+            enforce_eager=values["enforce_eager"],
+            is_multimodal_model=False,
+        ),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=4,
+            prefill_context_parallel_size=pcp_size,
+            pipeline_parallel_size=values["pp"],
+            decode_context_parallel_size=values["dcp"],
+            data_parallel_size=values["dp"],
+            enable_expert_parallel=values["enable_expert_parallel"],
+            cp_kv_cache_interleave_size=1,
+        ),
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=16,
+            max_num_batched_tokens=128,
+        ),
+        speculative_config=None,
+        lora_config=None,
+        cache_config=SimpleNamespace(kv_offloading_size=None),
+        kv_transfer_config=None,
+        additional_config={"hcu": HcuFeatureConfig().to_dict()},
+    )
+
+
+def _make_batch(
+    requests: list[tuple[str, list[int], int, bool]],
+    *,
+    pad_to: int | None = None,
+) -> InputBatch:
+    """Build a literal MRV2 step batch on CPU.
+
+    Each request tuple is ``(req_id, scheduled_token_ids, seq_len,
+    is_prefilling)``. Token IDs are intentionally globally unique so restored
+    order is independently visible in hidden states.
+    """
+
+    num_reqs = len(requests)
+    num_scheduled_tokens = np.asarray(
+        [len(tokens) for _, tokens, _, _ in requests], dtype=np.int32
+    )
+    num_tokens = int(num_scheduled_tokens.sum())
+    num_tokens_after_padding = pad_to or num_tokens
+    assert num_tokens_after_padding >= num_tokens
+
+    query_start_loc_np = np.empty(num_reqs + 1, dtype=np.int32)
+    query_start_loc_np[0] = 0
+    np.cumsum(num_scheduled_tokens, out=query_start_loc_np[1:])
+    query_start_loc = torch.from_numpy(query_start_loc_np.copy())
+
+    input_ids = torch.full((num_tokens_after_padding,), -99, dtype=torch.int32)
+    positions = torch.full((num_tokens_after_padding,), -99, dtype=torch.int64)
+    is_padding = torch.ones(num_tokens_after_padding, dtype=torch.bool)
+    num_computed_tokens_np = np.empty(num_reqs, dtype=np.int32)
+    for req_idx, (_, tokens, seq_len, _) in enumerate(requests):
+        start = int(query_start_loc_np[req_idx])
+        stop = int(query_start_loc_np[req_idx + 1])
+        computed = seq_len - len(tokens)
+        input_ids[start:stop] = torch.tensor(tokens, dtype=torch.int32)
+        positions[start:stop] = torch.arange(computed, seq_len)
+        is_padding[start:stop] = False
+        num_computed_tokens_np[req_idx] = computed
+
+    idx_mapping_np = np.arange(10, 10 + num_reqs, dtype=np.int32)
+    idx_mapping = torch.from_numpy(idx_mapping_np.copy())
+    cu_num_logits_np = np.arange(num_reqs + 1, dtype=np.int32)
+    return InputBatch(
+        req_ids=[req_id for req_id, _, _, _ in requests],
+        num_reqs=num_reqs,
+        num_reqs_after_padding=num_reqs,
+        idx_mapping=idx_mapping,
+        idx_mapping_np=idx_mapping_np,
+        expanded_idx_mapping=idx_mapping.clone(),
+        expanded_local_pos=torch.zeros(num_reqs, dtype=torch.int32),
+        num_scheduled_tokens=num_scheduled_tokens,
+        num_tokens=num_tokens,
+        num_tokens_after_padding=num_tokens_after_padding,
+        num_draft_tokens=0,
+        num_draft_tokens_per_req=None,
+        query_start_loc=query_start_loc,
+        query_start_loc_np=query_start_loc_np,
+        seq_lens=torch.tensor(
+            [seq_len for _, _, seq_len, _ in requests], dtype=torch.int32
+        ),
+        seq_lens_cpu_upper_bound=torch.tensor(
+            [seq_len for _, _, seq_len, _ in requests], dtype=torch.int32
+        ),
+        dcp_local_seq_lens=None,
+        num_computed_tokens_np=num_computed_tokens_np,
+        prefill_len_np=np.asarray(
+            [
+                seq_len if is_prefilling else 0
+                for _, _, seq_len, is_prefilling in requests
+            ],
+            dtype=np.int32,
+        ),
+        num_computed_prefill_tokens_np=num_computed_tokens_np.copy(),
+        is_prefilling_np=np.asarray(
+            [is_prefilling for _, _, _, is_prefilling in requests], dtype=np.bool_
+        ),
+        max_seq_len_np=None,
+        input_ids=input_ids,
+        positions=positions,
+        is_padding=is_padding,
+        logits_indices=query_start_loc[1:] - 1,
+        cu_num_logits=torch.from_numpy(cu_num_logits_np.copy()),
+        cu_num_logits_np=cu_num_logits_np,
+        has_structured_output_reqs=False,
+        prompt_lens=None,
+    )
+
+
+def _snapshot_batch(batch: InputBatch) -> dict[str, object]:
+    snapshot: dict[str, object] = {}
+    for name, value in vars(batch).items():
+        if isinstance(value, torch.Tensor):
+            snapshot[name] = value.clone()
+        elif isinstance(value, np.ndarray):
+            snapshot[name] = value.copy()
+        else:
+            snapshot[name] = deepcopy(value)
+    return snapshot
+
+
+def _assert_batch_matches_snapshot(
+    batch: InputBatch, snapshot: dict[str, object]
+) -> None:
+    for name, expected in snapshot.items():
+        actual = getattr(batch, name)
+        if isinstance(expected, torch.Tensor):
+            assert torch.equal(actual, expected), name
+        elif isinstance(expected, np.ndarray):
+            assert np.array_equal(actual, expected), name
+        else:
+            assert actual == expected, name
+
+
+def _make_managers(
+    pcp_size: int = 2,
+    *,
+    block_tables: object | None = None,
+) -> tuple[list[HcuPCPManager], list[_InMemoryPCPGroup]]:
+    groups = [_InMemoryPCPGroup(rank, pcp_size) for rank in range(pcp_size)]
+    managers = [
+        HcuPCPManager(
+            _make_config(pcp_size),
+            torch.device("cpu"),
+            req_states=SimpleNamespace(),
+            block_tables=[] if block_tables is None else block_tables,
+            pcp_group=groups[rank],
+        )
+        for rank in range(pcp_size)
+    ]
+    return managers, groups
+
+
+@pytest.mark.parametrize("length", [1, 2, 7, 8, 9, 31])
+def test_dual_chunk_swap_covers_each_prefill_token_once(length: int) -> None:
+    """A wrong chunk boundary must drop or duplicate a global prompt token."""
+
+    segments = [
+        HcuPCPManager.rank_segments(length, pcp_rank=rank, pcp_size=2)
+        for rank in range(2)
+    ]
+    covered = sorted(
+        token
+        for rank_segments in segments
+        for segment in rank_segments
+        for token in range(segment.start, segment.stop)
+    )
+    assert covered == list(range(length))
+    assert all(len(rank_segments) == 2 for rank_segments in segments)
+
+
+def test_dual_chunk_swap_uses_symmetric_segments_and_keeps_empty_rows() -> None:
+    """Collapsing either virtual row must break the two-row attention layout."""
+
+    assert HcuPCPManager.rank_segments(8, pcp_rank=0, pcp_size=2) == (
+        RankSegment(0, 2),
+        RankSegment(6, 8),
+    )
+    assert HcuPCPManager.rank_segments(8, pcp_rank=1, pcp_size=2) == (
+        RankSegment(2, 4),
+        RankSegment(4, 6),
+    )
+    segments = HcuPCPManager.rank_segments(1, pcp_rank=1, pcp_size=2)
+    assert len(segments) == 2
+    assert any(segment.start == segment.stop for segment in segments)
+
+
+def test_partition_creates_two_prefill_rows_and_replicates_decode() -> None:
+    """Treating decode like prefill must desynchronize decode request rows."""
+
+    global_batch = _make_batch(
+        [("prefill", list(range(100, 108)), 8, True), ("decode", [900], 17, False)]
+    )
+    snapshot = _snapshot_batch(global_batch)
+    managers, _ = _make_managers()
+    local_batches = [manager.partition_batch(global_batch) for manager in managers]
+
+    for local in local_batches:
+        assert local.req_ids.count("prefill") == 2
+        assert local.req_ids.count("decode") == 1
+        assert local.num_reqs == 3
+        assert sorted(local.idx_mapping_np.tolist()) == [10, 10, 11]
+        decode_row = local.req_ids.index("decode")
+        decode_start = int(local.query_start_loc_np[decode_row])
+        decode_stop = int(local.query_start_loc_np[decode_row + 1])
+        assert local.input_ids[decode_start:decode_stop].tolist() == [900]
+
+    prefill_tokens = sorted(
+        token
+        for local in local_batches
+        for row, req_id in enumerate(local.req_ids)
+        if req_id == "prefill"
+        for token in local.input_ids[
+            int(local.query_start_loc_np[row]) : int(local.query_start_loc_np[row + 1])
+        ].tolist()
+    )
+    assert prefill_tokens == list(range(100, 108))
+    _assert_batch_matches_snapshot(global_batch, snapshot)
+
+
+def test_partition_pads_each_rank_to_equal_width_and_remaps_logits() -> None:
+    """Unequal rank widths would make the hidden-state collective invalid."""
+
+    global_batch = _make_batch(
+        [("short", [10], 1, True), ("uneven", list(range(20, 29)), 9, True)],
+        pad_to=12,
+    )
+    managers, _ = _make_managers()
+    local_batches = [manager.partition_batch(global_batch) for manager in managers]
+
+    assert len({local.num_tokens_after_padding for local in local_batches}) == 1
+    for local in local_batches:
+        assert local.num_tokens == int(local.num_scheduled_tokens.sum())
+        assert local.input_ids.shape == local.positions.shape == local.is_padding.shape
+        assert local.input_ids.numel() == local.num_tokens_after_padding
+        nonempty_stops = [
+            int(local.query_start_loc_np[row + 1] - 1)
+            for row, count in enumerate(local.num_scheduled_tokens)
+            if count > 0
+        ]
+        assert local.logits_indices.tolist() == nonempty_stops
+        assert local.cu_num_logits_np.tolist() == np.cumsum(
+            [0]
+            + [int(count > 0) for count in local.num_scheduled_tokens]
+        ).tolist()
+
+
+def test_restore_returns_global_token_and_request_order() -> None:
+    """Rank-order concatenation without the global mapping must scramble output."""
+
+    global_batch = _make_batch(
+        [
+            ("a", list(range(100, 107)), 7, True),
+            ("decode", [500], 23, False),
+            ("b", list(range(200, 209)), 9, True),
+        ]
+    )
+    managers, groups = _make_managers()
+    local_batches = [manager.partition_batch(global_batch) for manager in managers]
+    local_hidden = [
+        local.input_ids.to(torch.float32).unsqueeze(1)
+        for local in local_batches
+    ]
+    for group in groups:
+        group.gathered = local_hidden
+
+    expected = global_batch.input_ids[: global_batch.num_tokens].to(torch.float32)
+    for manager, local in zip(managers, local_hidden):
+        restored = manager.restore_hidden_states(local)
+        assert restored[:, 0].tolist() == expected.tolist()
+        sampled_hidden, sampled_batch = manager.restore_for_sampling(local)
+        assert sampled_hidden[:, 0].tolist() == expected.tolist()
+        assert sampled_batch is global_batch
+
+
+def test_dummy_slots_are_invalid_without_touching_real_block_tables() -> None:
+    """A zero dummy slot could accidentally write a real KV cache block."""
+
+    manager, _ = _make_managers(block_tables=_InMemoryBlockTables())
+    slots = manager[0].get_dummy_slot_mappings(5)
+    assert slots.dtype == torch.int64
+    assert slots.device.type == "cpu"
+    assert slots.tolist() == [[-1] * 10]
+
+
+def test_prepare_attn_uses_local_rows_but_global_kv_slot_ownership() -> None:
+    """Replicated decode slots must be writable on exactly one PCP rank."""
+
+    block_tables = _InMemoryBlockTables()
+    global_batch = _make_batch(
+        [("prefill", list(range(100, 108)), 8, True), ("decode", [900], 17, False)]
+    )
+    managers, _ = _make_managers(block_tables=block_tables)
+    local_batches = [manager.partition_batch(global_batch) for manager in managers]
+    runner_owned_tables = [table.clone() for table in block_tables.input_block_tables]
+
+    for manager, local in zip(managers, local_batches):
+        local_tables, gathered_slots = manager.prepare_attn(local)
+        assert torch.equal(
+            local_tables[0],
+            block_tables.block_tables[0].gpu[local.idx_mapping.to(torch.int64)],
+        )
+        written_slots = gathered_slots[gathered_slots != -1].tolist()
+        assert sorted(written_slots) == list(range(1000, 1008)) + [1116]
+    for actual, expected in zip(block_tables.input_block_tables, runner_owned_tables):
+        assert torch.equal(actual, expected)
+
+
+def test_optional_helpers_are_true_noops_without_a_manager() -> None:
+    """PCP=1 must preserve object identity and allocate no manager or collective."""
+
+    batch = _make_batch([("decode", [42], 3, False)])
+    hidden = torch.tensor([[42.0]])
+    assert maybe_build_pcp_manager(
+        _make_config(1), torch.device("cpu"), SimpleNamespace(), []
+    ) is None
+    assert maybe_partition_pcp_batch(None, batch) is batch
+    restored_hidden, restored_batch = maybe_restore_pcp_for_sampling(
+        None, hidden, batch
+    )
+    assert restored_hidden is hidden
+    assert restored_batch is batch
+
+
+def test_build_helper_enforces_the_approved_runtime_contract() -> None:
+    """Constructing a manager after bypassing Task 1 scope validation is a bug."""
+
+    with pytest.raises((AssertionError, ValueError), match="pipeline parallel"):
+        maybe_build_pcp_manager(
+            _make_config(2, pp=2), torch.device("cpu"), SimpleNamespace(), []
+        )

--- a/tests/runtime_patch/test_glm52_pcp_manager.py
+++ b/tests/runtime_patch/test_glm52_pcp_manager.py
@@ -13,6 +13,7 @@ import torch
 
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm_hcu.patch.config import HcuFeatureConfig
+from vllm_hcu.patch.platform.core_fix._common import PatchCompatibilityError
 from vllm_hcu.v1.pcp_manager import (
     HcuPCPManager,
     RankSegment,
@@ -334,6 +335,8 @@ def test_partition_pads_each_rank_to_equal_width_and_remaps_logits() -> None:
             if count > 0
         ]
         assert local.logits_indices.tolist() == nonempty_stops
+        assert local.expanded_local_pos.dtype == torch.int32
+        assert local.expanded_local_pos.tolist() == [0] * len(nonempty_stops)
         assert local.cu_num_logits_np.tolist() == np.cumsum(
             [0]
             + [int(count > 0) for count in local.num_scheduled_tokens]
@@ -399,6 +402,36 @@ def test_prepare_attn_uses_local_rows_but_global_kv_slot_ownership() -> None:
         assert sorted(written_slots) == list(range(1000, 1008)) + [1116]
     for actual, expected in zip(block_tables.input_block_tables, runner_owned_tables):
         assert torch.equal(actual, expected)
+
+
+def test_prepare_attn_rejects_missing_canonical_block_storage() -> None:
+    """Falling back to gathered scratch rows could consume stale block IDs."""
+
+    block_tables = _InMemoryBlockTables()
+    managers, _ = _make_managers(block_tables=block_tables)
+    local_batch = managers[0].partition_batch(
+        _make_batch([("prefill", list(range(100, 108)), 8, True)])
+    )
+    del block_tables.block_tables
+
+    with pytest.raises(PatchCompatibilityError, match="canonical block_tables"):
+        managers[0].prepare_attn(local_batch)
+
+
+def test_prepare_attn_rejects_kv_group_count_mismatch() -> None:
+    """Silently truncating a KV group would leave its local table unprepared."""
+
+    block_tables = _InMemoryBlockTables()
+    block_tables.block_tables.append(
+        SimpleNamespace(gpu=block_tables.block_tables[0].gpu.clone())
+    )
+    managers, _ = _make_managers(block_tables=block_tables)
+    local_batch = managers[0].partition_batch(
+        _make_batch([("prefill", list(range(100, 108)), 8, True)])
+    )
+
+    with pytest.raises(PatchCompatibilityError, match="KV-group count"):
+        managers[0].prepare_attn(local_batch)
 
 
 def test_optional_helpers_are_true_noops_without_a_manager() -> None:

--- a/tests/runtime_patch/test_glm52_pcp_mla.py
+++ b/tests/runtime_patch/test_glm52_pcp_mla.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""CPU contracts for PCP MLA and sparse-indexer cache-input gathers."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+class _FakePCPGroup:
+    def __init__(self, expected_calls, *, world_size=2, rank=0):
+        self.world_size = world_size
+        self.rank_in_group = rank
+        self._expected_calls = list(expected_calls)
+        self.calls: list[str] = []
+
+    def all_gather(self, tensor: torch.Tensor, dim: int = 0) -> torch.Tensor:
+        assert dim == 0
+        name, expected_local, gathered = self._expected_calls.pop(0)
+        torch.testing.assert_close(tensor, expected_local)
+        self.calls.append(name)
+        return gathered
+
+    def assert_exhausted(self) -> None:
+        assert self._expected_calls == []
+
+
+def _pcp_module():
+    return importlib.import_module(
+        "vllm_hcu.model_executor.layers.attention.pcp"
+    )
+
+
+def test_mla_prefill_gathers_uneven_rank_inputs_in_collective_order(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    pcp = _pcp_module()
+    local_kv = torch.tensor([[10.0], [11.0], [12.0]])
+    local_rope = torch.tensor([[110.0], [111.0], [112.0]])
+    local_slots = torch.tensor([100, 101, 102], dtype=torch.int64)
+    gathered_kv = torch.tensor([[10.0], [11.0], [12.0], [20.0], [21.0]])
+    gathered_rope = torch.tensor(
+        [[110.0], [111.0], [112.0], [120.0], [121.0]]
+    )
+    gathered_slots = torch.tensor([100, 101, 102, 200, 201], dtype=torch.int64)
+    group = _FakePCPGroup(
+        [
+            ("kv", local_kv, gathered_kv),
+            ("rope_k", local_rope, gathered_rope),
+            ("slot_mapping", local_slots, gathered_slots),
+        ]
+    )
+    monkeypatch.setattr(pcp, "get_pcp_group", lambda: group)
+    metadata = SimpleNamespace(
+        pcp_world_size=2,
+        pcp_token_counts=(3, 2),
+        num_decode_tokens=0,
+        num_prefills=2,
+    )
+
+    actual_kv, actual_rope, actual_slots = (
+        pcp.maybe_gather_mla_latent_cache_inputs(
+            local_kv,
+            local_rope,
+            gathered_slots,
+            metadata,
+        )
+    )
+
+    assert actual_kv.shape[0] == sum(metadata.pcp_token_counts)
+    assert actual_rope.shape[0] == actual_kv.shape[0]
+    assert actual_slots.shape[0] == actual_kv.shape[0]
+    torch.testing.assert_close(actual_kv, gathered_kv)
+    torch.testing.assert_close(actual_rope, gathered_rope)
+    torch.testing.assert_close(actual_slots, gathered_slots)
+    assert group.calls == ["kv", "rope_k", "slot_mapping"]
+    group.assert_exhausted()
+
+
+def test_mla_mixed_batch_writes_decode_once_then_rank_ordered_prefills(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    pcp = _pcp_module()
+    local_kv = torch.tensor([[9.0], [10.0], [11.0]])
+    local_rope = torch.tensor([[109.0], [110.0], [111.0]])
+    expanded_slots = torch.tensor(
+        [900, 100, 101, -1, 200], dtype=torch.int64
+    )
+    group = _FakePCPGroup(
+        [
+            (
+                "kv",
+                torch.tensor([[10.0], [11.0]]),
+                torch.tensor([[10.0], [11.0], [20.0]]),
+            ),
+            (
+                "rope_k",
+                torch.tensor([[110.0], [111.0]]),
+                torch.tensor([[110.0], [111.0], [120.0]]),
+            ),
+            (
+                "slot_mapping",
+                torch.tensor([100, 101], dtype=torch.int64),
+                torch.tensor([100, 101, 200], dtype=torch.int64),
+            ),
+        ]
+    )
+    monkeypatch.setattr(pcp, "get_pcp_group", lambda: group)
+    metadata = SimpleNamespace(
+        pcp_world_size=2,
+        pcp_token_counts=(3, 2),
+        num_decode_tokens=1,
+        num_prefills=2,
+    )
+
+    actual_kv, actual_rope, actual_slots = (
+        pcp.maybe_gather_mla_latent_cache_inputs(
+            local_kv,
+            local_rope,
+            expanded_slots,
+            metadata,
+        )
+    )
+
+    torch.testing.assert_close(
+        actual_kv, torch.tensor([[9.0], [10.0], [11.0], [20.0]])
+    )
+    torch.testing.assert_close(
+        actual_rope,
+        torch.tensor([[109.0], [110.0], [111.0], [120.0]]),
+    )
+    torch.testing.assert_close(
+        actual_slots, torch.tensor([900, 100, 101, 200], dtype=torch.int64)
+    )
+    assert group.calls == ["kv", "rope_k", "slot_mapping"]
+    group.assert_exhausted()
+
+
+def test_indexer_prefill_gathers_k_and_matching_slots_in_rank_order(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    pcp = _pcp_module()
+    local_k = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    expanded_slots = torch.tensor([10, 11, 20], dtype=torch.int64)
+    gathered_k = torch.tensor(
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+    )
+    group = _FakePCPGroup(
+        [
+            ("indexer_k", local_k, gathered_k),
+            (
+                "slot_mapping",
+                torch.tensor([10, 11], dtype=torch.int64),
+                expanded_slots,
+            ),
+        ]
+    )
+    monkeypatch.setattr(pcp, "get_pcp_group", lambda: group)
+    metadata = SimpleNamespace(
+        pcp_world_size=2,
+        pcp_token_counts=(2, 1),
+        num_decode_tokens=0,
+        num_prefills=2,
+    )
+
+    actual_k, actual_slots = pcp.maybe_gather_indexer_k(
+        local_k,
+        expanded_slots,
+        metadata,
+    )
+
+    torch.testing.assert_close(actual_k, gathered_k)
+    torch.testing.assert_close(actual_slots, expanded_slots)
+    assert group.calls == ["indexer_k", "slot_mapping"]
+    group.assert_exhausted()
+
+
+@pytest.mark.parametrize(
+    ("pcp_world_size", "num_prefills", "num_decode_tokens"),
+    [(1, 1, 0), (2, 0, 3)],
+)
+def test_pcp_one_and_decode_only_avoid_collectives_with_aligned_slots(
+    monkeypatch: pytest.MonkeyPatch,
+    pcp_world_size: int,
+    num_prefills: int,
+    num_decode_tokens: int,
+):
+    pcp = _pcp_module()
+    monkeypatch.setattr(
+        pcp,
+        "get_pcp_group",
+        lambda: pytest.fail("identity branch entered a PCP collective"),
+    )
+    kv = torch.randn(3, 2)
+    rope = torch.randn(3, 1, 2)
+    indexer_k = torch.randn(3, 4)
+    slots = (
+        torch.arange(3, dtype=torch.int64)
+        if pcp_world_size == 1
+        else torch.tensor([10, 11, 12, -1, -1, -1], dtype=torch.int64)
+    )
+    metadata = SimpleNamespace(
+        pcp_world_size=pcp_world_size,
+        num_decode_tokens=num_decode_tokens,
+        num_prefills=num_prefills,
+    )
+
+    actual_kv, actual_rope, actual_slots = (
+        pcp.maybe_gather_mla_latent_cache_inputs(
+            kv,
+            rope,
+            slots,
+            metadata,
+        )
+    )
+    actual_indexer_k, actual_indexer_slots = pcp.maybe_gather_indexer_k(
+        indexer_k,
+        slots,
+        metadata,
+    )
+
+    assert actual_kv is kv
+    assert actual_rope is rope
+    assert actual_indexer_k is indexer_k
+    if pcp_world_size == 1:
+        assert actual_slots is slots
+        assert actual_indexer_slots is slots
+    else:
+        expected_slots = slots[:num_decode_tokens]
+        assert actual_slots is not slots
+        assert actual_indexer_slots is not slots
+        torch.testing.assert_close(actual_slots, expected_slots)
+        torch.testing.assert_close(actual_indexer_slots, expected_slots)
+        assert actual_slots.shape[0] == actual_kv.shape[0]
+        assert actual_indexer_slots.shape[0] == actual_indexer_k.shape[0]
+
+
+def test_mla_gather_rejects_mismatched_latent_and_rope_token_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    pcp = _pcp_module()
+    monkeypatch.setattr(
+        pcp,
+        "get_pcp_group",
+        lambda: pytest.fail("shape validation must precede collectives"),
+    )
+    metadata = SimpleNamespace(
+        pcp_world_size=2,
+        pcp_token_counts=(3, 2),
+        num_decode_tokens=0,
+        num_prefills=2,
+    )
+
+    with pytest.raises(AssertionError, match="same token dimension"):
+        pcp.maybe_gather_mla_latent_cache_inputs(
+            torch.ones(3, 2),
+            torch.ones(2, 1, 2),
+            torch.arange(5),
+            metadata,
+        )

--- a/tests/runtime_patch/test_glm52_pcp_mla.py
+++ b/tests/runtime_patch/test_glm52_pcp_mla.py
@@ -179,6 +179,167 @@ def test_indexer_prefill_gathers_k_and_matching_slots_in_rank_order(
     group.assert_exhausted()
 
 
+@pytest.mark.parametrize("kind", ["mla", "indexer"])
+def test_empty_shard_pure_prefill_still_joins_cache_collectives(
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+):
+    pcp = _pcp_module()
+    expanded_slots = torch.tensor([-1, 200], dtype=torch.int64)
+    metadata = SimpleNamespace(
+        pcp_world_size=2,
+        num_decode_tokens=0,
+        # This rank retains only an empty virtual prefill row. The peer owns
+        # a real prefill token, and Task 2 pads this rank to the same width.
+        num_prefills=0,
+    )
+    if kind == "mla":
+        local_k = torch.tensor([[-99.0]])
+        local_rope = torch.tensor([[[-199.0]]])
+        gathered_k = torch.tensor([[-99.0], [20.0]])
+        gathered_rope = torch.tensor([[[-199.0]], [[120.0]]])
+        group = _FakePCPGroup(
+            [
+                ("kv", local_k, gathered_k),
+                ("rope_k", local_rope.reshape(1, -1), gathered_rope.reshape(2, -1)),
+                (
+                    "slot_mapping",
+                    torch.tensor([-1], dtype=torch.int64),
+                    expanded_slots,
+                ),
+            ]
+        )
+        monkeypatch.setattr(pcp, "get_pcp_group", lambda: group)
+
+        actual_k, actual_rope, actual_slots = (
+            pcp.maybe_gather_mla_latent_cache_inputs(
+                local_k,
+                local_rope,
+                expanded_slots,
+                metadata,
+            )
+        )
+
+        torch.testing.assert_close(actual_rope, gathered_rope)
+        expected_calls = ["kv", "rope_k", "slot_mapping"]
+    else:
+        local_k = torch.tensor([[-99.0, -98.0]])
+        gathered_k = torch.tensor([[-99.0, -98.0], [20.0, 21.0]])
+        group = _FakePCPGroup(
+            [
+                ("indexer_k", local_k, gathered_k),
+                (
+                    "slot_mapping",
+                    torch.tensor([-1], dtype=torch.int64),
+                    expanded_slots,
+                ),
+            ]
+        )
+        monkeypatch.setattr(pcp, "get_pcp_group", lambda: group)
+
+        actual_k, actual_slots = pcp.maybe_gather_indexer_k(
+            local_k,
+            expanded_slots,
+            metadata,
+        )
+
+        expected_calls = ["indexer_k", "slot_mapping"]
+
+    torch.testing.assert_close(actual_k, gathered_k)
+    torch.testing.assert_close(actual_slots, expanded_slots)
+    assert group.calls == expected_calls
+    group.assert_exhausted()
+
+
+@pytest.mark.parametrize("kind", ["mla", "indexer"])
+def test_empty_shard_mixed_batch_still_joins_prefill_collectives(
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+):
+    pcp = _pcp_module()
+    expanded_slots = torch.tensor([900, -1, -1, 200], dtype=torch.int64)
+    gathered_prefill_slots = torch.tensor([-1, 200], dtype=torch.int64)
+    metadata = SimpleNamespace(
+        pcp_world_size=2,
+        num_decode_tokens=1,
+        # The decode row is replicated, while only the peer owns a nonempty
+        # prefill shard. The second local tensor row is Task 2 padding.
+        num_prefills=0,
+    )
+    if kind == "mla":
+        local_k = torch.tensor([[9.0], [-99.0]])
+        local_rope = torch.tensor([[[109.0]], [[-199.0]]])
+        gathered_prefill_k = torch.tensor([[-99.0], [20.0]])
+        gathered_prefill_rope = torch.tensor([[[-199.0]], [[120.0]]])
+        group = _FakePCPGroup(
+            [
+                ("kv", local_k[1:], gathered_prefill_k),
+                (
+                    "rope_k",
+                    local_rope[1:].reshape(1, -1),
+                    gathered_prefill_rope.reshape(2, -1),
+                ),
+                (
+                    "slot_mapping",
+                    torch.tensor([-1], dtype=torch.int64),
+                    gathered_prefill_slots,
+                ),
+            ]
+        )
+        monkeypatch.setattr(pcp, "get_pcp_group", lambda: group)
+
+        actual_k, actual_rope, actual_slots = (
+            pcp.maybe_gather_mla_latent_cache_inputs(
+                local_k,
+                local_rope,
+                expanded_slots,
+                metadata,
+            )
+        )
+
+        torch.testing.assert_close(
+            actual_rope,
+            torch.tensor([[[109.0]], [[-199.0]], [[120.0]]]),
+        )
+        expected_calls = ["kv", "rope_k", "slot_mapping"]
+        expected_k = torch.tensor([[9.0], [-99.0], [20.0]])
+    else:
+        local_k = torch.tensor([[9.0, 10.0], [-99.0, -98.0]])
+        gathered_prefill_k = torch.tensor(
+            [[-99.0, -98.0], [20.0, 21.0]]
+        )
+        group = _FakePCPGroup(
+            [
+                ("indexer_k", local_k[1:], gathered_prefill_k),
+                (
+                    "slot_mapping",
+                    torch.tensor([-1], dtype=torch.int64),
+                    gathered_prefill_slots,
+                ),
+            ]
+        )
+        monkeypatch.setattr(pcp, "get_pcp_group", lambda: group)
+
+        actual_k, actual_slots = pcp.maybe_gather_indexer_k(
+            local_k,
+            expanded_slots,
+            metadata,
+        )
+
+        expected_calls = ["indexer_k", "slot_mapping"]
+        expected_k = torch.tensor(
+            [[9.0, 10.0], [-99.0, -98.0], [20.0, 21.0]]
+        )
+
+    torch.testing.assert_close(actual_k, expected_k)
+    torch.testing.assert_close(
+        actual_slots,
+        torch.tensor([900, -1, 200], dtype=torch.int64),
+    )
+    assert group.calls == expected_calls
+    group.assert_exhausted()
+
+
 @pytest.mark.parametrize(
     ("pcp_world_size", "num_prefills", "num_decode_tokens"),
     [(1, 1, 0), (2, 0, 3)],

--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""PCP-aware MoE dispatch contracts for the HCU-owned runner."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+# This test imports the HCU-owned runner directly, outside the runtime patch
+# coordinator that owns the upstream replacement target.
+os.environ["VLLM_PLUGINS"] = "__disabled__"
+from vllm.utils import torch_utils
+
+_register_custom_op = torch_utils.direct_register_custom_op
+
+
+def _register_without_duplicate_moe_ops(op_name, *args, **kwargs):
+    if op_name in {"moe_forward", "moe_forward_shared"}:
+        return None
+    return _register_custom_op(op_name, *args, **kwargs)
+
+
+torch_utils.direct_register_custom_op = _register_without_duplicate_moe_ops
+
+from vllm_hcu.model_executor.layers.fused_moe import moe_runner
+
+torch_utils.direct_register_custom_op = _register_custom_op
+
+
+def make_hidden() -> torch.Tensor:
+    return torch.tensor([[10.0, 11.0], [20.0, 21.0]])
+
+
+def make_logits() -> torch.Tensor:
+    return torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+
+
+class _PCPCollectives:
+    """Two-rank in-memory PCP collective with observable token ordering."""
+
+    def __init__(self) -> None:
+        self.all_gather_count = 0
+        self.reduce_scatter_count = 0
+        self._peer_tensors = [
+            torch.tensor([[30.0, 31.0], [40.0, 41.0]]),
+            torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
+        ]
+
+    def all_gather(self, tensor: torch.Tensor, dim: int = 0) -> torch.Tensor:
+        assert dim == 0
+        peer = self._peer_tensors[self.all_gather_count]
+        self.all_gather_count += 1
+        return torch.cat((tensor, peer), dim=dim)
+
+    def reduce_scatter(self, tensor: torch.Tensor, dim: int = 0) -> torch.Tensor:
+        assert dim == 0
+        self.reduce_scatter_count += 1
+        return tensor[: tensor.shape[0] // 2]
+
+
+@pytest.fixture
+def make_runner(monkeypatch: pytest.MonkeyPatch):
+    def make(pcp: int, use_all2all_kernels: bool):
+        runner = object.__new__(moe_runner.MoERunner)
+        runner.moe_config = SimpleNamespace(
+            pcp_size=pcp,
+            dp_size=1,
+            is_sequence_parallel=False,
+            moe_parallel_config=SimpleNamespace(
+                use_all2all_kernels=use_all2all_kernels,
+            ),
+        )
+        runner.routed_experts = SimpleNamespace(
+            quant_method=SimpleNamespace(supports_internal_mk=False),
+        )
+        runner._shared_experts = None
+        group = _PCPCollectives()
+        monkeypatch.setattr(moe_runner, "get_pcp_group", lambda: group)
+        return runner, group
+
+    return make
+
+
+@pytest.mark.parametrize(
+    ("pcp", "use_all2all_kernels", "gathers", "reduce_scatters"),
+    [(1, False, 0, 0), (2, False, 2, 1), (2, True, 0, 0)],
+)
+def test_moe_uses_exactly_one_pcp_dispatch_path(
+    make_runner, pcp, use_all2all_kernels, gathers, reduce_scatters
+) -> None:
+    """An all-to-all kernel must not be wrapped in fallback PCP collectives."""
+
+    runner, group = make_runner(pcp, use_all2all_kernels)
+    hidden, logits = runner._maybe_dispatch(make_hidden(), make_logits())
+    combined = runner._maybe_combine(None, hidden)
+
+    expected_dispatched_hidden = (
+        torch.tensor([[10.0, 11.0], [20.0, 21.0], [30.0, 31.0], [40.0, 41.0]])
+        if pcp == 2 and not use_all2all_kernels
+        else make_hidden()
+    )
+    expected_dispatched_logits = (
+        torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
+        if pcp == 2 and not use_all2all_kernels
+        else make_logits()
+    )
+    torch.testing.assert_close(hidden, expected_dispatched_hidden)
+    torch.testing.assert_close(logits, expected_dispatched_logits)
+    torch.testing.assert_close(combined, make_hidden())
+    assert group.all_gather_count == gathers
+    assert group.reduce_scatter_count == reduce_scatters
+
+
+@pytest.mark.parametrize("use_all2all_kernels", [False, True])
+def test_pcp_dispatch_requires_router_logits(
+    make_runner, use_all2all_kernels: bool
+) -> None:
+    """Removing the PCP routing guard would admit unusable preselected input."""
+
+    runner, _ = make_runner(2, use_all2all_kernels)
+
+    with pytest.raises(RuntimeError, match="without router_logits"):
+        runner._maybe_dispatch(make_hidden(), None)
+
+
+def test_shared_and_routed_outputs_keep_local_token_order_before_addition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reordering either local output before the shared+routed add is a bug."""
+
+    runner = object.__new__(moe_runner.MoERunner)
+    runner.moe_config = SimpleNamespace(hidden_dim_unpadded=2)
+    runner.routed_experts = SimpleNamespace(
+        quant_method=SimpleNamespace(has_unpadded_output=False),
+    )
+    runner.routed_input_transform = None
+    runner.routed_output_transform = None
+    runner.routed_scaling_factor = 1.0
+    runner._shared_experts = object()
+    runner.router = object()
+    runner.__dict__["_forward_entry"] = lambda *_args: (
+        torch.tensor([[100.0, 101.0], [200.0, 201.0]]),
+        torch.tensor([[10.0, 11.0], [20.0, 21.0]]),
+    )
+    monkeypatch.setattr(
+        moe_runner.MoERunner,
+        "_maybe_pad_hidden_states",
+        lambda self, shared, hidden: (hidden, None, None),
+    )
+    monkeypatch.setattr(
+        moe_runner.MoERunner,
+        "_encode_layer_name",
+        lambda self: "test-layer",
+    )
+    monkeypatch.setattr(
+        moe_runner.MoERunner,
+        "_maybe_reduce_shared_expert_output",
+        lambda self, shared: shared,
+    )
+    monkeypatch.setattr(
+        moe_runner.MoERunner,
+        "_maybe_reduce_final_output",
+        lambda self, output, _truncate: output,
+    )
+    monkeypatch.setattr(
+        moe_runner.MoERunner,
+        "_maybe_add_zero_expert_output",
+        lambda self, output: output,
+    )
+
+    output = runner.forward(make_hidden(), make_logits())
+
+    torch.testing.assert_close(
+        output,
+        torch.tensor([[110.0, 112.0], [220.0, 222.0]]),
+    )

--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -4,31 +4,41 @@
 
 from __future__ import annotations
 
+import importlib
 import os
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 import torch
 
-# This test imports the HCU-owned runner directly, outside the runtime patch
-# coordinator that owns the upstream replacement target.
+# Defer the replacement import until fixture setup.  Pytest imports every test
+# module before running earlier platform fixtures, so a collection-time direct
+# import would race the coordinator that owns the canonical replacement target.
 os.environ["VLLM_PLUGINS"] = "__disabled__"
 from vllm.utils import torch_utils
 
-_register_custom_op = torch_utils.direct_register_custom_op
 
+@pytest.fixture(scope="module")
+def moe_runner_module() -> ModuleType:
+    from vllm_hcu.patch.platform import apply_platform_patches
 
-def _register_without_duplicate_moe_ops(op_name, *args, **kwargs):
-    if op_name in {"moe_forward", "moe_forward_shared"}:
-        return None
-    return _register_custom_op(op_name, *args, **kwargs)
+    apply_platform_patches()
+    register_custom_op = torch_utils.direct_register_custom_op
 
+    def register_without_duplicate_moe_ops(op_name, *args, **kwargs):
+        if op_name in {"moe_forward", "moe_forward_shared"}:
+            return None
+        return register_custom_op(op_name, *args, **kwargs)
 
-torch_utils.direct_register_custom_op = _register_without_duplicate_moe_ops
-
-from vllm_hcu.model_executor.layers.fused_moe import moe_runner
-
-torch_utils.direct_register_custom_op = _register_custom_op
+    torch_utils.direct_register_custom_op = register_without_duplicate_moe_ops
+    try:
+        module = importlib.import_module(
+            "vllm.model_executor.layers.fused_moe.runner.moe_runner"
+        )
+    finally:
+        torch_utils.direct_register_custom_op = register_custom_op
+    assert module.MoERunner.__module__.startswith("vllm_hcu.")
+    return module
 
 
 def make_hidden() -> torch.Tensor:
@@ -63,9 +73,12 @@ class _PCPCollectives:
 
 
 @pytest.fixture
-def make_runner(monkeypatch: pytest.MonkeyPatch):
+def make_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    moe_runner_module: ModuleType,
+):
     def make(pcp: int, use_all2all_kernels: bool):
-        runner = object.__new__(moe_runner.MoERunner)
+        runner = object.__new__(moe_runner_module.MoERunner)
         runner.moe_config = SimpleNamespace(
             pcp_size=pcp,
             dp_size=1,
@@ -79,7 +92,7 @@ def make_runner(monkeypatch: pytest.MonkeyPatch):
         )
         runner._shared_experts = None
         group = _PCPCollectives()
-        monkeypatch.setattr(moe_runner, "get_pcp_group", lambda: group)
+        monkeypatch.setattr(moe_runner_module, "get_pcp_group", lambda: group)
         return runner, group
 
     return make
@@ -129,10 +142,11 @@ def test_pcp_dispatch_requires_router_logits(
 
 def test_shared_and_routed_outputs_keep_local_token_order_before_addition(
     monkeypatch: pytest.MonkeyPatch,
+    moe_runner_module: ModuleType,
 ) -> None:
     """Reordering either local output before the shared+routed add is a bug."""
 
-    runner = object.__new__(moe_runner.MoERunner)
+    runner = object.__new__(moe_runner_module.MoERunner)
     runner.moe_config = SimpleNamespace(hidden_dim_unpadded=2)
     runner.routed_experts = SimpleNamespace(
         quant_method=SimpleNamespace(has_unpadded_output=False),
@@ -147,27 +161,27 @@ def test_shared_and_routed_outputs_keep_local_token_order_before_addition(
         torch.tensor([[10.0, 11.0], [20.0, 21.0]]),
     )
     monkeypatch.setattr(
-        moe_runner.MoERunner,
+        moe_runner_module.MoERunner,
         "_maybe_pad_hidden_states",
         lambda self, shared, hidden: (hidden, None, None),
     )
     monkeypatch.setattr(
-        moe_runner.MoERunner,
+        moe_runner_module.MoERunner,
         "_encode_layer_name",
         lambda self: "test-layer",
     )
     monkeypatch.setattr(
-        moe_runner.MoERunner,
+        moe_runner_module.MoERunner,
         "_maybe_reduce_shared_expert_output",
         lambda self, shared: shared,
     )
     monkeypatch.setattr(
-        moe_runner.MoERunner,
+        moe_runner_module.MoERunner,
         "_maybe_reduce_final_output",
         lambda self, output, _truncate: output,
     )
     monkeypatch.setattr(
-        moe_runner.MoERunner,
+        moe_runner_module.MoERunner,
         "_maybe_add_zero_expert_output",
         lambda self, output: output,
     )

--- a/tests/runtime_patch/test_glm52_pcp_runner.py
+++ b/tests/runtime_patch/test_glm52_pcp_runner.py
@@ -12,6 +12,7 @@ import sys
 import textwrap
 from dataclasses import dataclass
 from types import FunctionType, ModuleType, SimpleNamespace
+from typing import NamedTuple
 
 import numpy as np
 import pytest
@@ -90,6 +91,11 @@ def _config(pcp_size: int) -> object:
     )
 
 
+class _ExecuteModelState(NamedTuple):
+    input_batch: object
+    hidden_states: object
+
+
 def test_pcp_runner_orders_lifecycle_and_restores_sampling_state(
     pcp_runner_module,
     monkeypatch: pytest.MonkeyPatch,
@@ -153,14 +159,16 @@ def test_pcp_runner_orders_lifecycle_and_restores_sampling_state(
     assert prepared is local_batch
     assert runner.prepare_attn(prepared) == ("local-blocks", "gathered-slots")
 
-    state = SimpleNamespace(hidden_states=local_hidden, input_batch=local_batch)
+    state = _ExecuteModelState(local_batch, local_hidden)
     runner.execute_model_state = state
     runner.expected_hidden = global_hidden
     runner.expected_batch = global_batch
     assert runner.sample_tokens("grammar") == "sampled"
 
-    assert state.hidden_states is global_hidden
-    assert state.input_batch is global_batch
+    assert state.hidden_states is local_hidden
+    assert state.input_batch is local_batch
+    assert runner.execute_model_state.hidden_states is global_hidden
+    assert runner.execute_model_state.input_batch is global_batch
     assert synchronized_batches == [global_batch]
     assert events == [
         "super.initialize_kv_cache",
@@ -171,6 +179,44 @@ def test_pcp_runner_orders_lifecycle_and_restores_sampling_state(
         "restore_for_sampling",
         "super.sample_tokens",
     ]
+
+
+def test_pcp_runner_replaces_immutable_execute_model_state(
+    pcp_runner_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """v0.25.1 stores execution state in an immutable NamedTuple."""
+
+    runner_module, _ = pcp_runner_module
+    global_batch = object()
+    local_batch = object()
+    global_hidden = object()
+    local_hidden = object()
+
+    class Manager:
+        def restore_for_sampling(self, hidden_states):
+            assert hidden_states is local_hidden
+            return global_hidden, global_batch
+
+    monkeypatch.setattr(
+        runner_module,
+        "synchronize_pp_spec_draft_tokens",
+        lambda *args: False,
+    )
+    runner = runner_module.HcuGPUModelRunnerV2(_config(2), "hcu:0")
+    runner.pcp_manager = Manager()
+    original_state = _ExecuteModelState(local_batch, local_hidden)
+    runner.execute_model_state = original_state
+    runner.expected_hidden = global_hidden
+    runner.expected_batch = global_batch
+
+    assert runner.sample_tokens("grammar") == "sampled"
+
+    assert original_state.input_batch is local_batch
+    assert original_state.hidden_states is local_hidden
+    assert runner.execute_model_state is not original_state
+    assert runner.execute_model_state.input_batch is global_batch
+    assert runner.execute_model_state.hidden_states is global_hidden
 
 
 def test_pcp_runner_routes_dummy_slots_through_manager(

--- a/tests/runtime_patch/test_glm52_pcp_runner.py
+++ b/tests/runtime_patch/test_glm52_pcp_runner.py
@@ -1,0 +1,533 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""CPU contracts for GLM-5.2 PCP integration with Model Runner V2."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from dataclasses import dataclass
+from types import FunctionType, ModuleType, SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from vllm_hcu.patch.worker.framework_opt._common import PatchCompatibilityError
+
+
+@pytest.fixture
+def pcp_runner_module(monkeypatch: pytest.MonkeyPatch):
+    """Load the HCU runner over a behavior-recording upstream MRV2 base."""
+
+    events: list[str] = []
+    upstream_name = "vllm.v1.worker.gpu.model_runner"
+    adapter_name = "vllm_hcu.v1.hcu_model_runner_v2"
+    upstream_module = ModuleType(upstream_name)
+    pcp_module = ModuleType("vllm_hcu.v1.pcp_manager")
+    pcp_module.maybe_build_pcp_manager = lambda *args: None
+
+    class FakeBlockTables:
+        def get_dummy_block_tables(self, num_reqs):
+            events.append("block_tables.get_dummy_block_tables")
+            return ("dummy-blocks", num_reqs)
+
+        def get_dummy_slot_mappings(self, num_tokens):
+            events.append("block_tables.get_dummy_slot_mappings")
+            return ("global-dummy-slots", num_tokens)
+
+    class UpstreamGPUModelRunner:
+        def __init__(self, vllm_config, device):
+            events.append("super.__init__")
+            self.vllm_config = vllm_config
+            self.device = device
+            self.req_states = object()
+            self.execute_model_state = None
+
+        def initialize_kv_cache(self, kv_cache_config):
+            events.append("super.initialize_kv_cache")
+            self.kv_cache_config = kv_cache_config
+            self.block_tables = FakeBlockTables()
+
+        def prepare_inputs(self, scheduler_output, batch_desc):
+            events.append("super.prepare_inputs")
+            assert scheduler_output == "scheduler-output"
+            assert batch_desc == "batch-desc"
+            return self.global_batch
+
+        def prepare_attn(self, input_batch):
+            events.append("super.prepare_attn")
+            return ("global-blocks", input_batch), "global-slots"
+
+        def prepare_dummy_attn(self, input_batch):
+            events.append("super.prepare_dummy_attn")
+            return ("global-dummy-blocks", input_batch), "global-dummy-slots"
+
+        def sample_tokens(self, grammar_output):
+            events.append("super.sample_tokens")
+            assert grammar_output == "grammar"
+            assert self.execute_model_state.hidden_states is self.expected_hidden
+            assert self.execute_model_state.input_batch is self.expected_batch
+            return "sampled"
+
+    upstream_module.GPUModelRunner = UpstreamGPUModelRunner
+    monkeypatch.setitem(sys.modules, upstream_name, upstream_module)
+    monkeypatch.setitem(sys.modules, pcp_module.__name__, pcp_module)
+    monkeypatch.delitem(sys.modules, adapter_name, raising=False)
+    adapter_module = importlib.import_module(adapter_name)
+    yield adapter_module, events
+
+
+def _config(pcp_size: int) -> object:
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=pcp_size,
+        )
+    )
+
+
+def test_pcp_runner_orders_lifecycle_and_restores_sampling_state(
+    pcp_runner_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Moving partition or restore across its upstream boundary is a bug."""
+
+    runner_module, events = pcp_runner_module
+    global_batch = object()
+    local_batch = object()
+    global_hidden = object()
+    local_hidden = object()
+    synchronized_batches: list[object] = []
+
+    class Manager:
+        def partition_batch(self, input_batch):
+            events.append("partition_batch")
+            assert input_batch is global_batch
+            return local_batch
+
+        def prepare_attn(self, input_batch):
+            events.append("pcp.prepare_attn")
+            assert input_batch is local_batch
+            return "local-blocks", "gathered-slots"
+
+        def restore_for_sampling(self, hidden_states):
+            events.append("restore_for_sampling")
+            assert hidden_states is local_hidden
+            return global_hidden, global_batch
+
+    manager = Manager()
+
+    def build_manager(vllm_config, device, req_states, block_tables):
+        events.append("build_pcp_manager")
+        assert vllm_config.parallel_config.prefill_context_parallel_size == 2
+        assert device == "hcu:0"
+        assert req_states is runner.req_states
+        assert block_tables is runner.block_tables
+        return manager
+
+    def synchronize(model_runner, input_batch):
+        assert events[-1] == "super.sample_tokens"
+        assert model_runner is runner
+        synchronized_batches.append(input_batch)
+        return False
+
+    monkeypatch.setattr(runner_module, "maybe_build_pcp_manager", build_manager)
+    monkeypatch.setattr(
+        runner_module,
+        "synchronize_pp_spec_draft_tokens",
+        synchronize,
+    )
+
+    runner = runner_module.HcuGPUModelRunnerV2(_config(2), "hcu:0")
+    assert runner.pcp_manager is None
+    runner.global_batch = global_batch
+    events.clear()
+
+    runner.initialize_kv_cache("kv-config")
+    assert runner.pcp_manager is manager
+    prepared = runner.prepare_inputs("scheduler-output", "batch-desc")
+    assert prepared is local_batch
+    assert runner.prepare_attn(prepared) == ("local-blocks", "gathered-slots")
+
+    state = SimpleNamespace(hidden_states=local_hidden, input_batch=local_batch)
+    runner.execute_model_state = state
+    runner.expected_hidden = global_hidden
+    runner.expected_batch = global_batch
+    assert runner.sample_tokens("grammar") == "sampled"
+
+    assert state.hidden_states is global_hidden
+    assert state.input_batch is global_batch
+    assert synchronized_batches == [global_batch]
+    assert events == [
+        "super.initialize_kv_cache",
+        "build_pcp_manager",
+        "super.prepare_inputs",
+        "partition_batch",
+        "pcp.prepare_attn",
+        "restore_for_sampling",
+        "super.sample_tokens",
+    ]
+
+
+def test_pcp_runner_routes_dummy_slots_through_manager(
+    pcp_runner_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Using global dummy slots would under-size a PCP-expanded dummy batch."""
+
+    runner_module, events = pcp_runner_module
+    input_batch = SimpleNamespace(num_reqs=3, num_tokens=7)
+
+    class Manager:
+        def get_dummy_slot_mappings(self, num_tokens):
+            events.append("pcp.get_dummy_slot_mappings")
+            assert num_tokens == 7
+            return "pcp-dummy-slots"
+
+    manager = Manager()
+    monkeypatch.setattr(
+        runner_module,
+        "maybe_build_pcp_manager",
+        lambda *args: manager,
+    )
+
+    runner = runner_module.HcuGPUModelRunnerV2(_config(2), "hcu:0")
+    runner.initialize_kv_cache("kv-config")
+    events.clear()
+
+    assert runner.prepare_dummy_attn(input_batch) == (
+        ("dummy-blocks", 3),
+        "pcp-dummy-slots",
+    )
+    assert events == [
+        "block_tables.get_dummy_block_tables",
+        "pcp.get_dummy_slot_mappings",
+    ]
+
+
+def test_pcp_one_preserves_the_existing_runner_event_path(
+    pcp_runner_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PCP=1 must not call a manager helper or bypass an upstream method."""
+
+    runner_module, events = pcp_runner_module
+    global_batch = object()
+    hidden_states = object()
+
+    def unexpected_builder(*args):
+        pytest.fail("PCP=1 called maybe_build_pcp_manager")
+
+    def synchronize(model_runner, input_batch):
+        events.append("synchronize_pp_spec_draft_tokens")
+        assert model_runner is runner
+        assert input_batch is global_batch
+        return True
+
+    monkeypatch.setattr(
+        runner_module,
+        "maybe_build_pcp_manager",
+        unexpected_builder,
+    )
+    monkeypatch.setattr(
+        runner_module,
+        "synchronize_pp_spec_draft_tokens",
+        synchronize,
+    )
+
+    runner = runner_module.HcuGPUModelRunnerV2(_config(1), "hcu:0")
+    assert runner.pcp_manager is None
+    runner.global_batch = global_batch
+    events.clear()
+
+    runner.initialize_kv_cache("kv-config")
+    assert runner.prepare_inputs("scheduler-output", "batch-desc") is global_batch
+    assert runner.prepare_attn(global_batch) == (
+        ("global-blocks", global_batch),
+        "global-slots",
+    )
+    assert runner.prepare_dummy_attn(global_batch) == (
+        ("global-dummy-blocks", global_batch),
+        "global-dummy-slots",
+    )
+    runner.execute_model_state = SimpleNamespace(
+        hidden_states=hidden_states,
+        input_batch=global_batch,
+    )
+    runner.expected_hidden = hidden_states
+    runner.expected_batch = global_batch
+    assert runner.sample_tokens("grammar") == "sampled"
+
+    assert events == [
+        "super.initialize_kv_cache",
+        "super.prepare_inputs",
+        "super.prepare_attn",
+        "super.prepare_dummy_attn",
+        "super.sample_tokens",
+        "synchronize_pp_spec_draft_tokens",
+    ]
+
+
+@dataclass
+class _CommonAttentionMetadata:
+    query_start_loc: torch.Tensor
+    query_start_loc_cpu: torch.Tensor
+    is_prefilling: torch.Tensor | None = None
+
+
+CommonAttentionMetadata = _CommonAttentionMetadata
+
+
+def _build_attn_metadata(
+    attn_groups,
+    num_reqs,
+    num_tokens,
+    query_start_loc_gpu,
+    query_start_loc_cpu,
+    max_query_len,
+    seq_lens,
+    max_seq_len,
+    block_tables,
+    slot_mappings,
+    kv_cache_config,
+    seq_lens_cpu_upper_bound=None,
+    dcp_local_seq_lens=None,
+    positions=None,
+    mm_req_doc_ranges=None,
+    model_specific_attn_metadata=None,
+    for_cudagraph_capture=False,
+    causal=True,
+    rswa_prefix_lens=None,
+):
+    del (
+        num_tokens,
+        max_query_len,
+        seq_lens,
+        max_seq_len,
+        block_tables,
+        slot_mappings,
+        kv_cache_config,
+        seq_lens_cpu_upper_bound,
+        dcp_local_seq_lens,
+        positions,
+        mm_req_doc_ranges,
+        for_cudagraph_capture,
+        causal,
+        rswa_prefix_lens,
+    )
+    extra = model_specific_attn_metadata.get_extra_common_attn_kwargs(
+        0, num_reqs
+    )
+    common = CommonAttentionMetadata(
+        query_start_loc_gpu,
+        query_start_loc_cpu,
+        **extra,
+    )
+    builder = attn_groups[0][0].get_metadata_builder(0)
+    return {
+        "mla.layer": builder.build(
+            common_prefix_len=0,
+            common_attn_metadata=common,
+        )
+    }
+
+
+build_attn_metadata = _build_attn_metadata
+
+
+class CUDAGraphMode:
+    FULL = object()
+    NONE = object()
+
+
+def compute_mm_prefix_ranges(**kwargs):
+    return kwargs
+
+
+def _original_prepare_attn(
+    self,
+    input_batch,
+    cudagraph_mode,
+    block_tables,
+    slot_mappings,
+    attn_groups,
+    kv_cache_config,
+    for_capture=False,
+):
+    if cudagraph_mode == CUDAGraphMode.FULL:
+        num_reqs = input_batch.num_reqs_after_padding
+        num_tokens = input_batch.num_tokens_after_padding
+    else:
+        num_reqs = input_batch.num_reqs
+        num_tokens = input_batch.num_tokens
+    query_start_loc_cpu = torch.from_numpy(input_batch.query_start_loc_np)
+    max_query_len = input_batch.num_scheduled_tokens.max().item()
+    seq_lens_cpu_upper_bound = input_batch.seq_lens_cpu_upper_bound
+    if for_capture:
+        max_seq_len = self.max_model_len
+    else:
+        max_seq_len = seq_lens_cpu_upper_bound[:num_reqs].max().item()
+    req_doc_ranges = None
+    if (
+        self.supports_mm_inputs
+        and self.encoder_cache is not None
+        and self.model_config.is_mm_prefix_lm
+    ):
+        req_doc_ranges = compute_mm_prefix_ranges(
+            req_ids=input_batch.req_ids,
+            mm_features=self.encoder_cache.mm_features,
+            sliding_window=self.model_config.get_sliding_window(),
+        )
+    return build_attn_metadata(
+        attn_groups=attn_groups,
+        num_reqs=num_reqs,
+        num_tokens=num_tokens,
+        query_start_loc_gpu=input_batch.query_start_loc,
+        query_start_loc_cpu=query_start_loc_cpu,
+        max_query_len=max_query_len,
+        seq_lens=input_batch.seq_lens,
+        max_seq_len=max_seq_len,
+        block_tables=block_tables,
+        slot_mappings=slot_mappings,
+        kv_cache_config=kv_cache_config,
+        seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
+        dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
+        positions=input_batch.positions,
+        mm_req_doc_ranges=req_doc_ranges,
+        for_cudagraph_capture=for_capture,
+        rswa_prefix_lens=input_batch.prompt_lens,
+    )
+
+
+def _fake_default_model_state_module(adapter) -> ModuleType:
+    target = ModuleType(adapter.TARGET_MODULE)
+
+    class DefaultModelState:
+        pass
+
+    target.CUDAGraphMode = CUDAGraphMode
+    target.CommonAttentionMetadata = _CommonAttentionMetadata
+    target.torch = torch
+    target.compute_mm_prefix_ranges = compute_mm_prefix_ranges
+    target.build_attn_metadata = FunctionType(
+        _build_attn_metadata.__code__,
+        target.__dict__,
+        name="build_attn_metadata",
+        argdefs=_build_attn_metadata.__defaults__,
+    )
+    DefaultModelState.prepare_attn = FunctionType(
+        _original_prepare_attn.__code__,
+        target.__dict__,
+        name="prepare_attn",
+        argdefs=_original_prepare_attn.__defaults__,
+    )
+    target.DefaultModelState = DefaultModelState
+    return target
+
+
+def test_pcp_default_model_state_slices_metadata_and_propagates_phase() -> None:
+    """Trailing virtual rows or missing phase data break MLA classification."""
+
+    adapter = importlib.import_module(
+        "vllm_hcu.patch.worker.framework_opt.patch_pcp_model_state"
+    )
+    target = _fake_default_model_state_module(adapter)
+    assert adapter.apply_to_module(target) is True
+    assert adapter.apply_to_module(target) is False
+
+    class Builder:
+        def build(self, *, common_prefix_len, common_attn_metadata):
+            assert common_prefix_len == 0
+            return common_attn_metadata
+
+    class Group:
+        def get_metadata_builder(self, index):
+            assert index == 0
+            return Builder()
+
+    state = target.DefaultModelState()
+    state.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(prefill_context_parallel_size=2)
+    )
+    state.supports_mm_inputs = False
+    state.max_model_len = 64
+    input_batch = SimpleNamespace(
+        num_reqs=2,
+        num_reqs_after_padding=4,
+        num_tokens=3,
+        num_tokens_after_padding=8,
+        query_start_loc_np=np.array([0, 1, 3, 9, 9], dtype=np.int32),
+        query_start_loc=torch.tensor([0, 1, 3, 9, 9], dtype=torch.int32),
+        num_scheduled_tokens=np.array([1, 2], dtype=np.int32),
+        seq_lens_cpu_upper_bound=torch.tensor([1, 3], dtype=torch.int32),
+        seq_lens=torch.tensor([1, 3], dtype=torch.int32),
+        dcp_local_seq_lens=None,
+        positions=torch.tensor([0, 0, 1], dtype=torch.int64),
+        req_ids=["decode", "prefill"],
+        is_prefilling_np=np.array([False, True], dtype=np.bool_),
+        prompt_lens=None,
+    )
+    metadata = state.prepare_attn(
+        input_batch,
+        target.CUDAGraphMode.NONE,
+        (torch.zeros((2, 1), dtype=torch.int32),),
+        torch.zeros((1, 3), dtype=torch.int64),
+        [[Group()]],
+        SimpleNamespace(kv_cache_groups=[object()]),
+    )
+    common = metadata["mla.layer"]
+
+    captured: dict[str, object] = {}
+
+    def capture_original(**kwargs):
+        captured.update(kwargs)
+        return {"path": "original"}
+
+    target.build_attn_metadata = capture_original
+    state.vllm_config.parallel_config.prefill_context_parallel_size = 1
+    pcp_one = state.prepare_attn(
+        input_batch,
+        target.CUDAGraphMode.NONE,
+        (torch.zeros((2, 1), dtype=torch.int32),),
+        torch.zeros((1, 3), dtype=torch.int64),
+        [[Group()]],
+        SimpleNamespace(kv_cache_groups=[object()]),
+    )
+    payload = {
+        "pcp_query_gpu": common.query_start_loc.tolist(),
+        "pcp_query_cpu": common.query_start_loc_cpu.tolist(),
+        "pcp_is_prefilling": common.is_prefilling.tolist(),
+        "pcp_one_result": pcp_one,
+        "pcp_one_query_gpu": captured["query_start_loc_gpu"].tolist(),
+        "pcp_one_query_cpu": captured["query_start_loc_cpu"].tolist(),
+        "pcp_one_has_phase_adapter": (
+            "model_specific_attn_metadata" in captured
+        ),
+    }
+    assert payload == {
+        "pcp_query_gpu": [0, 1, 3],
+        "pcp_query_cpu": [0, 1, 3],
+        "pcp_is_prefilling": [False, True],
+        "pcp_one_result": {"path": "original"},
+        "pcp_one_query_gpu": [0, 1, 3, 9, 9],
+        "pcp_one_query_cpu": [0, 1, 3, 9, 9],
+        "pcp_one_has_phase_adapter": False,
+    }
+
+
+def test_pcp_default_model_state_rejects_signature_drift() -> None:
+    """A changed upstream prepare_attn contract must fail before installation."""
+
+    adapter = importlib.import_module(
+        "vllm_hcu.patch.worker.framework_opt.patch_pcp_model_state"
+    )
+    target = ModuleType(adapter.TARGET_MODULE)
+
+    class DefaultModelState:
+        def prepare_attn(self, input_batch):
+            return input_batch
+
+    target.DefaultModelState = DefaultModelState
+    with pytest.raises(PatchCompatibilityError, match="incompatible signature"):
+        adapter.apply_to_module(target)

--- a/tests/runtime_patch/test_glm52_pcp_runner.py
+++ b/tests/runtime_patch/test_glm52_pcp_runner.py
@@ -5,8 +5,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib
+import inspect
 import sys
+import textwrap
 from dataclasses import dataclass
 from types import FunctionType, ModuleType, SimpleNamespace
 
@@ -333,6 +336,52 @@ def _build_attn_metadata(
     }
 
 
+def _build_attn_metadata_without_common_hook(
+    attn_groups,
+    num_reqs,
+    num_tokens,
+    query_start_loc_gpu,
+    query_start_loc_cpu,
+    max_query_len,
+    seq_lens,
+    max_seq_len,
+    block_tables,
+    slot_mappings,
+    kv_cache_config,
+    seq_lens_cpu_upper_bound=None,
+    dcp_local_seq_lens=None,
+    positions=None,
+    mm_req_doc_ranges=None,
+    model_specific_attn_metadata=None,
+    for_cudagraph_capture=False,
+    causal=True,
+    rswa_prefix_lens=None,
+):
+    del (
+        attn_groups,
+        num_reqs,
+        num_tokens,
+        max_query_len,
+        seq_lens,
+        max_seq_len,
+        block_tables,
+        slot_mappings,
+        kv_cache_config,
+        seq_lens_cpu_upper_bound,
+        dcp_local_seq_lens,
+        positions,
+        mm_req_doc_ranges,
+        model_specific_attn_metadata,
+        for_cudagraph_capture,
+        causal,
+        rswa_prefix_lens,
+    )
+    return CommonAttentionMetadata(
+        query_start_loc_gpu,
+        query_start_loc_cpu,
+    )
+
+
 build_attn_metadata = _build_attn_metadata
 
 
@@ -400,6 +449,62 @@ def _original_prepare_attn(
     )
 
 
+def _prepare_attn_with_request_sizing_drift(
+    self,
+    input_batch,
+    cudagraph_mode,
+    block_tables,
+    slot_mappings,
+    attn_groups,
+    kv_cache_config,
+    for_capture=False,
+):
+    if cudagraph_mode == CUDAGraphMode.FULL:
+        num_reqs = input_batch.num_reqs_after_padding
+        num_tokens = input_batch.num_tokens_after_padding
+    else:
+        # Same signature and audited names, but silently changes request sizing.
+        num_reqs = input_batch.num_reqs + 1
+        num_tokens = input_batch.num_tokens
+    query_start_loc_cpu = torch.from_numpy(input_batch.query_start_loc_np)
+    max_query_len = input_batch.num_scheduled_tokens.max().item()
+    seq_lens_cpu_upper_bound = input_batch.seq_lens_cpu_upper_bound
+    if for_capture:
+        max_seq_len = self.max_model_len
+    else:
+        max_seq_len = seq_lens_cpu_upper_bound[:num_reqs].max().item()
+    req_doc_ranges = None
+    if (
+        self.supports_mm_inputs
+        and self.encoder_cache is not None
+        and self.model_config.is_mm_prefix_lm
+    ):
+        req_doc_ranges = compute_mm_prefix_ranges(
+            req_ids=input_batch.req_ids,
+            mm_features=self.encoder_cache.mm_features,
+            sliding_window=self.model_config.get_sliding_window(),
+        )
+    return build_attn_metadata(
+        attn_groups=attn_groups,
+        num_reqs=num_reqs,
+        num_tokens=num_tokens,
+        query_start_loc_gpu=input_batch.query_start_loc,
+        query_start_loc_cpu=query_start_loc_cpu,
+        max_query_len=max_query_len,
+        seq_lens=input_batch.seq_lens,
+        max_seq_len=max_seq_len,
+        block_tables=block_tables,
+        slot_mappings=slot_mappings,
+        kv_cache_config=kv_cache_config,
+        seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
+        dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
+        positions=input_batch.positions,
+        mm_req_doc_ranges=req_doc_ranges,
+        for_cudagraph_capture=for_capture,
+        rswa_prefix_lens=input_batch.prompt_lens,
+    )
+
+
 def _fake_default_model_state_module(adapter) -> ModuleType:
     target = ModuleType(adapter.TARGET_MODULE)
 
@@ -426,13 +531,40 @@ def _fake_default_model_state_module(adapter) -> ModuleType:
     return target
 
 
-def test_pcp_default_model_state_slices_metadata_and_propagates_phase() -> None:
+def _source_sha256(function) -> str:
+    source = textwrap.dedent(inspect.getsource(function))
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+
+def _accept_synthetic_model_state_sources(
+    monkeypatch: pytest.MonkeyPatch,
+    adapter,
+    target: ModuleType,
+) -> None:
+    monkeypatch.setattr(
+        adapter,
+        "_V0251_PREPARE_ATTN_SOURCE_SHA256",
+        _source_sha256(target.DefaultModelState.prepare_attn),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "_V0251_BUILD_ATTN_METADATA_SOURCE_SHA256",
+        _source_sha256(target.build_attn_metadata),
+        raising=False,
+    )
+
+
+def test_pcp_default_model_state_slices_metadata_and_propagates_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Trailing virtual rows or missing phase data break MLA classification."""
 
     adapter = importlib.import_module(
         "vllm_hcu.patch.worker.framework_opt.patch_pcp_model_state"
     )
     target = _fake_default_model_state_module(adapter)
+    _accept_synthetic_model_state_sources(monkeypatch, adapter, target)
     assert adapter.apply_to_module(target) is True
     assert adapter.apply_to_module(target) is False
 
@@ -514,6 +646,72 @@ def test_pcp_default_model_state_slices_metadata_and_propagates_phase() -> None:
         "pcp_one_query_cpu": [0, 1, 3, 9, 9],
         "pcp_one_has_phase_adapter": False,
     }
+
+
+def test_pcp_default_model_state_rejects_same_signature_behavior_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A changed request-sizing body must fail before wrapper installation."""
+
+    adapter = importlib.import_module(
+        "vllm_hcu.patch.worker.framework_opt.patch_pcp_model_state"
+    )
+    target = _fake_default_model_state_module(adapter)
+    _accept_synthetic_model_state_sources(monkeypatch, adapter, target)
+    drifted = FunctionType(
+        _prepare_attn_with_request_sizing_drift.__code__,
+        target.__dict__,
+        name="prepare_attn",
+        argdefs=_prepare_attn_with_request_sizing_drift.__defaults__,
+    )
+    target.DefaultModelState.prepare_attn = drifted
+
+    with pytest.raises(
+        PatchCompatibilityError, match="source fingerprint"
+    ) as error:
+        adapter.apply_to_module(target)
+
+    message = str(error.value)
+    assert adapter.TARGETS[0] in message
+    assert "expected sha256=" in message
+    assert "actual sha256=" in message
+    assert target.DefaultModelState.prepare_attn is drifted
+    assert not hasattr(target.DefaultModelState, "_vllm_hcu_original_prepare_attn")
+    assert not getattr(target, "_vllm_hcu_pcp_model_state_applied", False)
+
+
+def test_pcp_default_model_state_rejects_common_hook_behavior_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A helper that drops model-specific common metadata must fail closed."""
+
+    adapter = importlib.import_module(
+        "vllm_hcu.patch.worker.framework_opt.patch_pcp_model_state"
+    )
+    target = _fake_default_model_state_module(adapter)
+    _accept_synthetic_model_state_sources(monkeypatch, adapter, target)
+    original_prepare_attn = target.DefaultModelState.prepare_attn
+    drifted = FunctionType(
+        _build_attn_metadata_without_common_hook.__code__,
+        target.__dict__,
+        name="build_attn_metadata",
+        argdefs=_build_attn_metadata_without_common_hook.__defaults__,
+    )
+    target.build_attn_metadata = drifted
+
+    with pytest.raises(
+        PatchCompatibilityError, match="source fingerprint"
+    ) as error:
+        adapter.apply_to_module(target)
+
+    message = str(error.value)
+    assert adapter.TARGETS[1] in message
+    assert "expected sha256=" in message
+    assert "actual sha256=" in message
+    assert target.build_attn_metadata is drifted
+    assert target.DefaultModelState.prepare_attn is original_prepare_attn
+    assert not hasattr(target.DefaultModelState, "_vllm_hcu_original_prepare_attn")
+    assert not getattr(target, "_vllm_hcu_pcp_model_state_applied", False)
 
 
 def test_pcp_default_model_state_rejects_signature_drift() -> None:

--- a/tests/runtime_patch/test_mla_target_ownership.py
+++ b/tests/runtime_patch/test_mla_target_ownership.py
@@ -16,6 +16,16 @@ import torch
 from vllm_hcu.model_executor.layers import mla_runtime
 
 
+def split_decodes_and_prefills(
+    common_attn_metadata,
+    decode_threshold=1,
+    require_uniform=False,
+    treat_short_extends_as_decodes=True,
+):
+    del decode_threshold, require_uniform, treat_short_extends_as_decodes
+    return 0, 1, 0, common_attn_metadata.num_actual_tokens
+
+
 class _GenericStub:
     @classmethod
     def __class_getitem__(cls, item):
@@ -714,6 +724,13 @@ def test_dense_and_sparse_mla_metadata_carry_pcp_world_size(monkeypatch):
     )
 
     class FlashMLASparseMetadataBuilder:
+        def _build_fp8_separate_prefill_decode(
+            self, common_attn_metadata
+        ):
+            del self
+            counts = split_decodes_and_prefills(common_attn_metadata)
+            return SimpleNamespace(num_prefills=counts[1])
+
         def build(
             self,
             common_prefix_len,

--- a/tests/runtime_patch/test_mla_target_ownership.py
+++ b/tests/runtime_patch/test_mla_target_ownership.py
@@ -745,6 +745,12 @@ def test_dense_and_sparse_mla_metadata_carry_pcp_world_size(monkeypatch):
     sparse_module = ModuleType(sparse_adapter.TARGET_MODULE)
     sparse_module.FlashMLASparseMetadataBuilder = FlashMLASparseMetadataBuilder
     sparse_module.FlashMLASparseImpl = FlashMLASparseImpl
+    sparse_module.split_decodes_and_prefills = (
+        lambda common_attn_metadata,
+        decode_threshold=1,
+        require_uniform=False,
+        treat_short_extends_as_decodes=True: (0, 0, 0, 0)
+    )
     sparse_module.current_platform = SimpleNamespace(is_rocm=lambda: False)
     sparse_module.torch = torch
     assert sparse_adapter.apply_to_module(sparse_module) is True

--- a/tests/runtime_patch/test_mla_target_ownership.py
+++ b/tests/runtime_patch/test_mla_target_ownership.py
@@ -16,16 +16,6 @@ import torch
 from vllm_hcu.model_executor.layers import mla_runtime
 
 
-def split_decodes_and_prefills(
-    common_attn_metadata,
-    decode_threshold=1,
-    require_uniform=False,
-    treat_short_extends_as_decodes=True,
-):
-    del decode_threshold, require_uniform, treat_short_extends_as_decodes
-    return 0, 1, 0, common_attn_metadata.num_actual_tokens
-
-
 class _GenericStub:
     @classmethod
     def __class_getitem__(cls, item):
@@ -724,13 +714,6 @@ def test_dense_and_sparse_mla_metadata_carry_pcp_world_size(monkeypatch):
     )
 
     class FlashMLASparseMetadataBuilder:
-        def _build_fp8_separate_prefill_decode(
-            self, common_attn_metadata
-        ):
-            del self
-            counts = split_decodes_and_prefills(common_attn_metadata)
-            return SimpleNamespace(num_prefills=counts[1])
-
         def build(
             self,
             common_prefix_len,
@@ -770,6 +753,18 @@ def test_dense_and_sparse_mla_metadata_carry_pcp_world_size(monkeypatch):
     )
     sparse_module.current_platform = SimpleNamespace(is_rocm=lambda: False)
     sparse_module.torch = torch
+    sparse_module.SimpleNamespace = SimpleNamespace
+    exec(
+        """
+def _build_fp8_separate_prefill_decode(self, common_attn_metadata):
+    counts = split_decodes_and_prefills(common_attn_metadata)
+    return SimpleNamespace(num_prefills=counts[1])
+""",
+        sparse_module.__dict__,
+    )
+    FlashMLASparseMetadataBuilder._build_fp8_separate_prefill_decode = (
+        sparse_module._build_fp8_separate_prefill_decode
+    )
     assert sparse_adapter.apply_to_module(sparse_module) is True
     sparse_builder = FlashMLASparseMetadataBuilder()
     sparse_builder.vllm_config = SimpleNamespace(

--- a/tests/runtime_patch/test_mla_target_ownership.py
+++ b/tests/runtime_patch/test_mla_target_ownership.py
@@ -24,6 +24,8 @@ class _GenericStub:
 
 
 class _MLACommonImplStub(_GenericStub):
+    supports_pcp = False
+
     def __init__(
         self,
         num_heads,
@@ -187,8 +189,9 @@ def _adapter():
     )
 
 
-def _fake_mla_module(adapter, target_calls):
+def _fake_mla_module(adapter, target_calls, event_log=None):
     split_calls = []
+    full_forward_calls = []
 
     def split_decodes_and_prefills(
         common_attn_metadata,
@@ -244,6 +247,20 @@ def _fake_mla_module(adapter, target_calls):
                 topk_indices_buffer,
                 extra_impl_args,
             )
+            self.use_direct_call = False
+
+        def forward(
+            self,
+            q,
+            kv_c_normed,
+            k_pe,
+            output_shape=None,
+        ):
+            args = (q, kv_c_normed, k_pe, output_shape)
+            full_forward_calls.append((self, args))
+            if event_log is not None:
+                event_log.append("opaque_forward")
+            return "target-opaque-v0.25.1"
 
         def forward_impl(
             self,
@@ -275,6 +292,8 @@ def _fake_mla_module(adapter, target_calls):
                 quant_tma_aligned,
             )
             target_calls.append((self, args))
+            if event_log is not None:
+                event_log.append("forward_impl")
             return "target-v0.25.1"
 
         def process_weights_after_loading(self, act_dtype):
@@ -302,6 +321,12 @@ def _fake_mla_module(adapter, target_calls):
     module.MLACommonMetadataBuilder = MLACommonMetadataBuilder
     module.split_decodes_and_prefills = split_decodes_and_prefills
     module.split_calls = split_calls
+    module.full_forward_calls = full_forward_calls
+    module.get_forward_context = lambda: pytest.fail(
+        "test did not install a forward context"
+    )
+    module._encode_layer_name = lambda value: value
+    module.torch = torch
     module.current_platform = SimpleNamespace(
         is_rocm=lambda: pytest.fail(
             "feature ownership must not depend on the target platform"
@@ -428,6 +453,233 @@ def test_mla_feature_on_uses_hcu_lightly_cp_delta(monkeypatch):
     assert hcu_calls == [(module, instance, args)]
 
 
+@pytest.mark.parametrize(("pcp_size", "expected_direct"), [(1, False), (2, True)])
+def test_mla_init_enables_direct_calls_only_for_pcp(
+    monkeypatch,
+    pcp_size,
+    expected_direct,
+):
+    adapter = _adapter()
+    module = _fake_mla_module(adapter, [])
+    monkeypatch.setattr(
+        adapter,
+        "get_hcu_config",
+        lambda config: SimpleNamespace(enable_lightly_cp=False),
+    )
+    import vllm.config as vllm_config_module
+
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=pcp_size,
+        )
+    )
+    monkeypatch.setattr(
+        vllm_config_module,
+        "get_current_vllm_config_or_none",
+        lambda: config,
+    )
+    assert adapter.apply_to_module(module) is True
+    assert adapter.apply_to_module(module) is False
+
+    instance = module.MLAAttention(1, 1.0, 1, 1, 1, None, 1, object())
+
+    assert instance.use_direct_call is expected_direct
+    assert instance._hcu_pcp_world_size == pcp_size
+
+
+def test_mla_init_rejects_combined_pcp_and_lightly_cp(monkeypatch):
+    adapter = _adapter()
+    module = _fake_mla_module(adapter, [])
+    monkeypatch.setattr(
+        adapter,
+        "get_hcu_config",
+        lambda config: SimpleNamespace(enable_lightly_cp=True),
+    )
+    import vllm.config as vllm_config_module
+
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(prefill_context_parallel_size=2)
+    )
+    monkeypatch.setattr(
+        vllm_config_module,
+        "get_current_vllm_config_or_none",
+        lambda: config,
+    )
+    assert adapter.apply_to_module(module) is True
+
+    with pytest.raises(RuntimeError, match="PCP.*lightly-CP"):
+        module.MLAAttention(1, 1.0, 1, 1, 1, None, 1, object())
+
+
+def test_mla_pcp_full_forward_gathers_cache_inputs_and_keeps_q_local(
+    monkeypatch,
+):
+    adapter = _adapter()
+    target_calls = []
+    events = []
+    module = _fake_mla_module(adapter, target_calls, events)
+    context_holder = {}
+    module.get_forward_context = lambda: context_holder["context"]
+    assert adapter.apply_to_module(module) is True
+
+    q = torch.tensor([[1.0], [2.0]])
+    local_kv = torch.tensor([[10.0], [11.0]])
+    local_rope = torch.tensor([[[20.0]], [[21.0]]])
+    expanded_slots = torch.tensor([100, 101, 200], dtype=torch.int64)
+    gathered_kv = torch.tensor([[10.0], [11.0], [12.0]])
+    gathered_rope = torch.tensor([[[20.0]], [[21.0]], [[22.0]]])
+    gathered_slots = torch.tensor([100, 101, 200], dtype=torch.int64)
+    metadata = SimpleNamespace(
+        pcp_world_size=2,
+        num_decode_tokens=0,
+        num_prefills=2,
+    )
+    context = SimpleNamespace(
+        attn_metadata={"layer": metadata},
+        slot_mapping={"layer": expanded_slots},
+    )
+    context_holder["context"] = context
+
+    from vllm_hcu.model_executor.layers.attention import pcp
+
+    def gather(kv, rope, slots, actual_metadata):
+        events.append("gather")
+        assert kv is local_kv
+        assert rope is local_rope
+        assert slots is expanded_slots
+        assert actual_metadata is metadata
+        return gathered_kv, gathered_rope, gathered_slots
+
+    monkeypatch.setattr(pcp, "maybe_gather_mla_latent_cache_inputs", gather)
+
+    class Impl:
+        def do_kv_cache_update(
+            self,
+            kv,
+            rope,
+            cache,
+            slots,
+            cache_dtype,
+            k_scale,
+        ):
+            events.append("cache")
+            assert kv is gathered_kv
+            assert rope is gathered_rope
+            assert slots is gathered_slots
+
+    instance = object.__new__(module.MLAAttention)
+    instance._hcu_use_pcp = True
+    instance._hcu_pcp_world_size = 2
+    instance._hcu_feature_config = SimpleNamespace(enable_lightly_cp=False)
+    instance.calculate_kv_scales = False
+    instance.layer_name = "layer"
+    instance.kv_cache = torch.empty(0)
+    instance.kv_cache_dtype = "auto"
+    instance._k_scale = torch.tensor(1.0)
+    instance.impl = Impl()
+
+    result = instance.forward(
+        q,
+        local_kv,
+        local_rope,
+        output_shape=torch.Size([2, 1]),
+    )
+
+    assert result.shape == (2, 1)
+    assert events == ["gather", "cache", "forward_impl"]
+    assert module.full_forward_calls == []
+    assert len(target_calls) == 1
+    forwarded_args = target_calls[0][1]
+    assert forwarded_args[0] is q
+    assert forwarded_args[1] is local_kv
+    assert forwarded_args[2] is local_rope
+    assert forwarded_args[4] is metadata
+
+
+def test_mla_pcp_one_keeps_target_opaque_full_forward(monkeypatch):
+    adapter = _adapter()
+    events = []
+    module = _fake_mla_module(adapter, [], events)
+    assert adapter.apply_to_module(module) is True
+    from vllm_hcu.model_executor.layers.attention import pcp
+
+    monkeypatch.setattr(
+        pcp,
+        "maybe_gather_mla_latent_cache_inputs",
+        lambda *args: pytest.fail("PCP=1 gathered MLA cache inputs"),
+    )
+    instance = object.__new__(module.MLAAttention)
+    instance._hcu_use_pcp = False
+    q, kv, rope = object(), object(), object()
+
+    assert instance.forward(q, kv, rope) == "target-opaque-v0.25.1"
+    assert module.full_forward_calls == [(instance, (q, kv, rope, None))]
+    assert events == ["opaque_forward"]
+
+
+def test_dense_and_sparse_mla_metadata_carry_pcp_world_size(monkeypatch):
+    adapter = _adapter()
+    module = _fake_mla_module(adapter, [])
+    assert adapter.apply_to_module(module) is True
+    dense_builder = module.MLACommonMetadataBuilder()
+    dense_builder.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(prefill_context_parallel_size=2)
+    )
+    common = SimpleNamespace(num_actual_tokens=3, num_kv_actual_tokens=5)
+
+    dense_metadata = dense_builder.build(0, common)
+
+    assert dense_metadata.pcp_world_size == 2
+
+    sparse_adapter = importlib.import_module(
+        "vllm_hcu.patch.worker.op_opt.patch_flashmla_sparse"
+    )
+
+    class FlashMLASparseMetadataBuilder:
+        def build(
+            self,
+            common_prefix_len,
+            common_attn_metadata,
+            fast_build=False,
+        ):
+            del common_prefix_len, common_attn_metadata, fast_build
+            return SimpleNamespace(fp8_use_mixed_batch=False)
+
+    class FlashMLASparseImpl:
+        def _fp8_flash_mla_kernel(
+            self,
+            q,
+            kv_c_and_k_pe_cache,
+            topk_indices,
+            kernel_metadata,
+        ):
+            return q
+
+        def _bf16_flash_mla_kernel(
+            self,
+            q,
+            kv_c_and_k_pe_cache,
+            topk_indices,
+            topk_length=None,
+        ):
+            return q
+
+    sparse_module = ModuleType(sparse_adapter.TARGET_MODULE)
+    sparse_module.FlashMLASparseMetadataBuilder = FlashMLASparseMetadataBuilder
+    sparse_module.FlashMLASparseImpl = FlashMLASparseImpl
+    sparse_module.current_platform = SimpleNamespace(is_rocm=lambda: False)
+    sparse_module.torch = torch
+    assert sparse_adapter.apply_to_module(sparse_module) is True
+    sparse_builder = FlashMLASparseMetadataBuilder()
+    sparse_builder.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(prefill_context_parallel_size=2)
+    )
+
+    sparse_metadata = sparse_builder.build(0, common)
+
+    assert sparse_metadata.pcp_world_size == 2
+
+
 @pytest.mark.parametrize(
     ("is_gfx938", "use_cat_mla", "expected"),
     [
@@ -471,6 +723,46 @@ def test_flashmla_impl_owns_quant_query_capability(
         kv_sharing_target_layer_name=None,
     )
     assert impl.supports_quant_query_input is expected
+
+
+def test_only_hcu_dense_and_sparse_mla_impls_advertise_pcp(
+    monkeypatch,
+    cpu_flashmla,
+):
+    dense_impl = cpu_flashmla.HcuFlashMLABackend.get_impl_cls()
+    assert dense_impl is cpu_flashmla.FlashMLAImpl
+    assert dense_impl.supports_pcp is True
+    assert _MLACommonImplStub.supports_pcp is False
+
+    class UpstreamFlashMLASparseImpl:
+        supports_pcp = False
+
+    class UpstreamFlashMLASparseBackend:
+        @staticmethod
+        def get_impl_cls():
+            return UpstreamFlashMLASparseImpl
+
+    _install_stub(
+        monkeypatch,
+        "vllm.v1.attention.backends.mla.flashmla_sparse",
+        FlashMLASparseBackend=UpstreamFlashMLASparseBackend,
+        FlashMLASparseImpl=UpstreamFlashMLASparseImpl,
+    )
+    module_name = "_vllm_hcu_cpu_test_flashmla_sparse_backend"
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "vllm_hcu/v1/attention/backends/mla/flashmla_sparse.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, source)
+    assert spec is not None and spec.loader is not None
+    sparse = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, sparse)
+    spec.loader.exec_module(sparse)
+
+    sparse_impl = sparse.HcuFlashMLASparseBackend.get_impl_cls()
+    assert sparse_impl is sparse.HcuFlashMLASparseImpl
+    assert sparse_impl.supports_pcp is True
+    assert UpstreamFlashMLASparseImpl.supports_pcp is False
 
 
 def test_flashmla_cat_route_consumes_split_query(

--- a/tests/runtime_patch/test_mla_target_ownership.py
+++ b/tests/runtime_patch/test_mla_target_ownership.py
@@ -596,6 +596,84 @@ def test_mla_pcp_full_forward_gathers_cache_inputs_and_keeps_q_local(
     assert forwarded_args[4] is metadata
 
 
+def test_mla_pcp_profile_forward_skips_cache_without_metadata(monkeypatch):
+    adapter = _adapter()
+    target_calls = []
+    events = []
+    module = _fake_mla_module(adapter, target_calls, events)
+    module.get_forward_context = lambda: SimpleNamespace(
+        attn_metadata=None,
+        slot_mapping={},
+    )
+    assert adapter.apply_to_module(module) is True
+    from vllm_hcu.model_executor.layers.attention import pcp
+
+    monkeypatch.setattr(
+        pcp,
+        "maybe_gather_mla_latent_cache_inputs",
+        lambda *args: pytest.fail("profile forward gathered cache inputs"),
+    )
+
+    class Impl:
+        def do_kv_cache_update(self, *args):
+            pytest.fail("profile forward inserted into the KV cache")
+
+    instance = object.__new__(module.MLAAttention)
+    instance._hcu_use_pcp = True
+    instance._hcu_pcp_world_size = 2
+    instance._hcu_feature_config = SimpleNamespace(enable_lightly_cp=False)
+    instance.calculate_kv_scales = False
+    instance.layer_name = "layer"
+    instance.kv_cache = torch.empty(0)
+    instance.kv_cache_dtype = "auto"
+    instance._k_scale = torch.tensor(1.0)
+    instance.impl = Impl()
+    q = torch.tensor([[1.0], [2.0]])
+    local_kv = torch.tensor([[10.0], [11.0]])
+    local_rope = torch.tensor([[[20.0]], [[21.0]]])
+
+    result = instance.forward(
+        q,
+        local_kv,
+        local_rope,
+        output_shape=torch.Size([2, 1]),
+    )
+
+    assert result.shape == (2, 1)
+    assert events == ["forward_impl"]
+    assert len(target_calls) == 1
+    forwarded_args = target_calls[0][1]
+    assert forwarded_args[0] is q
+    assert forwarded_args[1] is local_kv
+    assert forwarded_args[2] is local_rope
+    assert forwarded_args[4] is None
+
+
+def test_mla_pcp_real_forward_rejects_missing_layer_slots():
+    adapter = _adapter()
+    module = _fake_mla_module(adapter, [])
+    metadata = SimpleNamespace(pcp_world_size=2)
+    module.get_forward_context = lambda: SimpleNamespace(
+        attn_metadata={"layer": metadata},
+        slot_mapping={},
+    )
+    assert adapter.apply_to_module(module) is True
+
+    instance = object.__new__(module.MLAAttention)
+    instance._hcu_use_pcp = True
+    instance._hcu_pcp_world_size = 2
+    instance.calculate_kv_scales = False
+    instance.layer_name = "layer"
+
+    with pytest.raises(RuntimeError, match="slot mapping is missing"):
+        instance.forward(
+            torch.ones(1, 1),
+            torch.ones(1, 1),
+            torch.ones(1, 1, 1),
+            output_shape=torch.Size([1, 1]),
+        )
+
+
 def test_mla_pcp_one_keeps_target_opaque_full_forward(monkeypatch):
     adapter = _adapter()
     events = []

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -1989,6 +1989,49 @@ def test_moe_runner_and_shared_experts_cold_replacement_contract():
         shared_experts._layer = SharedLayer()
         value = shared_experts._run_layer(hidden, (quanted, scale))
         assert torch.equal(value, hidden + 2)
+
+        class PCPGroup:
+            def __init__(self):
+                self.gathers = 0
+                self.reduce_scatters = 0
+
+            def all_gather(self, tensor, dim=0):
+                del tensor
+                assert dim == 0
+                self.gathers += 1
+                raise AssertionError("all-to-all kernel must consume PCP-local input")
+
+            def reduce_scatter(self, tensor, dim=0):
+                del tensor
+                assert dim == 0
+                self.reduce_scatters += 1
+                raise AssertionError("all-to-all kernel must produce PCP-local output")
+
+        pcp_group = PCPGroup()
+        runner = object.__new__(runner_module.MoERunner)
+        runner.moe_config = SimpleNamespace(
+            pcp_size=2,
+            dp_size=1,
+            is_sequence_parallel=False,
+            moe_parallel_config=SimpleNamespace(use_all2all_kernels=True),
+        )
+        runner.routed_experts = SimpleNamespace(
+            quant_method=SimpleNamespace(supports_internal_mk=False),
+        )
+        runner._shared_experts = None
+        runner_module.get_pcp_group = lambda: pcp_group
+        local_hidden = torch.tensor([[10.0], [20.0]])
+        local_logits = torch.tensor([[1.0], [2.0]])
+        dispatched_hidden, dispatched_logits = runner._maybe_dispatch(
+            local_hidden, local_logits
+        )
+        combined = runner._maybe_combine(None, dispatched_hidden)
+        assert torch.equal(dispatched_hidden, local_hidden)
+        assert torch.equal(dispatched_logits, local_logits)
+        assert torch.equal(combined, local_hidden)
+        assert pcp_group.gathers == 0
+        assert pcp_group.reduce_scatters == 0
+
         shared_source = inspect.getsource(shared_module.SharedExperts)
         assert "_output_pending_on_stream" in shared_source
         assert "VLLM_HCU_SHARED_EXPERTS_EARLY_LAUNCH" in shared_source

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -741,7 +741,10 @@ def _validation_config(feature_config: HcuFeatureConfig) -> object:
         additional_config={"hcu": feature_config.to_dict()},
         compilation_config=_ValidationCompilation(),
         model_config=SimpleNamespace(enforce_eager=True, use_mla=False),
-        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=1,
+            decode_context_parallel_size=1,
+        ),
         kernel_config=SimpleNamespace(moe_backend="auto"),
         kv_transfer_config=None,
     )

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -590,6 +590,12 @@ def _make_vllm_module() -> ModuleType:
             self.compilation_config.post_init_cudagraph_sizes()
             return "upstream-result"
 
+        def _get_v2_model_runner_unsupported_features(self) -> list[str]:
+            return []
+
+        def _validate_v2_model_runner(self) -> None:
+            return None
+
     module.VllmConfig = FakeVllmConfig
     module.ModelConfig = _FakeModelConfig
     return module

--- a/tests/runtime_patch/test_sparse_indexer_loading.py
+++ b/tests/runtime_patch/test_sparse_indexer_loading.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import ast
+import copy
+import importlib
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 import torch
@@ -41,6 +43,52 @@ def _load_model_helpers():
     }
     exec(compile(module, "deepseek_v2_helpers", "exec"), namespace)
     return namespace
+
+
+def _load_v32_sparse_indexer_contract(**dependencies):
+    source = (
+        REPO / "vllm_hcu/model_executor/layers/sparse_attn_indexer.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    class_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "V32SparseAttnIndexer"
+    )
+    method = copy.deepcopy(
+        next(
+            node
+            for node in class_node.body
+            if isinstance(node, ast.FunctionDef) and node.name == "forward_hip"
+        )
+    )
+    method.decorator_list = []
+    module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = dict(dependencies)
+    exec(compile(module, "v32_sparse_indexer_forward_hip", "exec"), namespace)
+    return namespace["forward_hip"]
+
+
+def _load_v32_sparse_indexer_class():
+    source = (
+        REPO / "vllm_hcu/model_executor/layers/sparse_attn_indexer.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    class_node = copy.deepcopy(
+        next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "V32SparseAttnIndexer"
+        )
+    )
+    class_node.bases = [ast.Name(id="SparseAttnIndexer", ctx=ast.Load())]
+    module = ast.Module(body=[class_node], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {"torch": torch, "SparseAttnIndexer": object}
+    exec(compile(module, "v32_sparse_indexer_class", "exec"), namespace)
+    return namespace["V32SparseAttnIndexer"]
 
 
 @pytest.mark.parametrize("dtype", [torch.int8, torch.float8_e4m3fn])
@@ -137,3 +185,193 @@ def test_stacked_name_rewrite_source_contract_is_component_bounded():
     assert rewrite(name, "gate_proj", "gate_up_proj") == (
         "model.gate_proj_alias.gate_up_proj.weight"
     )
+
+
+def test_v32_pcp_gathers_k_and_slots_before_hcu_cache_insertion():
+    events: list[tuple[object, ...]] = []
+    local_k = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    gathered_k = torch.tensor(
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+    )
+    expanded_slots = torch.tensor([10, 11, 20], dtype=torch.int64)
+    gathered_slots = torch.tensor([10, 11, 20], dtype=torch.int64)
+    metadata = SimpleNamespace(
+        slot_mapping=expanded_slots,
+        pcp_world_size=2,
+        num_decode_tokens=0,
+        num_prefills=2,
+    )
+
+    def gather(k, slots, actual_metadata):
+        events.append(("gather", k, slots, actual_metadata))
+        return gathered_k, gathered_slots
+
+    def cache_insert(k, cache, slots, block_size, scale_fmt):
+        events.append(
+            ("cache", k, cache, slots, block_size, scale_fmt)
+        )
+
+    def hcu_op(*args):
+        events.append(("hcu_op", *args))
+        return "topk"
+
+    fake_torch = SimpleNamespace(
+        Tensor=torch.Tensor,
+        ops=SimpleNamespace(vllm=SimpleNamespace(hcu_sparse_attn_indexer=hcu_op)),
+    )
+    forward_hip = _load_v32_sparse_indexer_contract(
+        torch=fake_torch,
+        get_forward_context=lambda: SimpleNamespace(
+            attn_metadata={"indexer": metadata}
+        ),
+        maybe_gather_indexer_k=gather,
+        ops=SimpleNamespace(indexer_k_quant_and_cache=cache_insert),
+        on_gfx938=lambda: True,
+        indexer_k_bf16_cache_triton=lambda *args: pytest.fail(
+            "gfx938 PCP cache write used the BF16 fallback"
+        ),
+        _encode_layer_name=lambda value: value,
+    )
+    cache = object()
+    q_quant = torch.tensor([[7.0, 8.0]])
+    weights = torch.tensor([[9.0]])
+    hidden_states = torch.tensor([[10.0]])
+    indexer = SimpleNamespace(
+        use_fp4_cache=False,
+        use_pcp=True,
+        pcp_world_size=2,
+        skip_k_cache_insert=False,
+        k_cache=SimpleNamespace(prefix="indexer", kv_cache=cache),
+        quant_block_size=128,
+        scale_fmt="e8m0",
+        topk_tokens=2048,
+        head_dim=128,
+        max_model_len=65536,
+        max_total_seq_len=65536,
+        topk_indices_buffer=object(),
+    )
+
+    assert forward_hip(indexer, hidden_states, q_quant, local_k, weights) == "topk"
+
+    assert [event[0] for event in events] == ["gather", "cache", "hcu_op"]
+    assert events[0][1] is local_k
+    assert events[0][2] is expanded_slots
+    assert events[0][3] is metadata
+    assert events[1][1] is gathered_k
+    assert events[1][2] is cache
+    assert events[1][3] is gathered_slots
+    hcu_args = events[2][1:]
+    assert hcu_args[0] is hidden_states
+    assert hcu_args[3] is q_quant
+    assert hcu_args[4] is local_k
+    assert hcu_args[5] is weights
+    assert hcu_args[8] == 2048
+    assert hcu_args[-1] is True
+
+
+def test_v32_hcu_indexer_impl_advertises_pcp_capability():
+    assert _load_v32_sparse_indexer_class().supports_pcp is True
+
+
+def test_indexer_metadata_adapter_propagates_pcp_world_size():
+    adapter = importlib.import_module(
+        "vllm_hcu.patch.worker.op_opt.patch_mla_indexer"
+    )
+
+    def split_chunks(
+        seq_lens_cpu,
+        query_lens_cpu,
+        workspace_size,
+        max_logits_bytes,
+        request_offset=0,
+    ):
+        return [(slice(0, 1), slice(0, 1))]
+
+    def split_batch(
+        common_attn_metadata,
+        decode_threshold=1,
+        require_uniform=False,
+        treat_short_extends_as_decodes=True,
+    ):
+        return (0, 1, 0, common_attn_metadata.num_actual_tokens)
+
+    class Builder:
+        def build(
+            self,
+            common_prefix_len,
+            common_attn_metadata,
+            fast_build=False,
+        ):
+            return SimpleNamespace(decode=None)
+
+    module = ModuleType(adapter.TARGET_MODULE)
+    module.split_indexer_prefill_chunks = split_chunks
+    module.split_decodes_and_prefills = split_batch
+    module.DeepseekV32IndexerMetadataBuilder = Builder
+    module.current_platform = SimpleNamespace(is_rocm=lambda: False)
+    assert adapter.apply_to_module(module) is True
+    builder = Builder()
+    builder.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(prefill_context_parallel_size=2)
+    )
+    common = SimpleNamespace(
+        num_actual_tokens=2,
+        num_kv_actual_tokens=3,
+    )
+
+    metadata = builder.build(0, common)
+
+    assert metadata.pcp_world_size == 2
+
+
+def test_v32_pcp_one_preserves_existing_hcu_custom_op_ownership():
+    calls: list[tuple[object, ...]] = []
+
+    def hcu_op(*args):
+        calls.append(args)
+        return "topk"
+
+    fake_torch = SimpleNamespace(
+        Tensor=torch.Tensor,
+        ops=SimpleNamespace(vllm=SimpleNamespace(hcu_sparse_attn_indexer=hcu_op)),
+    )
+    forward_hip = _load_v32_sparse_indexer_contract(
+        torch=fake_torch,
+        get_forward_context=lambda: pytest.fail(
+            "PCP=1 inspected forward metadata outside the custom op"
+        ),
+        maybe_gather_indexer_k=lambda *args: pytest.fail(
+            "PCP=1 gathered sparse-indexer cache inputs"
+        ),
+        ops=SimpleNamespace(
+            indexer_k_quant_and_cache=lambda *args: pytest.fail(
+                "PCP=1 moved cache ownership outside the custom op"
+            )
+        ),
+        on_gfx938=lambda: True,
+        indexer_k_bf16_cache_triton=lambda *args: pytest.fail(
+            "PCP=1 moved cache ownership outside the custom op"
+        ),
+        _encode_layer_name=lambda value: value,
+    )
+    local_k = torch.ones(1, 2)
+    q_quant = torch.ones(1, 2)
+    indexer = SimpleNamespace(
+        use_fp4_cache=False,
+        use_pcp=False,
+        pcp_world_size=1,
+        skip_k_cache_insert=False,
+        k_cache=SimpleNamespace(prefix="indexer", kv_cache=object()),
+        quant_block_size=128,
+        scale_fmt="e8m0",
+        topk_tokens=2048,
+        head_dim=128,
+        max_model_len=65536,
+        max_total_seq_len=65536,
+        topk_indices_buffer=object(),
+    )
+
+    assert forward_hip(indexer, object(), q_quant, local_k, object()) == "topk"
+    assert len(calls) == 1
+    assert calls[0][4] is local_k
+    assert calls[0][-1] is False

--- a/vllm_hcu/model_executor/layers/attention/pcp.py
+++ b/vllm_hcu/model_executor/layers/attention/pcp.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""PCP cache-input gathers for HCU MLA and sparse indexers.
+
+Adapted from ``vllm/model_executor/layers/attention/pcp.py`` in vLLM pull
+request #46570, commit ``b6ff8a2f509cc7ac9c58176f5115a836aa1e08bd``.
+The HCU adapter keeps the v0.25.1 eager call graph and consumes the
+rank-ordered slot mappings produced by :class:`HcuPCPManager`.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.distributed.parallel_state import get_pcp_group
+
+
+def _pcp_world_size(metadata: object | None) -> int:
+    if metadata is None:
+        return 1
+    world_size = int(getattr(metadata, "pcp_world_size", 1))
+    assert world_size >= 1, f"invalid PCP world size {world_size}"
+    return world_size
+
+
+def _rank_slot_slice(
+    slot_mapping: torch.Tensor,
+    local_num_tokens: int,
+    metadata: object,
+    world_size: int,
+    rank: int,
+) -> torch.Tensor:
+    assert slot_mapping.ndim == 1, (
+        "PCP cache slot mapping must be one-dimensional, got "
+        f"shape={tuple(slot_mapping.shape)}"
+    )
+    token_counts = getattr(metadata, "pcp_token_counts", None)
+    if token_counts is None:
+        expected_slots = world_size * local_num_tokens
+        assert slot_mapping.shape[0] == expected_slots, (
+            "PCP cache inputs require one equal-width slot segment per rank: "
+            f"slots={slot_mapping.shape[0]}, local_tokens={local_num_tokens}, "
+            f"world_size={world_size}"
+        )
+        start = rank * local_num_tokens
+        return slot_mapping[start : start + local_num_tokens]
+
+    counts = tuple(int(count) for count in token_counts)
+    assert len(counts) == world_size, (
+        "PCP token counts must contain one entry per rank: "
+        f"counts={counts}, world_size={world_size}"
+    )
+    assert all(count >= 0 for count in counts), (
+        f"PCP token counts must be non-negative, got {counts}"
+    )
+    assert counts[rank] == local_num_tokens, (
+        "PCP local tensor length does not match its token count: "
+        f"rank={rank}, tensor={local_num_tokens}, count={counts[rank]}"
+    )
+    assert slot_mapping.shape[0] == sum(counts), (
+        "PCP gathered slot mapping length does not match token counts: "
+        f"slots={slot_mapping.shape[0]}, counts={counts}"
+    )
+    start = sum(counts[:rank])
+    return slot_mapping[start : start + local_num_tokens]
+
+
+def _decode_only_slot_mapping(
+    slot_mapping: torch.Tensor,
+    local_num_tokens: int,
+    metadata: object,
+) -> torch.Tensor:
+    """Match rank-zero decode slots to local replicated cache tensors."""
+
+    num_decode_tokens = int(getattr(metadata, "num_decode_tokens"))
+    assert slot_mapping.ndim == 1, (
+        "PCP cache slot mapping must be one-dimensional, got "
+        f"shape={tuple(slot_mapping.shape)}"
+    )
+    assert 0 <= num_decode_tokens <= local_num_tokens, (
+        "PCP decode token count is outside the local tensor: "
+        f"decode={num_decode_tokens}, local={local_num_tokens}"
+    )
+    assert slot_mapping.shape[0] >= num_decode_tokens, (
+        "PCP cache slot mapping is shorter than the decode segment: "
+        f"slots={slot_mapping.shape[0]}, decode={num_decode_tokens}"
+    )
+    if slot_mapping.shape[0] == num_decode_tokens:
+        return slot_mapping
+    return slot_mapping[:num_decode_tokens]
+
+
+def _gather_prefill_cache_inputs(
+    tensors: tuple[torch.Tensor, ...],
+    slot_mapping: torch.Tensor,
+    metadata: object | None,
+) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+    """Keep replicated decode writes local and gather partitioned prefills."""
+
+    world_size = _pcp_world_size(metadata)
+    if world_size == 1 or metadata is None:
+        return tensors, slot_mapping
+
+    num_prefills = getattr(metadata, "num_prefills", None)
+    if num_prefills == 0:
+        return tensors, slot_mapping
+
+    num_decode_tokens = getattr(metadata, "num_decode_tokens", None)
+    if num_decode_tokens is None:
+        return tensors, slot_mapping
+    num_decode_tokens = int(num_decode_tokens)
+
+    assert tensors, "PCP cache gather requires at least one tensor"
+    local_num_tokens = tensors[0].shape[0]
+    assert all(tensor.shape[0] == local_num_tokens for tensor in tensors), (
+        "PCP cache tensors must have the same token dimension"
+    )
+    assert 0 <= num_decode_tokens <= local_num_tokens, (
+        "PCP decode token count is outside the local tensor: "
+        f"decode={num_decode_tokens}, local={local_num_tokens}"
+    )
+
+    pcp_group = get_pcp_group()
+    assert int(pcp_group.world_size) == world_size, (
+        "PCP metadata/process-group size mismatch: "
+        f"metadata={world_size}, group={pcp_group.world_size}"
+    )
+    rank = int(pcp_group.rank_in_group)
+    assert 0 <= rank < world_size, f"invalid PCP rank {rank}/{world_size}"
+    local_slots = _rank_slot_slice(
+        slot_mapping,
+        local_num_tokens,
+        metadata,
+        world_size,
+        rank,
+    )
+
+    gathered_prefills = tuple(
+        pcp_group.all_gather(
+            tensor[num_decode_tokens:].contiguous(),
+            dim=0,
+        )
+        for tensor in tensors
+    )
+    gathered_prefill_slots = pcp_group.all_gather(
+        local_slots[num_decode_tokens:].contiguous(),
+        dim=0,
+    )
+    if num_decode_tokens == 0:
+        return gathered_prefills, gathered_prefill_slots
+
+    cache_inputs = tuple(
+        torch.cat((tensor[:num_decode_tokens], gathered_prefill), dim=0)
+        for tensor, gathered_prefill in zip(tensors, gathered_prefills)
+    )
+    # Rank zero owns the single replicated-decode write in HcuPCPManager's
+    # rank-ordered slot mapping. Every rank uses that same leading segment.
+    cache_slot_mapping = torch.cat(
+        (
+            slot_mapping[:num_decode_tokens],
+            gathered_prefill_slots,
+        ),
+        dim=0,
+    )
+    return cache_inputs, cache_slot_mapping
+
+
+def maybe_gather_mla_latent_cache_inputs(
+    kv_c_normed: torch.Tensor,
+    k_pe: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    metadata: object | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Gather MLA latent KV, RoPE K, and matching slots for cache writes."""
+
+    world_size = _pcp_world_size(metadata)
+    if world_size == 1 or metadata is None:
+        return kv_c_normed, k_pe, slot_mapping
+    num_prefills = getattr(metadata, "num_prefills", None)
+    num_decode_tokens = getattr(metadata, "num_decode_tokens", None)
+    if num_decode_tokens is None:
+        return kv_c_normed, k_pe, slot_mapping
+    if num_prefills == 0:
+        cache_slot_mapping = _decode_only_slot_mapping(
+            slot_mapping,
+            kv_c_normed.shape[0],
+            metadata,
+        )
+        return kv_c_normed, k_pe, cache_slot_mapping
+    assert kv_c_normed.shape[0] == k_pe.shape[0], (
+        "PCP MLA latent KV and RoPE K must have the same token dimension"
+    )
+
+    num_tokens = kv_c_normed.shape[0]
+    k_pe_flat = k_pe.reshape(num_tokens, -1)
+    (cache_kv_c, cache_k_pe_flat), cache_slot_mapping = (
+        _gather_prefill_cache_inputs(
+            (kv_c_normed, k_pe_flat),
+            slot_mapping,
+            metadata,
+        )
+    )
+    cache_k_pe = cache_k_pe_flat.view(-1, *k_pe.shape[1:])
+    return cache_kv_c, cache_k_pe, cache_slot_mapping
+
+
+def maybe_gather_indexer_k(
+    k: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    metadata: object | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather sparse-indexer K and matching slots for its cache write."""
+
+    world_size = _pcp_world_size(metadata)
+    if world_size == 1 or metadata is None:
+        return k, slot_mapping
+    num_prefills = getattr(metadata, "num_prefills", None)
+    num_decode_tokens = getattr(metadata, "num_decode_tokens", None)
+    if num_decode_tokens is None:
+        return k, slot_mapping
+    if num_prefills == 0:
+        cache_slot_mapping = _decode_only_slot_mapping(
+            slot_mapping,
+            k.shape[0],
+            metadata,
+        )
+        return k, cache_slot_mapping
+    (cache_k,), cache_slot_mapping = _gather_prefill_cache_inputs(
+        (k,),
+        slot_mapping,
+        metadata,
+    )
+    return cache_k, cache_slot_mapping
+
+
+__all__ = (
+    "maybe_gather_indexer_k",
+    "maybe_gather_mla_latent_cache_inputs",
+)

--- a/vllm_hcu/model_executor/layers/attention/pcp.py
+++ b/vllm_hcu/model_executor/layers/attention/pcp.py
@@ -102,10 +102,6 @@ def _gather_prefill_cache_inputs(
     if world_size == 1 or metadata is None:
         return tensors, slot_mapping
 
-    num_prefills = getattr(metadata, "num_prefills", None)
-    if num_prefills == 0:
-        return tensors, slot_mapping
-
     num_decode_tokens = getattr(metadata, "num_decode_tokens", None)
     if num_decode_tokens is None:
         return tensors, slot_mapping
@@ -120,6 +116,12 @@ def _gather_prefill_cache_inputs(
         "PCP decode token count is outside the local tensor: "
         f"decode={num_decode_tokens}, local={local_num_tokens}"
     )
+    if num_decode_tokens == local_num_tokens:
+        return tensors, _decode_only_slot_mapping(
+            slot_mapping,
+            local_num_tokens,
+            metadata,
+        )
 
     pcp_group = get_pcp_group()
     assert int(pcp_group.world_size) == world_size, (
@@ -177,20 +179,19 @@ def maybe_gather_mla_latent_cache_inputs(
     world_size = _pcp_world_size(metadata)
     if world_size == 1 or metadata is None:
         return kv_c_normed, k_pe, slot_mapping
-    num_prefills = getattr(metadata, "num_prefills", None)
     num_decode_tokens = getattr(metadata, "num_decode_tokens", None)
     if num_decode_tokens is None:
         return kv_c_normed, k_pe, slot_mapping
-    if num_prefills == 0:
+    assert kv_c_normed.shape[0] == k_pe.shape[0], (
+        "PCP MLA latent KV and RoPE K must have the same token dimension"
+    )
+    if int(num_decode_tokens) == kv_c_normed.shape[0]:
         cache_slot_mapping = _decode_only_slot_mapping(
             slot_mapping,
             kv_c_normed.shape[0],
             metadata,
         )
         return kv_c_normed, k_pe, cache_slot_mapping
-    assert kv_c_normed.shape[0] == k_pe.shape[0], (
-        "PCP MLA latent KV and RoPE K must have the same token dimension"
-    )
 
     num_tokens = kv_c_normed.shape[0]
     k_pe_flat = k_pe.reshape(num_tokens, -1)
@@ -215,17 +216,9 @@ def maybe_gather_indexer_k(
     world_size = _pcp_world_size(metadata)
     if world_size == 1 or metadata is None:
         return k, slot_mapping
-    num_prefills = getattr(metadata, "num_prefills", None)
     num_decode_tokens = getattr(metadata, "num_decode_tokens", None)
     if num_decode_tokens is None:
         return k, slot_mapping
-    if num_prefills == 0:
-        cache_slot_mapping = _decode_only_slot_mapping(
-            slot_mapping,
-            k.shape[0],
-            metadata,
-        )
-        return k, cache_slot_mapping
     (cache_k,), cache_slot_mapping = _gather_prefill_cache_inputs(
         (k,),
         slot_mapping,

--- a/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
@@ -888,7 +888,11 @@ class MoERunner(MoERunnerInterface):
         # NOTE: Similar with DP, PCP also needs dispatch and combine. For
         # simplicity, AgRsAll2All was added separately for PCP here. Maybe
         # we should modify All2AllManager abstraction to better support PCP.
-        if self.moe_config.pcp_size > 1:
+        needs_fallback_pcp_collective = (
+            self.moe_config.pcp_size > 1
+            and not self.moe_config.moe_parallel_config.use_all2all_kernels
+        )
+        if needs_fallback_pcp_collective:
             hidden_states = get_pcp_group().all_gather(
                 hidden_states,
                 dim=0,
@@ -910,7 +914,11 @@ class MoERunner(MoERunnerInterface):
                 hidden_states, self.moe_config.is_sequence_parallel
             )
 
-        if self.moe_config.pcp_size > 1:
+        needs_fallback_pcp_collective = (
+            self.moe_config.pcp_size > 1
+            and not self.moe_config.moe_parallel_config.use_all2all_kernels
+        )
+        if needs_fallback_pcp_collective:
             hidden_states = get_pcp_group().reduce_scatter(
                 hidden_states,
                 dim=0,

--- a/vllm_hcu/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm_hcu/model_executor/layers/sparse_attn_indexer.py
@@ -37,6 +37,7 @@ from vllm.v1.attention.backends.mla.indexer import (
 )
 from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
 from vllm.v1.worker.workspace import current_workspace_manager
+from vllm_hcu.model_executor.layers.attention.pcp import maybe_gather_indexer_k
 
 logger = init_logger(__name__)
 
@@ -686,7 +687,9 @@ direct_register_custom_op(
 
 
 if current_platform.is_rocm():
+    from vllm_hcu.platforms.hcu import on_gfx938
     from vllm_hcu.v1.attention.ops.rocm_aiter_mla_sparse import (
+        indexer_k_bf16_cache_triton,
         rocm_aiter_sparse_attn_indexer_fake,
         rocm_aiter_sparse_attn_indexer_native,
     )
@@ -813,6 +816,8 @@ class SparseAttnIndexer(CustomOp):
         self.dcp_world_size = parallel_config.decode_context_parallel_size
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
         self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
+        self.pcp_world_size = parallel_config.prefill_context_parallel_size
+        self.use_pcp = self.pcp_world_size > 1
         if current_platform.is_cuda() and not has_deep_gemm():
             raise RuntimeError(
                 "Sparse Attention Indexer CUDA op requires DeepGEMM support in "
@@ -938,6 +943,8 @@ class SparseAttnIndexer(CustomOp):
 class V32SparseAttnIndexer(SparseAttnIndexer):
     """Compile-isolated HCU fallback for V3.2/V4/GLM-5 indexers."""
 
+    supports_pcp: bool = True
+
     def forward_hip(
         self,
         hidden_states: torch.Tensor,
@@ -949,6 +956,43 @@ class V32SparseAttnIndexer(SparseAttnIndexer):
         assert isinstance(q_quant, torch.Tensor), (
             "HCU sparse_attn_indexer expects a single FP8 q_quant tensor"
         )
+        skip_k_cache_insert = self.skip_k_cache_insert
+        if self.use_pcp and not skip_k_cache_insert:
+            attn_metadata = get_forward_context().attn_metadata
+            if isinstance(attn_metadata, dict):
+                layer_metadata = attn_metadata[self.k_cache.prefix]
+                metadata_world_size = int(
+                    getattr(layer_metadata, "pcp_world_size", 1)
+                )
+                if metadata_world_size != self.pcp_world_size:
+                    raise RuntimeError(
+                        "PCP sparse-indexer metadata world size mismatch: "
+                        f"indexer={self.pcp_world_size}, "
+                        f"metadata={metadata_world_size}"
+                    )
+                cache_k, cache_slots = maybe_gather_indexer_k(
+                    k,
+                    layer_metadata.slot_mapping,
+                    layer_metadata,
+                )
+                assert self.scale_fmt is not None
+                if on_gfx938():
+                    ops.indexer_k_quant_and_cache(
+                        cache_k,
+                        self.k_cache.kv_cache,
+                        cache_slots,
+                        self.quant_block_size,
+                        self.scale_fmt,
+                    )
+                else:
+                    indexer_k_bf16_cache_triton(
+                        cache_k,
+                        self.k_cache.kv_cache,
+                        cache_slots,
+                    )
+                # The complete cache write is explicit above.  Keep the
+                # existing HCU custom op for local Q/top-k work only.
+                skip_k_cache_insert = True
         return torch.ops.vllm.hcu_sparse_attn_indexer(
             hidden_states,
             _encode_layer_name(self.k_cache.prefix),
@@ -963,5 +1007,5 @@ class V32SparseAttnIndexer(SparseAttnIndexer):
             self.max_model_len,
             self.max_total_seq_len,
             self.topk_indices_buffer,
-            self.skip_k_cache_insert,
+            skip_k_cache_insert,
         )

--- a/vllm_hcu/patch/platform/__init__.py
+++ b/vllm_hcu/patch/platform/__init__.py
@@ -24,6 +24,10 @@ from .framework_opt import (
     patch_output_processor,
     patch_outputs,
     patch_parallel_state,
+    patch_pcp_kv_cache_coordinator,
+    patch_pcp_kv_cache_interface,
+    patch_pcp_kv_cache_utils,
+    patch_pcp_single_type_kv_cache_manager,
     patch_scheduler,
 )
 
@@ -36,12 +40,18 @@ _DISPATCH_LOCK = threading.RLock()
 # coordinator applies those callbacks immediately in the order below.  Keep
 # the HCU-owned Mooncake contract ahead of its factory registration, then arm
 # the vLLM integration points from low-level KV/distributed contracts through
-# scheduling and engine output.
+# scheduling and engine output.  PCP KV-ownership adapters must run before the
+# MTP coordinator wrapper so its base-constructor chain observes DCP-only
+# cache sizing while retaining the existing MTP group semantics.
 _ORDERED_FRAMEWORK_ADAPTERS = (
     patch_distributed_utils,
     patch_mooncake_connector,
     patch_kv_connector_factory,
     patch_parallel_state,
+    patch_pcp_kv_cache_utils,
+    patch_pcp_kv_cache_interface,
+    patch_pcp_single_type_kv_cache_manager,
+    patch_pcp_kv_cache_coordinator,
     patch_kv_cache_coordinator,
     patch_scheduler,
     patch_engine_core,

--- a/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
@@ -139,6 +139,7 @@ def _validate_hcu_pcp_scope(vllm_config: object) -> bool:
 def validate_and_update_hcu_config(vllm_config: object) -> HcuFeatureConfig:
     """Validate cross-config invariants and bind the compilation adapter."""
 
+    _validate_hcu_pcp_scope(vllm_config)
     feature_config = get_hcu_config(vllm_config)
     updates: dict[str, str] = {}
     if feature_config.hcu_flash_attn_mode is None:

--- a/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
@@ -312,7 +312,7 @@ def apply_to_module(module: ModuleType) -> bool:
     model_arch_signature = inspect.signature(get_model_arch_config)
     if tuple(model_arch_signature.parameters) != ("self",):
         raise PatchCompatibilityError(
-            f"required HCU patch target {TARGETS[2]} has incompatible "
+            f"required HCU patch target {TARGETS[4]} has incompatible "
             f"signature {model_arch_signature}"
         )
     with_hf_signature = inspect.signature(with_hf_config)

--- a/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
@@ -19,6 +19,8 @@ PATCH_ID = "platform.core_fix.hcu_config.vllm"
 TARGETS = (
     f"{TARGET_MODULE}.VllmConfig.with_hf_config",
     f"{TARGET_MODULE}.VllmConfig._set_cudagraph_sizes",
+    f"{TARGET_MODULE}.VllmConfig._get_v2_model_runner_unsupported_features",
+    f"{TARGET_MODULE}.VllmConfig._validate_v2_model_runner",
     "vllm.config.model.ModelConfig.get_model_arch_config",
     "vllm_hcu.platforms.hcu.HCUPlatform.check_and_update_config",
 )
@@ -29,6 +31,109 @@ _REQUEST_CAPTURE_SIZES = (
     *range(40, 65, 4),
     *range(72, 257, 8),
 )
+
+
+def _require_hcu_pcp_attribute(owner: object, name: str, owner_name: str) -> Any:
+    try:
+        return getattr(owner, name)
+    except AttributeError as exc:
+        raise PatchCompatibilityError(
+            f"GLM-5.2 PCP requires {owner_name}.{name} in vLLM 0.25.1"
+        ) from exc
+
+
+def _require_mrv2_mla_eager_pcp_contract(vllm_config: object) -> None:
+    """Reject every Model Runner V2 PCP configuration outside HCU support."""
+
+    if not _require_hcu_pcp_attribute(
+        vllm_config, "use_v2_model_runner", "VllmConfig"
+    ):
+        raise ValueError("GLM-5.2 PCP requires Model Runner V2.")
+
+    model_config = _require_hcu_pcp_attribute(
+        vllm_config, "model_config", "VllmConfig"
+    )
+    parallel_config = _require_hcu_pcp_attribute(
+        vllm_config, "parallel_config", "VllmConfig"
+    )
+    cache_config = _require_hcu_pcp_attribute(
+        vllm_config, "cache_config", "VllmConfig"
+    )
+
+    architectures = _require_hcu_pcp_attribute(
+        model_config, "architectures", "ModelConfig"
+    )
+    if architectures != ["GlmMoeDsaForCausalLM"]:
+        raise ValueError(
+            "GLM-5.2 PCP only supports architecture "
+            "GlmMoeDsaForCausalLM."
+        )
+    if not _require_hcu_pcp_attribute(model_config, "use_mla", "ModelConfig"):
+        raise ValueError("GLM-5.2 PCP requires MLA or sparse MLA.")
+    if _require_hcu_pcp_attribute(
+        parallel_config, "pipeline_parallel_size", "ParallelConfig"
+    ) != 1:
+        raise ValueError("GLM-5.2 PCP does not support pipeline parallelism.")
+    if _require_hcu_pcp_attribute(
+        parallel_config, "decode_context_parallel_size", "ParallelConfig"
+    ) != 1:
+        raise ValueError(
+            "GLM-5.2 PCP does not support decode context parallelism."
+        )
+    if _require_hcu_pcp_attribute(
+        parallel_config, "data_parallel_size", "ParallelConfig"
+    ) != 1:
+        raise ValueError("GLM-5.2 PCP does not support data parallelism.")
+    if not _require_hcu_pcp_attribute(
+        parallel_config, "enable_expert_parallel", "ParallelConfig"
+    ):
+        raise ValueError("GLM-5.2 PCP requires expert parallelism.")
+    if not _require_hcu_pcp_attribute(model_config, "enforce_eager", "ModelConfig"):
+        raise ValueError("GLM-5.2 PCP requires eager execution without graphs.")
+    if _require_hcu_pcp_attribute(
+        vllm_config, "speculative_config", "VllmConfig"
+    ) is not None:
+        raise ValueError("GLM-5.2 PCP does not support speculative decoding or MTP.")
+    if _require_hcu_pcp_attribute(vllm_config, "lora_config", "VllmConfig") is not None:
+        raise ValueError("GLM-5.2 PCP does not support LoRA.")
+    if _require_hcu_pcp_attribute(
+        model_config, "is_multimodal_model", "ModelConfig"
+    ):
+        raise ValueError("GLM-5.2 PCP does not support multimodal models.")
+    if _require_hcu_pcp_attribute(
+        cache_config, "kv_offloading_size", "CacheConfig"
+    ) is not None:
+        raise ValueError("GLM-5.2 PCP does not support KV offload.")
+
+    kv_transfer_config = _require_hcu_pcp_attribute(
+        vllm_config, "kv_transfer_config", "VllmConfig"
+    )
+    if kv_transfer_config is not None and _require_hcu_pcp_attribute(
+        kv_transfer_config, "kv_connector", "KVTransferConfig"
+    ) is not None:
+        raise ValueError("GLM-5.2 PCP does not support P/D disaggregation.")
+
+    feature_config = get_hcu_config(vllm_config)
+    if feature_config.enable_lightly_cp:
+        raise ValueError("GLM-5.2 PCP does not support lightly-CP.")
+    if feature_config.enable_multi_layers_mtp:
+        raise ValueError("GLM-5.2 PCP does not support speculative decoding or MTP.")
+
+
+def _validate_hcu_pcp_scope(vllm_config: object) -> bool:
+    """Return whether this configuration is in the HCU PCP support scope."""
+
+    parallel_config = _require_hcu_pcp_attribute(
+        vllm_config, "parallel_config", "VllmConfig"
+    )
+    pcp_size = _require_hcu_pcp_attribute(
+        parallel_config, "prefill_context_parallel_size", "ParallelConfig"
+    )
+    if pcp_size <= 1:
+        return False
+
+    _require_mrv2_mla_eager_pcp_contract(vllm_config)
+    return True
 
 
 def validate_and_update_hcu_config(vllm_config: object) -> HcuFeatureConfig:
@@ -188,10 +293,16 @@ def apply_to_module(module: ModuleType) -> bool:
 
     with_hf_config = vars(vllm_config).get("with_hf_config")
     set_cudagraph_sizes = vars(vllm_config).get("_set_cudagraph_sizes")
+    get_v2_unsupported_features = vars(vllm_config).get(
+        "_get_v2_model_runner_unsupported_features"
+    )
+    validate_v2_model_runner = vars(vllm_config).get("_validate_v2_model_runner")
     get_model_arch_config = vars(model_config_class).get("get_model_arch_config")
     if (
         not callable(with_hf_config)
         or not callable(set_cudagraph_sizes)
+        or not callable(get_v2_unsupported_features)
+        or not callable(validate_v2_model_runner)
         or not callable(get_model_arch_config)
     ):
         raise PatchCompatibilityError(
@@ -218,6 +329,18 @@ def apply_to_module(module: ModuleType) -> bool:
         raise PatchCompatibilityError(
             f"required HCU patch target {TARGETS[1]} has incompatible "
             f"signature {cudagraph_signature}"
+        )
+    unsupported_features_signature = inspect.signature(get_v2_unsupported_features)
+    if tuple(unsupported_features_signature.parameters) != ("self",):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[2]} has incompatible "
+            f"signature {unsupported_features_signature}"
+        )
+    validate_v2_signature = inspect.signature(validate_v2_model_runner)
+    if tuple(validate_v2_signature.parameters) != ("self",):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[3]} has incompatible "
+            f"signature {validate_v2_signature}"
         )
 
     @functools.wraps(get_model_arch_config)
@@ -292,6 +415,40 @@ def apply_to_module(module: ModuleType) -> bool:
         )
         return result
 
+    @functools.wraps(get_v2_unsupported_features)
+    def hcu_get_v2_model_runner_unsupported_features(self) -> list[str]:
+        unsupported = get_v2_unsupported_features(self)
+        try:
+            hcu_pcp_enabled = _validate_hcu_pcp_scope(self)
+        except ValueError:
+            # Leave every out-of-scope PCP configuration on the exact upstream
+            # rejection path. The direct scope check provides its actionable
+            # diagnostic without relaxing vLLM's generic V2 contract.
+            return unsupported
+        if not hcu_pcp_enabled:
+            return unsupported
+        return [
+            feature
+            for feature in unsupported
+            if feature != "prefill context parallelism"
+        ]
+
+    @functools.wraps(validate_v2_model_runner)
+    def hcu_validate_v2_model_runner(self) -> Any:
+        parallel_config = _require_hcu_pcp_attribute(
+            self, "parallel_config", "VllmConfig"
+        )
+        pcp_size = _require_hcu_pcp_attribute(
+            parallel_config, "prefill_context_parallel_size", "ParallelConfig"
+        )
+        if pcp_size > 1:
+            try:
+                _validate_hcu_pcp_scope(self)
+            except ValueError:
+                # Preserve v0.25.1 validation for every rejected PCP shape.
+                return validate_v2_model_runner(self)
+        return validate_v2_model_runner(self)
+
     setattr(vllm_config, "_vllm_hcu_original_with_hf_config", with_hf_config)
     setattr(vllm_config, "with_hf_config", hcu_with_hf_config)
     setattr(
@@ -300,6 +457,26 @@ def apply_to_module(module: ModuleType) -> bool:
         set_cudagraph_sizes,
     )
     setattr(vllm_config, "_set_cudagraph_sizes", hcu_set_cudagraph_sizes)
+    setattr(
+        vllm_config,
+        "_vllm_hcu_original_get_v2_model_runner_unsupported_features",
+        get_v2_unsupported_features,
+    )
+    setattr(
+        vllm_config,
+        "_get_v2_model_runner_unsupported_features",
+        hcu_get_v2_model_runner_unsupported_features,
+    )
+    setattr(
+        vllm_config,
+        "_vllm_hcu_original_validate_v2_model_runner",
+        validate_v2_model_runner,
+    )
+    setattr(
+        vllm_config,
+        "_validate_v2_model_runner",
+        hcu_validate_v2_model_runner,
+    )
     setattr(vllm_config, _MARKER, True)
     return True
 

--- a/vllm_hcu/patch/platform/framework_opt/patch_pcp_kv_cache_coordinator.py
+++ b/vllm_hcu/patch/platform/framework_opt/patch_pcp_kv_cache_coordinator.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Keep unitary coordinator KV ownership independent of PCP."""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from types import ModuleType
+
+from ._common import (
+    PatchCompatibilityError,
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_class,
+)
+
+
+TARGET_MODULE = "vllm.v1.core.kv_cache_coordinator"
+PATCH_ID = "platform.framework_opt.pcp_kv_cache_coordinator"
+TARGETS = (f"{TARGET_MODULE}.UnitaryKVCacheCoordinator.__init__",)
+_MARKER = "_vllm_hcu_pcp_kv_cache_coordinator_applied"
+_WRAPPER = "_vllm_hcu_pcp_unitary_coordinator_init_wrapper"
+_PARAMETERS = (
+    "self",
+    "kv_cache_config",
+    "max_model_len",
+    "max_num_batched_tokens",
+    "use_eagle",
+    "enable_caching",
+    "enable_kv_cache_events",
+    "dcp_world_size",
+    "pcp_world_size",
+    "scheduler_block_size",
+    "hash_block_size",
+    "metrics_collector",
+)
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    coordinator = load_exact_module(TARGET_MODULE, module)
+    unitary = require_class(
+        coordinator,
+        "UnitaryKVCacheCoordinator",
+        f"{TARGET_MODULE}.UnitaryKVCacheCoordinator",
+    )
+    if already_applied(
+        coordinator,
+        _MARKER,
+        ((unitary, "__init__", _WRAPPER),),
+    ):
+        return False
+
+    original = require_callable(unitary, "__init__", TARGETS[0])
+    signature = inspect.signature(original)
+    parameters = tuple(signature.parameters.values())
+    if (
+        tuple(signature.parameters) != _PARAMETERS
+        or any(
+            parameter.kind is not inspect.Parameter.POSITIONAL_OR_KEYWORD
+            for parameter in parameters
+        )
+        or any(
+            parameter.default
+            is not (
+                None
+                if parameter.name == "metrics_collector"
+                else inspect.Parameter.empty
+            )
+            for parameter in parameters
+        )
+    ):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[0]} has incompatible "
+            f"signature {signature}"
+        )
+    base = require_class(
+        coordinator,
+        "KVCacheCoordinator",
+        f"{TARGET_MODULE}.KVCacheCoordinator",
+    )
+    if unitary.__bases__ != (base,):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[0]} has incompatible base class"
+        )
+
+    @functools.wraps(original)
+    def hcu_init(
+        self,
+        kv_cache_config,
+        max_model_len,
+        max_num_batched_tokens,
+        use_eagle,
+        enable_caching,
+        enable_kv_cache_events,
+        dcp_world_size,
+        pcp_world_size,
+        scheduler_block_size,
+        hash_block_size,
+        metrics_collector=None,
+    ):
+        if pcp_world_size == 1:
+            return original(
+                self,
+                kv_cache_config,
+                max_model_len,
+                max_num_batched_tokens,
+                use_eagle,
+                enable_caching,
+                enable_kv_cache_events,
+                dcp_world_size,
+                pcp_world_size,
+                scheduler_block_size,
+                hash_block_size,
+                metrics_collector,
+            )
+
+        super(unitary, self).__init__(
+            kv_cache_config,
+            max_model_len,
+            max_num_batched_tokens,
+            use_eagle,
+            enable_caching,
+            enable_kv_cache_events,
+            dcp_world_size,
+            pcp_world_size,
+            scheduler_block_size,
+            hash_block_size,
+            metrics_collector,
+        )
+        self.kv_cache_spec = self.kv_cache_config.kv_cache_groups[0].kv_cache_spec
+        self.block_size = self.kv_cache_spec.block_size
+        self.dcp_world_size = dcp_world_size
+        self.pcp_world_size = pcp_world_size
+        if dcp_world_size > 1:
+            self.block_size *= dcp_world_size
+        assert not enable_caching or hash_block_size == self.block_size, (
+            "UnitaryKVCacheCoordinator assumes hash_block_size == block_size"
+        )
+        assert len(self.kv_cache_config.kv_cache_groups) == 1, (
+            "UnitaryKVCacheCoordinator assumes only one kv cache group"
+        )
+        self.single_type_managers[0].use_eagle = 0 in self.eagle_group_ids
+        return None
+
+    setattr(hcu_init, _WRAPPER, True)
+    setattr(unitary, "_vllm_hcu_original_init", original)
+    setattr(unitary, "__init__", hcu_init)
+    setattr(coordinator, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/platform/framework_opt/patch_pcp_kv_cache_interface.py
+++ b/vllm_hcu/patch/platform/framework_opt/patch_pcp_kv_cache_interface.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Keep full-attention memory capacity independent of PCP."""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from types import ModuleType
+
+from ._common import (
+    PatchCompatibilityError,
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_class,
+)
+
+
+TARGET_MODULE = "vllm.v1.kv_cache_interface"
+PATCH_ID = "platform.framework_opt.pcp_kv_cache_interface"
+TARGETS = (f"{TARGET_MODULE}.FullAttentionSpec.max_memory_usage_bytes",)
+_MARKER = "_vllm_hcu_pcp_kv_cache_interface_applied"
+_WRAPPER = "_vllm_hcu_pcp_full_attention_memory_wrapper"
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    interface = load_exact_module(TARGET_MODULE, module)
+    full_attention_spec = require_class(
+        interface,
+        "FullAttentionSpec",
+        f"{TARGET_MODULE}.FullAttentionSpec",
+    )
+    if already_applied(
+        interface,
+        _MARKER,
+        ((full_attention_spec, "max_memory_usage_bytes", _WRAPPER),),
+    ):
+        return False
+
+    original = require_callable(
+        full_attention_spec,
+        "max_memory_usage_bytes",
+        TARGETS[0],
+    )
+    signature = inspect.signature(original)
+    parameters = tuple(signature.parameters.values())
+    if (
+        tuple(signature.parameters) != ("self", "vllm_config")
+        or any(
+            parameter.kind is not inspect.Parameter.POSITIONAL_OR_KEYWORD
+            or parameter.default is not inspect.Parameter.empty
+            for parameter in parameters
+        )
+    ):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[0]} has incompatible "
+            f"signature {signature}"
+        )
+
+    cdiv = require_callable(interface, "cdiv", f"{TARGET_MODULE}.cdiv")
+
+    @functools.wraps(original)
+    def hcu_max_memory_usage_bytes(self, vllm_config):
+        parallel_config = vllm_config.parallel_config
+        if parallel_config.prefill_context_parallel_size == 1:
+            return original(self, vllm_config)
+
+        max_model_len = vllm_config.model_config.max_model_len
+        dcp_world_size = parallel_config.decode_context_parallel_size
+        if dcp_world_size > 1:
+            max_model_len = cdiv(max_model_len, dcp_world_size)
+        return cdiv(max_model_len, self.block_size) * self.page_size_bytes
+
+    setattr(hcu_max_memory_usage_bytes, _WRAPPER, True)
+    setattr(
+        full_attention_spec,
+        "_vllm_hcu_original_max_memory_usage_bytes",
+        original,
+    )
+    setattr(
+        full_attention_spec,
+        "max_memory_usage_bytes",
+        hcu_max_memory_usage_bytes,
+    )
+    setattr(interface, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/platform/framework_opt/patch_pcp_kv_cache_utils.py
+++ b/vllm_hcu/patch/platform/framework_opt/patch_pcp_kv_cache_utils.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Keep scheduler and hash block sizing independent of PCP ownership."""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import math
+from types import ModuleType
+
+from ._common import (
+    PatchCompatibilityError,
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_class,
+)
+
+
+TARGET_MODULE = "vllm.v1.core.kv_cache_utils"
+PATCH_ID = "platform.framework_opt.pcp_kv_cache_utils"
+TARGETS = (f"{TARGET_MODULE}.resolve_kv_cache_block_sizes",)
+_MARKER = "_vllm_hcu_pcp_kv_cache_utils_applied"
+_WRAPPER = "_vllm_hcu_pcp_kv_cache_utils_wrapper"
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    kv_cache_utils = load_exact_module(TARGET_MODULE, module)
+    if already_applied(
+        kv_cache_utils,
+        _MARKER,
+        ((kv_cache_utils, "resolve_kv_cache_block_sizes", _WRAPPER),),
+    ):
+        return False
+
+    original = require_callable(
+        kv_cache_utils, "resolve_kv_cache_block_sizes", TARGETS[0]
+    )
+    signature = inspect.signature(original)
+    parameters = tuple(signature.parameters.values())
+    if (
+        tuple(signature.parameters) != ("kv_cache_config", "vllm_config")
+        or any(
+            parameter.kind is not inspect.Parameter.POSITIONAL_OR_KEYWORD
+            or parameter.default is not inspect.Parameter.empty
+            for parameter in parameters
+        )
+    ):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[0]} has incompatible "
+            f"signature {signature}"
+        )
+
+    attention_spec = require_class(
+        kv_cache_utils,
+        "AttentionSpec",
+        f"{TARGET_MODULE}.AttentionSpec",
+    )
+    mamba_spec = require_class(
+        kv_cache_utils,
+        "MambaSpec",
+        f"{TARGET_MODULE}.MambaSpec",
+    )
+
+    @functools.wraps(original)
+    def hcu_resolve_kv_cache_block_sizes(kv_cache_config, vllm_config):
+        parallel_config = vllm_config.parallel_config
+        pcp = parallel_config.prefill_context_parallel_size
+        if pcp == 1:
+            return original(kv_cache_config, vllm_config)
+
+        cache_config = vllm_config.cache_config
+        dcp = parallel_config.decode_context_parallel_size
+        groups = kv_cache_config.kv_cache_groups
+
+        if len(groups) <= 1:
+            block_size = cache_config.block_size * dcp
+            return block_size, block_size
+
+        group_block_sizes = [
+            group.kv_cache_spec.block_size * dcp
+            if isinstance(group.kv_cache_spec, attention_spec)
+            else group.kv_cache_spec.block_size
+            for group in groups
+        ]
+        scheduler_block_size = math.lcm(*group_block_sizes)
+
+        connector_enabled = vllm_config.kv_transfer_config is not None
+        if not (cache_config.enable_prefix_caching or connector_enabled):
+            return scheduler_block_size, scheduler_block_size
+
+        if any(
+            isinstance(group.kv_cache_spec, mamba_spec)
+            and group.kv_cache_spec.block_size != cache_config.block_size
+            for group in groups
+        ):
+            return scheduler_block_size, scheduler_block_size
+
+        requested = cache_config.hash_block_size
+        hash_block_size = (
+            requested
+            if requested is not None
+            else math.gcd(*group_block_sizes)
+        )
+        if any(
+            block_size % hash_block_size != 0
+            for block_size in group_block_sizes
+        ):
+            raise ValueError(
+                f"Invalid hash_block_size={hash_block_size}; all KV cache "
+                "group block sizes must be divisible by hash_block_size. "
+                f"Got group block sizes={group_block_sizes}."
+            )
+        return scheduler_block_size, hash_block_size
+
+    setattr(hcu_resolve_kv_cache_block_sizes, _WRAPPER, True)
+    setattr(
+        kv_cache_utils,
+        "_vllm_hcu_original_resolve_kv_cache_block_sizes",
+        original,
+    )
+    setattr(
+        kv_cache_utils,
+        "resolve_kv_cache_block_sizes",
+        hcu_resolve_kv_cache_block_sizes,
+    )
+    setattr(kv_cache_utils, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/platform/framework_opt/patch_pcp_single_type_kv_cache_manager.py
+++ b/vllm_hcu/patch/platform/framework_opt/patch_pcp_single_type_kv_cache_manager.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Keep per-request KV allocation and hash lookup independent of PCP."""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from types import ModuleType
+
+from ._common import (
+    PatchCompatibilityError,
+    load_exact_module,
+    require_callable,
+    require_class,
+)
+
+
+TARGET_MODULE = "vllm.v1.core.single_type_kv_cache_manager"
+PATCH_ID = "platform.framework_opt.pcp_single_type_kv_cache_manager"
+TARGETS = (
+    f"{TARGET_MODULE}.SingleTypeKVCacheManager.__init__",
+    f"{TARGET_MODULE}.FullAttentionManager.find_longest_cache_hit",
+)
+_MARKER = "_vllm_hcu_pcp_single_type_kv_cache_manager_applied"
+_INIT_WRAPPER = "_vllm_hcu_pcp_single_type_manager_init_wrapper"
+_HASH_WRAPPER = "_vllm_hcu_pcp_full_attention_hash_wrapper"
+
+_INIT_PARAMETERS = (
+    "self",
+    "kv_cache_spec",
+    "block_pool",
+    "enable_caching",
+    "kv_cache_group_id",
+    "scheduler_block_size",
+    "dcp_world_size",
+    "pcp_world_size",
+    "max_admission_blocks_per_request",
+)
+_HASH_PARAMETERS = (
+    "cls",
+    "block_hashes",
+    "max_length",
+    "kv_cache_group_ids",
+    "block_pool",
+    "kv_cache_spec",
+    "drop_eagle_block",
+    "alignment_tokens",
+    "dcp_world_size",
+    "pcp_world_size",
+)
+
+
+def _require_exact_signature(
+    function, target: str, names: tuple[str, ...], defaults: dict[str, object]
+) -> None:
+    signature = inspect.signature(function)
+    parameters = tuple(signature.parameters.values())
+    if (
+        tuple(signature.parameters) != names
+        or any(
+            parameter.kind is not inspect.Parameter.POSITIONAL_OR_KEYWORD
+            for parameter in parameters
+        )
+        or any(
+            parameter.default
+            is not defaults.get(parameter.name, inspect.Parameter.empty)
+            for parameter in parameters
+        )
+    ):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {target} has incompatible "
+            f"signature {signature}"
+        )
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    managers = load_exact_module(TARGET_MODULE, module)
+    single_type_manager = require_class(
+        managers,
+        "SingleTypeKVCacheManager",
+        f"{TARGET_MODULE}.SingleTypeKVCacheManager",
+    )
+    full_attention_manager = require_class(
+        managers,
+        "FullAttentionManager",
+        f"{TARGET_MODULE}.FullAttentionManager",
+    )
+
+    hash_descriptor = vars(full_attention_manager).get("find_longest_cache_hit")
+    if not isinstance(hash_descriptor, classmethod):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[1]} must be a classmethod"
+        )
+
+    if getattr(managers, _MARKER, False):
+        init = getattr(single_type_manager, "__init__", None)
+        current_hash_descriptor = vars(full_attention_manager).get(
+            "find_longest_cache_hit"
+        )
+        if (
+            not callable(init)
+            or not getattr(init, _INIT_WRAPPER, False)
+            or not isinstance(current_hash_descriptor, classmethod)
+            or not getattr(
+                current_hash_descriptor.__func__, _HASH_WRAPPER, False
+            )
+        ):
+            raise PatchCompatibilityError(
+                "required HCU PCP single-type manager marker is stale; "
+                "restart the process"
+            )
+        return False
+
+    original_init = require_callable(
+        single_type_manager, "__init__", TARGETS[0]
+    )
+    original_hash = hash_descriptor.__func__
+    _require_exact_signature(
+        original_init,
+        TARGETS[0],
+        _INIT_PARAMETERS,
+        {
+            "dcp_world_size": 1,
+            "pcp_world_size": 1,
+            "max_admission_blocks_per_request": None,
+        },
+    )
+    _require_exact_signature(
+        original_hash,
+        TARGETS[1],
+        _HASH_PARAMETERS,
+        {"dcp_world_size": 1, "pcp_world_size": 1},
+    )
+
+    @functools.wraps(original_init)
+    def hcu_init(
+        self,
+        kv_cache_spec,
+        block_pool,
+        enable_caching,
+        kv_cache_group_id,
+        scheduler_block_size,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        max_admission_blocks_per_request=None,
+    ):
+        if pcp_world_size == 1:
+            return original_init(
+                self,
+                kv_cache_spec,
+                block_pool,
+                enable_caching,
+                kv_cache_group_id,
+                scheduler_block_size,
+                dcp_world_size,
+                pcp_world_size,
+                max_admission_blocks_per_request,
+            )
+
+        result = original_init(
+            self,
+            kv_cache_spec,
+            block_pool,
+            enable_caching,
+            kv_cache_group_id,
+            scheduler_block_size,
+            dcp_world_size,
+            1,
+            max_admission_blocks_per_request,
+        )
+        self.pcp_world_size = pcp_world_size
+        return result
+
+    @functools.wraps(original_hash)
+    def hcu_find_longest_cache_hit(
+        cls,
+        block_hashes,
+        max_length,
+        kv_cache_group_ids,
+        block_pool,
+        kv_cache_spec,
+        drop_eagle_block,
+        alignment_tokens,
+        dcp_world_size=1,
+        pcp_world_size=1,
+    ):
+        if pcp_world_size == 1:
+            return original_hash(
+                cls,
+                block_hashes,
+                max_length,
+                kv_cache_group_ids,
+                block_pool,
+                kv_cache_spec,
+                drop_eagle_block,
+                alignment_tokens,
+                dcp_world_size,
+                pcp_world_size,
+            )
+        return original_hash(
+            cls,
+            block_hashes,
+            max_length,
+            kv_cache_group_ids,
+            block_pool,
+            kv_cache_spec,
+            drop_eagle_block,
+            alignment_tokens,
+            dcp_world_size,
+            1,
+        )
+
+    setattr(hcu_init, _INIT_WRAPPER, True)
+    setattr(hcu_find_longest_cache_hit, _HASH_WRAPPER, True)
+    setattr(
+        single_type_manager,
+        "_vllm_hcu_original_init",
+        original_init,
+    )
+    setattr(
+        full_attention_manager,
+        "_vllm_hcu_original_find_longest_cache_hit",
+        hash_descriptor,
+    )
+    setattr(single_type_manager, "__init__", hcu_init)
+    setattr(
+        full_attention_manager,
+        "find_longest_cache_hit",
+        classmethod(hcu_find_longest_cache_hit),
+    )
+    setattr(managers, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -296,6 +296,9 @@ _FRAMEWORK_CALLBACKS: tuple[_CallbackSpec, ...] = (
         _adapter("framework_opt", "patch_gpu_worker_shutdown"),
     ),
     _CallbackSpec(
+        _adapter("framework_opt", "patch_pcp_model_state"),
+    ),
+    _CallbackSpec(
         _adapter("framework_opt", "patch_dp_utils"),
         feature="deepep_low_latency",
     ),

--- a/vllm_hcu/patch/worker/framework_opt/patch_pcp_model_state.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_pcp_model_state.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Attach PCP request-phase metadata to v0.25.1 DefaultModelState.
+
+This selectively backports the DefaultModelState portion of vLLM upstream
+commit b6ff8a2f50.  The pinned v0.25.1 ``build_attn_metadata`` predates its
+``is_prefilling`` parameter, so the adapter uses the existing model-specific
+metadata hook to populate the same ``CommonAttentionMetadata`` field without
+changing the upstream helper's public signature.
+"""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+from ._common import (
+    PatchCompatibilityError,
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_exact_signature,
+)
+
+TARGET_MODULE = "vllm.v1.worker.gpu.model_states.default"
+PATCH_ID = "worker.framework_opt.pcp.default_model_state_metadata"
+TARGETS = (
+    f"{TARGET_MODULE}.DefaultModelState.prepare_attn",
+    f"{TARGET_MODULE}.build_attn_metadata",
+)
+_MARKER = "_vllm_hcu_pcp_model_state_applied"
+_WRAPPER = "_vllm_hcu_pcp_model_state_wrapper"
+
+
+class _PCPRequestPhaseMetadata:
+    """Supply request phase through v0.25.1's existing metadata hook."""
+
+    def __init__(self, is_prefilling):
+        self.is_prefilling = is_prefilling
+
+    def get_extra_common_attn_kwargs(self, kv_cache_group_id, num_reqs):
+        del kv_cache_group_id
+        return {"is_prefilling": self.is_prefilling[:num_reqs]}
+
+    def get_extra_attn_kwargs(self, attn_metadata_builder, num_reqs):
+        del attn_metadata_builder, num_reqs
+        return {}
+
+
+def _validate_build_attn_metadata(build_attn_metadata) -> None:
+    positional = (
+        "attn_groups",
+        "num_reqs",
+        "num_tokens",
+        "query_start_loc_gpu",
+        "query_start_loc_cpu",
+        "max_query_len",
+        "seq_lens",
+        "max_seq_len",
+        "block_tables",
+        "slot_mappings",
+        "kv_cache_config",
+        "seq_lens_cpu_upper_bound",
+        "dcp_local_seq_lens",
+        "positions",
+        "mm_req_doc_ranges",
+        "model_specific_attn_metadata",
+        "for_cudagraph_capture",
+        "causal",
+        "rswa_prefix_lens",
+    )
+    require_exact_signature(
+        build_attn_metadata,
+        TARGETS[1],
+        positional=positional,
+        defaults={
+            "seq_lens_cpu_upper_bound": None,
+            "dcp_local_seq_lens": None,
+            "positions": None,
+            "mm_req_doc_ranges": None,
+            "model_specific_attn_metadata": None,
+            "for_cudagraph_capture": False,
+            "causal": True,
+            "rswa_prefix_lens": None,
+        },
+    )
+    function_globals = getattr(build_attn_metadata, "__globals__", {})
+    metadata_class = function_globals.get("CommonAttentionMetadata")
+    fields = getattr(metadata_class, "__dataclass_fields__", {})
+    if "is_prefilling" not in fields:
+        raise PatchCompatibilityError(
+            "required vLLM 0.25.1 CommonAttentionMetadata.is_prefilling "
+            "field is missing"
+        )
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    default = load_exact_module(TARGET_MODULE, module)
+    model_state = require_class(
+        default,
+        "DefaultModelState",
+        f"{TARGET_MODULE}.DefaultModelState",
+    )
+    wrapped = ((model_state, "prepare_attn", TARGETS[0], _WRAPPER),)
+    if already_applied(default, _MARKER, wrapped):
+        return False
+
+    original_prepare_attn = require_callable(
+        model_state, "prepare_attn", TARGETS[0]
+    )
+    require_exact_signature(
+        original_prepare_attn,
+        TARGETS[0],
+        positional=(
+            "self",
+            "input_batch",
+            "cudagraph_mode",
+            "block_tables",
+            "slot_mappings",
+            "attn_groups",
+            "kv_cache_config",
+            "for_capture",
+        ),
+        defaults={"for_capture": False},
+    )
+    original_code = getattr(original_prepare_attn, "__code__", None)
+    original_required_names = {
+        "CUDAGraphMode",
+        "build_attn_metadata",
+        "compute_mm_prefix_ranges",
+        "query_start_loc_np",
+        "query_start_loc",
+    }
+    # is_prefilling_np is the one expected addition, so the pinned original
+    # must contain every other audited name and must not already own that path.
+    if original_code is None or not original_required_names.issubset(
+        original_code.co_names
+    ):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[0]} no longer matches the "
+            "audited v0.25.1 metadata path"
+        )
+    if "is_prefilling_np" in original_code.co_names:
+        raise PatchCompatibilityError(
+            f"audited target vLLM API {TARGETS[0]} unexpectedly already "
+            "propagates request-phase metadata"
+        )
+
+    build_attn_metadata = require_callable(
+        default, "build_attn_metadata", TARGETS[1]
+    )
+    _validate_build_attn_metadata(build_attn_metadata)
+    compute_mm_prefix_ranges = require_callable(
+        default,
+        "compute_mm_prefix_ranges",
+        f"{TARGET_MODULE}.compute_mm_prefix_ranges",
+    )
+    torch = getattr(default, "torch", None)
+    cudagraph_mode_class = getattr(default, "CUDAGraphMode", None)
+    if torch is None or cudagraph_mode_class is None:
+        raise PatchCompatibilityError(
+            f"required HCU patch dependencies for {TARGETS[0]} are missing"
+        )
+
+    @functools.wraps(original_prepare_attn)
+    def hcu_prepare_attn(
+        self,
+        input_batch,
+        cudagraph_mode,
+        block_tables,
+        slot_mappings,
+        attn_groups,
+        kv_cache_config,
+        for_capture=False,
+    ):
+        pcp_size = int(
+            self.vllm_config.parallel_config.prefill_context_parallel_size
+        )
+        if pcp_size == 1:
+            return original_prepare_attn(
+                self,
+                input_batch,
+                cudagraph_mode,
+                block_tables,
+                slot_mappings,
+                attn_groups,
+                kv_cache_config,
+                for_capture,
+            )
+
+        if cudagraph_mode == cudagraph_mode_class.FULL:
+            num_reqs = input_batch.num_reqs_after_padding
+            num_tokens = input_batch.num_tokens_after_padding
+        else:
+            num_reqs = input_batch.num_reqs
+            num_tokens = input_batch.num_tokens
+        query_start_loc_cpu = torch.from_numpy(
+            input_batch.query_start_loc_np[: num_reqs + 1]
+        )
+        query_start_loc_gpu = input_batch.query_start_loc[: num_reqs + 1]
+        max_query_len = input_batch.num_scheduled_tokens.max().item()
+        seq_lens_cpu_upper_bound = input_batch.seq_lens_cpu_upper_bound
+        if for_capture:
+            max_seq_len = self.max_model_len
+        else:
+            max_seq_len = seq_lens_cpu_upper_bound[:num_reqs].max().item()
+        req_doc_ranges = None
+        if (
+            self.supports_mm_inputs
+            and self.encoder_cache is not None
+            and self.model_config.is_mm_prefix_lm
+        ):
+            req_doc_ranges = compute_mm_prefix_ranges(
+                req_ids=input_batch.req_ids,
+                mm_features=self.encoder_cache.mm_features,
+                sliding_window=self.model_config.get_sliding_window(),
+            )
+        request_phase = _PCPRequestPhaseMetadata(
+            torch.from_numpy(input_batch.is_prefilling_np)
+        )
+        return build_attn_metadata(
+            attn_groups=attn_groups,
+            num_reqs=num_reqs,
+            num_tokens=num_tokens,
+            query_start_loc_gpu=query_start_loc_gpu,
+            query_start_loc_cpu=query_start_loc_cpu,
+            max_query_len=max_query_len,
+            seq_lens=input_batch.seq_lens,
+            max_seq_len=max_seq_len,
+            block_tables=block_tables,
+            slot_mappings=slot_mappings,
+            kv_cache_config=kv_cache_config,
+            seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
+            dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
+            positions=input_batch.positions,
+            mm_req_doc_ranges=req_doc_ranges,
+            model_specific_attn_metadata=request_phase,
+            for_cudagraph_capture=for_capture,
+            rswa_prefix_lens=input_batch.prompt_lens,
+        )
+
+    setattr(hcu_prepare_attn, _WRAPPER, True)
+    setattr(
+        model_state,
+        "_vllm_hcu_original_prepare_attn",
+        original_prepare_attn,
+    )
+    setattr(model_state, "prepare_attn", hcu_prepare_attn)
+    setattr(default, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/worker/framework_opt/patch_pcp_model_state.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_pcp_model_state.py
@@ -13,6 +13,9 @@ changing the upstream helper's public signature.
 from __future__ import annotations
 
 import functools
+import hashlib
+import inspect
+import textwrap
 from types import ModuleType
 
 from ._common import (
@@ -32,6 +35,12 @@ TARGETS = (
 )
 _MARKER = "_vllm_hcu_pcp_model_state_applied"
 _WRAPPER = "_vllm_hcu_pcp_model_state_wrapper"
+_V0251_PREPARE_ATTN_SOURCE_SHA256 = (
+    "f71a0efd2110430144bd006e9e478dcecb7b07d6eeb841a91c789a6301b9d0b9"
+)
+_V0251_BUILD_ATTN_METADATA_SOURCE_SHA256 = (
+    "62890a577c861312c50b7400cf00908e223999fe2e9e400a0738a469655d2cd1"
+)
 
 
 class _PCPRequestPhaseMetadata:
@@ -47,6 +56,23 @@ class _PCPRequestPhaseMetadata:
     def get_extra_attn_kwargs(self, attn_metadata_builder, num_reqs):
         del attn_metadata_builder, num_reqs
         return {}
+
+
+def _require_source_fingerprint(function, target: str, expected: str) -> None:
+    try:
+        source = textwrap.dedent(inspect.getsource(function))
+    except (OSError, TypeError) as exc:
+        raise PatchCompatibilityError(
+            f"required HCU patch target {target} source fingerprint could "
+            f"not be computed: expected sha256={expected}, "
+            f"actual=<unavailable>; {type(exc).__name__}: {exc}"
+        ) from exc
+    actual = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    if actual != expected:
+        raise PatchCompatibilityError(
+            f"required HCU patch target {target} source fingerprint "
+            f"mismatch: expected sha256={expected}, actual sha256={actual}"
+        )
 
 
 def _validate_build_attn_metadata(build_attn_metadata) -> None:
@@ -86,6 +112,11 @@ def _validate_build_attn_metadata(build_attn_metadata) -> None:
             "rswa_prefix_lens": None,
         },
     )
+    _require_source_fingerprint(
+        build_attn_metadata,
+        TARGETS[1],
+        _V0251_BUILD_ATTN_METADATA_SOURCE_SHA256,
+    )
     function_globals = getattr(build_attn_metadata, "__globals__", {})
     metadata_class = function_globals.get("CommonAttentionMetadata")
     fields = getattr(metadata_class, "__dataclass_fields__", {})
@@ -124,6 +155,11 @@ def apply_to_module(module: ModuleType) -> bool:
             "for_capture",
         ),
         defaults={"for_capture": False},
+    )
+    _require_source_fingerprint(
+        original_prepare_attn,
+        TARGETS[0],
+        _V0251_PREPARE_ATTN_SOURCE_SHA256,
     )
     original_code = getattr(original_prepare_attn, "__code__", None)
     original_required_names = {

--- a/vllm_hcu/patch/worker/op_opt/patch_flashmla_sparse.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_flashmla_sparse.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import functools
-from types import ModuleType
+from types import FunctionType, ModuleType
 
 from ._common import (
     PatchCompatibilityError,
@@ -23,6 +23,7 @@ TARGETS = (
     f"{TARGET_MODULE}.FlashMLASparseImpl._fp8_flash_mla_kernel",
     f"{TARGET_MODULE}.FlashMLASparseImpl._bf16_flash_mla_kernel",
     f"{TARGET_MODULE}.split_decodes_and_prefills",
+    f"{TARGET_MODULE}.FlashMLASparseMetadataBuilder._build_fp8_separate_prefill_decode",
 )
 _MARKER = "_vllm_hcu_flashmla_sparse_applied"
 _WRAPPER = "_vllm_hcu_flashmla_sparse_wrapper"
@@ -80,6 +81,58 @@ def apply_to_module(module: ModuleType) -> bool:
             "treat_short_extends_as_decodes": True,
         },
     )
+    build_fp8_separate_prefill_decode = require_callable(
+        builder_cls, "_build_fp8_separate_prefill_decode", TARGETS[4]
+    )
+    require_exact_signature(
+        build_fp8_separate_prefill_decode,
+        TARGETS[4],
+        positional=("self", "common_attn_metadata"),
+    )
+    if not isinstance(build_fp8_separate_prefill_decode, FunctionType):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[4]} must be a Python function"
+        )
+    if (
+        "split_decodes_and_prefills"
+        not in build_fp8_separate_prefill_decode.__code__.co_names
+    ):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[4]} no longer consumes "
+            "split_decodes_and_prefills"
+        )
+
+    def pcp_split_decodes_and_prefills(
+        common_attn_metadata,
+        decode_threshold=1,
+        require_uniform=False,
+        treat_short_extends_as_decodes=True,
+    ):
+        del treat_short_extends_as_decodes
+        return split_decodes_and_prefills(
+            common_attn_metadata,
+            decode_threshold=decode_threshold,
+            require_uniform=require_uniform,
+            treat_short_extends_as_decodes=False,
+        )
+
+    # Execute the audited v0.25.1 helper bytecode with only its phase splitter
+    # rebound. This preserves its shape, workspace, and chunk construction
+    # without mutating module globals or copying that implementation here.
+    pcp_separate_globals = dict(build_fp8_separate_prefill_decode.__globals__)
+    pcp_separate_globals["split_decodes_and_prefills"] = (
+        pcp_split_decodes_and_prefills
+    )
+    pcp_build_fp8_separate_prefill_decode = FunctionType(
+        build_fp8_separate_prefill_decode.__code__,
+        pcp_separate_globals,
+        build_fp8_separate_prefill_decode.__name__,
+        build_fp8_separate_prefill_decode.__defaults__,
+        build_fp8_separate_prefill_decode.__closure__,
+    )
+    pcp_build_fp8_separate_prefill_decode.__kwdefaults__ = (
+        build_fp8_separate_prefill_decode.__kwdefaults__
+    )
     # Swap only the function bindings consumed by this backend.  The official
     # backend class remains registered and no global module alias is installed.
     from vllm_hcu.v1.attention.ops import flashmla as hcu_flashmla
@@ -95,22 +148,9 @@ def apply_to_module(module: ModuleType) -> bool:
         result = build(self, common_prefix_len, common_attn_metadata, fast_build)
         from vllm_hcu.platforms import envs as henvs
 
-        if (
-            getattr(result, "fp8_use_mixed_batch", False)
-            and not henvs.VLLM_HCU_USE_FP8_MIXED_BATCH
-        ):
-            result.fp8_extra_metadata = self._build_fp8_separate_prefill_decode(
-                common_attn_metadata
-            )
-            result.fp8_use_mixed_batch = False
-        result.num_kv_actual_tokens = getattr(
-            common_attn_metadata,
-            "num_kv_actual_tokens",
-            common_attn_metadata.num_actual_tokens,
-        )
         vllm_config = getattr(self, "vllm_config", None)
         if vllm_config is None:
-            result.pcp_world_size = int(
+            pcp_world_size = int(
                 getattr(common_attn_metadata, "pcp_world_size", 1)
             )
         else:
@@ -125,7 +165,34 @@ def apply_to_module(module: ModuleType) -> bool:
                     "required vLLM 0.25.1 prefill_context_parallel_size "
                     "is missing from sparse MLA metadata builder"
                 )
-            result.pcp_world_size = int(pcp_world_size)
+            pcp_world_size = int(pcp_world_size)
+        if not henvs.VLLM_HCU_USE_FP8_MIXED_BATCH:
+            has_fp8_metadata = (
+                getattr(result, "fp8_extra_metadata", None) is not None
+            )
+            if pcp_world_size > 1 and (
+                getattr(result, "fp8_use_mixed_batch", False)
+                or has_fp8_metadata
+            ):
+                result.fp8_extra_metadata = (
+                    pcp_build_fp8_separate_prefill_decode(
+                        self, common_attn_metadata
+                    )
+                )
+                result.fp8_use_mixed_batch = False
+            elif getattr(result, "fp8_use_mixed_batch", False):
+                result.fp8_extra_metadata = (
+                    self._build_fp8_separate_prefill_decode(
+                        common_attn_metadata
+                    )
+                )
+                result.fp8_use_mixed_batch = False
+        result.num_kv_actual_tokens = getattr(
+            common_attn_metadata,
+            "num_kv_actual_tokens",
+            common_attn_metadata.num_actual_tokens,
+        )
+        result.pcp_world_size = pcp_world_size
         if result.pcp_world_size > 1:
             (
                 result.num_decodes,

--- a/vllm_hcu/patch/worker/op_opt/patch_flashmla_sparse.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_flashmla_sparse.py
@@ -7,7 +7,14 @@ from __future__ import annotations
 import functools
 from types import ModuleType
 
-from ._common import already_applied, load_exact_module, require_callable, require_class, require_exact_signature
+from ._common import (
+    PatchCompatibilityError,
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_exact_signature,
+)
 
 TARGET_MODULE = "vllm.v1.attention.backends.mla.flashmla_sparse"
 PATCH_ID = "worker.op_opt.mla.flashmla_sparse_hcu"
@@ -82,6 +89,24 @@ def apply_to_module(module: ModuleType) -> bool:
             "num_kv_actual_tokens",
             common_attn_metadata.num_actual_tokens,
         )
+        vllm_config = getattr(self, "vllm_config", None)
+        if vllm_config is None:
+            result.pcp_world_size = int(
+                getattr(common_attn_metadata, "pcp_world_size", 1)
+            )
+        else:
+            parallel_config = getattr(vllm_config, "parallel_config", None)
+            pcp_world_size = getattr(
+                parallel_config,
+                "prefill_context_parallel_size",
+                None,
+            )
+            if pcp_world_size is None:
+                raise PatchCompatibilityError(
+                    "required vLLM 0.25.1 prefill_context_parallel_size "
+                    "is missing from sparse MLA metadata builder"
+                )
+            result.pcp_world_size = int(pcp_world_size)
         return result
 
     @functools.wraps(fp8)

--- a/vllm_hcu/patch/worker/op_opt/patch_flashmla_sparse.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_flashmla_sparse.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import dis
 import functools
 from types import FunctionType, ModuleType
 
@@ -93,14 +94,38 @@ def apply_to_module(module: ModuleType) -> bool:
         raise PatchCompatibilityError(
             f"required HCU patch target {TARGETS[4]} must be a Python function"
         )
-    if (
-        "split_decodes_and_prefills"
-        not in build_fp8_separate_prefill_decode.__code__.co_names
-    ):
+    if build_fp8_separate_prefill_decode.__globals__ is not flash.__dict__:
         raise PatchCompatibilityError(
-            f"required HCU patch target {TARGETS[4]} no longer consumes "
+            f"required HCU patch target {TARGETS[4]} globals must be the "
+            "target module namespace"
+        )
+    directly_loads_splitter = any(
+        instruction.opname == "LOAD_GLOBAL"
+        and instruction.argval == "split_decodes_and_prefills"
+        for instruction in dis.Bytecode(build_fp8_separate_prefill_decode)
+    )
+    if not directly_loads_splitter:
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[4]} must use direct LOAD_GLOBAL "
             "split_decodes_and_prefills"
         )
+
+    # Validate and collect every replacement before mutating the target module.
+    from vllm_hcu.v1.attention.ops import flashmla as hcu_flashmla
+
+    hcu_bindings = {}
+    for name in (
+        "FlashMLASchedMeta",
+        "flash_mla_sparse_fwd",
+        "flash_mla_with_kvcache",
+        "get_mla_metadata",
+    ):
+        value = getattr(hcu_flashmla, name, None)
+        if value is None:
+            raise RuntimeError(
+                f"required HCU FlashMLA symbol {name} is unavailable"
+            )
+        hcu_bindings[name] = value
 
     def pcp_split_decodes_and_prefills(
         common_attn_metadata,
@@ -120,6 +145,7 @@ def apply_to_module(module: ModuleType) -> bool:
     # rebound. This preserves its shape, workspace, and chunk construction
     # without mutating module globals or copying that implementation here.
     pcp_separate_globals = dict(build_fp8_separate_prefill_decode.__globals__)
+    pcp_separate_globals.update(hcu_bindings)
     pcp_separate_globals["split_decodes_and_prefills"] = (
         pcp_split_decodes_and_prefills
     )
@@ -133,16 +159,6 @@ def apply_to_module(module: ModuleType) -> bool:
     pcp_build_fp8_separate_prefill_decode.__kwdefaults__ = (
         build_fp8_separate_prefill_decode.__kwdefaults__
     )
-    # Swap only the function bindings consumed by this backend.  The official
-    # backend class remains registered and no global module alias is installed.
-    from vllm_hcu.v1.attention.ops import flashmla as hcu_flashmla
-
-    for name in ("FlashMLASchedMeta", "flash_mla_sparse_fwd", "flash_mla_with_kvcache", "get_mla_metadata"):
-        value = getattr(hcu_flashmla, name, None)
-        if value is None:
-            raise RuntimeError(f"required HCU FlashMLA symbol {name} is unavailable")
-        setattr(flash, name, value)
-
     @functools.wraps(build)
     def hcu_build(self, common_prefix_len, common_attn_metadata, fast_build=False):
         result = build(self, common_prefix_len, common_attn_metadata, fast_build)
@@ -256,6 +272,10 @@ def apply_to_module(module: ModuleType) -> bool:
 
     for function in (hcu_build, hcu_fp8, hcu_bf16):
         setattr(function, _WRAPPER, True)
+    # Apply all target mutations only after validation and wrapper construction.
+    # The official backend class remains registered and no module alias is used.
+    for name, value in hcu_bindings.items():
+        setattr(flash, name, value)
     setattr(builder_cls, "_vllm_hcu_original_build", build)
     setattr(impl_cls, "_vllm_hcu_original_fp8_kernel", fp8)
     setattr(impl_cls, "_vllm_hcu_original_bf16_kernel", bf16)

--- a/vllm_hcu/patch/worker/op_opt/patch_flashmla_sparse.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_flashmla_sparse.py
@@ -22,6 +22,7 @@ TARGETS = (
     f"{TARGET_MODULE}.FlashMLASparseMetadataBuilder.build",
     f"{TARGET_MODULE}.FlashMLASparseImpl._fp8_flash_mla_kernel",
     f"{TARGET_MODULE}.FlashMLASparseImpl._bf16_flash_mla_kernel",
+    f"{TARGET_MODULE}.split_decodes_and_prefills",
 )
 _MARKER = "_vllm_hcu_flashmla_sparse_applied"
 _WRAPPER = "_vllm_hcu_flashmla_sparse_wrapper"
@@ -60,6 +61,24 @@ def apply_to_module(module: ModuleType) -> bool:
             "topk_length",
         ),
         defaults={"topk_length": None},
+    )
+    split_decodes_and_prefills = require_callable(
+        flash, "split_decodes_and_prefills", TARGETS[3]
+    )
+    require_exact_signature(
+        split_decodes_and_prefills,
+        TARGETS[3],
+        positional=(
+            "common_attn_metadata",
+            "decode_threshold",
+            "require_uniform",
+            "treat_short_extends_as_decodes",
+        ),
+        defaults={
+            "decode_threshold": 1,
+            "require_uniform": False,
+            "treat_short_extends_as_decodes": True,
+        },
     )
     # Swap only the function bindings consumed by this backend.  The official
     # backend class remains registered and no global module alias is installed.
@@ -107,6 +126,21 @@ def apply_to_module(module: ModuleType) -> bool:
                     "is missing from sparse MLA metadata builder"
                 )
             result.pcp_world_size = int(pcp_world_size)
+        if result.pcp_world_size > 1:
+            (
+                result.num_decodes,
+                result.num_prefills,
+                result.num_decode_tokens,
+                _,
+            ) = split_decodes_and_prefills(
+                common_attn_metadata,
+                decode_threshold=getattr(
+                    self, "reorder_batch_threshold", None
+                )
+                or 1,
+                require_uniform=True,
+                treat_short_extends_as_decodes=False,
+            )
         return result
 
     @functools.wraps(fp8)

--- a/vllm_hcu/patch/worker/op_opt/patch_mla_attention.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_mla_attention.py
@@ -16,6 +16,7 @@ TARGET_MODULE = "vllm.model_executor.layers.attention.mla_attention"
 PATCH_ID = "worker.op_opt.mla.attention_runtime"
 TARGETS = (
     f"{TARGET_MODULE}.MLAAttention.__init__",
+    f"{TARGET_MODULE}.MLAAttention.forward",
     f"{TARGET_MODULE}.MLAAttention.forward_impl",
     f"{TARGET_MODULE}.MLAAttention.process_weights_after_loading",
     f"{TARGET_MODULE}.MLACommonMetadata.__init__",
@@ -33,11 +34,12 @@ def apply_to_module(module: ModuleType) -> bool:
     builder_cls = require_class(mla, "MLACommonMetadataBuilder", f"{TARGET_MODULE}.MLACommonMetadataBuilder")
     wrapped = (
         (cls, "__init__", TARGETS[0], _WRAPPER),
-        (cls, "forward_impl", TARGETS[1], _WRAPPER),
-        (cls, "process_weights_after_loading", TARGETS[2], _WRAPPER),
-        (metadata_cls, "__init__", TARGETS[3], _WRAPPER),
-        (builder_cls, "build", TARGETS[4], _WRAPPER),
-        (mla, "split_decodes_and_prefills", TARGETS[5], _WRAPPER),
+        (cls, "forward", TARGETS[1], _WRAPPER),
+        (cls, "forward_impl", TARGETS[2], _WRAPPER),
+        (cls, "process_weights_after_loading", TARGETS[3], _WRAPPER),
+        (metadata_cls, "__init__", TARGETS[4], _WRAPPER),
+        (builder_cls, "build", TARGETS[5], _WRAPPER),
+        (mla, "split_decodes_and_prefills", TARGETS[6], _WRAPPER),
     )
     if already_applied(mla, _MARKER, wrapped):
         return False
@@ -53,9 +55,16 @@ def apply_to_module(module: ModuleType) -> bool:
                   "topk_indices_buffer": None},
         var_keyword="extra_impl_args",
     )
-    original_forward = require_callable(cls, "forward_impl", TARGETS[1])
+    original_full_forward = require_callable(cls, "forward", TARGETS[1])
     require_exact_signature(
-        original_forward, TARGETS[1],
+        original_full_forward,
+        TARGETS[1],
+        positional=("self", "q", "kv_c_normed", "k_pe", "output_shape"),
+        defaults={"output_shape": None},
+    )
+    original_forward = require_callable(cls, "forward_impl", TARGETS[2])
+    require_exact_signature(
+        original_forward, TARGETS[2],
         positional=("self", "q", "k_c_normed", "k_pe", "kv_cache", "attn_metadata",
                     "output", "output_scale", "output_block_scale", "quant_group_size",
                     "quant_scale_ue8m0", "quant_col_major", "quant_tma_aligned"),
@@ -63,21 +72,23 @@ def apply_to_module(module: ModuleType) -> bool:
                   "quant_group_size": None, "quant_scale_ue8m0": None,
                   "quant_col_major": None, "quant_tma_aligned": None},
     )
-    process = require_callable(cls, "process_weights_after_loading", TARGETS[2])
-    require_exact_signature(process, TARGETS[2], positional=("self", "act_dtype"))
-    metadata_init = require_callable(metadata_cls, "__init__", TARGETS[3])
+    process = require_callable(cls, "process_weights_after_loading", TARGETS[3])
+    require_exact_signature(process, TARGETS[3], positional=("self", "act_dtype"))
+    metadata_init = require_callable(metadata_cls, "__init__", TARGETS[4])
     if "num_actual_tokens" not in inspect.signature(metadata_init).parameters:
-        raise PatchCompatibilityError(f"required target {TARGETS[3]} has incompatible fields")
-    builder = require_callable(builder_cls, "build", TARGETS[4])
+        raise PatchCompatibilityError(
+            f"required target {TARGETS[4]} has incompatible fields"
+        )
+    builder = require_callable(builder_cls, "build", TARGETS[5])
     require_exact_signature(
-        builder, TARGETS[4],
+        builder, TARGETS[5],
         positional=("self", "common_prefix_len", "common_attn_metadata", "fast_build"),
         defaults={"fast_build": False},
     )
-    split_batch = require_callable(mla, "split_decodes_and_prefills", TARGETS[5])
+    split_batch = require_callable(mla, "split_decodes_and_prefills", TARGETS[6])
     require_exact_signature(
         split_batch,
-        TARGETS[5],
+        TARGETS[6],
         positional=(
             "common_attn_metadata",
             "decode_threshold",
@@ -90,13 +101,138 @@ def apply_to_module(module: ModuleType) -> bool:
             "treat_short_extends_as_decodes": True,
         },
     )
+    get_forward_context = require_callable(
+        mla,
+        "get_forward_context",
+        f"{TARGET_MODULE}.get_forward_context",
+    )
+    encode_layer_name = require_callable(
+        mla,
+        "_encode_layer_name",
+        f"{TARGET_MODULE}._encode_layer_name",
+    )
+    torch_module = getattr(mla, "torch", None)
+    if torch_module is None:
+        raise PatchCompatibilityError(
+            f"required HCU patch dependency {TARGET_MODULE}.torch is missing"
+        )
+
+    def configured_pcp_world_size(vllm_config) -> int:
+        if vllm_config is None:
+            return 1
+        parallel_config = getattr(vllm_config, "parallel_config", None)
+        value = getattr(parallel_config, "prefill_context_parallel_size", None)
+        if value is None:
+            raise PatchCompatibilityError(
+                "required vLLM 0.25.1 prefill_context_parallel_size is missing"
+            )
+        world_size = int(value)
+        if world_size < 1:
+            raise PatchCompatibilityError(
+                f"invalid prefill_context_parallel_size={world_size}"
+            )
+        return world_size
 
     @functools.wraps(original_init)
     def hcu_init(self, *args, **kwargs):
         original_init(self, *args, **kwargs)
         from vllm.config import get_current_vllm_config_or_none
 
-        self._hcu_feature_config = get_hcu_config(get_current_vllm_config_or_none())
+        vllm_config = get_current_vllm_config_or_none()
+        self._hcu_feature_config = get_hcu_config(vllm_config)
+        self._hcu_pcp_world_size = configured_pcp_world_size(vllm_config)
+        self._hcu_use_pcp = self._hcu_pcp_world_size > 1
+        if self._hcu_use_pcp and self._hcu_feature_config.enable_lightly_cp:
+            raise RuntimeError("HCU PCP and lightly-CP cannot be enabled together")
+        if self._hcu_use_pcp:
+            # PCP is eager-only in this backport.  Keep the registered opaque
+            # custom-op graph untouched and take the direct Python path.
+            self.use_direct_call = True
+
+    @functools.wraps(original_full_forward)
+    def hcu_full_forward(
+        self,
+        q,
+        kv_c_normed,
+        k_pe,
+        output_shape=None,
+    ):
+        if not getattr(self, "_hcu_use_pcp", False):
+            return original_full_forward(
+                self,
+                q,
+                kv_c_normed,
+                k_pe,
+                output_shape,
+            )
+
+        if self.calculate_kv_scales:
+            torch_module.ops.vllm.maybe_calc_kv_scales(
+                q,
+                kv_c_normed,
+                k_pe,
+                encode_layer_name(self.layer_name),
+            )
+
+        forward_context = get_forward_context()
+        attn_metadata_raw = forward_context.attn_metadata
+        if isinstance(attn_metadata_raw, dict):
+            attn_metadata = attn_metadata_raw[self.layer_name]
+        elif isinstance(attn_metadata_raw, list):
+            attn_metadata = attn_metadata_raw[0][self.layer_name]
+        else:
+            attn_metadata = attn_metadata_raw
+        slot_mapping = forward_context.slot_mapping
+        if not isinstance(slot_mapping, dict):
+            raise RuntimeError(
+                "PCP MLA direct forward requires per-layer slot mappings"
+            )
+        layer_slot_mapping = slot_mapping.get(self.layer_name)
+        if layer_slot_mapping is None:
+            raise RuntimeError(
+                f"PCP MLA slot mapping is missing for layer {self.layer_name!r}"
+            )
+        if attn_metadata is not None:
+            metadata_world_size = int(
+                getattr(attn_metadata, "pcp_world_size", 1)
+            )
+            if metadata_world_size != self._hcu_pcp_world_size:
+                raise RuntimeError(
+                    "PCP MLA metadata world size mismatch: "
+                    f"layer={self._hcu_pcp_world_size}, "
+                    f"metadata={metadata_world_size}"
+                )
+
+        from vllm_hcu.model_executor.layers.attention.pcp import (
+            maybe_gather_mla_latent_cache_inputs,
+        )
+
+        kv_for_cache, kpe_for_cache, layer_slot_mapping = (
+            maybe_gather_mla_latent_cache_inputs(
+                kv_c_normed,
+                k_pe,
+                layer_slot_mapping,
+                attn_metadata,
+            )
+        )
+        self.impl.do_kv_cache_update(
+            kv_for_cache,
+            kpe_for_cache,
+            self.kv_cache,
+            layer_slot_mapping,
+            self.kv_cache_dtype,
+            self._k_scale,
+        )
+        output = torch_module.empty(output_shape, dtype=q.dtype, device=q.device)
+        self.forward_impl(
+            q,
+            kv_c_normed,
+            k_pe,
+            self.kv_cache,
+            attn_metadata,
+            output=output,
+        )
+        return output
 
     @functools.wraps(original_forward)
     def hcu_forward(self, q, k_c_normed, k_pe, kv_cache, attn_metadata, output,
@@ -145,6 +281,9 @@ def apply_to_module(module: ModuleType) -> bool:
             "num_kv_actual_tokens",
             common_attn_metadata.num_actual_tokens,
         )
+        result.pcp_world_size = configured_pcp_world_size(
+            getattr(self, "vllm_config", None)
+        )
         return result
 
     @functools.wraps(split_batch)
@@ -170,6 +309,7 @@ def apply_to_module(module: ModuleType) -> bool:
 
     for function in (
         hcu_init,
+        hcu_full_forward,
         hcu_forward,
         hcu_process,
         hcu_metadata_init,
@@ -178,12 +318,14 @@ def apply_to_module(module: ModuleType) -> bool:
     ):
         setattr(function, _WRAPPER, True)
     setattr(cls, "_vllm_hcu_original_init", original_init)
+    setattr(cls, "_vllm_hcu_original_forward", original_full_forward)
     setattr(cls, "_vllm_hcu_original_forward_impl", original_forward)
     setattr(cls, "_vllm_hcu_original_process_weights", process)
     setattr(metadata_cls, "_vllm_hcu_original_init", metadata_init)
     setattr(builder_cls, "_vllm_hcu_original_build", builder)
     setattr(mla, "_vllm_hcu_original_split_decodes_and_prefills", split_batch)
     setattr(cls, "__init__", hcu_init)
+    setattr(cls, "forward", hcu_full_forward)
     setattr(cls, "forward_impl", hcu_forward)
     setattr(cls, "process_weights_after_loading", hcu_process)
     setattr(metadata_cls, "__init__", hcu_metadata_init)

--- a/vllm_hcu/patch/worker/op_opt/patch_mla_attention.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_mla_attention.py
@@ -182,17 +182,18 @@ def apply_to_module(module: ModuleType) -> bool:
             attn_metadata = attn_metadata_raw[0][self.layer_name]
         else:
             attn_metadata = attn_metadata_raw
-        slot_mapping = forward_context.slot_mapping
-        if not isinstance(slot_mapping, dict):
-            raise RuntimeError(
-                "PCP MLA direct forward requires per-layer slot mappings"
-            )
-        layer_slot_mapping = slot_mapping.get(self.layer_name)
-        if layer_slot_mapping is None:
-            raise RuntimeError(
-                f"PCP MLA slot mapping is missing for layer {self.layer_name!r}"
-            )
         if attn_metadata is not None:
+            slot_mapping = forward_context.slot_mapping
+            if not isinstance(slot_mapping, dict):
+                raise RuntimeError(
+                    "PCP MLA direct forward requires per-layer slot mappings"
+                )
+            layer_slot_mapping = slot_mapping.get(self.layer_name)
+            if layer_slot_mapping is None:
+                raise RuntimeError(
+                    "PCP MLA slot mapping is missing for layer "
+                    f"{self.layer_name!r}"
+                )
             metadata_world_size = int(
                 getattr(attn_metadata, "pcp_world_size", 1)
             )
@@ -203,26 +204,26 @@ def apply_to_module(module: ModuleType) -> bool:
                     f"metadata={metadata_world_size}"
                 )
 
-        from vllm_hcu.model_executor.layers.attention.pcp import (
-            maybe_gather_mla_latent_cache_inputs,
-        )
-
-        kv_for_cache, kpe_for_cache, layer_slot_mapping = (
-            maybe_gather_mla_latent_cache_inputs(
-                kv_c_normed,
-                k_pe,
-                layer_slot_mapping,
-                attn_metadata,
+            from vllm_hcu.model_executor.layers.attention.pcp import (
+                maybe_gather_mla_latent_cache_inputs,
             )
-        )
-        self.impl.do_kv_cache_update(
-            kv_for_cache,
-            kpe_for_cache,
-            self.kv_cache,
-            layer_slot_mapping,
-            self.kv_cache_dtype,
-            self._k_scale,
-        )
+
+            kv_for_cache, kpe_for_cache, layer_slot_mapping = (
+                maybe_gather_mla_latent_cache_inputs(
+                    kv_c_normed,
+                    k_pe,
+                    layer_slot_mapping,
+                    attn_metadata,
+                )
+            )
+            self.impl.do_kv_cache_update(
+                kv_for_cache,
+                kpe_for_cache,
+                self.kv_cache,
+                layer_slot_mapping,
+                self.kv_cache_dtype,
+                self._k_scale,
+            )
         output = torch_module.empty(output_shape, dtype=q.dtype, device=q.device)
         self.forward_impl(
             q,

--- a/vllm_hcu/patch/worker/op_opt/patch_mla_indexer.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_mla_indexer.py
@@ -7,7 +7,14 @@ from __future__ import annotations
 import functools
 from types import ModuleType
 
-from ._common import already_applied, load_exact_module, require_callable, require_class, require_exact_signature
+from ._common import (
+    PatchCompatibilityError,
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_exact_signature,
+)
 
 TARGET_MODULE = "vllm.v1.attention.backends.mla.indexer"
 PATCH_ID = "worker.op_opt.mla.indexer_hcu"
@@ -81,6 +88,24 @@ def apply_to_module(module: ModuleType) -> bool:
             common_attn_metadata, "num_kv_actual_tokens",
             common_attn_metadata.num_actual_tokens,
         )
+        vllm_config = getattr(self, "vllm_config", None)
+        if vllm_config is None:
+            result.pcp_world_size = int(
+                getattr(common_attn_metadata, "pcp_world_size", 1)
+            )
+        else:
+            parallel_config = getattr(vllm_config, "parallel_config", None)
+            pcp_world_size = getattr(
+                parallel_config,
+                "prefill_context_parallel_size",
+                None,
+            )
+            if pcp_world_size is None:
+                raise PatchCompatibilityError(
+                    "required vLLM 0.25.1 prefill_context_parallel_size "
+                    "is missing from sparse indexer metadata builder"
+                )
+            result.pcp_world_size = int(pcp_world_size)
         if indexer.current_platform.is_rocm() and result.decode is not None:
             try:
                 from lightop import gemmopt

--- a/vllm_hcu/v1/attention/backends/mla/flashmla.py
+++ b/vllm_hcu/v1/attention/backends/mla/flashmla.py
@@ -238,6 +238,7 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
 
 
 class FlashMLAImpl(MLACommonImpl[FlashMLAMetadata]):
+    supports_pcp: bool = True
     can_return_lse_for_decode: bool = True
 
     def __init__(

--- a/vllm_hcu/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm_hcu/v1/attention/backends/mla/flashmla_sparse.py
@@ -3,10 +3,24 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
 # Modified by Hygon Information Technology Co., Ltd., 2026.
 
-from vllm.v1.attention.backends.mla.flashmla_sparse import FlashMLASparseBackend
+from vllm.v1.attention.backends.mla.flashmla_sparse import (
+    FlashMLASparseBackend,
+    FlashMLASparseImpl,
+)
+
+
+class HcuFlashMLASparseImpl(FlashMLASparseImpl):
+    supports_pcp: bool = True
+
 
 class HcuFlashMLASparseBackend(FlashMLASparseBackend):
-    
     @staticmethod
     def get_name() -> str:
         return "FLASHMLA_SPARSE"
+
+    @staticmethod
+    def get_impl_cls() -> type[HcuFlashMLASparseImpl]:
+        return HcuFlashMLASparseImpl
+
+
+__all__ = ["HcuFlashMLASparseBackend", "HcuFlashMLASparseImpl"]

--- a/vllm_hcu/v1/hcu_model_runner_v2.py
+++ b/vllm_hcu/v1/hcu_model_runner_v2.py
@@ -8,6 +8,7 @@ import functools
 import torch
 
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm_hcu.v1.pcp_manager import maybe_build_pcp_manager
 
 
 _FIXED_WIDTH_PP_BROADCAST_MARKER = "_vllm_hcu_fixed_width_pp_broadcast"
@@ -109,8 +110,51 @@ def synchronize_pp_spec_draft_tokens(
 class HcuGPUModelRunnerV2(GPUModelRunner):
     """HCU compatibility adapter around upstream v0.25.1 Model Runner V2."""
 
+    def __init__(self, vllm_config, device):
+        super().__init__(vllm_config, device)
+        self.pcp_manager = None
+
+    def initialize_kv_cache(self, kv_cache_config):
+        super().initialize_kv_cache(kv_cache_config)
+        if self.vllm_config.parallel_config.prefill_context_parallel_size > 1:
+            self.pcp_manager = maybe_build_pcp_manager(
+                self.vllm_config,
+                self.device,
+                self.req_states,
+                self.block_tables,
+            )
+
+    def prepare_inputs(self, scheduler_output, batch_desc):
+        input_batch = super().prepare_inputs(scheduler_output, batch_desc)
+        if self.pcp_manager is None:
+            return input_batch
+        return self.pcp_manager.partition_batch(input_batch)
+
+    def prepare_attn(self, input_batch):
+        if self.pcp_manager is None:
+            return super().prepare_attn(input_batch)
+        return self.pcp_manager.prepare_attn(input_batch)
+
+    def prepare_dummy_attn(self, input_batch):
+        if self.pcp_manager is None:
+            return super().prepare_dummy_attn(input_batch)
+        block_tables = self.block_tables.get_dummy_block_tables(
+            input_batch.num_reqs
+        )
+        slot_mappings = self.pcp_manager.get_dummy_slot_mappings(
+            input_batch.num_tokens
+        )
+        return block_tables, slot_mappings
+
     def sample_tokens(self, grammar_output):
         execute_model_state = self.execute_model_state
+        if self.pcp_manager is not None and execute_model_state is not None:
+            (
+                execute_model_state.hidden_states,
+                execute_model_state.input_batch,
+            ) = self.pcp_manager.restore_for_sampling(
+                execute_model_state.hidden_states
+            )
         input_batch = (
             None
             if execute_model_state is None

--- a/vllm_hcu/v1/hcu_model_runner_v2.py
+++ b/vllm_hcu/v1/hcu_model_runner_v2.py
@@ -150,11 +150,16 @@ class HcuGPUModelRunnerV2(GPUModelRunner):
         execute_model_state = self.execute_model_state
         if self.pcp_manager is not None and execute_model_state is not None:
             (
-                execute_model_state.hidden_states,
-                execute_model_state.input_batch,
+                restored_hidden_states,
+                restored_input_batch,
             ) = self.pcp_manager.restore_for_sampling(
                 execute_model_state.hidden_states
             )
+            execute_model_state = execute_model_state._replace(
+                hidden_states=restored_hidden_states,
+                input_batch=restored_input_batch,
+            )
+            self.execute_model_state = execute_model_state
         input_batch = (
             None
             if execute_model_state is None

--- a/vllm_hcu/v1/pcp_manager.py
+++ b/vllm_hcu/v1/pcp_manager.py
@@ -1,0 +1,558 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""HCU MRV2 virtual-batch prefill context parallelism.
+
+This is a narrow HCU backport of the DualChunkSwap batch-layout algorithm from
+vLLM upstream PR #46570 at commit b6ff8a2f50. Runner wiring is intentionally
+owned by the later integration task.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+import numpy as np
+import torch
+
+from vllm.distributed.parallel_state import get_pcp_group
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm_hcu.patch.platform.core_fix.patch_vllm_config import (
+    _validate_hcu_pcp_scope,
+)
+
+
+@dataclass(frozen=True)
+class RankSegment:
+    """Half-open token interval assigned to one PCP rank-local row."""
+
+    start: int
+    stop: int
+
+    @property
+    def num_tokens(self) -> int:
+        return self.stop - self.start
+
+
+@dataclass(frozen=True)
+class _BatchSegment:
+    global_req_idx: int
+    global_slice: slice
+    local_slice: slice
+
+    @property
+    def num_tokens(self) -> int:
+        return self.global_slice.stop - self.global_slice.start
+
+
+class HcuPCPManager:
+    """Build rank-local virtual rows while retaining the global step batch."""
+
+    def __init__(
+        self,
+        vllm_config: object,
+        device: torch.device,
+        req_states: object,
+        block_tables: object,
+        *,
+        pcp_group: object | None = None,
+    ) -> None:
+        parallel_config = vllm_config.parallel_config
+        self.pcp_size = int(parallel_config.prefill_context_parallel_size)
+        assert self.pcp_size > 1
+        self.device = device
+        self._pcp_group = pcp_group if pcp_group is not None else get_pcp_group()
+        self.pcp_rank = int(self._pcp_group.rank_in_group)
+        assert int(self._pcp_group.world_size) == self.pcp_size
+        assert 0 <= self.pcp_rank < self.pcp_size
+
+        self._req_states = req_states
+        self._block_tables = block_tables
+        self._global_batch: InputBatch | None = None
+        self._hidden_restore_idx: torch.Tensor | None = None
+        self._padded_gather_idx: torch.Tensor | None = None
+        self._gathered_kv_write_mask: torch.Tensor | None = None
+
+        scheduler_config = vllm_config.scheduler_config
+        self._max_local_reqs = 2 * int(scheduler_config.max_num_seqs)
+        self._max_local_tokens = int(scheduler_config.max_num_batched_tokens)
+
+        # Plugin-owned buffers must never alias the saved global InputBatch.
+        self._idx_mapping = torch.empty(
+            self._max_local_reqs, dtype=torch.int32, device=device
+        )
+        self._idx_mapping_np = np.empty(self._max_local_reqs, dtype=np.int32)
+        self._num_scheduled_tokens = np.empty(
+            self._max_local_reqs, dtype=np.int32
+        )
+        self._positions = torch.empty(
+            self._max_local_tokens, dtype=torch.int64, device=device
+        )
+        self._seq_lens = torch.empty(
+            self._max_local_reqs, dtype=torch.int32, device=device
+        )
+        self._query_start_loc = torch.empty(
+            self._max_local_reqs + 1, dtype=torch.int32, device=device
+        )
+        self._query_start_loc_np = np.empty(
+            self._max_local_reqs + 1, dtype=np.int32
+        )
+        self._input_ids = torch.empty(
+            self._max_local_tokens, dtype=torch.int32, device=device
+        )
+        self._is_padding = torch.empty(
+            self._max_local_tokens, dtype=torch.bool, device=device
+        )
+        self._logits_indices = torch.empty(
+            self._max_local_reqs, dtype=torch.int64, device=device
+        )
+        self._cu_num_logits = torch.empty(
+            self._max_local_reqs + 1, dtype=torch.int32, device=device
+        )
+        self._cu_num_logits_np = np.empty(
+            self._max_local_reqs + 1, dtype=np.int32
+        )
+        self._is_prefilling_np = np.empty(self._max_local_reqs, dtype=np.bool_)
+
+        input_block_tables = getattr(block_tables, "input_block_tables", ())
+        self._local_block_tables = tuple(
+            table.new_zeros((self._max_local_reqs, table.shape[1]))
+            for table in input_block_tables
+        )
+        self._local_block_table_ptrs = (
+            torch.tensor(
+                [table.data_ptr() for table in self._local_block_tables],
+                dtype=torch.uint64,
+                device=device,
+            )
+            if self._local_block_tables
+            else None
+        )
+        num_kv_groups = int(getattr(block_tables, "num_kv_cache_groups", 0))
+        self._global_slot_mappings = (
+            torch.empty(
+                (num_kv_groups, self._max_local_tokens),
+                dtype=torch.int64,
+                device=device,
+            )
+            if num_kv_groups
+            else None
+        )
+        self._gathered_slot_mappings = (
+            torch.empty(
+                (num_kv_groups, self._max_local_tokens * self.pcp_size),
+                dtype=torch.int64,
+                device=device,
+            )
+            if num_kv_groups
+            else None
+        )
+        self._pad_slot_id = torch.tensor(
+            PAD_SLOT_ID, dtype=torch.int64, device=device
+        )
+
+    @staticmethod
+    def rank_segments(
+        length: int, *, pcp_rank: int, pcp_size: int
+    ) -> tuple[RankSegment, RankSegment]:
+        """Return the two symmetric DualChunkSwap intervals for a rank."""
+
+        if length < 0:
+            raise ValueError("token length must be non-negative")
+        if pcp_size <= 0 or not 0 <= pcp_rank < pcp_size:
+            raise ValueError("invalid PCP rank or size")
+        chunk_count = 2 * pcp_size
+        chunk_size = (length + chunk_count - 1) // chunk_count
+
+        def segment(chunk_idx: int) -> RankSegment:
+            start = min(chunk_idx * chunk_size, length)
+            return RankSegment(start, min(start + chunk_size, length))
+
+        return segment(pcp_rank), segment(chunk_count - 1 - pcp_rank)
+
+    @staticmethod
+    def _reorder_segments(
+        segments: list[_BatchSegment],
+        num_computed_tokens: np.ndarray,
+        is_prefilling: np.ndarray,
+        query_start_loc_np: np.ndarray,
+    ) -> list[_BatchSegment]:
+        """Keep decode/continued-prefill rows before fresh-prefill rows."""
+
+        def is_pure_prefill(segment: _BatchSegment) -> bool:
+            req_idx = segment.global_req_idx
+            local_offset = segment.global_slice.start - query_start_loc_np[req_idx]
+            return bool(is_prefilling[req_idx]) and int(
+                num_computed_tokens[req_idx] + local_offset
+            ) == 0
+
+        segments.sort(key=is_pure_prefill)
+        result = []
+        local_offset = 0
+        for segment in segments:
+            result.append(
+                replace(
+                    segment,
+                    local_slice=slice(
+                        local_offset, local_offset + segment.num_tokens
+                    ),
+                )
+            )
+            local_offset += segment.num_tokens
+        return result
+
+    def _segments_for_rank(
+        self,
+        rank: int,
+        input_batch: InputBatch,
+    ) -> list[_BatchSegment]:
+        segments: list[_BatchSegment] = []
+        local_offset = 0
+        for req_idx, query_len_value in enumerate(
+            input_batch.num_scheduled_tokens
+        ):
+            query_len = int(query_len_value)
+            global_start = int(input_batch.query_start_loc_np[req_idx])
+            if bool(input_batch.is_prefilling_np[req_idx]):
+                rank_segments = self.rank_segments(
+                    query_len, pcp_rank=rank, pcp_size=self.pcp_size
+                )
+            else:
+                rank_segments = (RankSegment(0, query_len),)
+            for rank_segment in rank_segments:
+                segment = _BatchSegment(
+                    global_req_idx=req_idx,
+                    global_slice=slice(
+                        global_start + rank_segment.start,
+                        global_start + rank_segment.stop,
+                    ),
+                    local_slice=slice(
+                        local_offset, local_offset + rank_segment.num_tokens
+                    ),
+                )
+                segments.append(segment)
+                local_offset += rank_segment.num_tokens
+        return self._reorder_segments(
+            segments,
+            input_batch.num_computed_tokens_np,
+            input_batch.is_prefilling_np,
+            input_batch.query_start_loc_np,
+        )
+
+    def _build_batch_layout(
+        self, input_batch: InputBatch
+    ) -> tuple[list[list[_BatchSegment]], list[int]]:
+        segments_by_rank = [
+            self._segments_for_rank(rank, input_batch)
+            for rank in range(self.pcp_size)
+        ]
+        per_rank_num_tokens = [
+            sum(segment.num_tokens for segment in segments)
+            for segments in segments_by_rank
+        ]
+        padded_num_tokens = max(per_rank_num_tokens, default=0)
+        expanded_num_tokens = padded_num_tokens * self.pcp_size
+        padded_gather_idx = np.zeros(expanded_num_tokens, dtype=np.int64)
+        kv_write_mask = np.zeros(expanded_num_tokens, dtype=np.bool_)
+        hidden_restore_idx = np.empty(input_batch.num_tokens, dtype=np.int64)
+
+        for rank, segments in enumerate(segments_by_rank):
+            rank_start = rank * padded_num_tokens
+            for segment in segments:
+                gathered_slice = slice(
+                    rank_start + segment.local_slice.start,
+                    rank_start + segment.local_slice.stop,
+                )
+                padded_gather_idx[gathered_slice] = np.arange(
+                    segment.global_slice.start,
+                    segment.global_slice.stop,
+                    dtype=np.int64,
+                )
+                is_decode = not bool(
+                    input_batch.is_prefilling_np[segment.global_req_idx]
+                )
+                if not is_decode or rank == 0:
+                    kv_write_mask[gathered_slice] = True
+                    hidden_restore_idx[segment.global_slice] = np.arange(
+                        gathered_slice.start,
+                        gathered_slice.stop,
+                        dtype=np.int64,
+                    )
+
+        self._hidden_restore_idx = torch.from_numpy(hidden_restore_idx).to(
+            self.device
+        )
+        self._padded_gather_idx = torch.from_numpy(padded_gather_idx).to(
+            self.device
+        )
+        self._gathered_kv_write_mask = torch.from_numpy(kv_write_mask).to(
+            self.device
+        )
+        return segments_by_rank, per_rank_num_tokens
+
+    def partition_batch(self, input_batch: InputBatch) -> InputBatch:
+        """Return a rank-local InputBatch without mutating the global batch."""
+
+        if input_batch.num_draft_tokens:
+            raise NotImplementedError("HCU PCP does not support spec decode")
+        self._global_batch = input_batch
+        segments_by_rank, per_rank_num_tokens = self._build_batch_layout(input_batch)
+        segments = segments_by_rank[self.pcp_rank]
+        num_local_reqs = len(segments)
+        num_local_tokens = per_rank_num_tokens[self.pcp_rank]
+        num_padded_tokens = max(per_rank_num_tokens, default=0)
+        if num_local_reqs > self._max_local_reqs:
+            raise RuntimeError("PCP local request count exceeds its buffer")
+        if num_padded_tokens > self._max_local_tokens:
+            raise RuntimeError("PCP local token count exceeds its buffer")
+
+        global_req_indices = np.fromiter(
+            (segment.global_req_idx for segment in segments),
+            dtype=np.int32,
+            count=num_local_reqs,
+        )
+        local_lengths = self._num_scheduled_tokens[:num_local_reqs]
+        local_lengths[:] = [segment.num_tokens for segment in segments]
+        local_idx_mapping_np = self._idx_mapping_np[:num_local_reqs]
+        local_idx_mapping_np[:] = input_batch.idx_mapping_np[global_req_indices]
+        local_idx_mapping = self._idx_mapping[:num_local_reqs]
+        local_idx_mapping.copy_(torch.from_numpy(local_idx_mapping_np).to(self.device))
+
+        query_start_np = self._query_start_loc_np[: num_local_reqs + 1]
+        query_start_np[0] = 0
+        np.cumsum(local_lengths, out=query_start_np[1:])
+        query_start = self._query_start_loc[: num_local_reqs + 1]
+        query_start.copy_(torch.from_numpy(query_start_np).to(self.device))
+
+        local_start_pos_np = np.fromiter(
+            (
+                int(input_batch.num_computed_tokens_np[segment.global_req_idx])
+                + segment.global_slice.start
+                - int(input_batch.query_start_loc_np[segment.global_req_idx])
+                for segment in segments
+            ),
+            dtype=np.int32,
+            count=num_local_reqs,
+        )
+        seq_lens = self._seq_lens[:num_local_reqs]
+        seq_lens.copy_(
+            torch.from_numpy(local_start_pos_np + local_lengths).to(self.device)
+        )
+
+        input_ids = self._input_ids[:num_padded_tokens]
+        positions = self._positions[:num_padded_tokens]
+        is_padding = self._is_padding[:num_padded_tokens]
+        input_ids.zero_()
+        positions.zero_()
+        is_padding.fill_(True)
+        for row, segment in enumerate(segments):
+            local_slice = segment.local_slice
+            if segment.num_tokens == 0:
+                continue
+            input_ids[local_slice].copy_(input_batch.input_ids[segment.global_slice])
+            positions[local_slice].copy_(
+                torch.arange(
+                    int(local_start_pos_np[row]),
+                    int(local_start_pos_np[row] + segment.num_tokens),
+                    dtype=torch.int64,
+                    device=self.device,
+                )
+            )
+            is_padding[local_slice] = False
+
+        has_logits = local_lengths > 0
+        num_logits = int(np.count_nonzero(has_logits))
+        logits_indices = self._logits_indices[:num_logits]
+        logits_indices.copy_(
+            torch.from_numpy(query_start_np[1:][has_logits] - 1).to(self.device)
+        )
+        cu_num_logits_np = self._cu_num_logits_np[: num_local_reqs + 1]
+        cu_num_logits_np[0] = 0
+        np.cumsum(has_logits.astype(np.int32), out=cu_num_logits_np[1:])
+        cu_num_logits = self._cu_num_logits[: num_local_reqs + 1]
+        cu_num_logits.copy_(torch.from_numpy(cu_num_logits_np).to(self.device))
+
+        local_prefill_len = input_batch.prefill_len_np[global_req_indices].copy()
+        local_num_computed_prefill = np.minimum(
+            local_start_pos_np, local_prefill_len
+        )
+        local_is_prefilling = self._is_prefilling_np[:num_local_reqs]
+        local_is_prefilling[:] = (
+            local_num_computed_prefill < local_prefill_len
+        )
+        nonempty_rows = np.flatnonzero(has_logits)
+        expanded_idx_mapping = local_idx_mapping[
+            torch.from_numpy(nonempty_rows).to(self.device)
+        ]
+        expanded_local_pos = seq_lens[
+            torch.from_numpy(nonempty_rows).to(self.device)
+        ] - 1
+
+        return replace(
+            input_batch,
+            req_ids=[input_batch.req_ids[index] for index in global_req_indices],
+            num_reqs=num_local_reqs,
+            num_reqs_after_padding=num_local_reqs,
+            idx_mapping=local_idx_mapping,
+            idx_mapping_np=local_idx_mapping_np,
+            expanded_idx_mapping=expanded_idx_mapping,
+            expanded_local_pos=expanded_local_pos,
+            num_scheduled_tokens=local_lengths,
+            num_tokens=num_local_tokens,
+            num_tokens_after_padding=num_padded_tokens,
+            num_draft_tokens=0,
+            num_draft_tokens_per_req=None,
+            query_start_loc=query_start,
+            query_start_loc_np=query_start_np,
+            seq_lens=seq_lens,
+            seq_lens_cpu_upper_bound=torch.from_numpy(
+                local_start_pos_np + local_lengths
+            ),
+            dcp_local_seq_lens=None,
+            num_computed_tokens_np=local_start_pos_np,
+            prefill_len_np=local_prefill_len,
+            num_computed_prefill_tokens_np=local_num_computed_prefill,
+            is_prefilling_np=local_is_prefilling,
+            max_seq_len_np=(
+                input_batch.max_seq_len_np[global_req_indices].copy()
+                if input_batch.max_seq_len_np is not None
+                else None
+            ),
+            input_ids=input_ids,
+            positions=positions,
+            is_padding=is_padding,
+            logits_indices=logits_indices,
+            cu_num_logits=cu_num_logits,
+            cu_num_logits_np=cu_num_logits_np,
+            prompt_lens=None,
+        )
+
+    def prepare_attn(
+        self, input_batch: InputBatch
+    ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        """Prepare local block rows and global-ownership slot mappings."""
+
+        assert self._local_block_tables
+        assert self._local_block_table_ptrs is not None
+        canonical_tables = getattr(self._block_tables, "block_tables", None)
+        if canonical_tables is None:
+            source_tables = self._block_tables.input_block_tables
+        else:
+            source_tables = [
+                getattr(table, "gpu", table) for table in canonical_tables
+            ]
+        num_reqs = input_batch.num_reqs_after_padding
+        for source, destination in zip(
+            source_tables, self._local_block_tables
+        ):
+            torch.index_select(
+                source,
+                0,
+                input_batch.idx_mapping.to(torch.int64),
+                out=destination[:num_reqs],
+            )
+        local_tables = tuple(
+            table[:num_reqs] for table in self._local_block_tables
+        )
+        assert self._global_batch is not None
+        assert self._global_slot_mappings is not None
+        computed_slots = self._block_tables.compute_slot_mappings(
+            self._global_batch.idx_mapping,
+            self._global_batch.query_start_loc,
+            self._global_batch.positions,
+            self._global_batch.num_tokens,
+        )
+        global_slots = self._global_slot_mappings[
+            :, : self._global_batch.num_tokens
+        ]
+        global_slots.copy_(computed_slots)
+        return local_tables, self._convert_slot_mappings(global_slots)
+
+    def _convert_slot_mappings(self, global_slots: torch.Tensor) -> torch.Tensor:
+        assert self._padded_gather_idx is not None
+        assert self._gathered_kv_write_mask is not None
+        assert self._gathered_slot_mappings is not None
+        num_expanded_tokens = self._padded_gather_idx.numel()
+        gathered = self._gathered_slot_mappings[:, :num_expanded_tokens]
+        torch.index_select(
+            global_slots,
+            1,
+            self._padded_gather_idx,
+            out=gathered,
+        )
+        torch.where(
+            self._gathered_kv_write_mask.unsqueeze(0),
+            gathered,
+            self._pad_slot_id,
+            out=gathered,
+        )
+        return gathered
+
+    def get_dummy_slot_mappings(self, num_tokens: int) -> torch.Tensor:
+        """Return invalid slots for a PCP-expanded dummy attention batch."""
+
+        assert self._gathered_slot_mappings is not None
+        expanded_tokens = num_tokens * self.pcp_size
+        if expanded_tokens > self._gathered_slot_mappings.shape[1]:
+            raise RuntimeError("PCP dummy slot count exceeds its buffer")
+        slots = self._gathered_slot_mappings[:, :expanded_tokens]
+        slots.fill_(PAD_SLOT_ID)
+        return slots
+
+    def restore_hidden_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Gather equal-width local outputs and restore global token order."""
+
+        if self._hidden_restore_idx is None:
+            return hidden_states
+        gathered = self._pcp_group.all_gather(hidden_states, dim=0)
+        return gathered[self._hidden_restore_idx]
+
+    def restore_for_sampling(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, InputBatch]:
+        """Restore final hidden states and the exact saved global InputBatch."""
+
+        assert self._global_batch is not None
+        return self.restore_hidden_states(hidden_states), self._global_batch
+
+
+def maybe_build_pcp_manager(
+    vllm_config: object,
+    device: torch.device,
+    req_states: object,
+    block_tables: object,
+) -> HcuPCPManager | None:
+    """Build only for an already approved PCP>1 runtime contract."""
+
+    if vllm_config.parallel_config.prefill_context_parallel_size == 1:
+        return None
+    assert _validate_hcu_pcp_scope(vllm_config)
+    return HcuPCPManager(vllm_config, device, req_states, block_tables)
+
+
+def maybe_partition_pcp_batch(
+    manager: HcuPCPManager | None, input_batch: InputBatch
+) -> InputBatch:
+    if manager is None:
+        return input_batch
+    return manager.partition_batch(input_batch)
+
+
+def maybe_restore_pcp_for_sampling(
+    manager: HcuPCPManager | None,
+    hidden_states: torch.Tensor,
+    input_batch: InputBatch,
+) -> tuple[torch.Tensor, InputBatch]:
+    if manager is None:
+        return hidden_states, input_batch
+    return manager.restore_for_sampling(hidden_states)
+
+
+__all__ = [
+    "HcuPCPManager",
+    "RankSegment",
+    "maybe_build_pcp_manager",
+    "maybe_partition_pcp_batch",
+    "maybe_restore_pcp_for_sampling",
+]

--- a/vllm_hcu/v1/pcp_manager.py
+++ b/vllm_hcu/v1/pcp_manager.py
@@ -18,6 +18,7 @@ import torch
 from vllm.distributed.parallel_state import get_pcp_group
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm_hcu.patch.platform.core_fix._common import PatchCompatibilityError
 from vllm_hcu.patch.platform.core_fix.patch_vllm_config import (
     _validate_hcu_pcp_scope,
 )
@@ -385,9 +386,9 @@ class HcuPCPManager:
         expanded_idx_mapping = local_idx_mapping[
             torch.from_numpy(nonempty_rows).to(self.device)
         ]
-        expanded_local_pos = seq_lens[
-            torch.from_numpy(nonempty_rows).to(self.device)
-        ] - 1
+        expanded_local_pos = torch.zeros(
+            num_logits, dtype=torch.int32, device=self.device
+        )
 
         return replace(
             input_batch,
@@ -433,15 +434,43 @@ class HcuPCPManager:
     ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
         """Prepare local block rows and global-ownership slot mappings."""
 
-        assert self._local_block_tables
-        assert self._local_block_table_ptrs is not None
         canonical_tables = getattr(self._block_tables, "block_tables", None)
-        if canonical_tables is None:
-            source_tables = self._block_tables.input_block_tables
-        else:
-            source_tables = [
-                getattr(table, "gpu", table) for table in canonical_tables
-            ]
+        scratch_tables = getattr(
+            self._block_tables, "input_block_tables", None
+        )
+        declared_groups = getattr(
+            self._block_tables, "num_kv_cache_groups", None
+        )
+        if not isinstance(canonical_tables, list) or not canonical_tables:
+            raise PatchCompatibilityError(
+                "vLLM 0.25.1 BlockTables canonical block_tables storage is missing"
+            )
+        if not isinstance(scratch_tables, list) or not isinstance(
+            declared_groups, int
+        ):
+            raise PatchCompatibilityError(
+                "vLLM 0.25.1 BlockTables canonical block_tables contract changed"
+            )
+        group_counts = (
+            len(canonical_tables),
+            len(scratch_tables),
+            len(self._local_block_tables),
+            declared_groups,
+        )
+        if len(set(group_counts)) != 1:
+            raise PatchCompatibilityError(
+                "vLLM 0.25.1 BlockTables KV-group count mismatch: "
+                f"canonical/scratch/local/declared={group_counts}"
+            )
+        source_tables = []
+        for table in canonical_tables:
+            source = getattr(table, "gpu", None)
+            if not isinstance(source, torch.Tensor):
+                raise PatchCompatibilityError(
+                    "vLLM 0.25.1 BlockTables canonical block_tables GPU "
+                    "storage is missing"
+                )
+            source_tables.append(source)
         num_reqs = input_batch.num_reqs_after_padding
         for source, destination in zip(
             source_tables, self._local_block_tables

--- a/vllm_hcu/v1/pcp_manager.py
+++ b/vllm_hcu/v1/pcp_manager.py
@@ -214,6 +214,8 @@ class HcuPCPManager:
             input_batch.num_scheduled_tokens
         ):
             query_len = int(query_len_value)
+            if query_len == 0:
+                continue
             global_start = int(input_batch.query_start_loc_np[req_idx])
             if bool(input_batch.is_prefilling_np[req_idx]):
                 rank_segments = self.rank_segments(
@@ -222,6 +224,8 @@ class HcuPCPManager:
             else:
                 rank_segments = (RankSegment(0, query_len),)
             for rank_segment in rank_segments:
+                if rank_segment.num_tokens == 0:
+                    continue
                 segment = _BatchSegment(
                     global_req_idx=req_idx,
                     global_slice=slice(
@@ -300,6 +304,16 @@ class HcuPCPManager:
         self._global_batch = input_batch
         segments_by_rank, per_rank_num_tokens = self._build_batch_layout(input_batch)
         segments = segments_by_rank[self.pcp_rank]
+        if not segments:
+            # Preserve one metadata row on a rank with no owned prefill tokens,
+            # while keeping empty DualChunkSwap intervals out of normal batches.
+            segments = [
+                _BatchSegment(
+                    global_req_idx=0,
+                    global_slice=slice(0, 0),
+                    local_slice=slice(0, 0),
+                )
+            ]
         num_local_reqs = len(segments)
         num_local_tokens = per_rank_num_tokens[self.pcp_rank]
         num_padded_tokens = max(per_rank_num_tokens, default=0)


### PR DESCRIPTION
## Summary

- add plugin-owned Model Runner V2 PCP support for GLM-5.2 MLA/sparse MLA on vLLM v0.25.1
- add PCP virtual-batch management, DCP-only KV ownership, MRV2 lifecycle integration, MLA/indexer cache gathers, and PCP-aware Triton MoE dispatch
- keep `PCP=1` behavior unchanged and reject unsupported PCP combinations (V1, PP, MTP/speculation, graph mode, DCP, DP, LoRA, multimodal, KV offload, P/D, lightly-CP)
- keep `/models/zb/vllm_025/vllm` unchanged

## Supported topology

Validated on eight HCU devices with:

- baseline: TP8 + PCP1 + EP
- candidate: TP4 + PCP2 + EP
- Model Runner V2, eager execution, Triton MoE
- model: `/models/GLM-5___1-Channel-FP8-w8a8`
- no `--quantization slimquant_marlin`

## Candidate launch command

```bash
HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
VLLM_USE_V2_MODEL_RUNNER=1 \
VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1 \
VLLM_WORKER_MULTIPROC_METHOD=spawn \
vllm serve /models/GLM-5___1-Channel-FP8-w8a8 \
  --served-model-name glm52-pcp2 \
  --tensor-parallel-size 4 \
  --prefill-context-parallel-size 2 \
  --enable-expert-parallel \
  --moe-backend triton \
  --enforce-eager \
  --max-model-len 69632 \
  --default-chat-template-kwargs '{"enable_thinking":false}' \
  --port 8000
```

## EvalScope HumanEval-32

```bash
evalscope eval \
  --model glm52-pcp2 \
  --api-url http://127.0.0.1:8000/v1 \
  --api-key EMPTY \
  --eval-type openai_api \
  --generation-config '{"temperature":0,"do_sample":false,"max_tokens":2048,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}' \
  --stream \
  --eval-batch-size 1 \
  --timeout 7200 \
  --limit 32 \
  --datasets humaneval \
  --dataset-args '{"humaneval":{}}' \
  --no-timestamp
```

## Verification

- final CPU/static selection: `227 passed, 14 warnings`
- pre-change regression floor preserved
- baseline and candidate deterministic smoke token IDs match
- exact 32K and 64K prompts plus 8 decode tokens pass with token parity
- EvalScope HumanEval: baseline `32/32`, candidate `32/32`, `pass@1=1.0`
- candidate remained healthy after every request; owned process groups and HCU memory cleaned successfully
- `python -m compileall -q vllm_hcu tests`: pass
- `git diff --check`: pass
- plugin and vLLM worktrees: clean

The successful hardware run used the default `VLLM_HCU_USE_FP8_MIXED_BATCH=True`. Follow-up commits additionally harden the explicit separate-FP8 path (`VLLM_HCU_USE_FP8_MIXED_BATCH=0`) with focused CPU RED/GREEN coverage for short continuation, decode, long prefill, empty/dummy rows, and HCU metadata bindings.
