### PR TITLE
fix(hcu): route FlashAttention layout from KV cache layout

### DIFF
--- a/tests/accuracy/test_environment_routing.py
+++ b/tests/accuracy/test_environment_routing.py
@@ -211,6 +211,14 @@ def test_nn_layout_environment_reaches_mamba_path_selector(
     [
         ({}, "cutlass"),
         ({"VLLM_HCU_USE_FLASH_ATTN": "1"}, "classic"),
+        ({"VLLM_HCU_USE_FLASH_ATTN_VARLEN": "1"}, "varlen"),
+        (
+            {
+                "VLLM_HCU_USE_FLASH_ATTN_UNIFIED": "1",
+                "VLLM_HCU_USE_FLASH_ATTN_VARLEN": "1",
+            },
+            "varlen",
+        ),
         (
             {
                 "VLLM_HCU_USE_FLASH_ATTN": "1",
@@ -222,6 +230,7 @@ def test_nn_layout_environment_reaches_mamba_path_selector(
             {
                 "VLLM_HCU_USE_FLASH_ATTN": "1",
                 "VLLM_HCU_USE_FLASH_ATTN_UNIFIED": "1",
+                "VLLM_HCU_USE_FLASH_ATTN_VARLEN": "1",
                 "VLLM_HCU_USE_CUSTOM_FLASH_ATTN": "1",
             },
             "custom",
@@ -236,6 +245,7 @@ def test_flash_attention_environment_priority_routes_expected_backend(
     names = (
         "VLLM_HCU_USE_FLASH_ATTN",
         "VLLM_HCU_USE_FLASH_ATTN_UNIFIED",
+        "VLLM_HCU_USE_FLASH_ATTN_VARLEN",
         "VLLM_HCU_USE_CUSTOM_FLASH_ATTN",
     )
     for name in names:
@@ -252,6 +262,7 @@ def test_flash_attention_environment_priority_routes_expected_backend(
         ("classic", "classic"),
         ("unified", "cutlass"),
         ("cutlass", "cutlass"),
+        ("varlen", "varlen"),
         ("custom", "custom"),
     ],
 )

--- a/tests/runtime_patch/test_flash_attention_and_pp.py
+++ b/tests/runtime_patch/test_flash_attention_and_pp.py
@@ -31,16 +31,133 @@ def _load_hcu_flash_attention_module(monkeypatch: pytest.MonkeyPatch):
         flash_attn_extension.__name__,
         loader=None,
     )
+    def layout_entrypoint(
+        q=None,
+        k=None,
+        v=None,
+        *,
+        layout="bshd",
+        **kwargs,
+    ):
+        del q, k, v, layout, kwargs
+
+    for symbol in (
+        "flash_attn_varlen_func",
+        "hg_flash_attn_varlen_func",
+        "varlen_fwd_unified",
+    ):
+        setattr(flash_attn_extension, symbol, layout_entrypoint)
+    flash_attn_extension.vllm_flash_attn_varlen_func = (
+        lambda *args, **kwargs: None
+    )
+    monkeypatch.setitem(sys.modules, flash_attn_extension.__name__, flash_attn_extension)
+
+    return importlib.import_module("vllm_hcu.v1.attention.backends.flash_attn")
+
+
+def _load_hcu_fa_utils_module(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    kv_cache_layout: str,
+    missing_layout_on: str | None = None,
+):
+    """Load the real HCU FA boundary against observable kernel doubles."""
+
+    from vllm.v1.attention.backends import utils as attention_utils
+
+    monkeypatch.setattr(
+        attention_utils,
+        "get_kv_cache_layout",
+        lambda: kv_cache_layout,
+    )
+
+    hcu_ops = ModuleType("vllm_hcu.hcu_ops")
+    hcu_ops.__spec__ = ModuleSpec(hcu_ops.__name__, loader=None)
+    monkeypatch.setitem(sys.modules, hcu_ops.__name__, hcu_ops)
+
+    calls: dict[str, list[dict[str, object]]] = {}
+    flash_attn_extension = ModuleType("flash_attn")
+    flash_attn_extension.__spec__ = ModuleSpec(
+        flash_attn_extension.__name__,
+        loader=None,
+    )
+
+    def make_entrypoint(name: str):
+        calls[name] = []
+        if name == missing_layout_on:
+
+            def entrypoint(q=None, k=None, v=None, **kwargs):
+                calls[name].append(dict(kwargs))
+
+        else:
+
+            def entrypoint(
+                q=None,
+                k=None,
+                v=None,
+                *,
+                layout="unrouted",
+                **kwargs,
+            ):
+                calls[name].append({"layout": layout, **kwargs})
+
+        return entrypoint
+
     for symbol in (
         "flash_attn_varlen_func",
         "vllm_flash_attn_varlen_func",
         "hg_flash_attn_varlen_func",
         "varlen_fwd_unified",
     ):
-        setattr(flash_attn_extension, symbol, lambda *args, **kwargs: None)
+        setattr(flash_attn_extension, symbol, make_entrypoint(symbol))
     monkeypatch.setitem(sys.modules, flash_attn_extension.__name__, flash_attn_extension)
+    monkeypatch.delitem(
+        sys.modules,
+        "vllm_hcu.v1.attention.backends.fa_utils",
+        raising=False,
+    )
 
-    return importlib.import_module("vllm_hcu.v1.attention.backends.flash_attn")
+    module = importlib.import_module("vllm_hcu.v1.attention.backends.fa_utils")
+    return module, calls
+
+
+@pytest.mark.parametrize(
+    ("kv_cache_layout", "expected_fa_layout"),
+    [("HND", "bhsd"), ("NHD", "bshd")],
+)
+@pytest.mark.parametrize(
+    "entrypoint_name",
+    [
+        "flash_attn_varlen_func",
+        "hg_flash_attn_varlen_func",
+        "varlen_fwd_unified",
+    ],
+)
+def test_hcu_fa_entrypoints_map_kv_cache_layout_to_kernel_layout(
+    monkeypatch: pytest.MonkeyPatch,
+    kv_cache_layout: str,
+    expected_fa_layout: str,
+    entrypoint_name: str,
+) -> None:
+    fa_utils, calls = _load_hcu_fa_utils_module(
+        monkeypatch,
+        kv_cache_layout=kv_cache_layout,
+    )
+
+    getattr(fa_utils, entrypoint_name)(q="q", k="k", v="v")
+
+    assert calls[entrypoint_name] == [{"layout": expected_fa_layout}]
+
+
+def test_hcu_fa_boundary_rejects_interface_without_layout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(RuntimeError, match="hg_flash_attn_varlen_func.*layout"):
+        _load_hcu_fa_utils_module(
+            monkeypatch,
+            kv_cache_layout="HND",
+            missing_layout_on="hg_flash_attn_varlen_func",
+        )
 
 
 def test_pp_size_one_ignores_invalid_manual_partition(monkeypatch: pytest.MonkeyPatch):

--- a/tests/runtime_patch/test_flash_attention_and_pp.py
+++ b/tests/runtime_patch/test_flash_attention_and_pp.py
@@ -185,6 +185,7 @@ def test_pp_size_one_ignores_invalid_manual_partition(monkeypatch: pytest.Monkey
         (None, "cutlass"),
         ("VLLM_HCU_USE_FLASH_ATTN", "classic"),
         ("VLLM_HCU_USE_FLASH_ATTN_UNIFIED", "cutlass"),
+        ("VLLM_HCU_USE_FLASH_ATTN_VARLEN", "varlen"),
     ],
 )
 def test_flash_attention_mode_legacy_priority_and_default(
@@ -193,6 +194,7 @@ def test_flash_attention_mode_legacy_priority_and_default(
     for variable in (
         "VLLM_HCU_USE_FLASH_ATTN",
         "VLLM_HCU_USE_FLASH_ATTN_UNIFIED",
+        "VLLM_HCU_USE_FLASH_ATTN_VARLEN",
         "VLLM_HCU_USE_CUSTOM_FLASH_ATTN",
     ):
         monkeypatch.delenv(variable, raising=False)
@@ -244,6 +246,7 @@ def test_platform_flash_attention_mode_rejects_invalid_sidecar(
     [
         ("cutlass", (3, 2, 64, 4, 128), 0),
         ("classic", (3, 2, 64, 4, 128), 0),
+        ("varlen", (3, 2, 64, 4, 128), 0),
     ],
 )
 def test_flash_attention_kv_cache_contract_follows_resolved_mode(
@@ -571,6 +574,310 @@ def test_hcu_flash_attention_forward_uses_metadata_window_with_fallback(
     )
 
     assert calls[0]["window_size"] == expected_window
+
+
+@pytest.mark.parametrize(
+    ("kv_cache_layout", "expected_fa_layout"),
+    [("HND", "bhsd"), ("NHD", "bshd")],
+)
+def test_hcu_flash_attention_varlen_mode_routes_layout_to_native_interface(
+    monkeypatch: pytest.MonkeyPatch,
+    kv_cache_layout: str,
+    expected_fa_layout: str,
+) -> None:
+    _, calls = _load_hcu_fa_utils_module(
+        monkeypatch,
+        kv_cache_layout=kv_cache_layout,
+    )
+    monkeypatch.delitem(
+        sys.modules,
+        "vllm_hcu.v1.attention.backends.flash_attn",
+        raising=False,
+    )
+    flash_attn = importlib.import_module(
+        "vllm_hcu.v1.attention.backends.flash_attn"
+    )
+    impl = object.__new__(flash_attn.FlashAttentionImpl)
+    impl.vllm_flash_attn_version = 3
+    impl.attn_type = flash_attn.AttentionType.DECODER
+    impl.kv_cache_dtype = "auto"
+    impl.num_kv_heads = 1
+    impl.supports_quant_query_input = False
+    impl.dcp_world_size = 1
+    impl.scale = 1.0
+    impl.alibi_slopes = None
+    impl.logits_soft_cap = 0.0
+    impl.sinks = None
+    impl.sliding_window = (-1, -1)
+
+    monkeypatch.setattr(flash_attn, "_get_flash_attn_mode", lambda: "varlen")
+    monkeypatch.setattr(
+        flash_attn,
+        "canonicalize_singleton_dim_strides",
+        lambda tensor: tensor,
+    )
+    metadata = SimpleNamespace(
+        num_actual_tokens=1,
+        use_cascade=False,
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=torch.tensor([1], dtype=torch.int32),
+        max_query_len=1,
+        max_seq_len=1,
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+        scheduler_metadata=None,
+        causal=True,
+        sliding_window=None,
+    )
+    layer = SimpleNamespace(
+        _q_scale=torch.tensor(1.0),
+        _k_scale=torch.tensor(1.0),
+        _v_scale=torch.tensor(1.0),
+    )
+    query = torch.zeros(1, 1, 2)
+
+    impl.forward(
+        layer,
+        query,
+        query,
+        query,
+        torch.zeros(1, 2, 1, 1, 2),
+        metadata,
+        torch.empty_like(query),
+    )
+
+    assert len(calls["flash_attn_varlen_func"]) == 1
+    assert calls["flash_attn_varlen_func"][0]["layout"] == expected_fa_layout
+    assert calls["hg_flash_attn_varlen_func"] == []
+    assert calls["varlen_fwd_unified"] == []
+
+
+@pytest.mark.parametrize(
+    "kernel_result",
+    [("out", "lse"), ("out", "lse", "attention-probabilities")],
+)
+def test_hcu_native_varlen_lse_adapter_accepts_two_or_three_results(
+    monkeypatch: pytest.MonkeyPatch,
+    kernel_result: tuple[str, ...],
+) -> None:
+    flash_attn = _load_hcu_flash_attention_module(monkeypatch)
+    monkeypatch.setattr(
+        flash_attn,
+        "_get_native_flash_attn_varlen_func",
+        lambda: lambda **kwargs: kernel_result,
+    )
+
+    assert flash_attn._call_native_flash_attn_with_lse(q="query") == (
+        "out",
+        "lse",
+    )
+
+
+def test_hcu_native_varlen_lse_adapter_requests_nonpaged_lse_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flash_attn = _load_hcu_flash_attention_module(monkeypatch)
+    calls: list[dict[str, object]] = []
+
+    def native(**kwargs):
+        calls.append(kwargs)
+        if not kwargs.get("return_attn_probs"):
+            return "out-only"
+        return "out", "lse", "attention-probabilities"
+
+    monkeypatch.setattr(flash_attn, "_get_flash_attn_mode", lambda: "varlen")
+    monkeypatch.setattr(
+        flash_attn,
+        "_get_native_flash_attn_varlen_func",
+        lambda: native,
+    )
+
+    assert flash_attn._call_native_flash_attn_with_lse(
+        q="query",
+        block_table=None,
+        return_softmax_lse=True,
+    ) == ("out", "lse")
+    assert calls == [
+        {
+            "q": "query",
+            "block_table": None,
+            "return_softmax_lse": True,
+            "return_attn_probs": True,
+        }
+    ]
+
+
+def test_hcu_native_varlen_lse_adapter_bypasses_paged_decode_fast_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flash_attn = _load_hcu_flash_attention_module(monkeypatch)
+    calls: list[dict[str, object]] = []
+
+    def native(**kwargs):
+        calls.append(kwargs)
+        if kwargs["window_size"] == [-1, -1]:
+            return "out-only"
+        return "out", "lse"
+
+    monkeypatch.setattr(flash_attn, "_get_flash_attn_mode", lambda: "varlen")
+    monkeypatch.setattr(
+        flash_attn,
+        "_get_native_flash_attn_varlen_func",
+        lambda: native,
+    )
+
+    assert flash_attn._call_native_flash_attn_with_lse(
+        q="query",
+        block_table="paged-cache",
+        max_seqlen_k=128,
+        window_size=[-1, -1],
+        return_softmax_lse=True,
+    ) == ("out", "lse")
+    assert calls[0]["window_size"] == [128, -1]
+
+
+def test_hcu_varlen_cascade_consumes_two_value_lse_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flash_attn = _load_hcu_flash_attention_module(monkeypatch)
+    native_calls: list[dict[str, object]] = []
+    merge_calls: list[tuple[object, ...]] = []
+
+    def native(**kwargs):
+        native_calls.append(kwargs)
+        query = kwargs["q"]
+        return torch.zeros_like(query), torch.zeros(
+            query.shape[-2], query.shape[0]
+        )
+
+    monkeypatch.setattr(flash_attn, "_get_flash_attn_mode", lambda: "varlen")
+    monkeypatch.setattr(
+        flash_attn,
+        "_get_native_flash_attn_varlen_func",
+        lambda: native,
+    )
+    monkeypatch.setattr(
+        flash_attn,
+        "merge_attn_states",
+        lambda *args: merge_calls.append(args),
+    )
+    query = torch.zeros(2, 1, 64)
+    output = torch.empty_like(query)
+    cache = torch.zeros(4, 64, 1, 64)
+
+    flash_attn.cascade_attention(
+        output,
+        query,
+        cache,
+        cache,
+        cu_query_lens=torch.tensor([0, 1, 2], dtype=torch.int32),
+        max_query_len=1,
+        cu_prefix_query_lens=torch.tensor([0, 2], dtype=torch.int32),
+        prefix_kv_lens=torch.tensor([128], dtype=torch.int32),
+        suffix_kv_lens=torch.tensor([64, 64], dtype=torch.int32),
+        max_kv_len=192,
+        softmax_scale=1.0,
+        alibi_slopes=None,
+        sliding_window=(-1, -1),
+        logits_soft_cap=0.0,
+        block_table=torch.tensor([[0, 1, 2], [0, 1, 3]], dtype=torch.int32),
+        common_prefix_len=128,
+        max_num_splits=0,
+        fa_version=3,
+    )
+
+    assert len(native_calls) == 2
+    assert [call["window_size"] for call in native_calls] == [
+        [128, -1],
+        [64, -1],
+    ]
+    assert len(merge_calls) == 1
+
+
+def test_hcu_varlen_dcp_requests_lse_from_paged_and_nonpaged_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flash_attn = _load_hcu_flash_attention_module(monkeypatch)
+    native_calls: list[dict[str, object]] = []
+    merge_calls: list[tuple[object, ...]] = []
+
+    def native(**kwargs):
+        native_calls.append(kwargs)
+        if kwargs.get("block_table") is None:
+            assert kwargs["return_attn_probs"] is True
+        else:
+            assert kwargs["window_size"] == [8, -1]
+        query = kwargs["q"]
+        return torch.zeros_like(query), torch.zeros(
+            query.shape[-2], query.shape[0]
+        )
+
+    class _DcpGroup:
+        @staticmethod
+        def all_gather(tensor, dim):
+            assert dim == 1
+            return tensor
+
+    class _Workspace:
+        @staticmethod
+        def get_simultaneous(spec):
+            shape, dtype = spec
+            return (torch.empty(shape, dtype=dtype),)
+
+    monkeypatch.setattr(flash_attn, "_get_flash_attn_mode", lambda: "varlen")
+    monkeypatch.setattr(
+        flash_attn,
+        "_get_native_flash_attn_varlen_func",
+        lambda: native,
+    )
+    monkeypatch.setattr(flash_attn, "get_dcp_group", lambda: _DcpGroup())
+    monkeypatch.setattr(
+        flash_attn,
+        "current_workspace_manager",
+        lambda: _Workspace(),
+    )
+    monkeypatch.setattr(
+        flash_attn,
+        "merge_attn_states",
+        lambda *args: merge_calls.append(args),
+    )
+    impl = object.__new__(flash_attn.FlashAttentionImpl)
+    impl.vllm_flash_attn_version = 3
+    impl.num_heads = 1
+    impl.dcp_world_size = 1
+    impl.head_size = 64
+    impl._dcp_dtype = torch.float32
+    impl.scale = 1.0
+    impl.alibi_slopes = None
+    impl.sliding_window = (-1, -1)
+    impl.logits_soft_cap = 0.0
+    impl.dcp_combine = lambda out, lse, group, return_lse: (out, lse)
+    query = torch.zeros(1, 1, 64)
+    cache = torch.zeros(2, 64, 1, 64)
+    metadata = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        max_query_len=1,
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+        sliding_window=None,
+        causal=True,
+        dcp_context_kv_lens=torch.tensor([8], dtype=torch.int32),
+        max_dcp_context_kv_len=8,
+        scheduler_metadata=None,
+    )
+
+    impl._forward_with_dcp(
+        query,
+        query,
+        query,
+        cache,
+        cache,
+        torch.empty_like(query),
+        metadata,
+    )
+
+    assert len(native_calls) == 2
+    assert native_calls[0]["block_table"] is metadata.block_table
+    assert native_calls[1].get("block_table") is None
+    assert len(merge_calls) == 1
 
 
 def test_block_first_kv_update_passes_axis_one_views_to_aiter(

--- a/tests/runtime_patch/test_flash_attention_and_pp.py
+++ b/tests/runtime_patch/test_flash_attention_and_pp.py
@@ -662,11 +662,11 @@ def test_hcu_native_varlen_lse_adapter_accepts_two_or_three_results(
     flash_attn = _load_hcu_flash_attention_module(monkeypatch)
     monkeypatch.setattr(
         flash_attn,
-        "_get_native_flash_attn_varlen_func",
+        "_select_flash_attn_varlen_func",
         lambda: lambda **kwargs: kernel_result,
     )
 
-    assert flash_attn._call_native_flash_attn_with_lse(q="query") == (
+    assert flash_attn._call_select_flash_attn_with_lse(q="query") == (
         "out",
         "lse",
     )
@@ -687,11 +687,11 @@ def test_hcu_native_varlen_lse_adapter_requests_nonpaged_lse_flag(
     monkeypatch.setattr(flash_attn, "_get_flash_attn_mode", lambda: "varlen")
     monkeypatch.setattr(
         flash_attn,
-        "_get_native_flash_attn_varlen_func",
+        "_select_flash_attn_varlen_func",
         lambda: native,
     )
 
-    assert flash_attn._call_native_flash_attn_with_lse(
+    assert flash_attn._call_select_flash_attn_with_lse(
         q="query",
         block_table=None,
         return_softmax_lse=True,
@@ -721,11 +721,11 @@ def test_hcu_native_varlen_lse_adapter_bypasses_paged_decode_fast_path(
     monkeypatch.setattr(flash_attn, "_get_flash_attn_mode", lambda: "varlen")
     monkeypatch.setattr(
         flash_attn,
-        "_get_native_flash_attn_varlen_func",
+        "_select_flash_attn_varlen_func",
         lambda: native,
     )
 
-    assert flash_attn._call_native_flash_attn_with_lse(
+    assert flash_attn._call_select_flash_attn_with_lse(
         q="query",
         block_table="paged-cache",
         max_seqlen_k=128,
@@ -752,7 +752,7 @@ def test_hcu_varlen_cascade_consumes_two_value_lse_result(
     monkeypatch.setattr(flash_attn, "_get_flash_attn_mode", lambda: "varlen")
     monkeypatch.setattr(
         flash_attn,
-        "_get_native_flash_attn_varlen_func",
+        "_select_flash_attn_varlen_func",
         lambda: native,
     )
     monkeypatch.setattr(
@@ -826,7 +826,7 @@ def test_hcu_varlen_dcp_requests_lse_from_paged_and_nonpaged_calls(
     monkeypatch.setattr(flash_attn, "_get_flash_attn_mode", lambda: "varlen")
     monkeypatch.setattr(
         flash_attn,
-        "_get_native_flash_attn_varlen_func",
+        "_select_flash_attn_varlen_func",
         lambda: native,
     )
     monkeypatch.setattr(flash_attn, "get_dcp_group", lambda: _DcpGroup())

--- a/tests/runtime_patch/test_hcu_mrv2_cudagraph_stream.py
+++ b/tests/runtime_patch/test_hcu_mrv2_cudagraph_stream.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+from vllm_hcu.patch.worker.framework_opt.patch_mrv2_cudagraph_stream import (
+    apply_to_module,
+)
+
+
+TARGET_MODULE = "vllm.v1.worker.gpu.cudagraph_utils"
+
+
+def _make_target_module():
+    module = ModuleType(TARGET_MODULE)
+    current_stream = object()
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def graph(*args, **kwargs):
+        calls.append((args, kwargs))
+        return kwargs.get("stream")
+
+    cuda = SimpleNamespace(
+        CUDAGraph=object,
+        graph=graph,
+        current_stream=lambda: current_stream,
+    )
+    module.torch = SimpleNamespace(cuda=cuda)
+    exec(
+        "class CudaGraphManager:\n"
+        "    def __init__(self):\n"
+        "        self.pool = object()\n"
+        "    def capture(self, create_forward_fn, "
+        "progress_bar_desc='Capturing CUDA graphs'):\n"
+        "        graph = torch.cuda.CUDAGraph()\n"
+        "        return torch.cuda.graph(graph, self.pool)\n",
+        module.__dict__,
+    )
+    return module, current_stream, calls
+
+
+def test_mrv2_capture_reuses_current_graph_capture_stream() -> None:
+    module, current_stream, calls = _make_target_module()
+
+    assert apply_to_module(module) is True
+    manager = module.CudaGraphManager()
+    assert manager.capture(lambda: None) is current_stream
+
+    assert len(calls) == 1
+    args, kwargs = calls[0]
+    assert args[1] is manager.pool
+    assert kwargs == {"stream": current_stream}
+    assert apply_to_module(module) is False
+
+
+def test_non_mrv2_graph_calls_keep_their_default_stream_behavior() -> None:
+    module, _, calls = _make_target_module()
+    original_graph = module.torch.cuda.graph
+    assert apply_to_module(module) is True
+
+    original_graph(object(), object())
+    module.torch.cuda.graph(object(), object())
+
+    assert len(calls) == 2
+    assert [kwargs for _, kwargs in calls] == [{}, {}]

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -207,6 +207,7 @@ def test_engine_args_normalizes_deepep_auto_and_extends_cli_choice() -> None:
     [
         ("FLASH_ATTN_CLASSIC", "classic"),
         ("flash_attn_cutlass", "cutlass"),
+        ("flash_attn_varlen", "varlen"),
     ],
 )
 def test_engine_args_normalizes_hcu_flash_attention_aliases(
@@ -767,10 +768,13 @@ def test_hcu_config_validation_binds_sidecar_without_upstream_fields() -> None:
         patch_vllm_config.validate_and_update_hcu_config(config)
 
 
-def test_compilation_binding_is_recreated_after_pickle() -> None:
+@pytest.mark.parametrize("flash_attn_mode", ["cutlass", "varlen"])
+def test_compilation_binding_is_recreated_after_pickle(
+    flash_attn_mode: str,
+) -> None:
     feature_config = HcuFeatureConfig(
         enable_custom_sp=True,
-        hcu_flash_attn_mode="cutlass",
+        hcu_flash_attn_mode=flash_attn_mode,
     )
     config = _validation_config(feature_config)
     patch_vllm_config.validate_and_update_hcu_config(config)
@@ -1022,6 +1026,7 @@ def _vllm_hash(additional_config: dict[str, Any]) -> str:
         ({}, "cutlass"),
         ({"VLLM_HCU_USE_FLASH_ATTN": "1"}, "classic"),
         ({"VLLM_HCU_USE_FLASH_ATTN_UNIFIED": "1"}, "cutlass"),
+        ({"VLLM_HCU_USE_FLASH_ATTN_VARLEN": "1"}, "varlen"),
     ],
 )
 def test_hcu_flash_attention_mode_is_finalized_before_config_hash(
@@ -1032,6 +1037,7 @@ def test_hcu_flash_attention_mode_is_finalized_before_config_hash(
     for name in (
         "VLLM_HCU_USE_FLASH_ATTN",
         "VLLM_HCU_USE_FLASH_ATTN_UNIFIED",
+        "VLLM_HCU_USE_FLASH_ATTN_VARLEN",
         "VLLM_HCU_USE_CUSTOM_FLASH_ATTN",
     ):
         monkeypatch.delenv(name, raising=False)
@@ -1043,6 +1049,45 @@ def test_hcu_flash_attention_mode_is_finalized_before_config_hash(
 
     assert feature_config.hcu_flash_attn_mode == expected
     assert get_hcu_config(config) == feature_config
+
+
+def test_varlen_flash_attention_uses_64_token_cache_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.v1.attention.backends.registry import AttentionBackendEnum
+    from vllm_hcu.platforms import envs as hcu_envs
+    from vllm_hcu.platforms.hcu import HCUPlatform
+
+    class _NoFullGraphs:
+        @staticmethod
+        def has_full_cudagraphs() -> bool:
+            return False
+
+    monkeypatch.setattr(hcu_envs, "VLLM_HCU_USE_PD_SPLIT", False)
+    monkeypatch.setattr(
+        hcu_envs,
+        "VLLM_HCU_FLASH_ATTN_BLOCK_ALIGNMENT_SIZE",
+        128,
+    )
+    monkeypatch.setattr(hcu_envs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    config = _validation_config(
+        HcuFeatureConfig(hcu_flash_attn_mode="varlen")
+    )
+    config.compilation_config.cudagraph_mode = _NoFullGraphs()
+    config.parallel_config.prefill_context_parallel_size = 1
+    config.parallel_config.distributed_executor_backend = "uni"
+    config.parallel_config.worker_cls = "auto"
+    config.cache_config = SimpleNamespace(
+        user_specified_block_size=False,
+        block_size=None,
+    )
+    config.attention_config = SimpleNamespace(
+        backend=AttentionBackendEnum.FLASH_ATTN
+    )
+
+    HCUPlatform.check_and_update_config(config)
+
+    assert config.cache_config.block_size == 64
 
 
 def test_cutlass_block_first_mooncake_defers_to_worker_capability_gates() -> None:

--- a/vllm_hcu/distributed/kv_transfer/kv_connector/v1/du/du_swift_connector_dp.py
+++ b/vllm_hcu/distributed/kv_transfer/kv_connector/v1/du/du_swift_connector_dp.py
@@ -423,7 +423,11 @@ class DuSwiftConnectorDp(KVConnectorBase_V1):
             if (not isinstance(kv_layer, tuple)):
                 if (isinstance(attn_metadata, MLACommonMetadata) or kv_layer.ndim == 3 or layer.shape[1] == 2):
                     return layer[block_ids, ...]
-                elif get_hcu_flash_attn_mode() not in ("classic", "cutlass"): # FlashAttention_NV
+                elif get_hcu_flash_attn_mode() not in (
+                    "classic",
+                    "cutlass",
+                    "varlen",
+                ):  # FlashAttention_NV
                     return layer[:, block_ids, ...]
                 else:
                     logger.error("🚧kv_cache not mla && gqa")

--- a/vllm_hcu/patch/config.py
+++ b/vllm_hcu/patch/config.py
@@ -24,7 +24,9 @@ _FEATURE_FIELDS = (
 )
 _BOOLEAN_FIELDS = _FEATURE_FIELDS[:5]
 _SUPPORTED_MOE_BACKENDS = frozenset({"auto", "dpsk_deep_gemm"})
-_SUPPORTED_FLASH_ATTN_MODES = frozenset({"classic", "cutlass", "custom"})
+_SUPPORTED_FLASH_ATTN_MODES = frozenset(
+    {"classic", "cutlass", "custom", "varlen"}
+)
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_hcu/patch/platform/core_fix/patch_engine_args.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_engine_args.py
@@ -49,6 +49,7 @@ _HCU_FLASH_ATTN_ALIASES = {
     "FLASH_ATTN_CLASSIC": "classic",
     "FLASH_ATTN_CUTLASS": "cutlass",
     "FLASH_ATTN_CUSTOM": "custom",
+    "FLASH_ATTN_VARLEN": "varlen",
 }
 
 

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -296,6 +296,9 @@ _FRAMEWORK_CALLBACKS: tuple[_CallbackSpec, ...] = (
         _adapter("framework_opt", "patch_gpu_worker_shutdown"),
     ),
     _CallbackSpec(
+        _adapter("framework_opt", "patch_mrv2_cudagraph_stream"),
+    ),
+    _CallbackSpec(
         _adapter("framework_opt", "patch_dp_utils"),
         feature="deepep_low_latency",
     ),

--- a/vllm_hcu/patch/worker/framework_opt/patch_mrv2_cudagraph_stream.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_mrv2_cudagraph_stream.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Reuse vLLM's outer capture stream for Model Runner V2 full graphs."""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import sys
+from types import ModuleType
+
+from ._common import (
+    PatchCompatibilityError,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_exact_signature,
+)
+
+TARGET_MODULE = "vllm.v1.worker.gpu.cudagraph_utils"
+PATCH_ID = "worker.framework_opt.cudagraph.mrv2_current_stream"
+TARGETS = (f"{TARGET_MODULE}.CudaGraphManager.capture",)
+_MARKER = "_vllm_hcu_mrv2_cudagraph_stream_applied"
+_WRAPPER = "_vllm_hcu_mrv2_cudagraph_stream_wrapper"
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    cudagraph_utils = load_exact_module(TARGET_MODULE, module)
+    manager = require_class(
+        cudagraph_utils,
+        "CudaGraphManager",
+        f"{TARGET_MODULE}.CudaGraphManager",
+    )
+    capture = require_callable(manager, "capture", TARGETS[0])
+
+    if getattr(cudagraph_utils, _MARKER, False):
+        graph = require_callable(
+            cudagraph_utils.torch.cuda,
+            "graph",
+            "torch.cuda.graph",
+        )
+        if not getattr(graph, _WRAPPER, False):
+            raise PatchCompatibilityError(
+                f"required HCU patch marker for {TARGETS[0]} is stale"
+            )
+        return False
+
+    require_exact_signature(
+        capture,
+        TARGETS[0],
+        positional=("self", "create_forward_fn", "progress_bar_desc"),
+        defaults={"progress_bar_desc": "Capturing CUDA graphs"},
+    )
+    capture_impl = inspect.unwrap(capture)
+    capture_code = getattr(capture_impl, "__code__", None)
+    required_names = {"torch", "cuda", "CUDAGraph", "graph", "pool"}
+    if capture_code is None or not required_names.issubset(capture_code.co_names):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[0]} no longer contains the "
+            "audited v0.25 full-graph capture call"
+        )
+
+    cuda = getattr(getattr(cudagraph_utils, "torch", None), "cuda", None)
+    if cuda is None:
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGET_MODULE}.torch.cuda is missing"
+        )
+    original_graph = require_callable(cuda, "graph", "torch.cuda.graph")
+    current_stream = require_callable(
+        cuda,
+        "current_stream",
+        "torch.cuda.current_stream",
+    )
+
+    @functools.wraps(original_graph)
+    def graph_on_current_stream(*args, **kwargs):
+        caller = sys._getframe(1)
+        if (
+            caller.f_code is capture_code
+            and len(args) < 3
+            and "stream" not in kwargs
+        ):
+            kwargs["stream"] = current_stream()
+        return original_graph(*args, **kwargs)
+
+    setattr(graph_on_current_stream, _WRAPPER, True)
+    setattr(graph_on_current_stream, "_vllm_hcu_original_graph", original_graph)
+    setattr(cuda, "graph", graph_on_current_stream)
+    setattr(cudagraph_utils, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]

--- a/vllm_hcu/platforms/envs.py
+++ b/vllm_hcu/platforms/envs.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     VLLM_USE_NN : bool = False
     VLLM_HCU_USE_FLASH_ATTN: bool = False
     VLLM_HCU_USE_FLASH_ATTN_UNIFIED: bool = True
+    VLLM_HCU_USE_FLASH_ATTN_VARLEN: bool = False
     VLLM_HCU_USE_CUSTOM_FLASH_ATTN: bool = False
     VLLM_HCU_USE_FLASHMLA: bool = False
     VLLM_USE_OPT_CAT: bool = False
@@ -88,6 +89,7 @@ def resolve_hcu_flash_attn_mode(explicit_mode: Optional[str]) -> str:
             "unified": "cutlass",
             "classic": "classic",
             "cutlass": "cutlass",
+            "varlen": "varlen",
             "custom": "custom",
         }
         if normalized not in aliases:
@@ -100,6 +102,10 @@ def resolve_hcu_flash_attn_mode(explicit_mode: Optional[str]) -> str:
         "VLLM_HCU_USE_CUSTOM_FLASH_ATTN", "False"
     ).lower() in ("true", "1"):
         return "custom"
+    if os.environ.get(
+        "VLLM_HCU_USE_FLASH_ATTN_VARLEN", "False"
+    ).lower() in ("true", "1"):
+        return "varlen"
     # Only an explicitly enabled legacy switch participates in priority
     # resolution. The flagless CUTLASS default is applied below, so an
     # explicitly requested classic mode can still take effect.
@@ -128,6 +134,10 @@ hcu_vllm_environment_variables: dict[str, Callable[[], Any]] = {
     # vLLM will use FlashAttention Backend (varlen_fwd_unified) on hcu, cutlass attention layerout blocksize 64 for qwen3.5
     "VLLM_HCU_USE_FLASH_ATTN_UNIFIED":
     lambda: (os.environ.get("VLLM_HCU_USE_FLASH_ATTN_UNIFIED", "True").lower() in
+             ("true", "1")),
+    # Select flash_attn.flash_attn_varlen_func without changing legacy paths.
+    "VLLM_HCU_USE_FLASH_ATTN_VARLEN":
+    lambda: (os.environ.get("VLLM_HCU_USE_FLASH_ATTN_VARLEN", "False").lower() in
              ("true", "1")),
     # vLLM will use custom FlashAttention (convert kv cache) Backend on hcu,  not office attention layerout blocksize 64 
     "VLLM_HCU_USE_CUSTOM_FLASH_ATTN":

--- a/vllm_hcu/platforms/hcu.py
+++ b/vllm_hcu/platforms/hcu.py
@@ -607,6 +607,11 @@ class HCUPlatform(Platform):
                     logger.warning(
                         "[HCU FLASH_ATTN:custom]: Setting kv cache block size to 64."
                     )
+                elif mode == "varlen":
+                    cache_config.block_size = 64
+                    logger.warning(
+                        "[HCU FLASH_ATTN:varlen]: Setting kv cache block size to 64."
+                    )
                 elif (
                     henvs.VLLM_HCU_FLASH_ATTN_BLOCK_ALIGNMENT_SIZE is not None
                     and henvs.VLLM_HCU_USE_CUSTOM_OPS

--- a/vllm_hcu/v1/attention/backends/fa_utils.py
+++ b/vllm_hcu/v1/attention/backends/fa_utils.py
@@ -2,17 +2,81 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
 # Modified by Hygon Information Technology Co., Ltd., 2026.
+import functools
+import inspect
+from collections.abc import Callable
 from typing import Any
 
 from flash_attn import (
-    flash_attn_varlen_func,
-    hg_flash_attn_varlen_func,
-    varlen_fwd_unified,
+    flash_attn_varlen_func as _flash_attn_varlen_func,
+    hg_flash_attn_varlen_func as _hg_flash_attn_varlen_func,
+    varlen_fwd_unified as _varlen_fwd_unified,
     vllm_flash_attn_varlen_func,
 )
 from torch import Tensor
+from vllm.v1.attention.backends.utils import get_kv_cache_layout
 
 import vllm_hcu.hcu_ops as hcu_ops
+
+
+def _flash_attn_layout() -> str:
+    cache_layout = get_kv_cache_layout()
+    if cache_layout == "HND":
+        return "bhsd"
+    if cache_layout == "NHD":
+        return "bshd"
+    raise ValueError(f"Unknown cache layout format {cache_layout}.")
+
+
+def _with_kv_cache_layout(function: Callable[..., Any], name: str):
+    try:
+        signature = inspect.signature(function)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            f"HCU requires flash_attn.{name} to expose a layout parameter"
+        ) from exc
+    layout_parameter = signature.parameters.get("layout")
+    if layout_parameter is None or layout_parameter.kind not in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    ):
+        raise RuntimeError(
+            f"HCU requires flash_attn.{name} to expose a keyword-compatible "
+            "layout parameter"
+        )
+    layout_position = (
+        tuple(signature.parameters).index("layout")
+        if layout_parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+        else None
+    )
+
+    @functools.wraps(function)
+    def wrapped(*args: Any, **kwargs: Any):
+        layout = _flash_attn_layout()
+        if layout_position is not None and len(args) > layout_position:
+            positional = list(args)
+            positional[layout_position] = layout
+            args = tuple(positional)
+            kwargs.pop("layout", None)
+        else:
+            kwargs["layout"] = layout
+        return function(*args, **kwargs)
+
+    return wrapped
+
+
+flash_attn_varlen_func = _with_kv_cache_layout(
+    _flash_attn_varlen_func,
+    "flash_attn_varlen_func",
+)
+hg_flash_attn_varlen_func = _with_kv_cache_layout(
+    _hg_flash_attn_varlen_func,
+    "hg_flash_attn_varlen_func",
+)
+varlen_fwd_unified = _with_kv_cache_layout(
+    _varlen_fwd_unified,
+    "varlen_fwd_unified",
+)
 
 
 # Hcu doesn't use scheduler metadata (FA3 feature), provide stub

--- a/vllm_hcu/v1/attention/backends/flash_attn.py
+++ b/vllm_hcu/v1/attention/backends/flash_attn.py
@@ -41,6 +41,7 @@ from vllm.platforms import current_platform
 if is_flash_attn_varlen_func_available():
     from vllm_hcu.v1.attention.backends.fa_utils import (
         flash_attn_supports_sinks,
+        flash_attn_varlen_func,
         get_scheduler_metadata,
         vllm_flash_attn_varlen_func,
         hg_flash_attn_varlen_func,
@@ -79,6 +80,36 @@ def _get_flash_attn_mode() -> str:
     from vllm_hcu.platforms.hcu import get_hcu_flash_attn_mode
 
     return get_hcu_flash_attn_mode()
+
+
+def _get_native_flash_attn_varlen_func():
+    if _get_flash_attn_mode() == "varlen":
+        return flash_attn_varlen_func
+    return hg_flash_attn_varlen_func
+
+
+def _call_native_flash_attn_with_lse(**kwargs):
+    if _get_flash_attn_mode() == "varlen":
+        # The raw interface has two distinct LSE controls. Unpacked Q/K/V
+        # consumes return_attn_probs, while paged attention consumes
+        # return_softmax_lse. Request both without changing the legacy wrapper
+        # contract.
+        if kwargs.get("block_table") is None:
+            kwargs["return_attn_probs"] = True
+        else:
+            # Its 64-token paged decode fast path returns only ``out`` even
+            # when LSE is requested. A finite left window covering the full
+            # maximum sequence is mathematically equivalent to unbounded
+            # attention and selects the LSE-capable path.
+            window_size = kwargs.get("window_size")
+            if window_size is None or tuple(window_size) == (-1, -1):
+                kwargs["window_size"] = [kwargs["max_seqlen_k"], -1]
+    result = _get_native_flash_attn_varlen_func()(**kwargs)
+    if not isinstance(result, tuple) or len(result) < 2:
+        raise RuntimeError(
+            "HCU native FlashAttention must return output and softmax LSE"
+        )
+    return result[0], result[1]
 
 
 def _find_kv_cache_block_dim(shape, sentinel: int) -> int:
@@ -995,11 +1026,16 @@ class FlashAttentionImpl(AttentionImpl):
                     )   
 
                 else:
+                    path_name = (
+                        "flash_attn_varlen"
+                        if _get_flash_attn_mode() == "varlen"
+                        else "classic_flash_attn"
+                    )
                     logger.info_once(
-                        "[HCU FLASH_ATTN PATH] classic_flash_attn",
+                        f"[HCU FLASH_ATTN PATH] {path_name}",
                         scope="local",
                     )
-                    hg_flash_attn_varlen_func(
+                    _get_native_flash_attn_varlen_func()(
                         q=query[:num_actual_tokens],
                         k=key_cache,
                         v=value_cache,
@@ -1169,7 +1205,7 @@ class FlashAttentionImpl(AttentionImpl):
                 is_prefix_cache=True,
             )
         else:
-            context_attn_out, context_lse = hg_flash_attn_varlen_func(
+            context_attn_out, context_lse = _call_native_flash_attn_with_lse(
                 q=query_across_dcp,
                 k=key_cache,
                 v=value_cache,
@@ -1228,7 +1264,7 @@ class FlashAttentionImpl(AttentionImpl):
                 is_prefix_cache=True,
             )
         else:
-            query_attn_out, query_lse = hg_flash_attn_varlen_func(
+            query_attn_out, query_lse = _call_native_flash_attn_with_lse(
                 q=query,
                 k=key,
                 v=value,
@@ -1328,7 +1364,7 @@ class FlashAttentionImpl(AttentionImpl):
                 is_prefix_cache=False,
             )
         else:
-            hg_flash_attn_varlen_func(
+            _get_native_flash_attn_varlen_func()(
                 q=query,
                 k=key,
                 v=value,
@@ -1498,7 +1534,7 @@ def cascade_attention(
             is_prefix_cache=True,
         )
     else:
-        prefix_output, prefix_lse, _ = hg_flash_attn_varlen_func(
+        prefix_output, prefix_lse = _call_native_flash_attn_with_lse(
             q=query,
             k=key_cache,
             v=value_cache,
@@ -1551,7 +1587,7 @@ def cascade_attention(
             is_prefix_cache=True,
         )
     else:
-        suffix_output, suffix_lse, _ = hg_flash_attn_varlen_func(
+        suffix_output, suffix_lse = _call_native_flash_attn_with_lse(
             q=query,
             k=key_cache,
             v=value_cache,

--- a/vllm_hcu/v1/attention/backends/flash_attn.py
+++ b/vllm_hcu/v1/attention/backends/flash_attn.py
@@ -82,13 +82,13 @@ def _get_flash_attn_mode() -> str:
     return get_hcu_flash_attn_mode()
 
 
-def _get_native_flash_attn_varlen_func():
+def _select_flash_attn_varlen_func():
     if _get_flash_attn_mode() == "varlen":
         return flash_attn_varlen_func
     return hg_flash_attn_varlen_func
 
 
-def _call_native_flash_attn_with_lse(**kwargs):
+def _call_select_flash_attn_with_lse(**kwargs):
     if _get_flash_attn_mode() == "varlen":
         # The raw interface has two distinct LSE controls. Unpacked Q/K/V
         # consumes return_attn_probs, while paged attention consumes
@@ -104,7 +104,7 @@ def _call_native_flash_attn_with_lse(**kwargs):
             window_size = kwargs.get("window_size")
             if window_size is None or tuple(window_size) == (-1, -1):
                 kwargs["window_size"] = [kwargs["max_seqlen_k"], -1]
-    result = _get_native_flash_attn_varlen_func()(**kwargs)
+    result = _select_flash_attn_varlen_func()(**kwargs)
     if not isinstance(result, tuple) or len(result) < 2:
         raise RuntimeError(
             "HCU native FlashAttention must return output and softmax LSE"
@@ -1035,7 +1035,7 @@ class FlashAttentionImpl(AttentionImpl):
                         f"[HCU FLASH_ATTN PATH] {path_name}",
                         scope="local",
                     )
-                    _get_native_flash_attn_varlen_func()(
+                    _select_flash_attn_varlen_func()(
                         q=query[:num_actual_tokens],
                         k=key_cache,
                         v=value_cache,
@@ -1205,7 +1205,7 @@ class FlashAttentionImpl(AttentionImpl):
                 is_prefix_cache=True,
             )
         else:
-            context_attn_out, context_lse = _call_native_flash_attn_with_lse(
+            context_attn_out, context_lse = _call_select_flash_attn_with_lse(
                 q=query_across_dcp,
                 k=key_cache,
                 v=value_cache,
@@ -1264,7 +1264,7 @@ class FlashAttentionImpl(AttentionImpl):
                 is_prefix_cache=True,
             )
         else:
-            query_attn_out, query_lse = _call_native_flash_attn_with_lse(
+            query_attn_out, query_lse = _call_select_flash_attn_with_lse(
                 q=query,
                 k=key,
                 v=value,
@@ -1364,7 +1364,7 @@ class FlashAttentionImpl(AttentionImpl):
                 is_prefix_cache=False,
             )
         else:
-            _get_native_flash_attn_varlen_func()(
+            _select_flash_attn_varlen_func()(
                 q=query,
                 k=key,
                 v=value,
@@ -1534,7 +1534,7 @@ def cascade_attention(
             is_prefix_cache=True,
         )
     else:
-        prefix_output, prefix_lse = _call_native_flash_attn_with_lse(
+        prefix_output, prefix_lse = _call_select_flash_attn_with_lse(
             q=query,
             k=key_cache,
             v=value_cache,
@@ -1587,7 +1587,7 @@ def cascade_attention(
             is_prefix_cache=True,
         )
     else:
-        suffix_output, suffix_lse = _call_native_flash_attn_with_lse(
+        suffix_output, suffix_lse = _call_select_flash_attn_with_lse(
             q=query,
             k=key_cache,
             v=value_cache,


### PR DESCRIPTION
Supersedes #14. This PR reapplies the reviewed FlashAttention layout work directly onto the latest `v0.25.1` branch without carrying the former feature-branch baseline or its `docs/superpowers` files.

## v0.25.1 integration verification

```text
178 passed, 14 warnings in 68.47s
python -m compileall -q vllm_hcu tests  # passed
git diff --check origin/v0.25.1..HEAD  # passed
```

## Summary

- adapt the new FlashAttention `layout` interface at the HCU backend boundary
- add the parameterized `--attention-backend FLASH_ATTN_VARLEN` path for the native `flash_attn_varlen_func` entrypoint
- map `VLLM_KV_CACHE_LAYOUT=HND` to `layout="bhsd"` (recommended)
- map `VLLM_KV_CACHE_LAYOUT=NHD` to `layout="bshd"`
- automatically use KV-cache block size 64 for the native varlen path
- fail closed when a layout-aware external FlashAttention entrypoint no longer exposes a keyword-compatible `layout`
- keep `vllm_flash_attn_varlen_func` on its existing custom-layout path

## Interface and routing

The adapter covers `flash_attn_varlen_func`, `hg_flash_attn_varlen_func`, and `varlen_fwd_unified`. The custom `vllm_flash_attn_varlen_func` is intentionally not wrapped because its installed interface has no `layout` argument and internally selects `layout="custom"`.

### Parameterized backend selection

| CLI parameter | Effective implementation | Calls `flash_attn_varlen_func` | Default block size |
|---|---|---:|---:|
| `--attention-backend FLASH_ATTN_VARLEN` | HCU `FLASH_ATTN` backend with `hcu_flash_attn_mode=varlen` | Yes | 64 |
| `--attention-backend TRITON_ATTN` | HCU wrapper over upstream `TritonAttentionImpl` / `triton_unified_attention.unified_attention` | No | 16 |

`FLASH_ATTN_VARLEN` is an HCU CLI alias. The plugin normalizes it to the upstream `FLASH_ATTN` enum before upstream validation and serializes `hcu_flash_attn_mode=varlen` in the HCU feature sidecar. At runtime, varlen mode selects the wrapped `flash_attn.flash_attn_varlen_func` entrypoint.

`TRITON_ATTN` is the standard upstream backend selection. It dispatches to the Triton unified-attention kernels and is intentionally independent of `flash_attn_varlen_func`.

The native varlen path can therefore be selected without an HCU path-selection environment variable:

```bash
--attention-backend FLASH_ATTN_VARLEN
```

`VLLM_HCU_USE_FLASH_ATTN_VARLEN=1` remains available as a compatibility fallback, but is not needed when the CLI alias is used.

`VLLM_KV_CACHE_LAYOUT` remains the upstream vLLM layout selector:

| KV-cache layout | `flash_attn_varlen_func(layout=...)` |
|---|---|
| `HND` | `bhsd` |
| `NHD` | `bshd` |

When `VLLM_KV_CACHE_LAYOUT` is unset, its environment value is `None`; ordinary standalone inference resolves to NHD and passes `layout="bshd"`. Set HND before server startup to pass the recommended `layout="bhsd"`.

## Verification

CPU regression:

```text
84 passed, 14 warnings
```

```bash
VLLM_V0251_SOURCE_ROOT=/models/zb/vllm_025/vllm pytest -q \
  tests/runtime_patch/test_flash_attention_and_pp.py \
  tests/runtime_patch/test_mla_target_ownership.py \
  tests/runtime_patch/test_sparse_indexer_loading.py \
  tests/patch/test_plugin_lifecycle.py
python -m compileall -q vllm_hcu tests
git diff --check origin/v0.25.1..HEAD
```

Fresh focused routing verification:

```text
54 passed, 61 deselected, 14 warnings
```

The function-boundary regression replaces the external FlashAttention entrypoints with observable doubles. With varlen mode it verifies exactly one call to `flash_attn_varlen_func`, no call to `hg_flash_attn_varlen_func` or `varlen_fwd_unified`, and verifies `HND -> layout="bhsd"` plus `NHD -> layout="bshd"`.

### Qwen3-8B native varlen validation

Model: `/models/Qwen3-8B`; TP=1; Model Runner V2 explicitly enabled; graph enabled; thinking disabled; temperature=0; KV-cache block size automatically set to 64.

| Model runner | KV-cache layout | FA layout | HumanEval samples | HumanEval pass@1 |
|---|---|---|---:|---:|
| V2 | HND | bhsd | 32 | 30/32 (0.9375) |
| V2 | NHD | bshd | 32 | 30/32 (0.9375) |

Both runs produced 32 predictions and 32 reviews. The generated compile-cache factors independently record `VLLM_USE_V2_MODEL_RUNNER=true`, with `VLLM_KV_CACHE_LAYOUT=HND` and `NHD` respectively.

A fresh eager hardware smoke run on 2026-08-22 used `FLASH_ATTN_VARLEN` + HND and returned `VARLEN_OK` with HTTP 200. Its engine log confirmed:

```text
attention_backend: FLASH_ATTN_VARLEN
VLLM_KV_CACHE_LAYOUT detected: HND
[HCU FLASH_ATTN:varlen]: Setting kv cache block size to 64.
```

Combined with the observable function-boundary test and the direct runtime dispatch (`varlen` mode returns the wrapped `flash_attn_varlen_func`), this confirms that `FLASH_ATTN_VARLEN` enters `flash_attn_varlen_func`.

For comparison, a Qwen3-8B `TRITON_ATTN` hardware smoke request returned `TRITON_OK` with HTTP 200 and emitted:

```text
Triton kernel JIT compilation during inference: kernel_unified_attention
Triton kernel JIT compilation during inference: reduce_segments
```

This confirms `TRITON_ATTN` uses Triton unified attention and does not enter `flash_attn_varlen_func`.

Earlier compatibility coverage also exercised both Model Runner V1 and V2 across HND/NHD. The final native-varlen, block-size-64 HumanEval runs above used Model Runner V2. Note that log paths under `vllm/v1/...` identify the vLLM V1 engine and do not imply Model Runner V1.

Representative native-varlen server command (HND; use `NHD` for `layout="bshd"`):

```bash
HIP_VISIBLE_DEVICES=0 \
VLLM_USE_V2_MODEL_RUNNER=1 \
VLLM_KV_CACHE_LAYOUT=HND \
VLLM_WORKER_MULTIPROC_METHOD=spawn \
PYTHONPATH=/models/.worktrees/vllm-plugin-das-fa-kv-layout:/models/zb/vllm_025/vllm \
vllm serve /models/Qwen3-8B \
  --served-model-name qwen3-8b-varlen-hnd-final \
  --attention-backend FLASH_ATTN_VARLEN \
  --trust-remote-code \
  --tensor-parallel-size 1 \
  --gpu-memory-utilization 0.5 \
  --max-model-len 8192 \
  --default-chat-template-kwargs '{"enable_thinking":false}' \
  --port 8024
```

No `--block-size 64` argument is required: the platform sets it automatically for `FLASH_ATTN_VARLEN`.

Triton comparison command:

```bash
HIP_VISIBLE_DEVICES=0 \
VLLM_USE_V2_MODEL_RUNNER=1 \
VLLM_KV_CACHE_LAYOUT=HND \
vllm serve /models/Qwen3-8B \
  --served-model-name qwen3-8b-triton \
  --attention-backend TRITON_ATTN \
  --tensor-parallel-size 1 \
  --max-model-len 8192 \
  --default-chat-template-kwargs '{"enable_thinking":false}' \
  --port 8026
```

EvalScope command:

```bash
evalscope eval \
  --model qwen3-8b-varlen-hnd-final \
  --api-url http://127.0.0.1:8024/v1 \
  --api-key EMPTY \
  --eval-type openai_api \
  --generation-config '{"temperature":0,"max_tokens":4096,"timeout":1800,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}' \
  --eval-batch-size 1 \
  --limit 32 \
  --datasets humaneval \
  --dataset-args '{"humaneval":{}}' \
  --work-dir /tmp/evalscope-qwen3-8b-varlen-hnd-bs64-human32-final-20260821 \
  --no-timestamp
```

