### PR TITLE
feat(hcu): default FlashAttention to native varlen

### DIFF
--- a/tests/accuracy/test_environment_routing.py
+++ b/tests/accuracy/test_environment_routing.py
@@ -209,7 +209,7 @@ def test_nn_layout_environment_reaches_mamba_path_selector(
 @pytest.mark.parametrize(
     ("values", "expected"),
     [
-        ({}, "cutlass"),
+        ({}, "varlen"),
         ({"VLLM_HCU_USE_FLASH_ATTN": "1"}, "classic"),
         ({"VLLM_HCU_USE_FLASH_ATTN_VARLEN": "1"}, "varlen"),
         (
@@ -254,6 +254,16 @@ def test_flash_attention_environment_priority_routes_expected_backend(
         monkeypatch.setenv(name, value)
 
     assert hcu_envs.resolve_hcu_flash_attn_mode(None) == expected
+
+
+def test_flash_attention_lazy_environment_defaults_select_varlen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_HCU_USE_FLASH_ATTN_UNIFIED", raising=False)
+    monkeypatch.delenv("VLLM_HCU_USE_FLASH_ATTN_VARLEN", raising=False)
+
+    assert hcu_envs.VLLM_HCU_USE_FLASH_ATTN_UNIFIED is False
+    assert hcu_envs.VLLM_HCU_USE_FLASH_ATTN_VARLEN is True
 
 
 @pytest.mark.parametrize(

--- a/tests/patch/test_plugin_lifecycle.py
+++ b/tests/patch/test_plugin_lifecycle.py
@@ -64,6 +64,7 @@ def _fresh_python(
     code: str,
     *,
     plugins: str = "__disabled__",
+    assert_target_source: bool = True,
     assert_target_first: bool = True,
     no_site: bool = False,
 ) -> subprocess.CompletedProcess[str]:
@@ -71,11 +72,12 @@ def _fresh_python(
     env["VLLM_PLUGINS"] = plugins
     env["VLLM_V0251_SOURCE_ROOT"] = str(TARGET_VLLM_ROOT)
     env["PYTHONPATH"] = os.pathsep.join((str(TARGET_VLLM_ROOT), str(REPO)))
-    child_code = (
-        _TARGET_SOURCE_ASSERTION + code
-        if assert_target_first
-        else code + _TARGET_SOURCE_ASSERTION
-    )
+    if not assert_target_source:
+        child_code = code
+    elif assert_target_first:
+        child_code = _TARGET_SOURCE_ASSERTION + code
+    else:
+        child_code = code + _TARGET_SOURCE_ASSERTION
     command = [sys.executable]
     if no_site:
         command.append("-S")
@@ -314,7 +316,7 @@ print(
     )
 )
 ''',
-        assert_target_first=False,
+        assert_target_source=False,
         no_site=True,
     )
     assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/runtime_patch/test_flash_attention_and_pp.py
+++ b/tests/runtime_patch/test_flash_attention_and_pp.py
@@ -182,7 +182,7 @@ def test_pp_size_one_ignores_invalid_manual_partition(monkeypatch: pytest.Monkey
 @pytest.mark.parametrize(
     ("name", "expected"),
     [
-        (None, "cutlass"),
+        (None, "varlen"),
         ("VLLM_HCU_USE_FLASH_ATTN", "classic"),
         ("VLLM_HCU_USE_FLASH_ATTN_UNIFIED", "cutlass"),
         ("VLLM_HCU_USE_FLASH_ATTN_VARLEN", "varlen"),

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -205,6 +205,7 @@ def test_engine_args_normalizes_deepep_auto_and_extends_cli_choice() -> None:
 @pytest.mark.parametrize(
     ("alias", "mode"),
     [
+        ("FLASH_ATTN", "varlen"),
         ("FLASH_ATTN_CLASSIC", "classic"),
         ("flash_attn_cutlass", "cutlass"),
         ("flash_attn_varlen", "varlen"),
@@ -224,6 +225,25 @@ def test_engine_args_normalizes_hcu_flash_attention_aliases(
     nested = module.EngineArgs(attention_config={"backend": alias})
     assert nested.attention_config["backend"] == "FLASH_ATTN"
     assert get_hcu_config(nested).hcu_flash_attn_mode == mode
+
+
+@pytest.mark.parametrize(
+    "backend",
+    ["TRITON_ATTN", "ROCM_AITER_FA", "TORCH_SDPA"],
+)
+def test_engine_args_preserves_non_hcu_flash_attention_backends(
+    backend: str,
+) -> None:
+    module = _make_arg_utils_module()
+    patch_engine_args.apply_to_module(module)
+
+    top_level = module.EngineArgs(attention_backend=backend)
+    assert top_level.attention_backend == backend
+    assert get_hcu_config(top_level).hcu_flash_attn_mode is None
+
+    nested = module.EngineArgs(attention_config={"backend": backend})
+    assert nested.attention_config["backend"] == backend
+    assert get_hcu_config(nested).hcu_flash_attn_mode is None
 
 
 def test_async_engine_args_and_nested_dpsk_config_use_same_sidecar() -> None:
@@ -1036,7 +1056,7 @@ def _vllm_hash(additional_config: dict[str, Any]) -> str:
 @pytest.mark.parametrize(
     ("environment", "expected"),
     [
-        ({}, "cutlass"),
+        ({}, "varlen"),
         ({"VLLM_HCU_USE_FLASH_ATTN": "1"}, "classic"),
         ({"VLLM_HCU_USE_FLASH_ATTN_UNIFIED": "1"}, "cutlass"),
         ({"VLLM_HCU_USE_FLASH_ATTN_VARLEN": "1"}, "varlen"),

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -205,7 +205,6 @@ def test_engine_args_normalizes_deepep_auto_and_extends_cli_choice() -> None:
 @pytest.mark.parametrize(
     ("alias", "mode"),
     [
-        ("FLASH_ATTN", "varlen"),
         ("FLASH_ATTN_CLASSIC", "classic"),
         ("flash_attn_cutlass", "cutlass"),
         ("flash_attn_varlen", "varlen"),
@@ -225,6 +224,45 @@ def test_engine_args_normalizes_hcu_flash_attention_aliases(
     nested = module.EngineArgs(attention_config={"backend": alias})
     assert nested.attention_config["backend"] == "FLASH_ATTN"
     assert get_hcu_config(nested).hcu_flash_attn_mode == mode
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [
+        ({}, "varlen"),
+        ({"VLLM_HCU_USE_FLASH_ATTN": "1"}, "classic"),
+        ({"VLLM_HCU_USE_FLASH_ATTN_UNIFIED": "1"}, "cutlass"),
+    ],
+)
+def test_plain_flash_attention_defers_submode_to_legacy_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    environment: dict[str, str],
+    expected: str,
+) -> None:
+    for name in (
+        "VLLM_HCU_USE_FLASH_ATTN",
+        "VLLM_HCU_USE_FLASH_ATTN_UNIFIED",
+        "VLLM_HCU_USE_FLASH_ATTN_VARLEN",
+        "VLLM_HCU_USE_CUSTOM_FLASH_ATTN",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+
+    module = _make_arg_utils_module()
+    patch_engine_args.apply_to_module(module)
+
+    top_level = module.EngineArgs(attention_backend="FLASH_ATTN")
+    assert top_level.attention_backend == "FLASH_ATTN"
+    assert get_hcu_config(top_level).hcu_flash_attn_mode is None
+
+    nested = module.EngineArgs(attention_config={"backend": "FLASH_ATTN"})
+    assert nested.attention_config["backend"] == "FLASH_ATTN"
+    assert get_hcu_config(nested).hcu_flash_attn_mode is None
+
+    config = _validation_config(get_hcu_config(top_level.create_engine_config()))
+    feature_config = patch_vllm_config.validate_and_update_hcu_config(config)
+    assert feature_config.hcu_flash_attn_mode == expected
 
 
 @pytest.mark.parametrize(

--- a/vllm_hcu/compatibility.py
+++ b/vllm_hcu/compatibility.py
@@ -14,8 +14,6 @@ import importlib.metadata as importlib_metadata
 from dataclasses import dataclass
 from pathlib import Path
 
-from packaging.version import InvalidVersion, Version
-
 from vllm_hcu.version import (
     __hcu_version__,
     __version_tuple__,
@@ -97,6 +95,8 @@ def inspect_vllm_compatibility() -> VllmCompatibility:
 
     actual = distribution.version
     location = _distribution_location(distribution)
+    from packaging.version import InvalidVersion, Version
+
     try:
         parsed = Version(actual)
     except (InvalidVersion, TypeError) as exc:

--- a/vllm_hcu/patch/platform/core_fix/patch_engine_args.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_engine_args.py
@@ -45,7 +45,6 @@ _UPSTREAM_BACKEND = "auto"
 _DEEPEP_AUTO_BACKEND = "deepep_auto"
 _DEEPEP_AUTO_UPSTREAM_BACKEND = "deepep_low_latency"
 _FLASH_ATTN_BACKEND = "FLASH_ATTN"
-_DEFAULT_HCU_FLASH_ATTN_MODE = "varlen"
 _HCU_FLASH_ATTN_ALIASES = {
     "FLASH_ATTN_CLASSIC": "classic",
     "FLASH_ATTN_CUTLASS": "cutlass",
@@ -60,7 +59,7 @@ def _resolve_requested_flash_mode(
 ) -> str | None:
     normalized = backend.upper()
     if normalized == _FLASH_ATTN_BACKEND:
-        return existing_mode or _DEFAULT_HCU_FLASH_ATTN_MODE
+        return existing_mode
     return _HCU_FLASH_ATTN_ALIASES.get(normalized)
 
 

--- a/vllm_hcu/patch/platform/core_fix/patch_engine_args.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_engine_args.py
@@ -45,12 +45,23 @@ _UPSTREAM_BACKEND = "auto"
 _DEEPEP_AUTO_BACKEND = "deepep_auto"
 _DEEPEP_AUTO_UPSTREAM_BACKEND = "deepep_low_latency"
 _FLASH_ATTN_BACKEND = "FLASH_ATTN"
+_DEFAULT_HCU_FLASH_ATTN_MODE = "varlen"
 _HCU_FLASH_ATTN_ALIASES = {
     "FLASH_ATTN_CLASSIC": "classic",
     "FLASH_ATTN_CUTLASS": "cutlass",
     "FLASH_ATTN_CUSTOM": "custom",
     "FLASH_ATTN_VARLEN": "varlen",
 }
+
+
+def _resolve_requested_flash_mode(
+    backend: str,
+    existing_mode: str | None,
+) -> str | None:
+    normalized = backend.upper()
+    if normalized == _FLASH_ATTN_BACKEND:
+        return existing_mode or _DEFAULT_HCU_FLASH_ATTN_MODE
+    return _HCU_FLASH_ATTN_ALIASES.get(normalized)
 
 
 def _require_engine_args_class(module: ModuleType, name: str) -> type:
@@ -130,8 +141,9 @@ def _normalise_constructor_kwargs(
     requested_flash_mode: str | None = None
     top_level_attention_backend = bound.arguments.get("attention_backend")
     if isinstance(top_level_attention_backend, str):
-        requested_flash_mode = _HCU_FLASH_ATTN_ALIASES.get(
-            top_level_attention_backend.upper()
+        requested_flash_mode = _resolve_requested_flash_mode(
+            top_level_attention_backend,
+            feature_config.hcu_flash_attn_mode,
         )
         if requested_flash_mode is not None:
             if "attention_backend" not in kwargs:
@@ -145,7 +157,10 @@ def _normalise_constructor_kwargs(
     if isinstance(attention_config, Mapping):
         nested_backend = attention_config.get("backend")
         if isinstance(nested_backend, str):
-            nested_mode = _HCU_FLASH_ATTN_ALIASES.get(nested_backend.upper())
+            nested_mode = _resolve_requested_flash_mode(
+                nested_backend,
+                feature_config.hcu_flash_attn_mode,
+            )
             if nested_mode is not None:
                 if "attention_config" not in kwargs:
                     raise TypeError(
@@ -271,8 +286,9 @@ def _normalise_existing_engine_args(engine_args: object) -> HcuFeatureConfig:
 
     attention_backend = getattr(engine_args, "attention_backend", None)
     if isinstance(attention_backend, str):
-        requested_flash_mode = _HCU_FLASH_ATTN_ALIASES.get(
-            attention_backend.upper()
+        requested_flash_mode = _resolve_requested_flash_mode(
+            attention_backend,
+            feature_config.hcu_flash_attn_mode,
         )
         if requested_flash_mode is not None:
             if (

--- a/vllm_hcu/platforms/envs.py
+++ b/vllm_hcu/platforms/envs.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 if TYPE_CHECKING:
     VLLM_USE_NN : bool = False
     VLLM_HCU_USE_FLASH_ATTN: bool = False
-    VLLM_HCU_USE_FLASH_ATTN_UNIFIED: bool = True
-    VLLM_HCU_USE_FLASH_ATTN_VARLEN: bool = False
+    VLLM_HCU_USE_FLASH_ATTN_UNIFIED: bool = False
+    VLLM_HCU_USE_FLASH_ATTN_VARLEN: bool = True
     VLLM_HCU_USE_CUSTOM_FLASH_ATTN: bool = False
     VLLM_HCU_USE_FLASHMLA: bool = False
     VLLM_USE_OPT_CAT: bool = False
@@ -79,8 +79,8 @@ def resolve_hcu_flash_attn_mode(explicit_mode: Optional[str]) -> str:
     """Resolve an HCU flash-attention sub-mode without touching vLLM schema.
 
     An explicit sidecar value wins.  The legacy environment switches retain
-    their historical priority, and the flagless HCU default uses the CUTLASS
-    unified implementation.
+    their historical priority, and the flagless HCU default uses the native
+    varlen implementation.
     """
 
     if explicit_mode is not None:
@@ -107,8 +107,8 @@ def resolve_hcu_flash_attn_mode(explicit_mode: Optional[str]) -> str:
     ).lower() in ("true", "1"):
         return "varlen"
     # Only an explicitly enabled legacy switch participates in priority
-    # resolution. The flagless CUTLASS default is applied below, so an
-    # explicitly requested classic mode can still take effect.
+    # resolution. The flagless varlen default is applied below, so an
+    # explicitly requested classic or CUTLASS mode can still take effect.
     if os.environ.get(
         "VLLM_HCU_USE_FLASH_ATTN_UNIFIED", "False"
     ).lower() in ("true", "1"):
@@ -118,7 +118,7 @@ def resolve_hcu_flash_attn_mode(explicit_mode: Optional[str]) -> str:
         "1",
     ):
         return "classic"
-    return "cutlass"
+    return "varlen"
 
 hcu_vllm_environment_variables: dict[str, Callable[[], Any]] = {
     # path to the logs of redirect-output, abstrac of related are ok
@@ -133,11 +133,12 @@ hcu_vllm_environment_variables: dict[str, Callable[[], Any]] = {
              ("true", "1")),
     # vLLM will use FlashAttention Backend (varlen_fwd_unified) on hcu, cutlass attention layerout blocksize 64 for qwen3.5
     "VLLM_HCU_USE_FLASH_ATTN_UNIFIED":
-    lambda: (os.environ.get("VLLM_HCU_USE_FLASH_ATTN_UNIFIED", "True").lower() in
+    lambda: (os.environ.get("VLLM_HCU_USE_FLASH_ATTN_UNIFIED", "False").lower() in
              ("true", "1")),
-    # Select flash_attn.flash_attn_varlen_func without changing legacy paths.
+    # Select flash_attn.flash_attn_varlen_func by default without changing
+    # legacy paths.
     "VLLM_HCU_USE_FLASH_ATTN_VARLEN":
-    lambda: (os.environ.get("VLLM_HCU_USE_FLASH_ATTN_VARLEN", "False").lower() in
+    lambda: (os.environ.get("VLLM_HCU_USE_FLASH_ATTN_VARLEN", "True").lower() in
              ("true", "1")),
     # vLLM will use custom FlashAttention (convert kv cache) Backend on hcu,  not office attention layerout blocksize 64 
     "VLLM_HCU_USE_CUSTOM_FLASH_ATTN":


### PR DESCRIPTION
## Summary

- make plain `FLASH_ATTN` and automatic HCU FlashAttention selection use the native varlen path by default
- preserve explicit HCU FA aliases and leave `TRITON_ATTN`, `ROCM_AITER_FA`, `TORCH_SDPA`, and other non-HCU-FA backends unchanged
- keep clean plugin imports dependency-light under isolated `python -S` startup

## FlashAttention usage

### `--attention-backend` values

| Value | Resolved HCU mode | FlashAttention interface |
| --- | --- | --- |
| `FLASH_ATTN` | legacy environment selection, otherwise `varlen` | interface selected from the resolved mode |
| `FLASH_ATTN_VARLEN` | `varlen` | `flash_attn.flash_attn_varlen_func` |
| `FLASH_ATTN_CLASSIC` | `classic` | `flash_attn.hg_flash_attn_varlen_func` |
| `FLASH_ATTN_CUTLASS` | `cutlass` | `flash_attn.varlen_fwd_unified` |
| `FLASH_ATTN_CUSTOM` | `custom` (legacy compatibility path) | `flash_attn.vllm_flash_attn_varlen_func` |

With no legacy FA environment variable, both automatic HCU FA selection and plain `FLASH_ATTN` default to native varlen:

```bash
vllm serve MODEL
vllm serve MODEL --attention-backend FLASH_ATTN
```

Select an HCU FA implementation explicitly through the CLI:

```bash
vllm serve MODEL --attention-backend FLASH_ATTN_VARLEN
vllm serve MODEL --attention-backend FLASH_ATTN_CLASSIC
vllm serve MODEL --attention-backend FLASH_ATTN_CUTLASS
```

Explicit `FLASH_ATTN_*` aliases write an HCU mode sidecar and therefore override legacy FA environment variables. Plain `FLASH_ATTN` deliberately leaves the sidecar unset until final configuration so legacy variables remain effective.

Standard vLLM backends remain unchanged, for example:

```bash
vllm serve MODEL --attention-backend TRITON_ATTN
vllm serve MODEL --attention-backend ROCM_AITER_FA
vllm serve MODEL --attention-backend TORCH_SDPA
```

### Legacy environment variables

Legacy variables are supported when the backend is automatic or plain `FLASH_ATTN`:

```bash
# classic: hg_flash_attn_varlen_func
VLLM_HCU_USE_FLASH_ATTN=1   vllm serve MODEL --attention-backend FLASH_ATTN

# CUTLASS unified: varlen_fwd_unified
VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1   vllm serve MODEL --attention-backend FLASH_ATTN

# native varlen: flash_attn_varlen_func
VLLM_HCU_USE_FLASH_ATTN_VARLEN=1   vllm serve MODEL --attention-backend FLASH_ATTN

# legacy custom path: vllm_flash_attn_varlen_func
VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1   vllm serve MODEL --attention-backend FLASH_ATTN
```

If multiple legacy switches are enabled, resolution priority is:

`CUSTOM > VARLEN > UNIFIED/CUTLASS > CLASSIC > default VARLEN`

## Testing

- `python tools/run_patch_tests.py --suite contract --vllm-source /models/zb/vllm_025/vllm -q`
- `python -m compileall -q ...`
- `git diff --check`
