### PR TITLE
fix(hcu): enable GLM-5.2 DCP on v0.25.1

### DIFF
--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -425,7 +425,10 @@ def test_flashmla_sparse_mixed_metadata_exposes_pcp_cache_phase(monkeypatch):
     assert adapter.apply_to_module(module)
     builder = FlashMLASparseMetadataBuilder()
     builder.vllm_config = SimpleNamespace(
-        parallel_config=SimpleNamespace(prefill_context_parallel_size=2)
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=2,
+            cp_kv_cache_interleave_size=1,
+        )
     )
     common = SimpleNamespace(num_actual_tokens=8)
 
@@ -630,7 +633,10 @@ def test_flashmla_sparse_pcp_separate_metadata_keeps_short_extend_as_prefill(
     assert adapter.apply_to_module(module)
     builder = builder_cls()
     builder.vllm_config = SimpleNamespace(
-        parallel_config=SimpleNamespace(prefill_context_parallel_size=2)
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=2,
+            cp_kv_cache_interleave_size=1,
+        )
     )
     common = SimpleNamespace(
         num_actual_tokens=4,
@@ -707,7 +713,10 @@ def test_flashmla_sparse_pcp_one_preserves_separate_phase_default(monkeypatch):
     )
     builder = builder_cls()
     builder.vllm_config = SimpleNamespace(
-        parallel_config=SimpleNamespace(prefill_context_parallel_size=1)
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=1,
+            cp_kv_cache_interleave_size=1,
+        )
     )
 
     metadata = builder.build(

--- a/tests/runtime_patch/test_glm52_pcp_runner.py
+++ b/tests/runtime_patch/test_glm52_pcp_runner.py
@@ -21,6 +21,21 @@ import torch
 from vllm_hcu.patch.worker.framework_opt._common import PatchCompatibilityError
 
 
+def test_unitary_pcp_world_size_is_fullgraph_compilable() -> None:
+    """TP/DCP-only GLM execution must not inspect dynamic PCP/MTP state."""
+
+    from vllm_hcu.model_executor.layers.attention.pcp import (
+        effective_pcp_world_size,
+    )
+
+    def resolve_world_size(value: torch.Tensor) -> torch.Tensor:
+        return value + effective_pcp_world_size(1)
+
+    compiled = torch.compile(resolve_world_size, backend="eager", fullgraph=True)
+
+    torch.testing.assert_close(compiled(torch.tensor(1)), torch.tensor(2))
+
+
 @pytest.fixture
 def pcp_runner_module(monkeypatch: pytest.MonkeyPatch):
     """Load the HCU runner over a behavior-recording upstream MRV2 base."""

--- a/tests/runtime_patch/test_mla_target_ownership.py
+++ b/tests/runtime_patch/test_mla_target_ownership.py
@@ -730,7 +730,7 @@ def test_replicated_mtp_scope_uses_target_mla_forward(monkeypatch):
     assert events == ["opaque_forward"]
 
 
-def test_dense_and_sparse_mla_metadata_carry_pcp_world_size(monkeypatch):
+def test_dense_and_sparse_mla_metadata_carry_parallel_sizes(monkeypatch):
     adapter = _adapter()
     module = _fake_mla_module(adapter, [])
     assert adapter.apply_to_module(module) is True
@@ -803,12 +803,16 @@ def _build_fp8_separate_prefill_decode(self, common_attn_metadata):
     assert sparse_adapter.apply_to_module(sparse_module) is True
     sparse_builder = FlashMLASparseMetadataBuilder()
     sparse_builder.vllm_config = SimpleNamespace(
-        parallel_config=SimpleNamespace(prefill_context_parallel_size=2)
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=2,
+            cp_kv_cache_interleave_size=4,
+        )
     )
 
     sparse_metadata = sparse_builder.build(0, common)
 
     assert sparse_metadata.pcp_world_size == 2
+    assert sparse_metadata.cp_kv_cache_interleave_size == 4
 
     from vllm_hcu.model_executor.layers.attention import pcp
 
@@ -913,7 +917,7 @@ def test_only_hcu_dense_and_sparse_mla_impls_advertise_pcp(
     assert UpstreamFlashMLASparseImpl.can_return_lse_for_decode is False
 
 
-def test_hcu_sparse_mla_dcp_preserves_gathered_heads_and_returns_lse(
+def test_hcu_sparse_mla_dcp_localizes_owned_indices_and_masks_empty_rows(
     monkeypatch,
 ):
     calls: list[tuple[object, ...]] = []
@@ -934,34 +938,68 @@ def test_hcu_sparse_mla_dcp_preserves_gathered_heads_and_returns_lse(
     def concat_mla_q(q_nope, q_pe, output):
         output.copy_(torch.cat((q_nope, q_pe), dim=-1))
 
-    def convert_indices(
+    def convert_indices(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("DCP sparse MLA used the non-DCP index converter")
+
+    def filter_dcp_indices(
         req_id_per_token,
         block_table,
         topk_indices,
         *,
+        dcp_size,
+        dcp_rank,
+        cp_kv_cache_interleave_size,
         BLOCK_SIZE,
         NUM_TOPK_TOKENS,
         return_valid_counts,
     ):
+        torch.testing.assert_close(
+            req_id_per_token,
+            torch.tensor([0, 1], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            block_table,
+            torch.tensor([[7], [11]], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            topk_indices,
+            torch.tensor(
+                [[0, 1, 2, 3], [0, 2, 4, 6]],
+                dtype=torch.int32,
+            ),
+        )
         calls.append(
             (
-                "convert",
+                "filter_dcp",
                 req_id_per_token,
                 block_table,
                 topk_indices,
+                dcp_size,
+                dcp_rank,
+                cp_kv_cache_interleave_size,
                 BLOCK_SIZE,
                 NUM_TOPK_TOKENS,
                 return_valid_counts,
             )
         )
-        return topk_indices + 10, torch.tensor([2, 3])
+        # For DCP size=2/rank=1/interleave=1, global positions 1 and 3
+        # become local positions 0 and 1. With physical block 7, those
+        # are slots 112 and 113. The second row has no rank-1 ownership.
+        return (
+            torch.tensor(
+                [[112, 113, -1, -1], [-1, -1, -1, -1]],
+                dtype=torch.int32,
+            ),
+            torch.tensor([2, 0], dtype=torch.int32),
+        )
 
-    expected_output = torch.arange(24).view(2, 4, 3)
-    expected_lse = torch.arange(8).view(2, 4)
+    kernel_output = torch.arange(24, dtype=torch.float32).view(2, 4, 3)
+    kernel_lse = torch.arange(8, dtype=torch.float32).view(2, 4)
 
     def sparse_fwd(q, cache, indices, scale, *, topk_length):
         calls.append(("kernel", q.clone(), cache, indices, scale, topk_length))
-        return expected_output, torch.empty(0), expected_lse
+        return kernel_output.clone(), torch.empty(0), kernel_lse.clone()
 
     _install_stub(
         monkeypatch,
@@ -974,6 +1012,7 @@ def test_hcu_sparse_mla_dcp_preserves_gathered_heads_and_returns_lse(
         monkeypatch,
         "vllm.v1.attention.backends.mla.sparse_utils",
         triton_convert_req_index_to_global_index=convert_indices,
+        triton_filter_and_convert_dcp_index=filter_dcp_indices,
     )
     _install_stub(
         monkeypatch,
@@ -994,33 +1033,47 @@ def test_hcu_sparse_mla_dcp_preserves_gathered_heads_and_returns_lse(
 
     impl = sparse.HcuFlashMLASparseImpl()
     impl.dcp_world_size = 2
+    impl.dcp_rank = 1
     impl.kv_cache_dtype = "auto"
     impl.softmax_scale = 0.25
     impl.q_concat_buffer = torch.empty(2, 4, 4)
-    impl.topk_indices_buffer = torch.tensor([[0, 1, 2], [3, 4, 5]])
+    impl.topk_indices_buffer = torch.tensor(
+        [[0, 1, 2, 3], [0, 2, 4, 6]], dtype=torch.int32
+    )
     q_nope = torch.ones(2, 4, 3)
     q_pe = torch.full((2, 4, 1), 2.0)
     cache = torch.ones(6, 4)
     metadata = SimpleNamespace(
-        req_id_per_token=torch.tensor([0, 1]),
-        block_table=torch.tensor([[0], [1]]),
+        req_id_per_token=torch.tensor([0, 1], dtype=torch.int32),
+        block_table=torch.tensor([[7], [11]], dtype=torch.int32),
         block_size=16,
+        cp_kv_cache_interleave_size=1,
     )
     layer = object()
 
     output, lse = impl.forward_mqa((q_nope, q_pe), cache, metadata, layer)
 
-    assert output is expected_output
-    assert lse is expected_lse
+    torch.testing.assert_close(output[0], kernel_output[0])
+    torch.testing.assert_close(output[1], torch.zeros_like(output[1]))
+    torch.testing.assert_close(lse[0], kernel_lse[0])
+    assert torch.isneginf(lse[1]).all()
+    filter_call = calls[-2]
+    assert filter_call[0] == "filter_dcp"
+    assert filter_call[4:10] == (2, 1, 1, 16, 4, True)
     kernel_call = calls[-1]
     assert kernel_call[0] == "kernel"
     assert kernel_call[1].shape == (2, 4, 4)
     assert kernel_call[2].shape == (6, 1, 4)
     torch.testing.assert_close(
         kernel_call[3],
-        torch.tensor([[[10, 11, 12]], [[13, 14, 15]]]),
+        torch.tensor(
+            [[[112, 113, -1, -1]], [[-1, -1, -1, -1]]],
+            dtype=torch.int32,
+        ),
     )
-    torch.testing.assert_close(kernel_call[-1], torch.tensor([2, 3]))
+    torch.testing.assert_close(
+        kernel_call[-1], torch.tensor([2, 0], dtype=torch.int32)
+    )
 
     impl.dcp_world_size = 1
     assert impl.forward_mqa(q_nope, cache, metadata, layer) == (

--- a/tests/runtime_patch/test_mla_target_ownership.py
+++ b/tests/runtime_patch/test_mla_target_ownership.py
@@ -877,6 +877,11 @@ def test_only_hcu_dense_and_sparse_mla_impls_advertise_pcp(
 
     class UpstreamFlashMLASparseImpl:
         supports_pcp = False
+        can_return_lse_for_decode = False
+
+        def forward_mqa(self, q, kv_cache, attn_metadata, layer):
+            del self, q, kv_cache, attn_metadata, layer
+            return "upstream-output", None
 
     class UpstreamFlashMLASparseBackend:
         @staticmethod
@@ -903,7 +908,126 @@ def test_only_hcu_dense_and_sparse_mla_impls_advertise_pcp(
     sparse_impl = sparse.HcuFlashMLASparseBackend.get_impl_cls()
     assert sparse_impl is sparse.HcuFlashMLASparseImpl
     assert sparse_impl.supports_pcp is True
+    assert sparse_impl.can_return_lse_for_decode is True
     assert UpstreamFlashMLASparseImpl.supports_pcp is False
+    assert UpstreamFlashMLASparseImpl.can_return_lse_for_decode is False
+
+
+def test_hcu_sparse_mla_dcp_preserves_gathered_heads_and_returns_lse(
+    monkeypatch,
+):
+    calls: list[tuple[object, ...]] = []
+
+    class UpstreamFlashMLASparseImpl:
+        supports_pcp = False
+        can_return_lse_for_decode = False
+
+        def forward_mqa(self, q, kv_cache, attn_metadata, layer):
+            calls.append(("upstream", q, kv_cache, attn_metadata, layer))
+            return "upstream-output", None
+
+    class UpstreamFlashMLASparseBackend:
+        @staticmethod
+        def get_impl_cls():
+            return UpstreamFlashMLASparseImpl
+
+    def concat_mla_q(q_nope, q_pe, output):
+        output.copy_(torch.cat((q_nope, q_pe), dim=-1))
+
+    def convert_indices(
+        req_id_per_token,
+        block_table,
+        topk_indices,
+        *,
+        BLOCK_SIZE,
+        NUM_TOPK_TOKENS,
+        return_valid_counts,
+    ):
+        calls.append(
+            (
+                "convert",
+                req_id_per_token,
+                block_table,
+                topk_indices,
+                BLOCK_SIZE,
+                NUM_TOPK_TOKENS,
+                return_valid_counts,
+            )
+        )
+        return topk_indices + 10, torch.tensor([2, 3])
+
+    expected_output = torch.arange(24).view(2, 4, 3)
+    expected_lse = torch.arange(8).view(2, 4)
+
+    def sparse_fwd(q, cache, indices, scale, *, topk_length):
+        calls.append(("kernel", q.clone(), cache, indices, scale, topk_length))
+        return expected_output, torch.empty(0), expected_lse
+
+    _install_stub(
+        monkeypatch,
+        "vllm.v1.attention.backends.mla.flashmla_sparse",
+        FlashMLASparseBackend=UpstreamFlashMLASparseBackend,
+        FlashMLASparseImpl=UpstreamFlashMLASparseImpl,
+    )
+    _install_stub(monkeypatch, "vllm._custom_ops", concat_mla_q=concat_mla_q)
+    _install_stub(
+        monkeypatch,
+        "vllm.v1.attention.backends.mla.sparse_utils",
+        triton_convert_req_index_to_global_index=convert_indices,
+    )
+    _install_stub(
+        monkeypatch,
+        "vllm_hcu.v1.attention.ops.flashmla",
+        flash_mla_sparse_fwd=sparse_fwd,
+    )
+
+    module_name = "_vllm_hcu_cpu_test_flashmla_sparse_dcp_backend"
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "vllm_hcu/v1/attention/backends/mla/flashmla_sparse.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, source)
+    assert spec is not None and spec.loader is not None
+    sparse = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, sparse)
+    spec.loader.exec_module(sparse)
+
+    impl = sparse.HcuFlashMLASparseImpl()
+    impl.dcp_world_size = 2
+    impl.kv_cache_dtype = "auto"
+    impl.softmax_scale = 0.25
+    impl.q_concat_buffer = torch.empty(2, 4, 4)
+    impl.topk_indices_buffer = torch.tensor([[0, 1, 2], [3, 4, 5]])
+    q_nope = torch.ones(2, 4, 3)
+    q_pe = torch.full((2, 4, 1), 2.0)
+    cache = torch.ones(6, 4)
+    metadata = SimpleNamespace(
+        req_id_per_token=torch.tensor([0, 1]),
+        block_table=torch.tensor([[0], [1]]),
+        block_size=16,
+    )
+    layer = object()
+
+    output, lse = impl.forward_mqa((q_nope, q_pe), cache, metadata, layer)
+
+    assert output is expected_output
+    assert lse is expected_lse
+    kernel_call = calls[-1]
+    assert kernel_call[0] == "kernel"
+    assert kernel_call[1].shape == (2, 4, 4)
+    assert kernel_call[2].shape == (6, 1, 4)
+    torch.testing.assert_close(
+        kernel_call[3],
+        torch.tensor([[[10, 11, 12]], [[13, 14, 15]]]),
+    )
+    torch.testing.assert_close(kernel_call[-1], torch.tensor([2, 3]))
+
+    impl.dcp_world_size = 1
+    assert impl.forward_mqa(q_nope, cache, metadata, layer) == (
+        "upstream-output",
+        None,
+    )
+    assert calls[-1][0] == "upstream"
 
 
 def test_flashmla_cat_route_consumes_split_query(

--- a/vllm_hcu/model_executor/layers/attention/pcp.py
+++ b/vllm_hcu/model_executor/layers/attention/pcp.py
@@ -44,6 +44,12 @@ def in_replicated_mtp_batch() -> bool:
 def effective_pcp_world_size(configured_world_size: int) -> int:
     """Return the logical PCP width for the current model invocation."""
 
+    # TP/DCP-only execution is compiled as a full graph.  Avoid consulting the
+    # dynamic MTP scope in that common case because Dynamo cannot trace
+    # ContextVar.get().  A unitary PCP group is already unaffected by replicated
+    # MTP execution, so the lookup cannot change the result.
+    if configured_world_size == 1:
+        return 1
     if in_replicated_mtp_batch():
         return 1
     return configured_world_size

--- a/vllm_hcu/patch/worker/op_opt/patch_flashmla_sparse.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_flashmla_sparse.py
@@ -172,6 +172,13 @@ def apply_to_module(module: ModuleType) -> bool:
             pcp_world_size = int(
                 getattr(common_attn_metadata, "pcp_world_size", 1)
             )
+            cp_kv_cache_interleave_size = int(
+                getattr(
+                    common_attn_metadata,
+                    "cp_kv_cache_interleave_size",
+                    1,
+                )
+            )
         else:
             parallel_config = getattr(vllm_config, "parallel_config", None)
             pcp_world_size = getattr(
@@ -185,6 +192,17 @@ def apply_to_module(module: ModuleType) -> bool:
                     "is missing from sparse MLA metadata builder"
                 )
             pcp_world_size = int(pcp_world_size)
+            cp_kv_cache_interleave_size = getattr(
+                parallel_config,
+                "cp_kv_cache_interleave_size",
+                None,
+            )
+            if cp_kv_cache_interleave_size is None:
+                raise PatchCompatibilityError(
+                    "required vLLM 0.25.1 cp_kv_cache_interleave_size "
+                    "is missing from sparse MLA metadata builder"
+                )
+            cp_kv_cache_interleave_size = int(cp_kv_cache_interleave_size)
         pcp_world_size = effective_pcp_world_size(pcp_world_size)
         if not henvs.VLLM_HCU_USE_FP8_MIXED_BATCH:
             has_fp8_metadata = (
@@ -213,6 +231,7 @@ def apply_to_module(module: ModuleType) -> bool:
             common_attn_metadata.num_actual_tokens,
         )
         result.pcp_world_size = pcp_world_size
+        result.cp_kv_cache_interleave_size = cp_kv_cache_interleave_size
         if result.pcp_world_size > 1:
             (
                 result.num_decodes,

--- a/vllm_hcu/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm_hcu/v1/attention/backends/mla/flashmla_sparse.py
@@ -36,7 +36,7 @@ class HcuFlashMLASparseImpl(FlashMLASparseImpl):
 
         from vllm import _custom_ops as ops
         from vllm.v1.attention.backends.mla.sparse_utils import (
-            triton_convert_req_index_to_global_index,
+            triton_filter_and_convert_dcp_index,
         )
         from vllm_hcu.v1.attention.ops.flashmla import flash_mla_sparse_fwd
 
@@ -52,10 +52,15 @@ class HcuFlashMLASparseImpl(FlashMLASparseImpl):
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
         topk_indices, topk_length = (
-            triton_convert_req_index_to_global_index(
-                attn_metadata.req_id_per_token,
+            triton_filter_and_convert_dcp_index(
+                attn_metadata.req_id_per_token[:num_actual_toks],
                 attn_metadata.block_table,
                 topk_indices,
+                dcp_size=self.dcp_world_size,
+                dcp_rank=self.dcp_rank,
+                cp_kv_cache_interleave_size=(
+                    attn_metadata.cp_kv_cache_interleave_size
+                ),
                 BLOCK_SIZE=attn_metadata.block_size,
                 NUM_TOPK_TOKENS=topk_indices.shape[1],
                 return_valid_counts=True,
@@ -76,6 +81,9 @@ class HcuFlashMLASparseImpl(FlashMLASparseImpl):
         )
         if lse is None:
             raise RuntimeError("HCU sparse MLA DCP kernel did not return LSE")
+        empty_rows = topk_length == 0
+        attn_out.masked_fill_(empty_rows.view(-1, 1, 1), 0.0)
+        lse.masked_fill_(empty_rows.view(-1, 1), float("-inf"))
         return attn_out, lse
 
 

--- a/vllm_hcu/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm_hcu/v1/attention/backends/mla/flashmla_sparse.py
@@ -3,6 +3,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
 # Modified by Hygon Information Technology Co., Ltd., 2026.
 
+from __future__ import annotations
+
+import torch
+
 from vllm.v1.attention.backends.mla.flashmla_sparse import (
     FlashMLASparseBackend,
     FlashMLASparseImpl,
@@ -11,6 +15,68 @@ from vllm.v1.attention.backends.mla.flashmla_sparse import (
 
 class HcuFlashMLASparseImpl(FlashMLASparseImpl):
     supports_pcp: bool = True
+    can_return_lse_for_decode: bool = True
+
+    def forward_mqa(
+        self,
+        q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata,
+        layer,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if self.dcp_world_size <= 1:
+            return super().forward_mqa(
+                q,
+                kv_c_and_k_pe_cache,
+                attn_metadata,
+                layer,
+            )
+        if self.kv_cache_dtype == "fp8_ds_mla":
+            raise RuntimeError("HCU sparse MLA DCP does not support FP8 KV cache")
+
+        from vllm import _custom_ops as ops
+        from vllm.v1.attention.backends.mla.sparse_utils import (
+            triton_convert_req_index_to_global_index,
+        )
+        from vllm_hcu.v1.attention.ops.flashmla import flash_mla_sparse_fwd
+
+        # DCP gathers the query-head dimension before this call. Keep every
+        # gathered head and return the kernel LSE so the common MLA runtime can
+        # perform its numerically stable cross-rank reduction.
+        if isinstance(q, tuple):
+            ql_nope, q_pe = q
+            q = self.q_concat_buffer[: ql_nope.shape[0]]
+            ops.concat_mla_q(ql_nope, q_pe, q)
+
+        num_actual_toks = q.shape[0]
+        assert self.topk_indices_buffer is not None
+        topk_indices = self.topk_indices_buffer[:num_actual_toks]
+        topk_indices, topk_length = (
+            triton_convert_req_index_to_global_index(
+                attn_metadata.req_id_per_token,
+                attn_metadata.block_table,
+                topk_indices,
+                BLOCK_SIZE=attn_metadata.block_size,
+                NUM_TOPK_TOKENS=topk_indices.shape[1],
+                return_valid_counts=True,
+            )
+        )
+        cache = kv_c_and_k_pe_cache.view(
+            -1,
+            1,
+            kv_c_and_k_pe_cache.shape[-1],
+        )
+        indices = topk_indices.view(num_actual_toks, 1, -1)
+        attn_out, _, lse = flash_mla_sparse_fwd(
+            q,
+            cache,
+            indices,
+            self.softmax_scale,
+            topk_length=topk_length,
+        )
+        if lse is None:
+            raise RuntimeError("HCU sparse MLA DCP kernel did not return LSE")
+        return attn_out, lse
 
 
 class HcuFlashMLASparseBackend(FlashMLASparseBackend):


### PR DESCRIPTION
## Summary

- keep TP/DCP-only GLM-5.2 execution fullgraph-compilable by avoiding the dynamic PCP/MTP `ContextVar` lookup when PCP size is 1
- advertise HCU sparse FlashMLA decode-LSE capability required by DCP
- preserve all DCP-gathered query heads and return the kernel's natural-log LSE for the cross-rank stable softmax reduction
- retain the upstream path unchanged when DCP size is 1 and reject the already-unsupported FP8 KV-cache DCP combination explicitly

## Root cause

The GLM-5.2 sparse indexer always resolved the effective PCP size inside the compiled graph. Even for PCP=1, that called `ContextVar.get()`, which Dynamo cannot capture in a full graph. After startup passed, vLLM's DCP compatibility check rejected `HcuFlashMLASparseImpl` because it did not declare decode-LSE support. The HCU FlashMLA kernel already returns the required LSE, but the adapter discarded it and sliced its output back to the local head count; DCP needs both the full gathered-head output and LSE before reduce-scatter.

## Validation

- real model: `/models/GLM-5.2-Channel-INT8-w8a8`
- configuration: TP=8, DCP=2, BF16 KV cache, normal `torch.compile` and CUDA Graph path
- deterministic 32-token request: HTTP 200; output tokens exactly match DCP=1
- first-token logprob: DCP=1 `-0.69114`, DCP=2 `-0.69860` (absolute delta `0.00746`)
- four concurrent completion requests: 4/4 HTTP 200
- focused regression suite: 62 passed
- full `tests/runtime_patch`: 698 passed; two unrelated baseline/environment failures remain because `v0.25.1` does not contain `vllm_hcu/csrc/hcu_cache_kernel.hip` and the configured vLLM `.venv/bin/python` is absent on the test host
