### PR TITLE
feat: support DeepSeek V4 SlimQuant W4A8 runtimes

### DIFF
--- a/docs/superpowers/plans/2026-09-01-slimquant-w4a8-v0251-dspark.md
+++ b/docs/superpowers/plans/2026-09-01-slimquant-w4a8-v0251-dspark.md
@@ -1,0 +1,504 @@
+# SlimQuant W4A8 Latest v0.25.1 and DSpark Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild MR #38 on the latest `v0.25.1`, retain the base branch's unified AITER SlimQuant W4A8 design, add only missing DP8+EP8 `deepep_auto` W4A8 DeepGEMM support, and validate DSpark on TP8 and DP8+EP8.
+
+**Architecture:** Reconstruct the feature branch from `origin/v0.25.1@85a4ad5`, then port a minimal W4A8 DeepEP expert implementation into the existing `deepep_auto` modular-kernel lifecycle. Pure TP remains owned by the base branch's unified AITER dispatcher. Existing HCU DSpark target and draft models are reused without new speculative-decoding architecture.
+
+**Tech Stack:** Python 3.10, PyTorch/HCU, vLLM 0.25.1, AITER, DeepEP, DeepGEMM HIPC W4A8, pytest, EvalScope, Git/GitHub API.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-slimquant-w4a8-v0251-dspark-design.md`
+
+## Global Constraints
+
+- Base all production changes on current `origin/v0.25.1@85a4ad5` or a newer fetched tip if it advances before reconstruction.
+- Pure TP SlimQuant W4A8 must use the base branch's unified AITER dispatcher; do not restore the former LightOp/AITER split.
+- DP8+EP8 must expose only `deepep_auto`; HT/LL selection belongs to the existing forward snapshot.
+- Do not add or modify `.github`, workflows, or scripts.
+- Preserve authorship as `zhangzbb <1414695739@qq.com>`.
+- Never store or print access tokens in files, Git configuration, remotes, logs, or MR content.
+- Do not claim DSpark support without successful live startup and request evidence.
+
+---
+
+### Task 1: Reconstruct MR #38 on the latest base
+
+**Files:**
+- Preserve: `docs/superpowers/specs/2026-09-01-slimquant-w4a8-v0251-dspark-design.md`
+- Preserve: `docs/superpowers/plans/2026-09-01-slimquant-w4a8-v0251-dspark.md`
+- Remove from final diff: obsolete MR-owned DeepSeek-V4, sampler, LightOp, and duplicate AITER changes already provided by the latest base
+
+**Interfaces:**
+- Consumes: `origin/v0.25.1` and MR #38 head history.
+- Produces: a clean reconstructed branch whose initial diff contains only the approved design/plan before runtime implementation.
+
+- [ ] **Step 1: Record recoverable branch state**
+
+Run:
+
+```bash
+git status --short
+git branch backup/mr38-before-v0251-rebuild HEAD
+git fetch origin v0.25.1
+git rev-parse origin/v0.25.1
+```
+
+Expected: clean worktree, backup branch at the old MR head, and a concrete current base SHA.
+
+- [ ] **Step 2: Inventory old changes against the new base**
+
+Run:
+
+```bash
+git diff --name-status origin/v0.25.1...backup/mr38-before-v0251-rebuild
+git log --format='%h %an <%ae> %s' origin/v0.25.1..backup/mr38-before-v0251-rebuild
+```
+
+Expected: overlapping DeepSeek-V4/AITER files are explicitly identified; no uncommitted user files are lost.
+
+- [ ] **Step 3: Reconstruct the branch**
+
+Create a temporary reconstruction branch from the fetched base and restore only the approved spec and plan from the backup:
+
+```bash
+git switch -c rebuild/deepseek-v4-pro-slimquant-w4a8-v0251 origin/v0.25.1
+git checkout backup/mr38-before-v0251-rebuild -- \
+  docs/superpowers/specs/2026-09-01-slimquant-w4a8-v0251-dspark-design.md \
+  docs/superpowers/plans/2026-09-01-slimquant-w4a8-v0251-dspark.md
+git status --short
+```
+
+Expected: only the two approved documentation files differ from the latest base.
+
+- [ ] **Step 4: Commit the reconstructed documentation**
+
+```bash
+git add docs/superpowers/specs/2026-09-01-slimquant-w4a8-v0251-dspark-design.md \
+  docs/superpowers/plans/2026-09-01-slimquant-w4a8-v0251-dspark.md
+git commit -m "docs: redesign W4A8 integration for latest v0.25.1"
+```
+
+Expected: commit author is `zhangzbb <1414695739@qq.com>`.
+
+### Task 2: Characterize the missing W4A8 `deepep_auto` contract
+
+**Files:**
+- Test: `tests/runtime_patch/test_moe_deepep.py`
+- Test: `tests/runtime_patch/test_quant_gemm_aiter.py`
+- Read: `vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py`
+- Read: `vllm_hcu/model_executor/layers/fused_moe/prepare_finalize/deepep_auto.py`
+- Read: `vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py`
+
+**Interfaces:**
+- Consumes: latest `deepep_auto` selection snapshot and `SlimQuantW4A8Int8AiterMoEMethod`.
+- Produces: failing tests that define DP+EP expert selection without changing TP AITER behavior.
+
+- [ ] **Step 1: Write a failing DP+EP selection test**
+
+Add a test that constructs a W4A8 `FusedMoEQuantConfig` with
+`weight_quant_dtype == "int4"`, DP size greater than one, expert parallelism,
+and `deepep_auto`. Assert that the SlimQuant method delegates expert creation
+to a W4A8 DeepGEMM auto expert factory rather than `apply_aiter_w4a8_moe`.
+
+- [ ] **Step 2: Verify the selection test fails for the missing capability**
+
+Run:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/usr/local/lib/python3.10/dist-packages \
+pytest -q tests/runtime_patch/test_quant_gemm_aiter.py -k 'slimquant_w4a8 and deepep_auto'
+```
+
+Expected: FAIL because the latest base has no SlimQuant W4A8 DeepEP expert implementation.
+
+- [ ] **Step 3: Write failing snapshot/layout tests**
+
+Add tests proving one `deepep_auto` forward snapshot selects:
+
+```python
+"high_throughput" -> contiguous W4A8 expert
+"low_latency" -> masked W4A8 expert
+```
+
+Include an empty-rank case where all ranks retain the same snapshot and no
+local token count is treated as a backend change.
+
+- [ ] **Step 4: Verify snapshot/layout tests fail**
+
+Run:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/usr/local/lib/python3.10/dist-packages \
+pytest -q tests/runtime_patch/test_moe_deepep.py -k 'w4a8 and deepep_auto'
+```
+
+Expected: FAIL because no W4A8 auto experts are registered.
+
+- [ ] **Step 5: Commit the failing contract tests**
+
+```bash
+git add tests/runtime_patch/test_moe_deepep.py \
+  tests/runtime_patch/test_quant_gemm_aiter.py
+git commit -m "test: define W4A8 DeepEP auto contract"
+```
+
+### Task 3: Implement W4A8 DeepGEMM expert layouts
+
+**Files:**
+- Create: `vllm_hcu/model_executor/layers/quantization/slimquant_w4a8_deepgemm_runtime.py`
+- Modify: `vllm_hcu/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py`
+- Test: `tests/runtime_patch/test_deep_gemm_utils.py`
+- Test: `tests/runtime_patch/test_moe_deepep.py`
+
+**Interfaces:**
+- Consumes: canonical packed `[E,N,K/2]` W4A8 parameters and base DeepGEMM expert interfaces.
+- Produces: `DeepEPDeepGemmW4A8ContiguousExperts` and `DeepEPDeepGemmW4A8BatchedExperts`, both compatible with the existing modular kernel ABI.
+
+- [ ] **Step 1: Write failing contiguous-layout tests**
+
+Cover pack-once behavior, canonical-parameter preservation, W4A8 channel scale
+shape, both GEMM stages, expert-map propagation, and zero-token output.
+
+- [ ] **Step 2: Run the contiguous tests and observe failure**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/usr/local/lib/python3.10/dist-packages \
+pytest -q tests/runtime_patch/test_deep_gemm_utils.py -k 'w4a8 and contiguous'
+```
+
+Expected: FAIL because the class/API does not exist.
+
+- [ ] **Step 3: Implement the contiguous expert**
+
+Use DeepGEMM's HIPC W4A8 contiguous packing and
+`m_grouped_w4a8_gemm_nt_contiguous_hipc`. Store derived packed tensors outside
+registered canonical parameters, validate channel scales before packing, and
+reuse the base branch's DeepEP permutation and reduction helpers.
+
+- [ ] **Step 4: Run contiguous tests**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing masked-layout tests**
+
+Cover N32 six-dimensional view shape, pack-once behavior, gate/up and down
+scale propagation, `m_grouped_w4a8_gemm_nt_masked_hipc`, masked token counts,
+and an empty dispatch.
+
+- [ ] **Step 6: Run the masked tests and observe failure**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/usr/local/lib/python3.10/dist-packages \
+pytest -q tests/runtime_patch/test_deep_gemm_utils.py -k 'w4a8 and masked'
+```
+
+Expected: FAIL because the masked expert is absent.
+
+- [ ] **Step 7: Implement the masked expert**
+
+Pack canonical weights with `pack_w4a8_moe_hipc_weight`, expose the N32 view
+with `view_w4a8_moe_hipc_weight_n32_layout`, and extend the batched DeepGEMM
+expert only when `weight_quant_dtype == "int4"`. Preserve all existing W8A8,
+FP8, BF16, and MXFP4 branches.
+
+- [ ] **Step 8: Run focused DeepGEMM tests**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/usr/local/lib/python3.10/dist-packages \
+pytest -q tests/runtime_patch/test_deep_gemm_utils.py \
+  tests/runtime_patch/test_moe_deepep.py -k 'w4a8 or deepep_auto'
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit the expert implementation**
+
+```bash
+git add vllm_hcu/model_executor/layers/quantization/slimquant_w4a8_deepgemm_runtime.py \
+  vllm_hcu/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py \
+  tests/runtime_patch/test_deep_gemm_utils.py tests/runtime_patch/test_moe_deepep.py
+git commit -m "feat: add W4A8 DeepGEMM auto experts"
+```
+
+### Task 4: Integrate SlimQuant W4A8 with `deepep_auto`
+
+**Files:**
+- Modify: `vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py`
+- Modify: `vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py`
+- Test: `tests/runtime_patch/test_quant_gemm_aiter.py`
+- Test: `tests/runtime_patch/test_moe_deepep.py`
+
+**Interfaces:**
+- Consumes: the two W4A8 DeepGEMM expert classes from Task 3.
+- Produces: DP+EP modular selection that bypasses TP AITER only for `deepep_auto`.
+
+- [ ] **Step 1: Implement strict topology detection**
+
+Select W4A8 DeepEP experts only when data parallel size is greater than one,
+expert parallelism is enabled, and the configured all-to-all backend is
+`deepep_auto`. Raise a descriptive error for fixed or incompatible DeepEP
+settings rather than silently using the TP path.
+
+- [ ] **Step 2: Bind HT and LL experts to the auto snapshot**
+
+Register contiguous and masked experts through the latest base's auto expert
+selection interface. Do not duplicate prepare/finalize selection logic.
+
+- [ ] **Step 3: Keep pure TP behavior unchanged**
+
+Assert in tests that TP explicit AITER still calls the shared AITER adapter,
+explicit Triton still uses vLLM fallback, and no LightOp runtime is imported.
+
+- [ ] **Step 4: Run focused routing tests**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/usr/local/lib/python3.10/dist-packages \
+pytest -q tests/runtime_patch/test_quant_gemm_aiter.py \
+  tests/runtime_patch/test_moe_deepep.py -k 'slimquant_w4a8 or deepep_auto'
+```
+
+Expected: PASS, including tests written in Task 2.
+
+- [ ] **Step 5: Commit integration**
+
+```bash
+git add vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py \
+  vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py \
+  tests/runtime_patch/test_quant_gemm_aiter.py tests/runtime_patch/test_moe_deepep.py
+git commit -m "feat: route W4A8 DP EP through deepep auto"
+```
+
+### Task 5: Run static, unit, and operator verification
+
+**Files:**
+- Verify: all files changed since `origin/v0.25.1`
+
+**Interfaces:**
+- Consumes: reconstructed implementation.
+- Produces: clean static checks and reproducible test evidence before model startup.
+
+- [ ] **Step 1: Check production boundaries and forbidden changes**
+
+```bash
+git diff --check origin/v0.25.1...HEAD
+git diff --name-only origin/v0.25.1...HEAD | rg '(^|/)(\.github|workflows|scripts)(/|$)' && exit 1 || true
+python tools/check_production_boundary.py
+```
+
+Expected: no whitespace errors, forbidden paths, or boundary violations.
+
+- [ ] **Step 2: Run focused runtime tests**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/usr/local/lib/python3.10/dist-packages \
+pytest -q tests/runtime_patch/test_quant_gemm_aiter.py \
+  tests/runtime_patch/test_moe_deepep.py \
+  tests/runtime_patch/test_deep_gemm_utils.py \
+  tests/runtime_patch/test_deepseek_v4_dspark_model.py \
+  tests/runtime_patch/test_deepseek_v4_dspark_patches.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run available HCU operator tests**
+
+```bash
+HIP_VISIBLE_DEVICES=0 VLLM_PLUGINS=__disabled__ \
+pytest -q tests/accuracy/test_deepseek_v4_dspark_ops.py -s
+```
+
+Expected: existing DSpark operators pass; add a focused W4A8 device test if the
+base suite does not exercise both HIPC W4A8 layouts.
+
+- [ ] **Step 4: Run the broad relevant suite**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/usr/local/lib/python3.10/dist-packages \
+pytest -q tests/runtime_patch
+```
+
+Expected: all collected runtime-patch tests pass.
+
+### Task 6: Validate TP8 AITER with DSpark
+
+**Files:**
+- Artifact: `/tmp/vllm-w4a8-tp8-aiter-dspark.log`
+- Artifact: `/tmp/vllm-w4a8-tp8-aiter-dspark-response.json`
+
+**Interfaces:**
+- Consumes: target checkpoint and explicit AITER backend.
+- Produces: live startup, output, AITER selection, and speculative acceptance evidence.
+
+- [ ] **Step 1: Confirm resources and terminate no unrelated services**
+
+Run read-only process/device checks and select a free port. Stop only service
+processes launched by this task if cleanup is needed.
+
+- [ ] **Step 2: Start TP8+AITER+DSpark**
+
+```bash
+vllm serve /models/DeepSeek-V4-Pro-0813-INT4-Channel \
+  --host 0.0.0.0 --port 10140 --trust-remote-code \
+  --tokenizer-mode deepseek_v4 --distributed-executor-backend mp \
+  --quantization slimquant_w4a8 --tensor-parallel-size 8 \
+  --moe-backend aiter --kv-cache-dtype fp8 --block-size 256 \
+  --max-model-len 4096 --max-num-batched-tokens 512 --max-num-seqs 8 \
+  --gpu-memory-utilization 0.9 \
+  --served-model-name deepseek-v4-pro-int4-channel \
+  --speculative-config '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}' \
+  > /tmp/vllm-w4a8-tp8-aiter-dspark.log 2>&1
+```
+
+Expected: API ready and all target/draft workers loaded.
+
+- [ ] **Step 3: Send a deterministic client request**
+
+```bash
+curl --noproxy '*' -sS http://127.0.0.1:10140/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"deepseek-v4-pro-int4-channel","messages":[{"role":"user","content":"Write a Python hello-world program."}],"temperature":0,"max_tokens":128,"chat_template_kwargs":{"thinking":false}}' \
+  > /tmp/vllm-w4a8-tp8-aiter-dspark-response.json
+```
+
+Expected: non-empty assistant output.
+
+- [ ] **Step 4: Record route and acceptance evidence**
+
+Inspect the log for unified AITER W4A8 config selection, DSpark proposed and
+accepted token counters, and absence of load/runtime errors.
+
+- [ ] **Step 5: Stop the task-owned TP service cleanly**
+
+Expected: only the recorded TP service process tree is terminated.
+
+### Task 7: Validate DP8+EP8 `deepep_auto` with DSpark
+
+**Files:**
+- Artifact: `/tmp/vllm-w4a8-dp8-ep8-deepep-auto-dspark.log`
+- Artifact: `/tmp/vllm-w4a8-dp8-ep8-deepep-auto-dspark-response.json`
+
+**Interfaces:**
+- Consumes: W4A8 auto experts and base DSpark runtime.
+- Produces: live DP+EP startup, output, DeepEP/DeepGEMM route, and speculative evidence.
+
+- [ ] **Step 1: Start DP8+EP8+DSpark**
+
+```bash
+vllm serve /models/DeepSeek-V4-Pro-0813-INT4-Channel \
+  --host 0.0.0.0 --port 10137 --trust-remote-code \
+  --tokenizer-mode deepseek_v4 --distributed-executor-backend mp \
+  --quantization slimquant_w4a8 --tensor-parallel-size 1 \
+  --data-parallel-size 8 --enable-expert-parallel \
+  --all2all-backend deepep_auto --kv-cache-dtype fp8 --block-size 256 \
+  --max-model-len 4096 --max-num-batched-tokens 512 --max-num-seqs 8 \
+  --gpu-memory-utilization 0.9 \
+  --served-model-name deepseek-v4-pro-int4-channel \
+  --speculative-config '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}' \
+  > /tmp/vllm-w4a8-dp8-ep8-deepep-auto-dspark.log 2>&1
+```
+
+Expected: one API service and eight DP workers become ready.
+
+- [ ] **Step 2: Send the same deterministic request**
+
+Use the Task 6 request with port `10137` and write the DP artifact.
+
+Expected: non-empty assistant output.
+
+- [ ] **Step 3: Verify DeepEP auto and DSpark evidence**
+
+Inspect synchronized rank logs for DeepEP dispatch/combine, W4A8 DeepGEMM,
+the selected contiguous or masked layout, and proposed/accepted speculative
+tokens. Treat rank disagreement, empty-rank collective failure, or fallback to
+the TP AITER path as failure.
+
+- [ ] **Step 4: Stop the task-owned DP service cleanly**
+
+Expected: all eight task-owned workers terminate without affecting unrelated processes.
+
+### Task 8: Run HumanEval-32 and consolidate evidence
+
+**Files:**
+- Artifact: `/tmp/vllm-hcu-evalscope/deepseek-v4-pro-int4-dspark-tp8/`
+- Artifact: `/tmp/vllm-hcu-evalscope/deepseek-v4-pro-int4-dspark-dp8-ep8/`
+
+**Interfaces:**
+- Consumes: successful Task 6 and Task 7 services.
+- Produces: 32 predictions, 32 reviews, pass@1, latency, and artifact paths per supported topology.
+
+- [ ] **Step 1: Run the repository-owned EvalScope gate for TP8**
+
+Adapt the latest base's `test_evalscope_deepseek_v4_dspark_humaneval.py` model
+environment and server arguments to the INT4 checkpoint without creating a
+new script.
+
+Expected: exactly 32 prediction and 32 review records.
+
+- [ ] **Step 2: Run the DP8+EP8 gate**
+
+Use the same dataset and scoring contract against the `deepep_auto` service.
+
+Expected: exactly 32 prediction and 32 review records, or a precisely recorded
+resource/runtime blocker.
+
+- [ ] **Step 3: Summarize raw results**
+
+Record pass@1, successful sample count, mean latency, TTFT, output throughput,
+and report paths. Do not replace raw metrics with normalized-only claims.
+
+### Task 9: Final review, MR update, and safe branch replacement
+
+**Files:**
+- Update remotely: MR #38 Summary and its consolidated Summary comment
+- Verify locally: complete `origin/v0.25.1...HEAD` diff
+
+**Interfaces:**
+- Consumes: verified implementation and artifacts.
+- Produces: an updated MR #38 based on the latest design with no unresolved Critical/Important findings.
+
+- [ ] **Step 1: Run final verification**
+
+Repeat Task 5 static and broad tests after the last code change. Confirm the
+worktree is clean and every new commit has the required author.
+
+- [ ] **Step 2: Request independent code review**
+
+Review the complete new-base diff, focusing on TP ownership, DP auto snapshot,
+W4A8 layout/scale correctness, DSpark draft layers, non-SlimQuant impact, and
+empty-rank collectives.
+
+Expected: findings sorted by Critical, Important, and Minor.
+
+- [ ] **Step 3: Fix Critical and Important findings with TDD**
+
+For each accepted finding, first add a failing regression test, make the
+minimal fix, rerun focused tests, and then repeat final verification. Request a
+targeted re-review of the fix.
+
+- [ ] **Step 4: Replace the MR branch safely**
+
+After verifying the backup branch and exact remote target, move the local MR
+branch name to the reconstructed commit and push with lease protection:
+
+```bash
+git push --force-with-lease origin \
+  HEAD:fix/deepseek-v4-pro-slimquant-w4a8-v0251
+```
+
+Expected: MR #38 updates without overwriting an unexpected remote change.
+
+- [ ] **Step 5: Rewrite MR Summary**
+
+Include latest-base ownership, retained W4A8 DP+EP delta, exact TP/DP server
+commands, client command, unit/operator results, DSpark route and acceptance
+evidence, HumanEval32 metrics, review status, and explicit absence of
+`.github`/workflow/script changes.
+
+- [ ] **Step 6: Verify the published MR**
+
+Confirm MR #38 targets `v0.25.1`, its head SHA equals the local verified SHA,
+its diff excludes forbidden paths and obsolete patches, and its Summary
+matches observed evidence.

--- a/docs/superpowers/plans/2026-09-01-slimquant-w4a8-v0251-dspark.md
+++ b/docs/superpowers/plans/2026-09-01-slimquant-w4a8-v0251-dspark.md
@@ -307,7 +307,7 @@ Expected: all tests pass.
 
 ```bash
 HIP_VISIBLE_DEVICES=0 VLLM_PLUGINS=__disabled__ \
-pytest -q tests/accuracy/test_deepseek_v4_dspark_ops.py -s
+pytest -q tests/accuracy/test_unified_aiter_moe_operator.py -s
 ```
 
 Expected: existing DSpark operators pass; add a focused W4A8 device test if the

--- a/docs/superpowers/specs/2026-09-01-slimquant-w4a8-v0251-dspark-design.md
+++ b/docs/superpowers/specs/2026-09-01-slimquant-w4a8-v0251-dspark-design.md
@@ -1,0 +1,166 @@
+# SlimQuant W4A8 v0.25.1 and DSpark Design
+
+## Context
+
+MR #38 was developed against `v0.25.1@8615729`. The current remote base is
+`v0.25.1@85a4ad5`, which now owns the public SlimQuant registry, unified AITER
+MoE dispatch, DeepSeek-V4 DSpark integration, and `deepep_auto` runtime policy.
+MR #38 overlaps those implementations and must not retain competing LightOp,
+AITER, DeepSeek-V4, sampler, or fixed DeepEP routing paths.
+
+The target checkpoint is:
+
+```text
+/models/DeepSeek-V4-Pro-0813-INT4-Channel
+```
+
+Its configuration exposes the DSpark metadata, target layers, Markov rank,
+noise token, and MTP projection quantization needed for a live feasibility
+test. Support is accepted only after the checkpoint starts and produces valid
+speculative output on HCU.
+
+## Goals
+
+1. Rebuild MR #38 on the latest remote `v0.25.1` instead of mechanically
+   retaining obsolete conflict resolutions.
+2. Use the base branch's SlimQuant W4A8 AITER implementation unchanged for
+   pure TP: canonical packed weights, runtime config selection, solution-aware
+   derived layouts, and vLLM Triton fallback only on an explicit capability
+   miss.
+3. Add only the missing SlimQuant W4A8 DP+EP integration for DeepEP and
+   DeepGEMM.
+4. Use `deepep_auto` as the single DP+EP public contract. Runtime batch state
+   chooses contiguous high-throughput or masked low-latency experts.
+5. Validate DSpark on TP8+AITER and DP8+EP8+`deepep_auto` using the target
+   checkpoint.
+6. Keep the MR free of `.github`, workflow, and script changes.
+
+## Non-goals
+
+- Restoring the MR's previous default-LightOp versus explicit-AITER split.
+- Forcing AITER ASM, HIPC, Triton, MOE_C, or CK from plugin call sites.
+- Adding public fixed `deepep_high_throughput` or `deepep_low_latency` recipes.
+- Replacing the latest base's DeepSeek-V4 DSpark, attention, weight-loading,
+  ROCm layout, or sampler patches.
+- Claiming DSpark support from configuration or unit tests without live model
+  evidence.
+
+## Selected Architecture
+
+### Branch reconstruction
+
+Create the updated MR branch from `origin/v0.25.1@85a4ad5` and port only code
+that remains absent from the base. Preserve the existing MR number by updating
+its remote head after verification. The resulting diff must be reviewed as a
+new delta against the current base, rather than as conflict resolutions on top
+of the obsolete base.
+
+### Pure TP ownership
+
+The latest base remains the sole owner of TP SlimQuant W4A8:
+
+```text
+--quantization slimquant_w4a8 --moe-backend aiter
+    -> unified AITER problem/config dispatcher
+    -> AITER-selected solution and derived layout
+    -> vLLM Triton only when AITER reports status=False
+```
+
+MR #38 must not introduce a second AITER runtime, mutate canonical packed
+parameters, or route `auto` to LightOp.
+
+### DP+EP ownership
+
+For DP8+EP8, `--all2all-backend deepep_auto` owns dispatch and combine. The
+SlimQuant method supplies W4A8 DeepGEMM experts compatible with both layouts:
+
+```text
+deepep_auto forward snapshot
+    |-- high throughput -> contiguous HIPC W4A8 DeepGEMM
+    `-- low latency     -> masked N32 HIPC W4A8 DeepGEMM
+```
+
+The implementation must preserve raw checkpoint parameters as canonical
+owners and cache any packed/view layout separately when required by the base
+branch's expert lifecycle. Scale conversion remains exactly once at the
+quantization boundary. Expert maps, empty-rank behavior, shared experts, and
+prepare/expert/finalize selection must follow the existing `deepep_auto`
+snapshot contract.
+
+Unsupported topologies or quantization metadata fail with an explicit error;
+they must not silently enter AITER, LightOp, or an incompatible W8A8 kernel.
+
+### DSpark integration
+
+No new DSpark model class is added. The latest base's HCU
+`DSparkDeepseekV4ForCausalLM`, target auxiliary-state patch, weight aliases,
+and non-PCP cache insertion remain authoritative. The SlimQuant delta must
+work for both target and draft MoE layers through the same quantization and
+backend contracts.
+
+The supported speculative configuration is:
+
+```json
+{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}
+```
+
+## Validation
+
+### Static and unit gates
+
+- Rebased diff contains no obsolete duplicate patches and no `.github`,
+  workflow, or script changes.
+- Existing latest-base SlimQuant W4A8 and unified AITER suites remain green.
+- New tests cover `deepep_auto` expert selection, contiguous and masked W4A8
+  layouts, scale propagation, empty dispatch, expert-map behavior, and
+  fail-closed unsupported metadata.
+- Existing DSpark target/draft and DeepEP-auto synchronization tests remain
+  green.
+
+### Live TP8 gate
+
+Start the checkpoint with TP8, explicit AITER, and DSpark. Acceptance requires:
+
+- all eight workers complete model and draft-model loading;
+- logs show unified AITER W4A8 selection rather than a duplicate MR runtime;
+- a deterministic OpenAI-compatible request returns non-empty output;
+- speculative decoding reports proposed and accepted tokens without runtime
+  or weight-loading errors.
+
+### Live DP8+EP8 gate
+
+Start one service with DP8, EP enabled, `deepep_auto`, and DSpark. Acceptance
+requires:
+
+- all ranks complete target and draft loading;
+- DeepEP dispatch/combine and W4A8 DeepGEMM execute successfully;
+- synchronized runtime evidence includes the expected auto-selected layout;
+- a client request returns non-empty output and DSpark acceptance evidence.
+
+After both runtime gates pass, run HumanEval-32 where time and environment
+permit. Report raw predictions/reviews, pass@1, and artifact paths. A startup
+or request failure is reported as evidence and debugged before support is
+claimed.
+
+## MR and Review Requirements
+
+- Update MR #38 rather than opening a competing MR.
+- Rewrite its Summary around the latest-base ownership boundaries, exact
+  server/client commands, observed DSpark evidence, and test results.
+- Preserve commit authorship as `zhangzbb <1414695739@qq.com>`.
+- Perform an independent code review of the complete final diff. Critical and
+  Important findings must be fixed and reverified before the MR is declared
+  ready.
+
+## Acceptance Criteria
+
+- MR #38 is based on current `origin/v0.25.1` and contains only the missing
+  SlimQuant W4A8 DP+EP delta plus its tests and documentation.
+- Pure TP uses the base branch's unified AITER dispatcher without a competing
+  LightOp/AITER routing implementation.
+- DP8+EP8 uses one `deepep_auto` public configuration and correct HT/LL W4A8
+  DeepGEMM layouts.
+- TP8+AITER+DSpark and DP8+EP8+DSpark have reproducible live evidence, or the
+  exact blocking root cause is documented without claiming support.
+- The final test suite passes and independent review has no unresolved
+  Critical or Important findings.

--- a/docs/superpowers/specs/2026-09-01-slimquant-w4a8-v0251-dspark-design.md
+++ b/docs/superpowers/specs/2026-09-01-slimquant-w4a8-v0251-dspark-design.md
@@ -80,12 +80,26 @@ deepep_auto forward snapshot
     `-- low latency     -> masked N32 HIPC W4A8 DeepGEMM
 ```
 
-The implementation must preserve raw checkpoint parameters as canonical
-owners and cache any packed/view layout separately when required by the base
-branch's expert lifecycle. Scale conversion remains exactly once at the
-quantization boundary. Expert maps, empty-rank behavior, shared experts, and
-prepare/expert/finalize selection must follow the existing `deepep_auto`
-snapshot contract.
+Raw checkpoint parameters remain the canonical owners for pure-TP AITER,
+which can select a different dynamic solution after load. The strict
+`dp_size > 1` plus EP plus `deepep_auto` route is the only ownership exception:
+after checkpoint load it packs each local W4A8 parameter once in place, keeps
+the registered rank-3 tensor as the single HIPC owner, and gives masked LL an
+N32 rank-6 view of that same storage. Fixed Mooncake P/D roles build only their
+selected rank-3 or N32 handle. No raw HCU copy or second packed weight owner is
+retained. Scale conversion remains exactly once at the quantization boundary.
+Expert maps, empty-rank behavior, shared experts, and prepare/expert/finalize
+selection must follow the existing `deepep_auto` snapshot contract.
+
+The auto-route layout marker is idempotent and fail-closed: an unchanged
+post-load owner is rebound without repacking; checkpoint reload packs the new
+raw parameter once and copies it into the existing kernel storage used by
+v0.25.1 layerwise reload; an unknown marker, missing owner, or incompatible
+shape is rejected before transformed bytes can be packed again. Level-1
+sleep/wake restores the allocator's `weights` storage at the same address, so
+the rank-3/N32 alias remains valid. A post-load state dict contains the packed
+registered owners, not extra N32 tensors; such a dict is kernel-format state,
+not raw checkpoint-format input.
 
 Unsupported topologies or quantization metadata fail with an explicit error;
 they must not silently enter AITER, LightOp, or an incompatible W8A8 kernel.
@@ -112,8 +126,10 @@ The supported speculative configuration is:
   workflow, or script changes.
 - Existing latest-base SlimQuant W4A8 and unified AITER suites remain green.
 - New tests cover `deepep_auto` expert selection, contiguous and masked W4A8
-  layouts, scale propagation, empty dispatch, expert-map behavior, and
-  fail-closed unsupported metadata.
+  layouts, one in-place pack per local weight, HT/LL storage aliasing, fixed
+  roles, reload/sleep/state-dict idempotence, scale propagation, empty
+  dispatch, expert-map behavior, and fail-closed unsupported metadata or
+  marker state.
 - Existing DSpark target/draft and DeepEP-auto synchronization tests remain
   green.
 
@@ -158,8 +174,8 @@ claimed.
   SlimQuant W4A8 DP+EP delta plus its tests and documentation.
 - Pure TP uses the base branch's unified AITER dispatcher without a competing
   LightOp/AITER routing implementation.
-- DP8+EP8 uses one `deepep_auto` public configuration and correct HT/LL W4A8
-  DeepGEMM layouts.
+- DP8+EP8 uses one `deepep_auto` public configuration and one in-place W4A8
+  HIPC owner per local weight; HT rank-3 and LL N32 layouts share its storage.
 - TP8+AITER+DSpark and DP8+EP8+DSpark have reproducible live evidence, or the
   exact blocking root cause is documented without claiming support.
 - The final test suite passes and independent review has no unresolved

--- a/tests/accuracy/deepseek_v4_dspark_ops_cases.py
+++ b/tests/accuracy/deepseek_v4_dspark_ops_cases.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
-"""Live gfx938 numerical checks for the DeepSeek-V4 DSpark operator path."""
+"""Live gfx938 numerical cases collected by the unified AITER test module."""
 
 from __future__ import annotations
 

--- a/tests/accuracy/test_deepseek_v4_dspark_ops.py
+++ b/tests/accuracy/test_deepseek_v4_dspark_ops.py
@@ -64,19 +64,22 @@ def _unpack_signed_int4_high_low(packed: torch.Tensor) -> torch.Tensor:
     return torch.stack((high, low), dim=-1).flatten(-2).contiguous()
 
 
-def test_contiguous_w4a8_hipc_deepgemm_matches_unpacked_reference() -> None:
-    """A HIPC pack must not mutate canonical INT4 bytes and must dequantize."""
+def test_auto_w4a8_shared_storage_feeds_ht_and_ll_with_empty_expert() -> None:
+    """One auto-owned HIPC storage must produce matching HT and LL values."""
     from deepgemm import (
         m_grouped_w4a8_gemm_nt_contiguous_hipc,
-        pack_w4a8_moe_hipc_weight,
+        m_grouped_w4a8_gemm_nt_masked_hipc,
+    )
+    from vllm_hcu.model_executor.layers.fused_moe.experts import (
+        dpsk_v4_deep_gemm_moe as experts_module,
+    )
+    from vllm_hcu.model_executor.layers.quantization import (
+        slimquant_w4a8_deepgemm_runtime as runtime,
     )
 
     device = _hcu_device()
-    # W4A8 HIPC accepts N32/K64-aligned storage, but its numerical kernel is
-    # specialized for DeepSeek-V4's logical MoE dimensions. Keep E/M small
-    # while exercising the production K=7168, N=3072 contract.
     experts, tokens, hidden, output_size = 2, 512, 7168, 3072
-    generator = torch.Generator(device=device).manual_seed(741)
+    generator = torch.Generator(device=device).manual_seed(743)
     activation = torch.randint(
         -8,
         8,
@@ -86,9 +89,12 @@ def test_contiguous_w4a8_hipc_deepgemm_matches_unpacked_reference() -> None:
         dtype=torch.int8,
     )
     activation_scale = torch.rand(
-        (tokens, 1), generator=generator, device=device, dtype=torch.float32
+        (tokens, 1),
+        generator=generator,
+        device=device,
+        dtype=torch.float32,
     ).add_(0.01)
-    logical_weight = torch.randint(
+    logical_w13 = torch.randint(
         -8,
         8,
         (experts, output_size, hidden),
@@ -96,131 +102,104 @@ def test_contiguous_w4a8_hipc_deepgemm_matches_unpacked_reference() -> None:
         device=device,
         dtype=torch.int8,
     )
-    canonical_weight = _pack_signed_int4_high_low(logical_weight)
-    canonical_before_pack = canonical_weight.clone()
-    checkpoint_weight_scale = torch.rand(
+    canonical_w13 = _pack_signed_int4_high_low(logical_w13)
+    raw_w13 = canonical_w13.clone()
+    # Supply a shape-compatible companion down projection; the numerical
+    # assertion below exercises the shared gate/up storage in both modes.
+    logical_w2 = torch.randint(
+        -8,
+        8,
+        (experts, hidden, output_size // 2),
+        generator=generator,
+        device=device,
+        dtype=torch.int8,
+    )
+    canonical_w2 = _pack_signed_int4_high_low(logical_w2)
+    checkpoint_scale = torch.rand(
         (experts, output_size, 1),
         generator=generator,
         device=device,
         dtype=torch.float32,
     ).add_(0.01)
-    # The runtime converts SlimQuant's high-nibble checkpoint scale exactly
-    # once before passing it to signed-INT4 HIPC W4A8.
-    hipc_weight_scale = checkpoint_weight_scale * 16.0
-    packed_weight = pack_w4a8_moe_hipc_weight(canonical_weight.clone())
-    m_indices = torch.cat(
-        (
-            torch.zeros(tokens // 2, device=device, dtype=torch.int32),
-            torch.ones(tokens // 2, device=device, dtype=torch.int32),
-        )
+    hipc_scale = checkpoint_scale * 16.0
+
+    layer = torch.nn.Module()
+    layer.w13_weight = torch.nn.Parameter(canonical_w13, requires_grad=False)
+    layer.w2_weight = torch.nn.Parameter(canonical_w2, requires_grad=False)
+    layer.w13_weight_scale = torch.nn.Parameter(
+        checkpoint_scale,
+        requires_grad=False,
     )
-    output = torch.empty(
+    layer.w2_weight_scale = torch.nn.Parameter(
+        torch.ones(
+            (experts, hidden, 1),
+            device=device,
+            dtype=torch.float32,
+        ),
+        requires_grad=False,
+    )
+    auto = object.__new__(experts_module.DeepEPAutoW4A8Experts)
+    auto._fixed_use_low_latency = None
+    auto._use_low_latency_snapshot = False
+    auto.ht_experts = object.__new__(
+        runtime.DeepEPDeepGemmW4A8ContiguousExperts
+    )
+    auto.ll_experts = object.__new__(runtime.DeepEPDeepGemmW4A8MaskedExperts)
+    for child in (auto.ht_experts, auto.ll_experts):
+        child._deepgemm_w13 = None
+        child._deepgemm_w2 = None
+
+    auto.process_weights_after_loading(layer)
+
+    ht_weight = auto.ht_experts._deepgemm_w13
+    ll_weight = auto.ll_experts._deepgemm_w13
+    assert ht_weight.ndim == 3
+    assert ll_weight.ndim == 6
+    assert ht_weight.untyped_storage().data_ptr() == (
+        ll_weight.untyped_storage().data_ptr()
+    )
+    assert ht_weight.untyped_storage().data_ptr() == (
+        layer.w13_weight.untyped_storage().data_ptr()
+    )
+
+    ht_output = torch.empty(
         (tokens, output_size), device=device, dtype=torch.bfloat16
     )
-
     m_grouped_w4a8_gemm_nt_contiguous_hipc(
         (activation, activation_scale),
-        (packed_weight, hipc_weight_scale),
-        output,
-        m_indices,
+        (ht_weight, hipc_scale),
+        ht_output,
+        torch.zeros(tokens, device=device, dtype=torch.int32),
     )
-
-    torch.testing.assert_close(canonical_weight, canonical_before_pack)
-    unpacked_weight = _unpack_signed_int4_high_low(canonical_weight)
-    references = []
-    tokens_per_expert = tokens // experts
-    for expert in range(experts):
-        start = expert * tokens_per_expert
-        stop = start + tokens_per_expert
-        references.append(
-            (activation[start:stop].float() * activation_scale[start:stop])
-            @ (unpacked_weight[expert].float() * hipc_weight_scale[expert]).T
-        )
-    reference = torch.cat(references)
-    assert output.dtype == torch.bfloat16
-    assert torch.isfinite(output).all()
-    torch.testing.assert_close(output.float(), reference, rtol=3e-2, atol=0.1)
-
-
-def test_masked_w4a8_hipc_deepgemm_matches_reference_and_preserves_invalid_rows(
-) -> None:
-    """N32 HIPC masked GEMM must honor token counts, including an empty expert."""
-    from deepgemm import (
-        m_grouped_w4a8_gemm_nt_masked_hipc,
-        pack_w4a8_moe_hipc_weight,
-        view_w4a8_moe_hipc_weight_n32_layout,
-    )
-
-    device = _hcu_device()
-    # Keep the dispatch small while using the production W4A8 HIPC geometry.
-    experts, max_tokens, hidden, output_size = 2, 32, 7168, 3072
-    active_tokens = 17
-    generator = torch.Generator(device=device).manual_seed(742)
-    activation = torch.randint(
-        -8,
-        8,
-        (experts, max_tokens, hidden),
-        generator=generator,
-        device=device,
-        dtype=torch.int8,
-    )
-    activation_scale = torch.rand(
-        (experts, max_tokens, 1),
-        generator=generator,
-        device=device,
-        dtype=torch.float32,
-    ).add_(0.01)
-    logical_weight = torch.randint(
-        -8,
-        8,
-        (experts, output_size, hidden),
-        generator=generator,
-        device=device,
-        dtype=torch.int8,
-    )
-    canonical_weight = _pack_signed_int4_high_low(logical_weight)
-    canonical_before_pack = canonical_weight.clone()
-    checkpoint_weight_scale = torch.rand(
-        (experts, output_size, 1),
-        generator=generator,
-        device=device,
-        dtype=torch.float32,
-    ).add_(0.01)
-    # Match SlimQuant's boundary conversion from high-nibble-domain scales.
-    hipc_weight_scale = checkpoint_weight_scale * 16.0
-    packed_weight = pack_w4a8_moe_hipc_weight(canonical_weight.clone())
-    n32_weight = view_w4a8_moe_hipc_weight_n32_layout(packed_weight)
-    tokens_per_expert = torch.tensor(
-        [active_tokens, 0], device=device, dtype=torch.int32
-    )
-    output = torch.full(
-        (experts, max_tokens, output_size),
+    ll_output = torch.full(
+        (experts, tokens, output_size),
         torch.nan,
         device=device,
         dtype=torch.bfloat16,
     )
-
     m_grouped_w4a8_gemm_nt_masked_hipc(
-        (activation, activation_scale),
-        (n32_weight, hipc_weight_scale),
-        output,
-        tokens_per_expert,
-        max_tokens,
+        (
+            activation.unsqueeze(0).expand(experts, -1, -1).contiguous(),
+            activation_scale
+            .unsqueeze(0)
+            .expand(experts, -1, -1)
+            .contiguous(),
+        ),
+        (ll_weight, hipc_scale),
+        ll_output,
+        torch.tensor([tokens, 0], device=device, dtype=torch.int32),
+        tokens,
     )
 
-    torch.testing.assert_close(canonical_weight, canonical_before_pack)
-    unpacked_weight = _unpack_signed_int4_high_low(canonical_weight)
-    reference = (
-        activation[0, :active_tokens].float()
-        * activation_scale[0, :active_tokens]
-    ) @ (unpacked_weight[0].float() * hipc_weight_scale[0]).T
-    assert output.dtype == torch.bfloat16
-    assert torch.isfinite(output[0, :active_tokens]).all()
+    unpacked_w13 = _unpack_signed_int4_high_low(raw_w13)
+    reference = (activation.float() * activation_scale) @ (
+        unpacked_w13[0].float() * hipc_scale[0]
+    ).T
+    torch.testing.assert_close(ht_output.float(), reference, rtol=3e-2, atol=0.1)
     torch.testing.assert_close(
-        output[0, :active_tokens].float(), reference, rtol=3e-2, atol=0.1
+        ll_output[0].float(), reference, rtol=3e-2, atol=0.1
     )
-    assert torch.isnan(output[0, active_tokens:]).all()
-    assert torch.isnan(output[1]).all()
+    assert torch.isnan(ll_output[1]).all()
 
 
 def test_contiguous_channel_fp8_deepgemm_matches_dequantized_reference() -> None:

--- a/tests/accuracy/test_deepseek_v4_dspark_ops.py
+++ b/tests/accuracy/test_deepseek_v4_dspark_ops.py
@@ -45,6 +45,184 @@ def _channel_int8_quantize(
     return quantized, scales.float()
 
 
+def _pack_signed_int4_high_low(weight: torch.Tensor) -> torch.Tensor:
+    """Encode signed INT4 values as SlimQuant's high-nibble-first bytes."""
+    assert weight.dtype == torch.int8
+    assert weight.size(-1) % 2 == 0
+    nibbles = weight.to(torch.int16) & 0xF
+    pairs = nibbles.view(*weight.shape[:-1], -1, 2)
+    return ((pairs[..., 0] << 4) | pairs[..., 1]).to(torch.int8)
+
+
+def _unpack_signed_int4_high_low(packed: torch.Tensor) -> torch.Tensor:
+    """Decode canonical SlimQuant W4A8 bytes without DeepGEMM helpers."""
+    bytes_u8 = packed.view(torch.uint8)
+    high = ((bytes_u8 >> 4) & 0xF).to(torch.int16)
+    low = (bytes_u8 & 0xF).to(torch.int16)
+    high = torch.where(high >= 8, high - 16, high).to(torch.int8)
+    low = torch.where(low >= 8, low - 16, low).to(torch.int8)
+    return torch.stack((high, low), dim=-1).flatten(-2).contiguous()
+
+
+def test_contiguous_w4a8_hipc_deepgemm_matches_unpacked_reference() -> None:
+    """A HIPC pack must not mutate canonical INT4 bytes and must dequantize."""
+    from deepgemm import (
+        m_grouped_w4a8_gemm_nt_contiguous_hipc,
+        pack_w4a8_moe_hipc_weight,
+    )
+
+    device = _hcu_device()
+    # W4A8 HIPC accepts N32/K64-aligned storage, but its numerical kernel is
+    # specialized for DeepSeek-V4's logical MoE dimensions. Keep E/M small
+    # while exercising the production K=7168, N=3072 contract.
+    experts, tokens, hidden, output_size = 2, 512, 7168, 3072
+    generator = torch.Generator(device=device).manual_seed(741)
+    activation = torch.randint(
+        -8,
+        8,
+        (tokens, hidden),
+        generator=generator,
+        device=device,
+        dtype=torch.int8,
+    )
+    activation_scale = torch.rand(
+        (tokens, 1), generator=generator, device=device, dtype=torch.float32
+    ).add_(0.01)
+    logical_weight = torch.randint(
+        -8,
+        8,
+        (experts, output_size, hidden),
+        generator=generator,
+        device=device,
+        dtype=torch.int8,
+    )
+    canonical_weight = _pack_signed_int4_high_low(logical_weight)
+    canonical_before_pack = canonical_weight.clone()
+    checkpoint_weight_scale = torch.rand(
+        (experts, output_size, 1),
+        generator=generator,
+        device=device,
+        dtype=torch.float32,
+    ).add_(0.01)
+    # The runtime converts SlimQuant's high-nibble checkpoint scale exactly
+    # once before passing it to signed-INT4 HIPC W4A8.
+    hipc_weight_scale = checkpoint_weight_scale * 16.0
+    packed_weight = pack_w4a8_moe_hipc_weight(canonical_weight.clone())
+    m_indices = torch.cat(
+        (
+            torch.zeros(tokens // 2, device=device, dtype=torch.int32),
+            torch.ones(tokens // 2, device=device, dtype=torch.int32),
+        )
+    )
+    output = torch.empty(
+        (tokens, output_size), device=device, dtype=torch.bfloat16
+    )
+
+    m_grouped_w4a8_gemm_nt_contiguous_hipc(
+        (activation, activation_scale),
+        (packed_weight, hipc_weight_scale),
+        output,
+        m_indices,
+    )
+
+    torch.testing.assert_close(canonical_weight, canonical_before_pack)
+    unpacked_weight = _unpack_signed_int4_high_low(canonical_weight)
+    references = []
+    tokens_per_expert = tokens // experts
+    for expert in range(experts):
+        start = expert * tokens_per_expert
+        stop = start + tokens_per_expert
+        references.append(
+            (activation[start:stop].float() * activation_scale[start:stop])
+            @ (unpacked_weight[expert].float() * hipc_weight_scale[expert]).T
+        )
+    reference = torch.cat(references)
+    assert output.dtype == torch.bfloat16
+    assert torch.isfinite(output).all()
+    torch.testing.assert_close(output.float(), reference, rtol=3e-2, atol=0.1)
+
+
+def test_masked_w4a8_hipc_deepgemm_matches_reference_and_preserves_invalid_rows(
+) -> None:
+    """N32 HIPC masked GEMM must honor token counts, including an empty expert."""
+    from deepgemm import (
+        m_grouped_w4a8_gemm_nt_masked_hipc,
+        pack_w4a8_moe_hipc_weight,
+        view_w4a8_moe_hipc_weight_n32_layout,
+    )
+
+    device = _hcu_device()
+    # Keep the dispatch small while using the production W4A8 HIPC geometry.
+    experts, max_tokens, hidden, output_size = 2, 32, 7168, 3072
+    active_tokens = 17
+    generator = torch.Generator(device=device).manual_seed(742)
+    activation = torch.randint(
+        -8,
+        8,
+        (experts, max_tokens, hidden),
+        generator=generator,
+        device=device,
+        dtype=torch.int8,
+    )
+    activation_scale = torch.rand(
+        (experts, max_tokens, 1),
+        generator=generator,
+        device=device,
+        dtype=torch.float32,
+    ).add_(0.01)
+    logical_weight = torch.randint(
+        -8,
+        8,
+        (experts, output_size, hidden),
+        generator=generator,
+        device=device,
+        dtype=torch.int8,
+    )
+    canonical_weight = _pack_signed_int4_high_low(logical_weight)
+    canonical_before_pack = canonical_weight.clone()
+    checkpoint_weight_scale = torch.rand(
+        (experts, output_size, 1),
+        generator=generator,
+        device=device,
+        dtype=torch.float32,
+    ).add_(0.01)
+    # Match SlimQuant's boundary conversion from high-nibble-domain scales.
+    hipc_weight_scale = checkpoint_weight_scale * 16.0
+    packed_weight = pack_w4a8_moe_hipc_weight(canonical_weight.clone())
+    n32_weight = view_w4a8_moe_hipc_weight_n32_layout(packed_weight)
+    tokens_per_expert = torch.tensor(
+        [active_tokens, 0], device=device, dtype=torch.int32
+    )
+    output = torch.full(
+        (experts, max_tokens, output_size),
+        torch.nan,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    m_grouped_w4a8_gemm_nt_masked_hipc(
+        (activation, activation_scale),
+        (n32_weight, hipc_weight_scale),
+        output,
+        tokens_per_expert,
+        max_tokens,
+    )
+
+    torch.testing.assert_close(canonical_weight, canonical_before_pack)
+    unpacked_weight = _unpack_signed_int4_high_low(canonical_weight)
+    reference = (
+        activation[0, :active_tokens].float()
+        * activation_scale[0, :active_tokens]
+    ) @ (unpacked_weight[0].float() * hipc_weight_scale[0]).T
+    assert output.dtype == torch.bfloat16
+    assert torch.isfinite(output[0, :active_tokens]).all()
+    torch.testing.assert_close(
+        output[0, :active_tokens].float(), reference, rtol=3e-2, atol=0.1
+    )
+    assert torch.isnan(output[0, active_tokens:]).all()
+    assert torch.isnan(output[1]).all()
+
+
 def test_contiguous_channel_fp8_deepgemm_matches_dequantized_reference() -> None:
     from deepgemm import (
         marlin_fp8_contiguous_weight,

--- a/tests/accuracy/test_unified_aiter_moe_operator.py
+++ b/tests/accuracy/test_unified_aiter_moe_operator.py
@@ -20,6 +20,19 @@ from vllm_hcu.model_executor.layers.fused_moe.aiter_runtime import (
     aiter_asm_boltops_fp8_quant_context,
     aiter_asm_boltops_int8_quant_context,
 )
+from tests.accuracy.deepseek_v4_dspark_ops_cases import (
+    test_auto_w4a8_shared_storage_feeds_ht_and_ll_with_empty_expert,
+    test_contiguous_channel_fp8_deepgemm_matches_dequantized_reference,
+    test_contiguous_channel_int8_deepgemm_matches_dequantized_reference,
+    test_dspark_non_pcp_lightop_context_insert_matches_vllm_reference,
+    test_dspark_non_pcp_lightop_context_insert_writes_fp8_cache,
+    test_lightop_fp8_silu_quant_matches_float_reference_for_ht_and_ll,
+    test_lightop_int8_clamped_silu_quant_matches_vllm_for_ht_and_ll,
+    test_masked_channel_fp8_deepgemm_matches_dequantized_reference,
+    test_masked_channel_int8_deepgemm_matches_dequantized_reference,
+)
+
+pytestmark = pytest.mark.hcu
 
 NUMERICAL_LIMITS = {
     "w16a16": {

--- a/tests/integration/spec_decode/README.md
+++ b/tests/integration/spec_decode/README.md
@@ -41,6 +41,15 @@ contiguous high-throughput or masked low-latency DeepEP/DeepGEMM path for each
 forward. PCP+DSpark and prefill/decode disaggregation are intentionally not
 part of these tests.
 
+SlimQuant W4A8 keeps different ownership by topology. Pure TP AITER retains
+the raw packed checkpoint Parameters because its runtime solution may change.
+Only strict DP+EP `deepep_auto` repacks each local expert Parameter once in
+place: contiguous HT uses the registered rank-3 HIPC owner and masked LL uses
+an N32 rank-6 view of the same storage. Fixed Mooncake P/D roles retain only
+the selected handle. The post-load state dict is therefore kernel-format for
+this DP route; it contains the packed registered owner and no separate N32 or
+raw HCU weight copy.
+
 The default checkpoint is
 `/models/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8`; override it with
 `VLLM_HCU_DEEPSEEK_V4_FLASH_0731_MODEL`. Run the gates in order:

--- a/tests/runtime_patch/test_deep_gemm_utils.py
+++ b/tests/runtime_patch/test_deep_gemm_utils.py
@@ -9,6 +9,7 @@ from contextlib import nullcontext
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
+import pytest
 import torch
 
 
@@ -338,3 +339,481 @@ def test_w8a8_batched_apply_uses_masked_int8_deepgemm_api(
     )
 
     assert len(calls) == 2
+
+
+def _make_w4a8_expert_layer() -> torch.nn.Module:
+    layer = torch.nn.Module()
+    layer.w13_weight = torch.nn.Parameter(
+        torch.arange(2 * 8 * 2, dtype=torch.int8).reshape(2, 8, 2),
+        requires_grad=False,
+    )
+    layer.w2_weight = torch.nn.Parameter(
+        torch.arange(2 * 4 * 2, dtype=torch.int8).reshape(2, 4, 2),
+        requires_grad=False,
+    )
+    layer.w13_weight_scale = torch.nn.Parameter(
+        torch.ones((2, 8, 1), dtype=torch.float32),
+        requires_grad=False,
+    )
+    layer.w2_weight_scale = torch.nn.Parameter(
+        torch.ones((2, 4, 1), dtype=torch.float32),
+        requires_grad=False,
+    )
+    return layer
+
+
+def test_w4a8_contiguous_packs_once_without_replacing_canonical_parameters(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Derived HIPC layouts must never take ownership from checkpoint params."""
+
+    from vllm_hcu.model_executor.layers.quantization import (
+        slimquant_w4a8_deepgemm_runtime as module,
+    )
+
+    layer = _make_w4a8_expert_layer()
+    canonical_w13 = layer.w13_weight
+    canonical_w2 = layer.w2_weight
+    expected_w13 = canonical_w13.detach().clone()
+    expected_w2 = canonical_w2.detach().clone()
+    packed: list[torch.Tensor] = []
+
+    def pack(weight: torch.Tensor) -> torch.Tensor:
+        weight.fill_(41 + len(packed))
+        packed.append(weight)
+        return weight
+
+    monkeypatch.setattr(module, "pack_w4a8_moe_hipc_weight", pack)
+
+    experts = object.__new__(module.DeepEPDeepGemmW4A8ContiguousExperts)
+    experts._deepgemm_w13 = None
+    experts._deepgemm_w2 = None
+    experts.process_weights_after_loading(layer)
+
+    assert layer.w13_weight is canonical_w13
+    assert layer.w2_weight is canonical_w2
+    torch.testing.assert_close(layer.w13_weight, expected_w13)
+    torch.testing.assert_close(layer.w2_weight, expected_w2)
+    assert len(packed) == 2
+    assert experts._deepgemm_w13.ndim == 3
+    assert experts._deepgemm_w2.ndim == 3
+    assert experts._deepgemm_w13.untyped_storage().data_ptr() != (
+        layer.w13_weight.untyped_storage().data_ptr()
+    )
+
+    replacement = object.__new__(
+        module.DeepEPDeepGemmW4A8ContiguousExperts
+    )
+    replacement._deepgemm_w13 = None
+    replacement._deepgemm_w2 = None
+    replacement.process_weights_after_loading(layer)
+
+    assert len(packed) == 2
+    assert replacement._deepgemm_w13 is experts._deepgemm_w13
+    assert replacement._deepgemm_w2 is experts._deepgemm_w2
+
+
+def test_w4a8_contiguous_rejects_invalid_channel_scale_before_packing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A non-channel scale must fail before a derived layout is allocated."""
+
+    from vllm_hcu.model_executor.layers.quantization import (
+        slimquant_w4a8_deepgemm_runtime as module,
+    )
+
+    layer = _make_w4a8_expert_layer()
+    layer.w13_weight_scale = torch.nn.Parameter(
+        torch.ones((2, 7, 1), dtype=torch.float32),
+        requires_grad=False,
+    )
+    pack_calls = 0
+
+    def pack(_weight: torch.Tensor) -> torch.Tensor:
+        nonlocal pack_calls
+        pack_calls += 1
+        raise AssertionError("invalid channel scales reached the packer")
+
+    monkeypatch.setattr(module, "pack_w4a8_moe_hipc_weight", pack)
+    experts = object.__new__(module.DeepEPDeepGemmW4A8ContiguousExperts)
+    experts._deepgemm_w13 = None
+    experts._deepgemm_w2 = None
+
+    with pytest.raises(RuntimeError, match="w13_weight_scale"):
+        experts.process_weights_after_loading(layer)
+
+    assert pack_calls == 0
+
+
+def test_w4a8_contiguous_runs_two_hipc_gemms_with_expert_map_and_scales(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Both GEMM stages must retain scale and expert-map ownership."""
+
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm_hcu.model_executor.layers.quantization import (
+        slimquant_w4a8_deepgemm_runtime as module,
+    )
+
+    w13_scale = torch.ones((2, 8, 1), dtype=torch.float32)
+    w2_scale = torch.full((2, 4, 1), 2.0, dtype=torch.float32)
+    experts = object.__new__(module.DeepEPDeepGemmW4A8ContiguousExperts)
+    experts._deepgemm_w13 = torch.full((2, 1, 1, 1, 8, 2), 13, dtype=torch.int8)
+    experts._deepgemm_w2 = torch.full((2, 1, 1, 1, 4, 2), 17, dtype=torch.int8)
+    experts.quant_config = SimpleNamespace(
+        w1_scale=w13_scale,
+        w2_scale=w2_scale,
+    )
+    experts.adjust_N_for_activation = lambda n, _activation: n // 2
+
+    hidden_states = torch.arange(8, dtype=torch.int8).reshape(2, 4)
+    input_scale = torch.ones((2, 1), dtype=torch.float32)
+    topk_ids = torch.tensor([[0], [1]], dtype=torch.int32)
+    topk_weights = torch.ones((2, 1), dtype=torch.float32)
+    expert_map = torch.tensor([1, 0], dtype=torch.int32)
+    m_indices = torch.tensor([0, 1], dtype=torch.int64)
+    inv_perm = torch.tensor([1, 0], dtype=torch.int32)
+    expert_tokens_meta = SimpleNamespace(
+        expert_num_tokens=torch.tensor([1, 1], dtype=torch.int32),
+        expert_num_tokens_cpu=torch.tensor([1, 1], dtype=torch.int32),
+    )
+    permute_call: dict[str, object] = {}
+    reduce_call: dict[str, object] = {}
+    gemm_calls: list[tuple[object, object, torch.Tensor]] = []
+
+    monkeypatch.setattr(module, "compute_aligned_M", lambda **_kwargs: 2)
+    monkeypatch.setattr(
+        module,
+        "_resize_cache",
+        lambda tensor, shape: torch.empty(shape, dtype=tensor.dtype),
+    )
+
+    def permute(**kwargs: object):
+        permute_call.update(kwargs)
+        return hidden_states, input_scale, m_indices, inv_perm, 256
+
+    monkeypatch.setattr(module, "deepgemm_moe_permute", permute)
+
+    def grouped_gemm(a, b, output, passed_m_indices):
+        gemm_calls.append((a, b, passed_m_indices))
+        output.fill_(len(gemm_calls))
+
+    monkeypatch.setattr(
+        module,
+        "m_grouped_w4a8_gemm_nt_contiguous_hipc",
+        grouped_gemm,
+    )
+
+    def quantize(gate_up: torch.Tensor, **kwargs: object):
+        del gate_up
+        quant_output = kwargs["output"]
+        assert isinstance(quant_output, torch.Tensor)
+        quant_output.fill_(7)
+        return quant_output, torch.full((2, 1), 0.5, dtype=torch.float32)
+
+    monkeypatch.setattr(module, "fuse_silu_mul_quant", quantize)
+
+    def unpermute(**kwargs: object) -> None:
+        reduce_call.update(kwargs)
+        output = kwargs["output"]
+        down = kwargs["a"]
+        assert isinstance(output, torch.Tensor)
+        assert isinstance(down, torch.Tensor)
+        output.copy_(down[:2])
+
+    monkeypatch.setattr(module, "deepgemm_unpermute_and_reduce", unpermute)
+
+    output = torch.empty((2, 4), dtype=torch.bfloat16)
+    experts.apply(
+        output=output,
+        hidden_states=hidden_states,
+        w1=torch.empty((2, 8, 2), dtype=torch.int8),
+        w2=torch.empty((2, 4, 2), dtype=torch.int8),
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        global_num_experts=2,
+        expert_map=expert_map,
+        a1q_scale=input_scale,
+        a2_scale=None,
+        workspace13=torch.empty(32, dtype=torch.int8),
+        workspace2=torch.empty(32, dtype=torch.bfloat16),
+        expert_tokens_meta=expert_tokens_meta,
+        apply_router_weight_on_input=False,
+    )
+
+    assert len(gemm_calls) == 2
+    assert gemm_calls[0][1] == (experts._deepgemm_w13, w13_scale)
+    assert gemm_calls[1][1] == (experts._deepgemm_w2, w2_scale)
+    assert gemm_calls[0][2].dtype == torch.int32
+    assert gemm_calls[1][2] is gemm_calls[0][2]
+    assert permute_call["expert_map"] is expert_map
+    assert permute_call["expert_tokens_meta"] is expert_tokens_meta
+    assert reduce_call["expert_map"] is expert_map
+    torch.testing.assert_close(output, torch.full_like(output, 2))
+
+
+def test_w4a8_contiguous_zero_token_output_skips_all_kernels(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An empty HT dispatch is a valid no-op with an empty output."""
+
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm_hcu.model_executor.layers.quantization import (
+        slimquant_w4a8_deepgemm_runtime as module,
+    )
+
+    experts = object.__new__(module.DeepEPDeepGemmW4A8ContiguousExperts)
+    experts._deepgemm_w13 = torch.empty((2, 1), dtype=torch.int8)
+    experts._deepgemm_w2 = torch.empty((2, 1), dtype=torch.int8)
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("empty contiguous dispatch launched a kernel")
+
+    monkeypatch.setattr(
+        module, "m_grouped_w4a8_gemm_nt_contiguous_hipc", forbidden
+    )
+    monkeypatch.setattr(module, "deepgemm_moe_permute", forbidden)
+    output = torch.empty((0, 4), dtype=torch.bfloat16)
+
+    experts.apply(
+        output=output,
+        hidden_states=torch.empty((0, 4), dtype=torch.int8),
+        w1=torch.empty((2, 8, 2), dtype=torch.int8),
+        w2=torch.empty((2, 4, 2), dtype=torch.int8),
+        topk_weights=torch.empty((0, 1), dtype=torch.float32),
+        topk_ids=torch.empty((0, 1), dtype=torch.int32),
+        activation=MoEActivation.SILU,
+        global_num_experts=2,
+        expert_map=None,
+        a1q_scale=torch.empty((0, 1), dtype=torch.float32),
+        a2_scale=None,
+        workspace13=torch.empty(0, dtype=torch.int8),
+        workspace2=torch.empty(0, dtype=torch.bfloat16),
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+
+    assert output.shape == (0, 4)
+
+
+def test_w4a8_masked_packs_once_into_n32_view_without_replacing_parameters(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """LL experts cache the documented six-dimensional N32 weight view."""
+
+    from vllm_hcu.model_executor.layers.quantization import (
+        slimquant_w4a8_deepgemm_runtime as module,
+    )
+
+    layer = torch.nn.Module()
+    layer.w13_weight = torch.nn.Parameter(
+        torch.arange(128 * 32, dtype=torch.int8).reshape(1, 128, 32),
+        requires_grad=False,
+    )
+    layer.w2_weight = torch.nn.Parameter(
+        torch.arange(64 * 32, dtype=torch.int8).reshape(1, 64, 32),
+        requires_grad=False,
+    )
+    layer.w13_weight_scale = torch.nn.Parameter(
+        torch.ones((1, 128, 1), dtype=torch.float32),
+        requires_grad=False,
+    )
+    layer.w2_weight_scale = torch.nn.Parameter(
+        torch.ones((1, 64, 1), dtype=torch.float32),
+        requires_grad=False,
+    )
+    canonical_w13 = layer.w13_weight
+    canonical_w2 = layer.w2_weight
+    expected_w13 = canonical_w13.detach().clone()
+    expected_w2 = canonical_w2.detach().clone()
+    pack_calls: list[torch.Tensor] = []
+    view_shapes: list[tuple[int, ...]] = []
+
+    def pack(weight: torch.Tensor) -> torch.Tensor:
+        weight.fill_(53 + len(pack_calls))
+        pack_calls.append(weight)
+        return weight
+
+    def n32_view(weight: torch.Tensor) -> torch.Tensor:
+        experts, n, k_half = weight.shape
+        viewed = weight.view(experts, k_half // 32, n // 32, 4, 32, 8)
+        view_shapes.append(tuple(viewed.shape))
+        return viewed
+
+    monkeypatch.setattr(module, "pack_w4a8_moe_hipc_weight", pack)
+    monkeypatch.setattr(
+        module, "view_w4a8_moe_hipc_weight_n32_layout", n32_view
+    )
+
+    experts = object.__new__(module.DeepEPDeepGemmW4A8BatchedExperts)
+    experts._deepgemm_w13 = None
+    experts._deepgemm_w2 = None
+    experts.process_weights_after_loading(layer)
+
+    assert layer.w13_weight is canonical_w13
+    assert layer.w2_weight is canonical_w2
+    torch.testing.assert_close(layer.w13_weight, expected_w13)
+    torch.testing.assert_close(layer.w2_weight, expected_w2)
+    assert len(pack_calls) == 2
+    assert view_shapes == [(1, 1, 4, 4, 32, 8), (1, 1, 2, 4, 32, 8)]
+    assert tuple(experts._deepgemm_w13.shape) == view_shapes[0]
+    assert tuple(experts._deepgemm_w2.shape) == view_shapes[1]
+
+    replacement = object.__new__(module.DeepEPDeepGemmW4A8BatchedExperts)
+    replacement._deepgemm_w13 = None
+    replacement._deepgemm_w2 = None
+    replacement.process_weights_after_loading(layer)
+
+    assert len(pack_calls) == 2
+    assert replacement._deepgemm_w13 is experts._deepgemm_w13
+    assert replacement._deepgemm_w2 is experts._deepgemm_w2
+
+
+def test_w4a8_masked_batched_apply_propagates_scales_and_token_counts(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The int4 branch must use HIPC masked GEMMs for gate/up and down."""
+
+    lightop = ModuleType("lightop")
+    activation_call: dict[str, object] = {}
+
+    def quantize(tensor: torch.Tensor, tokens_per_expert: torch.Tensor):
+        activation_call.update(
+            tensor=tensor,
+            tokens_per_expert=tokens_per_expert,
+        )
+        return (
+            torch.full((1, 2, 64), 7, dtype=torch.int8),
+            torch.full((1, 2, 1), 0.5, dtype=torch.float32),
+        )
+
+    lightop.fuse_silu_mul_quant_ep = quantize
+    monkeypatch.setitem(sys.modules, "lightop", lightop)
+
+    gemm_calls: list[tuple[object, ...]] = []
+    deepgemm = ModuleType("deepgemm")
+    deepgemm.__path__ = []
+    deepgemm.m_grouped_w4a8_gemm_nt_masked_hipc = (
+        lambda *args: gemm_calls.append(args)
+    )
+    deepgemm.m_grouped_i8_gemm_nt_masked = lambda *_args: (_ for _ in ()).throw(
+        AssertionError("W8A8 masked API invoked for W4A8 weights")
+    )
+    monkeypatch.setitem(sys.modules, "deepgemm", deepgemm)
+
+    hcu = _load_batched_deep_gemm_apply()
+    hcu["current_platform"] = SimpleNamespace(is_rocm=lambda: True)
+    w13_scale = torch.ones((1, 128, 1), dtype=torch.float32)
+    w2_scale = torch.full((1, 64, 1), 2.0, dtype=torch.float32)
+    derived_w13 = torch.full((1, 1, 4, 4, 32, 8), 13, dtype=torch.int8)
+    derived_w2 = torch.full((1, 1, 2, 4, 32, 8), 17, dtype=torch.int8)
+    expert_num_tokens = torch.tensor([2], dtype=torch.int32)
+    experts = SimpleNamespace(
+        block_shape=None,
+        quant_config=SimpleNamespace(
+            use_int8_w8a8=True,
+            use_fp8_w8a8=False,
+            weight_quant_dtype="int4",
+        ),
+        w1_scale=w13_scale,
+        w2_scale=w2_scale,
+        _deepgemm_w13=derived_w13,
+        _deepgemm_w2=derived_w2,
+        _hcu_logical_n=128,
+        _hcu_logical_k=64,
+        moe_problem_size=lambda *_args: (1, 2, 128, 64, 1),
+        estimate_expected_m=lambda **_kwargs: 2,
+    )
+
+    output = torch.empty((1, 2, 64), dtype=torch.bfloat16)
+    hcu["apply"](
+        experts,
+        output=output,
+        hidden_states=torch.zeros((1, 2, 64), dtype=torch.int8),
+        w1=torch.zeros((1, 128, 32), dtype=torch.int8),
+        w2=torch.zeros((1, 64, 32), dtype=torch.int8),
+        topk_weights=torch.ones((2, 1)),
+        topk_ids=torch.zeros((2, 1), dtype=torch.int32),
+        activation="silu",
+        global_num_experts=1,
+        expert_map=None,
+        a1q_scale=torch.ones((1, 2, 1), dtype=torch.float32),
+        a2_scale=None,
+        workspace13=torch.empty(256, dtype=torch.bfloat16),
+        workspace2=torch.empty(256, dtype=torch.bfloat16),
+        expert_tokens_meta=SimpleNamespace(
+            expert_num_tokens=expert_num_tokens
+        ),
+        apply_router_weight_on_input=False,
+    )
+
+    assert len(gemm_calls) == 2
+    assert gemm_calls[0][1] == (derived_w13, w13_scale)
+    assert gemm_calls[1][1] == (derived_w2, w2_scale)
+    assert gemm_calls[0][3] is expert_num_tokens
+    assert gemm_calls[1][3] is expert_num_tokens
+    assert gemm_calls[0][4] == 2
+    assert gemm_calls[1][4] == 2
+    assert activation_call["tokens_per_expert"] is expert_num_tokens
+
+
+def test_w4a8_masked_empty_dispatch_skips_all_kernels(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An empty LL dispatch must not launch a masked GEMM."""
+
+    lightop = ModuleType("lightop")
+    lightop.fuse_silu_mul_quant_ep = lambda *_args: (_ for _ in ()).throw(
+        AssertionError("empty masked dispatch launched activation")
+    )
+    monkeypatch.setitem(sys.modules, "lightop", lightop)
+    deepgemm = ModuleType("deepgemm")
+    deepgemm.__path__ = []
+    deepgemm.m_grouped_w4a8_gemm_nt_masked_hipc = lambda *_args: (
+        _ for _ in ()
+    ).throw(AssertionError("empty masked dispatch launched DeepGEMM"))
+    monkeypatch.setitem(sys.modules, "deepgemm", deepgemm)
+
+    hcu = _load_batched_deep_gemm_apply()
+    hcu["current_platform"] = SimpleNamespace(is_rocm=lambda: True)
+    experts = SimpleNamespace(
+        block_shape=None,
+        quant_config=SimpleNamespace(
+            use_int8_w8a8=True,
+            use_fp8_w8a8=False,
+            weight_quant_dtype="int4",
+        ),
+        w1_scale=torch.ones((1, 128, 1), dtype=torch.float32),
+        w2_scale=torch.ones((1, 64, 1), dtype=torch.float32),
+        _deepgemm_w13=torch.empty((1, 1, 4, 4, 32, 8), dtype=torch.int8),
+        _deepgemm_w2=torch.empty((1, 1, 2, 4, 32, 8), dtype=torch.int8),
+        _hcu_logical_n=128,
+        _hcu_logical_k=64,
+        moe_problem_size=lambda *_args: (1, 0, 128, 64, 1),
+        estimate_expected_m=lambda **_kwargs: 0,
+    )
+    output = torch.empty((1, 0, 64), dtype=torch.bfloat16)
+
+    hcu["apply"](
+        experts,
+        output=output,
+        hidden_states=torch.empty((1, 0, 64), dtype=torch.int8),
+        w1=torch.empty((1, 128, 32), dtype=torch.int8),
+        w2=torch.empty((1, 64, 32), dtype=torch.int8),
+        topk_weights=torch.empty((0, 1)),
+        topk_ids=torch.empty((0, 1), dtype=torch.int32),
+        activation="silu",
+        global_num_experts=1,
+        expert_map=None,
+        a1q_scale=torch.empty((1, 0, 1), dtype=torch.float32),
+        a2_scale=None,
+        workspace13=torch.empty(0, dtype=torch.bfloat16),
+        workspace2=torch.empty(0, dtype=torch.bfloat16),
+        expert_tokens_meta=SimpleNamespace(
+            expert_num_tokens=torch.zeros(1, dtype=torch.int32)
+        ),
+        apply_router_weight_on_input=False,
+    )
+
+    assert output.shape == (1, 0, 64)

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -3136,6 +3136,119 @@ def test_slimquant_w4a8_auto_rejects_incompatible_marker_before_repacking(
     assert len(pack_calls) == 2
 
 
+@pytest.mark.parametrize("failure_mode", ["raise", "wrong_rank"])
+def test_slimquant_w4a8_auto_pack_failure_leaves_fail_closed_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_mode: str,
+):
+    """A partially transformed owner must never be accepted as raw again."""
+
+    from vllm_hcu.model_executor.layers.quantization import (
+        slimquant_w4a8_deepgemm_runtime as runtime,
+    )
+
+    layer = _slimquant_w4a8_auto_layer()
+    experts = _slimquant_w4a8_auto_experts(None)
+    pack_calls: list[torch.Tensor] = []
+
+    def fail_second_pack(weight: torch.Tensor) -> torch.Tensor:
+        pack_calls.append(weight)
+        if len(pack_calls) == 1:
+            weight.fill_(91)
+            return weight
+        if failure_mode == "raise":
+            raise RuntimeError("second pack failed")
+        return weight.flatten()
+
+    monkeypatch.setattr(
+        runtime,
+        "pack_w4a8_moe_hipc_weight",
+        fail_second_pack,
+    )
+    expected_error = (
+        "second pack failed"
+        if failure_mode == "raise"
+        else "must reuse rank-3 weight storage"
+    )
+    with pytest.raises(RuntimeError, match=expected_error):
+        experts.process_weights_after_loading(layer)
+
+    assert layer._slimquant_w4a8_deepep_auto_layout == "packing"
+    assert torch.count_nonzero(layer.w13_weight != 91) == 0
+    with pytest.raises(RuntimeError, match="invalid.*deepep_auto.*marker"):
+        experts.process_weights_after_loading(layer)
+    assert len(pack_calls) == 2
+
+
+def test_slimquant_w4a8_auto_n32_bind_failure_leaves_packing_marker(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The final layout must not publish before both child handles bind."""
+
+    from vllm_hcu.model_executor.layers.quantization import (
+        slimquant_w4a8_deepgemm_runtime as runtime,
+    )
+
+    pack_calls, _ = _install_in_place_w4a8_packers(monkeypatch)
+    layer = _slimquant_w4a8_auto_layer()
+    experts = _slimquant_w4a8_auto_experts(None)
+    monkeypatch.setattr(
+        runtime,
+        "view_w4a8_moe_hipc_weight_n32_layout",
+        lambda _weight: (_ for _ in ()).throw(RuntimeError("N32 view failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="N32 view failed"):
+        experts.process_weights_after_loading(layer)
+
+    assert layer._slimquant_w4a8_deepep_auto_layout == "packing"
+    with pytest.raises(RuntimeError, match="invalid.*deepep_auto.*marker"):
+        experts.process_weights_after_loading(layer)
+    assert len(pack_calls) == 2
+
+
+def test_slimquant_w4a8_auto_reload_pack_failure_leaves_repacking_marker(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A partial reload must not retry transformed temporary Parameters."""
+
+    from vllm_hcu.model_executor.layers.quantization import (
+        slimquant_w4a8_deepgemm_runtime as runtime,
+    )
+
+    _install_in_place_w4a8_packers(monkeypatch)
+    layer = _slimquant_w4a8_auto_layer()
+    _slimquant_w4a8_auto_experts(None).process_weights_after_loading(layer)
+    layer.w13_weight = torch.nn.Parameter(
+        torch.zeros_like(layer.w13_weight), requires_grad=False
+    )
+    layer.w2_weight = torch.nn.Parameter(
+        torch.zeros_like(layer.w2_weight), requires_grad=False
+    )
+    reload_pack_calls: list[torch.Tensor] = []
+
+    def fail_second_reload_pack(weight: torch.Tensor) -> torch.Tensor:
+        reload_pack_calls.append(weight)
+        if len(reload_pack_calls) == 1:
+            weight.fill_(92)
+            return weight
+        raise RuntimeError("second reload pack failed")
+
+    monkeypatch.setattr(
+        runtime,
+        "pack_w4a8_moe_hipc_weight",
+        fail_second_reload_pack,
+    )
+    replacement = _slimquant_w4a8_auto_experts(None)
+    with pytest.raises(RuntimeError, match="second reload pack failed"):
+        replacement.process_weights_after_loading(layer)
+
+    assert layer._slimquant_w4a8_deepep_auto_layout == "repacking"
+    with pytest.raises(RuntimeError, match="invalid.*deepep_auto.*marker"):
+        replacement.process_weights_after_loading(layer)
+    assert len(reload_pack_calls) == 2
+
+
 def test_channel_int8_auto_factory_builds_unified_ht_ll_kernel(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -2935,6 +2935,61 @@ def test_channel_int8_auto_factory_builds_unified_ht_ll_kernel(
     }
 
 
+def test_slimquant_w4a8_auto_factory_reuses_unified_prepare_finalize(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import vllm.model_executor.layers.fused_moe.all2all_utils as all2all_utils
+    from vllm_hcu.model_executor.layers.fused_moe.experts import (
+        dpsk_v4_deep_gemm_moe as module,
+    )
+
+    class PrepareFinalize:
+        ll_prepare_finalize = SimpleNamespace(
+            max_num_tokens_per_rank=lambda: 64,
+        )
+
+        @staticmethod
+        def num_dispatchers():
+            return 8
+
+    prepare_finalize = PrepareFinalize()
+    monkeypatch.setattr(
+        all2all_utils,
+        "maybe_make_prepare_finalize",
+        lambda **_kwargs: prepare_finalize,
+    )
+    constructed: dict[str, object] = {}
+
+    class AutoW4A8Experts:
+        def __init__(self, **kwargs):
+            constructed.update(kwargs)
+
+    monkeypatch.setattr(module, "DeepEPAutoW4A8Experts", AutoW4A8Experts)
+    monkeypatch.setattr(
+        module.mk,
+        "FusedMoEKernel",
+        lambda prepare, experts: (prepare, experts),
+    )
+    quant_config = SimpleNamespace(weight_quant_dtype="int4")
+    moe_config = SimpleNamespace()
+
+    kernel = module.make_deepep_auto_deepgemm_w4a8_moe_kernel(
+        moe_quant_config=quant_config,
+        moe_config=moe_config,
+        routing_tables="routing",
+    )
+
+    assert kernel[0] is prepare_finalize
+    assert isinstance(kernel[1], AutoW4A8Experts)
+    assert constructed == {
+        "moe_config": moe_config,
+        "quant_config": quant_config,
+        "max_num_tokens": 64,
+        "num_dispatchers": 8,
+        "fixed_use_low_latency": None,
+    }
+
+
 @pytest.mark.parametrize("use_fp8", [True, False])
 def test_deepep_ht_preserves_channel_quant_dispatch_contract(use_fp8: bool):
     class DeepEPHTPrepareAndFinalize:

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -443,6 +443,29 @@ def test_slimquant_w4a8_deepep_auto_empty_rank_keeps_global_snapshot(
     assert selected_layouts == contiguous_by_rank
 
 
+def test_slimquant_w4a8_deepep_auto_advertises_w4a8_quant_scheme_only():
+    """The W4A8 auto wrapper must not inherit the channel-W8A8 oracle."""
+
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        kFp8DynamicTokenSym,
+        kFp8StaticChannelSym,
+        kInt4W4A8StaticChannelSym,
+        kInt8DynamicTokenSym,
+    )
+    from vllm_hcu.model_executor.layers.fused_moe.experts.dpsk_v4_deep_gemm_moe import (
+        DeepEPAutoW4A8Experts,
+    )
+
+    assert DeepEPAutoW4A8Experts._supports_quant_scheme(
+        kInt4W4A8StaticChannelSym,
+        kInt8DynamicTokenSym,
+    )
+    assert not DeepEPAutoW4A8Experts._supports_quant_scheme(
+        kFp8StaticChannelSym,
+        kFp8DynamicTokenSym,
+    )
+
+
 def test_modular_prepare_begins_auto_call_before_expert_contract_queries():
     from vllm_hcu.model_executor.layers.fused_moe import modular_kernel as module
 

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -3308,6 +3308,7 @@ def test_slimquant_w4a8_auto_factory_reuses_unified_prepare_finalize(
     monkeypatch: pytest.MonkeyPatch,
 ):
     import vllm.model_executor.layers.fused_moe.all2all_utils as all2all_utils
+    from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
     from vllm_hcu.model_executor.layers.fused_moe.experts import (
         dpsk_v4_deep_gemm_moe as module,
     )
@@ -3349,7 +3350,15 @@ def test_slimquant_w4a8_auto_factory_reuses_unified_prepare_finalize(
         "FusedMoEKernel",
         lambda prepare, experts: (prepare, experts),
     )
-    quant_config = SimpleNamespace(weight_quant_dtype="int4")
+    quant_config = FusedMoEQuantConfig.make(
+        torch.int8,
+        w1_scale=torch.ones((2, 8, 1)),
+        w2_scale=torch.ones((2, 4, 1)),
+        per_act_token_quant=True,
+        per_out_ch_quant=False,
+        block_shape=None,
+        weight_dtype="int4",
+    )
     moe_config = SimpleNamespace()
 
     kernel = module.make_deepep_auto_deepgemm_w4a8_moe_kernel(
@@ -3368,6 +3377,113 @@ def test_slimquant_w4a8_auto_factory_reuses_unified_prepare_finalize(
         "num_dispatchers": 8,
         "fixed_use_low_latency": None,
     }
+
+
+def test_slimquant_w4a8_auto_factory_rejects_non_dynamic_token_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+    from vllm_hcu.model_executor.layers.fused_moe.experts import (
+        dpsk_v4_deep_gemm_moe as module,
+    )
+
+    monkeypatch.setattr(
+        module,
+        "_make_deepep_auto_deepgemm_moe_kernel",
+        lambda **_kwargs: pytest.fail(
+            "invalid W4A8 quantization reached DeepGEMM construction"
+        ),
+    )
+    quant_config = FusedMoEQuantConfig.make(
+        torch.int8,
+        w1_scale=torch.ones((2, 8, 1)),
+        w2_scale=torch.ones((2, 4, 1)),
+        per_act_token_quant=False,
+        per_out_ch_quant=False,
+        block_shape=None,
+        weight_dtype="int4",
+    )
+
+    with pytest.raises(ValueError, match="dynamic per-token INT8"):
+        module.make_deepep_auto_deepgemm_w4a8_moe_kernel(
+            moe_quant_config=quant_config,
+            moe_config=SimpleNamespace(),
+        )
+
+
+def test_slimquant_w4a8_auto_factory_requires_channel_weight_scales(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+    from vllm_hcu.model_executor.layers.fused_moe.experts import (
+        dpsk_v4_deep_gemm_moe as module,
+    )
+
+    monkeypatch.setattr(
+        module,
+        "_make_deepep_auto_deepgemm_moe_kernel",
+        lambda **_kwargs: pytest.fail(
+            "unscaled W4A8 weights reached DeepGEMM construction"
+        ),
+    )
+    quant_config = FusedMoEQuantConfig.make(
+        torch.int8,
+        w1_scale=None,
+        w2_scale=torch.ones((2, 4, 1)),
+        per_act_token_quant=True,
+        per_out_ch_quant=False,
+        block_shape=None,
+        weight_dtype="int4",
+    )
+
+    with pytest.raises(ValueError, match="channel weight scales"):
+        module.make_deepep_auto_deepgemm_w4a8_moe_kernel(
+            moe_quant_config=quant_config,
+            moe_config=SimpleNamespace(),
+        )
+
+
+@pytest.mark.parametrize(
+    "unsupported_metadata",
+    [
+        {"w1_zp": torch.zeros((2, 8, 1), dtype=torch.int8)},
+        {"a1_scale": torch.ones((1,), dtype=torch.float32)},
+        {"g1_alphas": torch.ones((2, 8, 1), dtype=torch.float32)},
+        {"w1_bias": torch.zeros((2, 8), dtype=torch.float32)},
+    ],
+)
+def test_slimquant_w4a8_auto_factory_rejects_auxiliary_quant_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    unsupported_metadata: dict[str, torch.Tensor],
+):
+    from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+    from vllm_hcu.model_executor.layers.fused_moe.experts import (
+        dpsk_v4_deep_gemm_moe as module,
+    )
+
+    monkeypatch.setattr(
+        module,
+        "_make_deepep_auto_deepgemm_moe_kernel",
+        lambda **_kwargs: pytest.fail(
+            "unsupported W4A8 metadata reached DeepGEMM construction"
+        ),
+    )
+    quant_config = FusedMoEQuantConfig.make(
+        torch.int8,
+        w1_scale=torch.ones((2, 8, 1)),
+        w2_scale=torch.ones((2, 4, 1)),
+        per_act_token_quant=True,
+        per_out_ch_quant=False,
+        block_shape=None,
+        weight_dtype="int4",
+        **unsupported_metadata,
+    )
+
+    with pytest.raises(ValueError, match="symmetric.*without auxiliary"):
+        module.make_deepep_auto_deepgemm_w4a8_moe_kernel(
+            moe_quant_config=quant_config,
+            moe_config=SimpleNamespace(),
+        )
 
 
 @pytest.mark.parametrize("use_fp8", [True, False])

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -2880,6 +2880,262 @@ def test_channel_auto_experts_construct_only_mooncake_pd_role_layout(
     assert experts.ht_experts is experts.ll_experts
 
 
+def _slimquant_w4a8_auto_experts(fixed_use_low_latency: bool | None):
+    from vllm_hcu.model_executor.layers.fused_moe.experts import (
+        dpsk_v4_deep_gemm_moe as module,
+    )
+    from vllm_hcu.model_executor.layers.quantization import (
+        slimquant_w4a8_deepgemm_runtime as runtime,
+    )
+
+    experts = object.__new__(module.DeepEPAutoW4A8Experts)
+    experts._fixed_use_low_latency = fixed_use_low_latency
+    experts._use_low_latency_snapshot = False
+    if fixed_use_low_latency is True:
+        child = object.__new__(runtime.DeepEPDeepGemmW4A8MaskedExperts)
+        experts.ht_experts = child
+        experts.ll_experts = child
+    elif fixed_use_low_latency is False:
+        child = object.__new__(runtime.DeepEPDeepGemmW4A8ContiguousExperts)
+        experts.ht_experts = child
+        experts.ll_experts = child
+    else:
+        experts.ht_experts = object.__new__(
+            runtime.DeepEPDeepGemmW4A8ContiguousExperts
+        )
+        experts.ll_experts = object.__new__(
+            runtime.DeepEPDeepGemmW4A8MaskedExperts
+        )
+    for child in {experts.ht_experts, experts.ll_experts}:
+        child._deepgemm_w13 = None
+        child._deepgemm_w2 = None
+    return experts
+
+
+def _slimquant_w4a8_auto_layer() -> torch.nn.Module:
+    layer = torch.nn.Module()
+    layer.w13_weight = torch.nn.Parameter(
+        torch.zeros((1, 128, 32), dtype=torch.int8),
+        requires_grad=False,
+    )
+    layer.w2_weight = torch.nn.Parameter(
+        torch.zeros((1, 64, 32), dtype=torch.int8),
+        requires_grad=False,
+    )
+    layer.w13_weight_scale = torch.nn.Parameter(
+        torch.ones((1, 128, 1), dtype=torch.float32),
+        requires_grad=False,
+    )
+    layer.w2_weight_scale = torch.nn.Parameter(
+        torch.ones((1, 64, 1), dtype=torch.float32),
+        requires_grad=False,
+    )
+    return layer
+
+
+def _install_in_place_w4a8_packers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    from vllm_hcu.model_executor.layers.quantization import (
+        slimquant_w4a8_deepgemm_runtime as runtime,
+    )
+
+    pack_calls: list[torch.Tensor] = []
+    view_calls: list[torch.Tensor] = []
+
+    def pack(weight: torch.Tensor) -> torch.Tensor:
+        pack_calls.append(weight)
+        weight.fill_(40 + len(pack_calls))
+        return weight
+
+    def n32_view(weight: torch.Tensor) -> torch.Tensor:
+        view_calls.append(weight)
+        experts, n, k_half = weight.shape
+        return weight.view(experts, k_half // 32, n // 32, 4, 32, 8)
+
+    monkeypatch.setattr(runtime, "pack_w4a8_moe_hipc_weight", pack)
+    monkeypatch.setattr(
+        runtime,
+        "view_w4a8_moe_hipc_weight_n32_layout",
+        n32_view,
+    )
+    return pack_calls, view_calls
+
+
+@pytest.mark.parametrize(
+    ("fixed_use_low_latency", "layout", "expected_view_calls"),
+    [
+        (None, "shared_hipc_auto", 2),
+        (False, "shared_hipc_contiguous", 0),
+        (True, "shared_hipc_n32", 2),
+    ],
+)
+def test_slimquant_w4a8_auto_packs_original_storage_once_for_role(
+    monkeypatch: pytest.MonkeyPatch,
+    fixed_use_low_latency: bool | None,
+    layout: str,
+    expected_view_calls: int,
+):
+    """The strict auto owner must not retain a full cloned weight layout."""
+
+    pack_calls, view_calls = _install_in_place_w4a8_packers(monkeypatch)
+    experts = _slimquant_w4a8_auto_experts(fixed_use_low_latency)
+    layer = _slimquant_w4a8_auto_layer()
+    original_w13 = layer.w13_weight
+    original_w2 = layer.w2_weight
+
+    experts.process_weights_after_loading(layer)
+
+    assert len(pack_calls) == 2
+    assert [weight.untyped_storage().data_ptr() for weight in pack_calls] == [
+        original_w13.untyped_storage().data_ptr(),
+        original_w2.untyped_storage().data_ptr(),
+    ]
+    assert layer.w13_weight is original_w13
+    assert layer.w2_weight is original_w2
+    assert len(view_calls) == expected_view_calls
+    assert layer._slimquant_w4a8_deepep_auto_layout == layout
+    current = experts._current()
+    expected_rank = 6 if fixed_use_low_latency is True else 3
+    assert current._deepgemm_w13.ndim == expected_rank
+    assert current._deepgemm_w2.ndim == expected_rank
+    assert current._deepgemm_w13.untyped_storage().data_ptr() == (
+        layer.w13_weight.untyped_storage().data_ptr()
+    )
+    assert current._deepgemm_w2.untyped_storage().data_ptr() == (
+        layer.w2_weight.untyped_storage().data_ptr()
+    )
+    if fixed_use_low_latency is None:
+        assert experts.ht_experts._deepgemm_w13.ndim == 3
+        assert experts.ht_experts._deepgemm_w2.ndim == 3
+        assert experts.ll_experts._deepgemm_w13.ndim == 6
+        assert experts.ll_experts._deepgemm_w2.ndim == 6
+        assert experts.ht_experts._deepgemm_w13.untyped_storage().data_ptr() == (
+            experts.ll_experts._deepgemm_w13.untyped_storage().data_ptr()
+        )
+        assert experts.ht_experts._deepgemm_w2.untyped_storage().data_ptr() == (
+            experts.ll_experts._deepgemm_w2.untyped_storage().data_ptr()
+        )
+
+
+def test_slimquant_w4a8_auto_is_idempotent_across_state_dict_and_sleep_restore(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Restoring the packed owner in place must only rebuild aliasing views."""
+
+    pack_calls, _ = _install_in_place_w4a8_packers(monkeypatch)
+    layer = _slimquant_w4a8_auto_layer()
+    experts = _slimquant_w4a8_auto_experts(None)
+    experts.process_weights_after_loading(layer)
+    owner_ptrs = (
+        layer.w13_weight.untyped_storage().data_ptr(),
+        layer.w2_weight.untyped_storage().data_ptr(),
+    )
+    packed_state = {name: value.clone() for name, value in layer.state_dict().items()}
+
+    # CuMem level-1 sleep/wake restores the tagged weight allocation at the
+    # same virtual address.  Exercise the equivalent in-place byte restore.
+    layer.w13_weight.zero_()
+    layer.w2_weight.zero_()
+    layer.load_state_dict(packed_state)
+    replacement = _slimquant_w4a8_auto_experts(None)
+    replacement.process_weights_after_loading(layer)
+
+    assert len(pack_calls) == 2
+    assert owner_ptrs == (
+        layer.w13_weight.untyped_storage().data_ptr(),
+        layer.w2_weight.untyped_storage().data_ptr(),
+    )
+    torch.testing.assert_close(layer.w13_weight, packed_state["w13_weight"])
+    torch.testing.assert_close(layer.w2_weight, packed_state["w2_weight"])
+    assert replacement.ht_experts._deepgemm_w13.untyped_storage().data_ptr() == (
+        replacement.ll_experts._deepgemm_w13.untyped_storage().data_ptr()
+    )
+    assert not any("deepep_auto" in name for name in packed_state)
+
+
+def test_slimquant_w4a8_auto_reloads_raw_weights_into_existing_owner(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Checkpoint reload may use temporary Parameters but must retain one owner."""
+
+    from vllm.model_executor.model_loader.reload.layerwise import (
+        _copy_and_restore_kernel_tensors,
+    )
+
+    pack_calls, _ = _install_in_place_w4a8_packers(monkeypatch)
+    layer = _slimquant_w4a8_auto_layer()
+    experts = _slimquant_w4a8_auto_experts(None)
+    experts.process_weights_after_loading(layer)
+    kernel_parameters = dict(layer.named_parameters(recurse=False))
+    owner_w13 = layer.w13_weight
+    owner_w2 = layer.w2_weight
+    owner_ptrs = (
+        owner_w13.untyped_storage().data_ptr(),
+        owner_w2.untyped_storage().data_ptr(),
+    )
+
+    reloaded_w13 = torch.nn.Parameter(
+        torch.full_like(owner_w13, 3), requires_grad=False
+    )
+    reloaded_w2 = torch.nn.Parameter(
+        torch.full_like(owner_w2, 5), requires_grad=False
+    )
+    layer.w13_weight = reloaded_w13
+    layer.w2_weight = reloaded_w2
+    replacement = _slimquant_w4a8_auto_experts(None)
+    replacement.process_weights_after_loading(layer)
+    _copy_and_restore_kernel_tensors(
+        layer,
+        SimpleNamespace(kernel_tensors=(kernel_parameters, {})),
+    )
+
+    assert len(pack_calls) == 4
+    assert [weight.untyped_storage().data_ptr() for weight in pack_calls] == [
+        owner_w13.untyped_storage().data_ptr(),
+        owner_w2.untyped_storage().data_ptr(),
+        reloaded_w13.untyped_storage().data_ptr(),
+        reloaded_w2.untyped_storage().data_ptr(),
+    ]
+    assert layer.w13_weight is owner_w13
+    assert layer.w2_weight is owner_w2
+    assert layer.w13_weight.untyped_storage().data_ptr() == owner_ptrs[0]
+    assert layer.w2_weight.untyped_storage().data_ptr() == owner_ptrs[1]
+    assert torch.count_nonzero(layer.w13_weight != 43) == 0
+    assert torch.count_nonzero(layer.w2_weight != 44) == 0
+    assert replacement.ht_experts._deepgemm_w13.untyped_storage().data_ptr() == (
+        replacement.ll_experts._deepgemm_w13.untyped_storage().data_ptr()
+    )
+
+
+def test_slimquant_w4a8_auto_rejects_incompatible_marker_before_repacking(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A partial/unknown packed marker must not repack transformed bytes."""
+
+    pack_calls, _ = _install_in_place_w4a8_packers(monkeypatch)
+    layer = _slimquant_w4a8_auto_layer()
+    layer._slimquant_w4a8_deepep_auto_layout = "unknown_transformed_layout"
+    experts = _slimquant_w4a8_auto_experts(None)
+
+    with pytest.raises(RuntimeError, match="invalid.*deepep_auto.*marker"):
+        experts.process_weights_after_loading(layer)
+
+    assert pack_calls == []
+
+    valid_layer = _slimquant_w4a8_auto_layer()
+    valid_experts = _slimquant_w4a8_auto_experts(None)
+    valid_experts.process_weights_after_loading(valid_layer)
+    valid_layer._slimquant_w4a8_deepep_auto_packed_w13 = (
+        valid_layer._slimquant_w4a8_deepep_auto_packed_w13.flatten()
+    )
+
+    with pytest.raises(RuntimeError, match="invalid.*deepep_auto.*marker"):
+        valid_experts.process_weights_after_loading(valid_layer)
+
+    assert len(pack_calls) == 2
+
+
 def test_channel_int8_auto_factory_builds_unified_ht_ll_kernel(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -387,6 +387,8 @@ def test_slimquant_w4a8_deepep_auto_empty_rank_keeps_global_snapshot(
 ):
     """An empty DP rank must not reinterpret a shared HT snapshot as LL."""
 
+    import vllm.forward_context as forward_context
+
     from vllm_hcu.model_executor.layers.fused_moe.experts import (
         dpsk_v4_deep_gemm_moe as deepgemm_module,
     )
@@ -398,11 +400,26 @@ def test_slimquant_w4a8_deepep_auto_empty_rank_keeps_global_snapshot(
         def post_init_setup(self, _experts: object) -> None:
             pass
 
-    monkeypatch.setattr(auto_module, "_forward_uses_low_latency", lambda: False)
+    active_tokens = torch.ones((5, 4), dtype=torch.bfloat16)
+    empty_tokens = torch.empty((0, 4), dtype=torch.bfloat16)
+    synchronized_snapshot = False
+    current_context: object | None = None
+    monkeypatch.setattr(
+        forward_context,
+        "get_forward_context",
+        lambda: current_context,
+    )
+
     selected_layouts: list[tuple[int, object]] = []
     contiguous_by_rank: list[tuple[int, object]] = []
-    local_token_counts = (0, 5)
-    for local_token_count in local_token_counts:
+    for local_tokens in (active_tokens, empty_tokens):
+        local_token_count = local_tokens.size(0)
+        assert (local_token_count > 0) is (local_tokens is active_tokens)
+        current_context = SimpleNamespace(
+            deepep_auto_use_low_latency=synchronized_snapshot,
+            local_token_count=local_token_count,
+        )
+        assert auto_module._forward_uses_low_latency() is synchronized_snapshot
         contiguous = object.__new__(
             deepgemm_module.DeepEPDeepGemmW4A8ContiguousExperts
         )
@@ -420,7 +437,7 @@ def test_slimquant_w4a8_deepep_auto_empty_rank_keeps_global_snapshot(
         )
         prepare_finalize.post_init_setup(experts)
 
-        assert prepare_finalize.begin_moe_call() is False
+        assert prepare_finalize.begin_moe_call() is synchronized_snapshot
         selected_layouts.append((local_token_count, experts._current()))
 
     assert selected_layouts == contiguous_by_rank

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -2943,9 +2943,12 @@ def test_slimquant_w4a8_auto_factory_reuses_unified_prepare_finalize(
         dpsk_v4_deep_gemm_moe as module,
     )
 
+    routing_tables = (object(), object(), object())
+
     class PrepareFinalize:
         ll_prepare_finalize = SimpleNamespace(
             max_num_tokens_per_rank=lambda: 64,
+            routing_tables=None,
         )
 
         @staticmethod
@@ -2953,10 +2956,17 @@ def test_slimquant_w4a8_auto_factory_reuses_unified_prepare_finalize(
             return 8
 
     prepare_finalize = PrepareFinalize()
+
+    def maybe_make_prepare_finalize(**kwargs):
+        prepare_finalize.ll_prepare_finalize.routing_tables = kwargs[
+            "routing_tables"
+        ]
+        return prepare_finalize
+
     monkeypatch.setattr(
         all2all_utils,
         "maybe_make_prepare_finalize",
-        lambda **_kwargs: prepare_finalize,
+        maybe_make_prepare_finalize,
     )
     constructed: dict[str, object] = {}
 
@@ -2976,10 +2986,11 @@ def test_slimquant_w4a8_auto_factory_reuses_unified_prepare_finalize(
     kernel = module.make_deepep_auto_deepgemm_w4a8_moe_kernel(
         moe_quant_config=quant_config,
         moe_config=moe_config,
-        routing_tables="routing",
+        routing_tables=routing_tables,
     )
 
     assert kernel[0] is prepare_finalize
+    assert kernel[0].ll_prepare_finalize.routing_tables is routing_tables
     assert isinstance(kernel[1], AutoW4A8Experts)
     assert constructed == {
         "moe_config": moe_config,

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -334,6 +334,98 @@ def test_deepep_auto_prepare_snapshots_mode_for_matching_finalize(
     ]
 
 
+@pytest.mark.parametrize(
+    ("use_low_latency",),
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_slimquant_w4a8_deepep_auto_snapshot_selects_matching_layout(
+    monkeypatch: pytest.MonkeyPatch,
+    use_low_latency: bool,
+):
+    """One W4A8 forward snapshot must select the matching HT or LL experts."""
+
+    from vllm_hcu.model_executor.layers.fused_moe.experts import (
+        dpsk_v4_deep_gemm_moe as deepgemm_module,
+    )
+    from vllm_hcu.model_executor.layers.fused_moe.prepare_finalize import (
+        deepep_auto as auto_module,
+    )
+
+    contiguous = object.__new__(
+        deepgemm_module.DeepEPDeepGemmW4A8ContiguousExperts
+    )
+    masked = object.__new__(deepgemm_module.DeepEPDeepGemmW4A8MaskedExperts)
+    experts = object.__new__(deepgemm_module.DeepEPAutoW4A8Experts)
+    experts._fixed_use_low_latency = None
+    experts._use_low_latency_snapshot = not use_low_latency
+    experts.ht_experts = contiguous
+    experts.ll_experts = masked
+
+    class Delegate:
+        def post_init_setup(self, _experts: object) -> None:
+            pass
+
+    prepare_finalize = auto_module.DeepEPAutoPrepareAndFinalize(
+        Delegate(), Delegate()
+    )
+    monkeypatch.setattr(
+        auto_module,
+        "_forward_uses_low_latency",
+        lambda: use_low_latency,
+    )
+
+    prepare_finalize.post_init_setup(experts)
+    assert prepare_finalize.begin_moe_call() is use_low_latency
+    assert experts._current() is (masked if use_low_latency else contiguous)
+
+
+def test_slimquant_w4a8_deepep_auto_empty_rank_keeps_global_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An empty DP rank must not reinterpret a shared HT snapshot as LL."""
+
+    from vllm_hcu.model_executor.layers.fused_moe.experts import (
+        dpsk_v4_deep_gemm_moe as deepgemm_module,
+    )
+    from vllm_hcu.model_executor.layers.fused_moe.prepare_finalize import (
+        deepep_auto as auto_module,
+    )
+
+    class Delegate:
+        def post_init_setup(self, _experts: object) -> None:
+            pass
+
+    monkeypatch.setattr(auto_module, "_forward_uses_low_latency", lambda: False)
+    selected_layouts: list[tuple[int, object]] = []
+    contiguous_by_rank: list[tuple[int, object]] = []
+    local_token_counts = (0, 5)
+    for local_token_count in local_token_counts:
+        contiguous = object.__new__(
+            deepgemm_module.DeepEPDeepGemmW4A8ContiguousExperts
+        )
+        masked = object.__new__(
+            deepgemm_module.DeepEPDeepGemmW4A8MaskedExperts
+        )
+        experts = object.__new__(deepgemm_module.DeepEPAutoW4A8Experts)
+        experts._fixed_use_low_latency = None
+        experts._use_low_latency_snapshot = True
+        experts.ht_experts = contiguous
+        experts.ll_experts = masked
+        contiguous_by_rank.append((local_token_count, contiguous))
+        prepare_finalize = auto_module.DeepEPAutoPrepareAndFinalize(
+            Delegate(), Delegate()
+        )
+        prepare_finalize.post_init_setup(experts)
+
+        assert prepare_finalize.begin_moe_call() is False
+        selected_layouts.append((local_token_count, experts._current()))
+
+    assert selected_layouts == contiguous_by_rank
+
+
 def test_modular_prepare_begins_auto_call_before_expert_contract_queries():
     from vllm_hcu.model_executor.layers.fused_moe import modular_kernel as module
 

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -3804,6 +3804,50 @@ def test_slimquant_w4a8_deepep_auto_rejects_incomplete_hipc_runtime(
 
 
 @pytest.mark.hcu
+def test_slimquant_w4a8_deepep_auto_rejects_missing_ll_lightop(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm_hcu.model_executor.layers.fused_moe import deepep_runtime
+
+    deepep_runtime._require_slimquant_w4a8_hipc_runtime.cache_clear()
+    noop = lambda *_args, **_kwargs: None
+    monkeypatch.setitem(
+        sys.modules,
+        "deepgemm",
+        _module(
+            "deepgemm",
+            pack_w4a8_moe_hipc_weight=noop,
+            view_w4a8_moe_hipc_weight_n32_layout=noop,
+            m_grouped_w4a8_gemm_nt_contiguous_hipc=noop,
+            m_grouped_w4a8_gemm_nt_masked_hipc=noop,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "lightop",
+        _module("lightop", fuse_silu_mul_quant=noop),
+    )
+    moe = SimpleNamespace(
+        activation=SimpleNamespace(value="silu"),
+        moe_backend="auto",
+        moe_parallel_config=SimpleNamespace(
+            dp_size=2,
+            use_ep=True,
+            all2all_backend="deepep_auto",
+            use_deepep_auto_kernels=True,
+        ),
+        _hcu_vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(
+                architectures=["DeepseekV4ForCausalLM"]
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="lightop.fuse_silu_mul_quant_ep"):
+        deepep_runtime.slimquant_w4a8_uses_deepep_auto(moe)
+
+
+@pytest.mark.hcu
 @pytest.mark.parametrize(
     (
         "dp_size",

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -3615,12 +3615,18 @@ def test_slimquant_w4a8_deepep_auto_uses_w4a8_deepgemm_factory_not_aiter(
     )
 
     moe = SimpleNamespace(
+        activation=SimpleNamespace(value="silu"),
         moe_backend="auto",
         moe_parallel_config=SimpleNamespace(
             dp_size=2,
             use_ep=True,
             all2all_backend="deepep_auto",
             use_deepep_auto_kernels=True,
+        ),
+        _hcu_vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(
+                architectures=["DeepseekV4ForCausalLM"]
+            )
         ),
     )
     method = slimquant_w4a8.SlimQuantW4A8Int8AiterMoEMethod(object(), moe)
@@ -3665,6 +3671,136 @@ def test_slimquant_w4a8_deepep_auto_uses_w4a8_deepgemm_factory_not_aiter(
         ),
         x + 3,
     )
+
+
+@pytest.mark.hcu
+def test_slimquant_w4a8_deepep_auto_rejects_non_deepseek_v4_architecture():
+    from vllm_hcu.model_executor.layers.fused_moe.deepep_runtime import (
+        slimquant_w4a8_uses_deepep_auto,
+    )
+
+    moe = SimpleNamespace(
+        activation=SimpleNamespace(value="silu"),
+        moe_backend="auto",
+        moe_parallel_config=SimpleNamespace(
+            dp_size=2,
+            use_ep=True,
+            all2all_backend="deepep_auto",
+            use_deepep_auto_kernels=True,
+        ),
+        _hcu_vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(
+                architectures=["DeepseekV3ForCausalLM"]
+            )
+        ),
+    )
+
+    with pytest.raises(ValueError, match="validated only for DeepSeek-V4"):
+        slimquant_w4a8_uses_deepep_auto(moe)
+
+
+@pytest.mark.hcu
+def test_slimquant_w4a8_deepep_auto_rejects_non_silu_activation():
+    from vllm_hcu.model_executor.layers.fused_moe.deepep_runtime import (
+        slimquant_w4a8_uses_deepep_auto,
+    )
+
+    moe = SimpleNamespace(
+        activation=SimpleNamespace(value="gelu"),
+        moe_backend="auto",
+        moe_parallel_config=SimpleNamespace(
+            dp_size=2,
+            use_ep=True,
+            all2all_backend="deepep_auto",
+            use_deepep_auto_kernels=True,
+        ),
+        _hcu_vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(
+                architectures=["DeepseekV4ForCausalLM"]
+            )
+        ),
+    )
+
+    with pytest.raises(ValueError, match="supports only SiLU activation"):
+        slimquant_w4a8_uses_deepep_auto(moe)
+
+
+@pytest.mark.hcu
+def test_slimquant_w4a8_deepep_auto_rejects_non_rocm_platform(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm_hcu.model_executor.layers.fused_moe import deepep_runtime
+
+    monkeypatch.setattr(
+        deepep_runtime,
+        "current_platform",
+        SimpleNamespace(is_rocm=lambda: False),
+        raising=False,
+    )
+    moe = SimpleNamespace(
+        activation=SimpleNamespace(value="silu"),
+        moe_backend="auto",
+        moe_parallel_config=SimpleNamespace(
+            dp_size=2,
+            use_ep=True,
+            all2all_backend="deepep_auto",
+            use_deepep_auto_kernels=True,
+        ),
+        _hcu_vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(
+                architectures=["DeepseekV4ForCausalLM"]
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="requires the HCU ROCm runtime"):
+        deepep_runtime.slimquant_w4a8_uses_deepep_auto(moe)
+
+
+@pytest.mark.hcu
+def test_slimquant_w4a8_deepep_auto_rejects_incomplete_hipc_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm_hcu.model_executor.layers.fused_moe import deepep_runtime
+
+    deepep_runtime._require_slimquant_w4a8_hipc_runtime.cache_clear()
+    noop = lambda *_args, **_kwargs: None
+    monkeypatch.setitem(
+        sys.modules,
+        "deepgemm",
+        _module(
+            "deepgemm",
+            pack_w4a8_moe_hipc_weight=noop,
+            view_w4a8_moe_hipc_weight_n32_layout=noop,
+            m_grouped_w4a8_gemm_nt_contiguous_hipc=noop,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "lightop",
+        _module("lightop", fuse_silu_mul_quant=noop),
+    )
+    moe = SimpleNamespace(
+        activation=SimpleNamespace(value="silu"),
+        moe_backend="auto",
+        moe_parallel_config=SimpleNamespace(
+            dp_size=2,
+            use_ep=True,
+            all2all_backend="deepep_auto",
+            use_deepep_auto_kernels=True,
+        ),
+        _hcu_vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(
+                architectures=["DeepseekV4ForCausalLM"]
+            )
+        ),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="m_grouped_w4a8_gemm_nt_masked_hipc",
+    ):
+        deepep_runtime.slimquant_w4a8_uses_deepep_auto(moe)
 
 
 @pytest.mark.hcu
@@ -4332,6 +4468,109 @@ def test_slimquant_w4a8_apply_accepts_runner_owned_shared_experts(
         topk_ids,
         shared_experts=object(),
         shared_experts_input=x,
+    )
+
+    assert result is x
+
+
+@pytest.mark.hcu
+def test_slimquant_w4a8_deepep_auto_restores_native_nonidentity_expert_map(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm_hcu.model_executor.layers.fused_moe import deepep_runtime
+    from vllm_hcu.model_executor.layers.quantization import slimquant_w4a8
+
+    monkeypatch.setattr(
+        deepep_runtime,
+        "slimquant_w4a8_uses_deepep_auto",
+        lambda _moe: True,
+    )
+    calls: list[dict[str, object]] = []
+
+    class W4A8Kernel:
+        @staticmethod
+        def apply(**kwargs: object) -> torch.Tensor:
+            calls.append(kwargs)
+            return kwargs["hidden_states"]
+
+    native_expert_map = torch.tensor([-1, 0, 1, -1], dtype=torch.int32)
+    expert_mask = torch.tensor([0, 1, 1, 0, 0], dtype=torch.int32)
+    expert_mask._vllm_hcu_native_expert_map = native_expert_map
+    method = object.__new__(slimquant_w4a8.SlimQuantW4A8Int8AiterMoEMethod)
+    method.moe = SimpleNamespace(num_experts=4)
+    method.moe_kernel = W4A8Kernel()
+    layer = SimpleNamespace(
+        w13_weight=torch.zeros((2, 8, 2), dtype=torch.int8),
+        w2_weight=torch.zeros((2, 4, 2), dtype=torch.int8),
+        activation=SimpleNamespace(value="silu"),
+        global_num_experts=4,
+        expert_map=expert_mask,
+        apply_router_weight_on_input=False,
+    )
+    x = torch.zeros((2, 4), dtype=torch.bfloat16)
+
+    result = method.apply(
+        layer,
+        x,
+        torch.ones((2, 1), dtype=torch.float32),
+        torch.zeros((2, 1), dtype=torch.int32),
+        None,
+        None,
+    )
+
+    assert result is x
+    assert calls[0]["expert_map"] is native_expert_map
+
+
+@pytest.mark.hcu
+def test_slimquant_w4a8_apply_reuses_initialized_deepep_auto_route(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import vllm.config
+
+    from vllm_hcu.model_executor.layers.quantization import slimquant_w4a8
+
+    monkeypatch.setattr(
+        vllm.config,
+        "get_current_vllm_config_or_none",
+        lambda: None,
+    )
+
+    class W4A8Kernel:
+        @staticmethod
+        def apply(**kwargs: object) -> torch.Tensor:
+            return kwargs["hidden_states"]
+
+    method = object.__new__(slimquant_w4a8.SlimQuantW4A8Int8AiterMoEMethod)
+    method.moe = SimpleNamespace(
+        activation=SimpleNamespace(value="silu"),
+        moe_backend="auto",
+        num_experts=2,
+        moe_parallel_config=SimpleNamespace(
+            dp_size=2,
+            use_ep=True,
+            all2all_backend="deepep_auto",
+            use_deepep_auto_kernels=True,
+        ),
+    )
+    method.moe_kernel = W4A8Kernel()
+    layer = SimpleNamespace(
+        w13_weight=torch.zeros((2, 8, 2), dtype=torch.int8),
+        w2_weight=torch.zeros((2, 4, 2), dtype=torch.int8),
+        activation=SimpleNamespace(value="silu"),
+        global_num_experts=2,
+        expert_map=torch.tensor([0, 1], dtype=torch.int32),
+        apply_router_weight_on_input=False,
+    )
+    x = torch.zeros((2, 4), dtype=torch.bfloat16)
+
+    result = method.apply(
+        layer,
+        x,
+        torch.ones((2, 1), dtype=torch.float32),
+        torch.zeros((2, 1), dtype=torch.int32),
+        None,
+        None,
     )
 
     assert result is x

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -3570,6 +3570,7 @@ def test_slimquant_w4a8_deepep_auto_uses_w4a8_deepgemm_factory_not_aiter(
         ),
     )
     method = slimquant_w4a8.SlimQuantW4A8Int8AiterMoEMethod(object(), moe)
+    routing_tables = (object(), object(), object())
     layer = SimpleNamespace(
         w13_weight=torch.nn.Parameter(
             torch.zeros((2, 8, 2), dtype=torch.int8), requires_grad=False
@@ -3585,14 +3586,17 @@ def test_slimquant_w4a8_deepep_auto_uses_w4a8_deepgemm_factory_not_aiter(
         ),
         w13_input_scale=None,
         w2_input_scale=None,
+        _expert_routing_tables=lambda: routing_tables,
     )
 
-    quant_config = method.get_fused_moe_quant_config(layer)
-    assert quant_config.weight_quant_dtype == "int4"
+    assert method.moe_quant_config is None
 
     method.process_weights_after_loading(layer)
 
-    assert factory_calls == [(quant_config, moe, None)]
+    quant_config = method.moe_quant_config
+    assert quant_config is not None
+    assert quant_config.weight_quant_dtype == "int4"
+    assert factory_calls == [(quant_config, moe, routing_tables)]
     assert processed_layers == [layer]
     assert method.moe_kernel is not None
     x = torch.zeros((2, 4), dtype=torch.bfloat16)

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -3506,6 +3506,110 @@ def test_slimquant_w4a8_moe_method_is_a_direct_fused_moe_method():
 
 
 @pytest.mark.hcu
+def test_slimquant_w4a8_deepep_auto_uses_w4a8_deepgemm_factory_not_aiter(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """DP+EP W4A8 must own an auto DeepGEMM kernel, not an AITER fallback."""
+
+    from vllm_hcu.model_executor.layers.fused_moe.experts import (
+        dpsk_v4_deep_gemm_moe as deepgemm_module,
+    )
+    from vllm_hcu.model_executor.layers.quantization import slimquant_w4a8
+
+    factory_calls: list[tuple[object, object, object]] = []
+    processed_layers: list[object] = []
+
+    class W4A8Experts:
+        def process_weights_after_loading(self, layer: object) -> None:
+            processed_layers.append(layer)
+
+    class W4A8Kernel:
+        fused_experts = SimpleNamespace(experts=W4A8Experts())
+
+        @staticmethod
+        def apply(**kwargs: object) -> torch.Tensor:
+            return kwargs["hidden_states"] + 3
+
+    def make_deepep_auto_deepgemm_w4a8_moe_kernel(
+        *,
+        moe_quant_config: object,
+        moe_config: object,
+        routing_tables: object = None,
+    ) -> W4A8Kernel:
+        factory_calls.append((moe_quant_config, moe_config, routing_tables))
+        return W4A8Kernel()
+
+    monkeypatch.setattr(
+        deepgemm_module,
+        "make_deepep_auto_deepgemm_w4a8_moe_kernel",
+        make_deepep_auto_deepgemm_w4a8_moe_kernel,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        compressed_tensors_moe_runtime,
+        "prewarm_aiter_w4a8_moe",
+        lambda *_args: pytest.fail(
+            "deepep_auto W4A8 must create DeepGEMM experts, not prewarm AITER"
+        ),
+    )
+    monkeypatch.setattr(
+        compressed_tensors_moe_runtime,
+        "apply_aiter_w4a8_moe",
+        lambda *_args: pytest.fail(
+            "deepep_auto W4A8 must execute its DeepGEMM kernel, not AITER"
+        ),
+    )
+
+    moe = SimpleNamespace(
+        moe_backend="auto",
+        moe_parallel_config=SimpleNamespace(
+            dp_size=2,
+            use_ep=True,
+            all2all_backend="deepep_auto",
+            use_deepep_auto_kernels=True,
+        ),
+    )
+    method = slimquant_w4a8.SlimQuantW4A8Int8AiterMoEMethod(object(), moe)
+    layer = SimpleNamespace(
+        w13_weight=torch.nn.Parameter(
+            torch.zeros((2, 8, 2), dtype=torch.int8), requires_grad=False
+        ),
+        w2_weight=torch.nn.Parameter(
+            torch.zeros((2, 4, 2), dtype=torch.int8), requires_grad=False
+        ),
+        w13_weight_scale=torch.nn.Parameter(
+            torch.ones((2, 8, 1)), requires_grad=False
+        ),
+        w2_weight_scale=torch.nn.Parameter(
+            torch.ones((2, 4, 1)), requires_grad=False
+        ),
+        w13_input_scale=None,
+        w2_input_scale=None,
+    )
+
+    quant_config = method.get_fused_moe_quant_config(layer)
+    assert quant_config.weight_quant_dtype == "int4"
+
+    method.process_weights_after_loading(layer)
+
+    assert factory_calls == [(quant_config, moe, None)]
+    assert processed_layers == [layer]
+    assert method.moe_kernel is not None
+    x = torch.zeros((2, 4), dtype=torch.bfloat16)
+    torch.testing.assert_close(
+        method.apply(
+            layer,
+            x,
+            torch.ones((2, 1), dtype=torch.float32),
+            torch.zeros((2, 1), dtype=torch.int32),
+            None,
+            None,
+        ),
+        x + 3,
+    )
+
+
+@pytest.mark.hcu
 def test_slimquant_w4a8_prewarms_m1_with_logical_packed_dimensions(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -3856,6 +3856,55 @@ def test_slimquant_w4a8_prewarms_m1_with_logical_packed_dimensions(
 
 
 @pytest.mark.hcu
+def test_slimquant_w4a8_tp_aiter_keeps_raw_canonical_owner(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The DP auto ownership exception must not mutate pure-TP AITER weights."""
+
+    from vllm_hcu.model_executor.layers.quantization import slimquant_w4a8
+
+    method = slimquant_w4a8.SlimQuantW4A8Int8AiterMoEMethod(
+        quant_config=object(),
+        moe=SimpleNamespace(moe_backend="aiter"),
+    )
+    w13 = torch.nn.Parameter(
+        torch.arange(16, dtype=torch.int8).reshape(1, 8, 2),
+        requires_grad=False,
+    )
+    w2 = torch.nn.Parameter(
+        torch.arange(8, dtype=torch.int8).reshape(1, 4, 2),
+        requires_grad=False,
+    )
+    layer = SimpleNamespace(
+        w13_weight=w13,
+        w2_weight=w2,
+        w13_weight_scale=torch.nn.Parameter(
+            torch.ones((1, 8, 1), dtype=torch.float32), requires_grad=False
+        ),
+        w2_weight_scale=torch.nn.Parameter(
+            torch.ones((1, 4, 1), dtype=torch.float32), requires_grad=False
+        ),
+    )
+    expected_w13 = w13.detach().clone()
+    expected_w2 = w2.detach().clone()
+    prewarm_calls: list[object] = []
+    monkeypatch.setattr(
+        compressed_tensors_moe_runtime,
+        "prewarm_aiter_w4a8_moe",
+        lambda _method, owner: prewarm_calls.append(owner),
+    )
+
+    method.process_weights_after_loading(layer)
+
+    assert prewarm_calls == [layer]
+    assert layer.w13_weight is w13
+    assert layer.w2_weight is w2
+    torch.testing.assert_close(layer.w13_weight, expected_w13)
+    torch.testing.assert_close(layer.w2_weight, expected_w2)
+    assert not hasattr(layer, "_slimquant_w4a8_deepep_auto_layout")
+
+
+@pytest.mark.hcu
 def test_slimquant_w4a8_explicit_triton_prepares_only_vllm_weights(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -3610,6 +3610,119 @@ def test_slimquant_w4a8_deepep_auto_uses_w4a8_deepgemm_factory_not_aiter(
 
 
 @pytest.mark.hcu
+@pytest.mark.parametrize(
+    (
+        "dp_size",
+        "use_ep",
+        "all2all_backend",
+        "auto_kernels",
+        "moe_backend",
+        "match",
+    ),
+    [
+        (
+            2,
+            True,
+            "deepep_high_throughput",
+            False,
+            "auto",
+            "requires all2all_backend='deepep_auto'",
+        ),
+        (
+            2,
+            True,
+            "deepep_low_latency",
+            False,
+            "auto",
+            "requires all2all_backend='deepep_auto'",
+        ),
+        (
+            1,
+            False,
+            "deepep_auto",
+            True,
+            "auto",
+            "requires dp_size > 1 and expert parallelism",
+        ),
+        (
+            2,
+            False,
+            "deepep_auto",
+            True,
+            "auto",
+            "requires dp_size > 1 and expert parallelism",
+        ),
+        (
+            2,
+            True,
+            "deepep_auto",
+            False,
+            "auto",
+            "incompatible use_deepep_auto_kernels metadata",
+        ),
+        (
+            2,
+            True,
+            "deepep_auto",
+            True,
+            "aiter",
+            "requires moe_backend='auto' or 'deep_gemm'",
+        ),
+    ],
+)
+def test_slimquant_w4a8_deepep_routing_fails_closed_before_tp_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    dp_size: int,
+    use_ep: bool,
+    all2all_backend: str,
+    auto_kernels: bool,
+    moe_backend: str,
+    match: str,
+):
+    """Invalid DeepEP metadata must never fall through to TP AITER/Triton."""
+
+    from vllm_hcu.model_executor.layers.quantization import slimquant_w4a8
+
+    monkeypatch.setattr(
+        compressed_tensors_moe_runtime,
+        "prewarm_aiter_w4a8_moe",
+        lambda *_args: pytest.fail("invalid DeepEP metadata entered TP AITER"),
+    )
+    method = slimquant_w4a8.SlimQuantW4A8Int8AiterMoEMethod(
+        object(),
+        SimpleNamespace(
+            moe_backend=moe_backend,
+            moe_parallel_config=SimpleNamespace(
+                dp_size=dp_size,
+                use_ep=use_ep,
+                all2all_backend=all2all_backend,
+                use_deepep_auto_kernels=auto_kernels,
+            ),
+        ),
+    )
+    layer = SimpleNamespace(
+        w13_weight=torch.nn.Parameter(
+            torch.zeros((2, 8, 2), dtype=torch.int8), requires_grad=False
+        ),
+        w2_weight=torch.nn.Parameter(
+            torch.zeros((2, 4, 2), dtype=torch.int8), requires_grad=False
+        ),
+        w13_weight_scale=torch.nn.Parameter(
+            torch.ones((2, 8, 1)), requires_grad=False
+        ),
+        w2_weight_scale=torch.nn.Parameter(
+            torch.ones((2, 4, 1)), requires_grad=False
+        ),
+        w13_input_scale=None,
+        w2_input_scale=None,
+    )
+    method.get_fused_moe_quant_config(layer)
+
+    with pytest.raises(ValueError, match=match):
+        method.process_weights_after_loading(layer)
+
+
+@pytest.mark.hcu
 def test_slimquant_w4a8_prewarms_m1_with_logical_packed_dimensions(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -4957,6 +4957,14 @@ def test_moe_fp8_aiter_path_accepts_v0251_shared_expert_contract(
             aiter_moe=aiter_moe,
         ),
     )
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.fused_moe_asm_wna16",
+        _module(
+            "aiter.fused_moe_asm_wna16",
+            per_token_quant_hip=_fp8_quant_abi_stub,
+        ),
+    )
     from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 
     assert "disable_inplace" not in FusedMoEConfig.__dataclass_fields__

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -3445,6 +3445,60 @@ def test_compressed_scheme_inactive_anchor_is_corrected_at_runtime():
 
 
 @pytest.mark.hcu
+def test_slimquant_w4a8_dispatches_current_routed_experts_to_aiter_method():
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+    from vllm_hcu.model_executor.layers.quantization import slimquant_w4a8
+
+    # FusedMoE is a factory in v0.25.1. It constructs RoutedExperts, whose
+    # constructor immediately calls get_quant_method. Build that exact public
+    # layer type without recursively entering the dispatch under test.
+    layer = RoutedExperts.__new__(RoutedExperts)
+    torch.nn.Module.__init__(layer)
+    layer.moe_config = SimpleNamespace(
+        moe_backend="aiter",
+        moe_parallel_config=SimpleNamespace(
+            tp_size=8,
+            dp_size=1,
+            use_ep=False,
+            all2all_backend="allgather_reducescatter",
+        ),
+    )
+    config = slimquant_w4a8.SlimQuantW4A8Int8Config()
+
+    method = config.get_quant_method(layer, "model.layers.0.mlp.experts")
+
+    assert type(method) is slimquant_w4a8.SlimQuantW4A8Int8AiterMoEMethod
+    assert method.moe is layer.moe_config
+
+
+@pytest.mark.hcu
+def test_slimquant_w4a8_dispatch_preserves_linear_method():
+    from vllm.model_executor.layers.linear import ReplicatedLinear
+    from vllm_hcu.model_executor.layers.quantization import slimquant_w4a8
+
+    layer = ReplicatedLinear.__new__(ReplicatedLinear)
+    torch.nn.Module.__init__(layer)
+
+    method = slimquant_w4a8.SlimQuantW4A8Int8Config().get_quant_method(
+        layer, "model.layers.0.self_attn.q_proj"
+    )
+
+    assert type(method) is slimquant_w4a8.SlimQuantW4A8Int8LinearMethod
+    assert isinstance(layer.scheme, slimquant_w4a8.CompressedTensorsW8A8Int8)
+
+
+@pytest.mark.hcu
+def test_slimquant_w4a8_dispatch_returns_none_for_unsupported_layer():
+    from vllm_hcu.model_executor.layers.quantization import slimquant_w4a8
+
+    method = slimquant_w4a8.SlimQuantW4A8Int8Config().get_quant_method(
+        torch.nn.Embedding(4, 4), "model.embed_tokens"
+    )
+
+    assert method is None
+
+
+@pytest.mark.hcu
 def test_slimquant_w4a8_moe_quant_config_uses_int4_weight_contract(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py
@@ -9,7 +9,41 @@ argument avoids importing optional communication libraries eagerly.
 
 from __future__ import annotations
 
+import functools
+import importlib
 import inspect
+
+from vllm.platforms import current_platform
+
+
+@functools.lru_cache(maxsize=1)
+def _require_slimquant_w4a8_hipc_runtime() -> None:
+    required_ops = {
+        "deepgemm": (
+            "pack_w4a8_moe_hipc_weight",
+            "view_w4a8_moe_hipc_weight_n32_layout",
+            "m_grouped_w4a8_gemm_nt_contiguous_hipc",
+            "m_grouped_w4a8_gemm_nt_masked_hipc",
+        ),
+        "lightop": ("fuse_silu_mul_quant",),
+    }
+    missing: list[str] = []
+    for module_name, op_names in required_ops.items():
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            missing.append(module_name)
+            continue
+        missing.extend(
+            f"{module_name}.{name}"
+            for name in op_names
+            if not callable(getattr(module, name, None))
+        )
+    if missing:
+        raise RuntimeError(
+            "SlimQuant W4A8 deepep_auto requires HIPC DeepGEMM/LightOP "
+            f"operators; missing {', '.join(missing)}"
+        )
 
 
 def slimquant_w4a8_uses_deepep_auto(moe_config: object) -> bool:
@@ -72,6 +106,30 @@ def slimquant_w4a8_uses_deepep_auto(moe_config: object) -> bool:
             "SlimQuant W4A8 deepep_auto requires moe_backend='auto' or "
             f"'deep_gemm', got {moe_backend!r}"
         )
+    from vllm.config import get_current_vllm_config_or_none
+    from vllm_hcu.deepseek_v4_runtime import model_architectures
+
+    vllm_config = get_current_vllm_config_or_none()
+    if vllm_config is None:
+        vllm_config = getattr(moe_config, "_hcu_vllm_config", None)
+    architectures = model_architectures(vllm_config)
+    if "DeepseekV4ForCausalLM" not in architectures:
+        raise ValueError(
+            "SlimQuant W4A8 deepep_auto is validated only for DeepSeek-V4; "
+            f"got architectures={architectures!r}"
+        )
+    activation = getattr(moe_config, "activation", None)
+    activation_name = getattr(activation, "value", activation)
+    if activation_name != "silu":
+        raise ValueError(
+            "SlimQuant W4A8 deepep_auto supports only SiLU activation; "
+            f"got {activation_name!r}"
+        )
+    if not current_platform.is_rocm():
+        raise RuntimeError(
+            "SlimQuant W4A8 deepep_auto requires the HCU ROCm runtime"
+        )
+    _require_slimquant_w4a8_hipc_runtime()
     return True
 
 

--- a/vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py
@@ -25,7 +25,10 @@ def _require_slimquant_w4a8_hipc_runtime() -> None:
             "m_grouped_w4a8_gemm_nt_contiguous_hipc",
             "m_grouped_w4a8_gemm_nt_masked_hipc",
         ),
-        "lightop": ("fuse_silu_mul_quant",),
+        "lightop": (
+            "fuse_silu_mul_quant",
+            "fuse_silu_mul_quant_ep",
+        ),
     }
     missing: list[str] = []
     for module_name, op_names in required_ops.items():

--- a/vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py
@@ -12,6 +12,69 @@ from __future__ import annotations
 import inspect
 
 
+def slimquant_w4a8_uses_deepep_auto(moe_config: object) -> bool:
+    """Validate and classify the SlimQuant W4A8 MoE execution route.
+
+    Pure TP remains owned by the quantization method's AITER/Triton path.
+    Once DeepEP or DP+EP metadata is present, only the synchronized
+    ``deepep_auto`` contract is supported; fixed DeepEP layouts must not fall
+    through to a TP kernel.
+    """
+
+    parallel_config = getattr(moe_config, "moe_parallel_config", None)
+    if parallel_config is None:
+        return False
+
+    dp_size = getattr(parallel_config, "dp_size", 1)
+    use_ep = bool(getattr(parallel_config, "use_ep", False))
+    all2all_backend = getattr(parallel_config, "all2all_backend", None)
+    auto_kernels = getattr(
+        parallel_config,
+        "use_deepep_auto_kernels",
+        None,
+    )
+    is_dp_ep = dp_size > 1 and use_ep
+
+    fixed_deepep_backends = {
+        "deepep_high_throughput",
+        "deepep_low_latency",
+    }
+    if all2all_backend in fixed_deepep_backends or (
+        is_dp_ep and all2all_backend != "deepep_auto"
+    ):
+        raise ValueError(
+            "SlimQuant W4A8 DP+EP requires "
+            "all2all_backend='deepep_auto'; fixed or incompatible all-to-all "
+            f"backend {all2all_backend!r} is unsupported"
+        )
+
+    if all2all_backend != "deepep_auto":
+        if auto_kernels is True:
+            raise ValueError(
+                "SlimQuant W4A8 has incompatible use_deepep_auto_kernels "
+                f"metadata for all2all_backend={all2all_backend!r}"
+            )
+        return False
+
+    if not is_dp_ep:
+        raise ValueError(
+            "SlimQuant W4A8 deepep_auto requires dp_size > 1 and expert "
+            "parallelism enabled"
+        )
+    if auto_kernels is False:
+        raise ValueError(
+            "SlimQuant W4A8 deepep_auto has incompatible "
+            "use_deepep_auto_kernels metadata"
+        )
+    moe_backend = getattr(moe_config, "moe_backend", "auto")
+    if moe_backend not in ("auto", "deep_gemm"):
+        raise ValueError(
+            "SlimQuant W4A8 deepep_auto requires moe_backend='auto' or "
+            f"'deep_gemm', got {moe_backend!r}"
+        )
+    return True
+
+
 def _has_hcu_low_latency_dispatch_abi(buffer) -> bool:
     dispatch = getattr(buffer, "low_latency_dispatch", None)
     if dispatch is None:
@@ -535,4 +598,5 @@ __all__ = [
     "ll_init",
     "ll_prepare_async",
     "ll_receiver",
+    "slimquant_w4a8_uses_deepep_auto",
 ]

--- a/vllm_hcu/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py
@@ -26,6 +26,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8DynamicTokenSym,
     kFp8Static128BlockSym,
     kFp8StaticChannelSym,
+    kInt4W4A8StaticChannelSym,
     kInt8DynamicTokenSym,
     kInt8StaticChannelSym,
 )
@@ -293,6 +294,7 @@ class BatchedDeepGemmExperts(mk.FusedMoEExpertsModular):
         )
         if current_platform.is_rocm() and (
             self.quant_config.use_int8_w8a8
+            or getattr(self.quant_config, "weight_quant_dtype", None) == "int4"
             or self.quant_config.use_fp8_w8a8
         ):
             # HCU LightOP consumes per-token Channel scales (block_shape=None).
@@ -331,6 +333,7 @@ class BatchedDeepGemmExperts(mk.FusedMoEExpertsModular):
             SUPPORTED_W_A.extend(
                 [
                     (kInt8StaticChannelSym, kInt8DynamicTokenSym),
+                    (kInt4W4A8StaticChannelSym, kInt8DynamicTokenSym),
                     (kFp8StaticChannelSym, kFp8DynamicTokenSym),
                 ]
             )
@@ -438,6 +441,7 @@ class BatchedDeepGemmExperts(mk.FusedMoEExpertsModular):
             current_platform.is_rocm()
             and (
                 self.quant_config.use_int8_w8a8
+                or getattr(self.quant_config, "weight_quant_dtype", None) == "int4"
                 or self.quant_config.use_fp8_w8a8
             )
         )
@@ -450,6 +454,12 @@ class BatchedDeepGemmExperts(mk.FusedMoEExpertsModular):
             N = self._hcu_logical_n
             K = self._hcu_logical_k
 
+        use_w4a8 = (
+            getattr(self.quant_config, "weight_quant_dtype", None) == "int4"
+        )
+        if use_w4a8 and max_num_tokens == 0:
+            return
+
         workspace1 = _resize_cache(workspace13, (E, max_num_tokens, N))
 
         expected_m = self.estimate_expected_m(
@@ -458,7 +468,40 @@ class BatchedDeepGemmExperts(mk.FusedMoEExpertsModular):
             topk=topk_ids.size(-1),
         )
 
-        if self.quant_config.use_int8_w8a8:
+        if use_w4a8:
+            if activation != MoEActivation.SILU:
+                raise ValueError(
+                    "HCU Channel W4A8 batched DeepGEMM supports only SiLU activation"
+                )
+            if (
+                getattr(self, "_deepgemm_w13", None) is None
+                or getattr(self, "_deepgemm_w2", None) is None
+            ):
+                raise RuntimeError(
+                    "SlimQuant W4A8 masked weights were not packed before apply"
+                )
+            from deepgemm import m_grouped_w4a8_gemm_nt_masked_hipc
+            from lightop import fuse_silu_mul_quant_ep
+
+            m_grouped_w4a8_gemm_nt_masked_hipc(
+                (a1q, a1q_scale),
+                (self._deepgemm_w13, self.w1_scale),
+                workspace1,
+                expert_num_tokens,
+                expected_m,
+            )
+            a2q, a2q_scale = fuse_silu_mul_quant_ep(
+                workspace1,
+                tokens_per_expert=expert_num_tokens,
+            )
+            m_grouped_w4a8_gemm_nt_masked_hipc(
+                (a2q, a2q_scale),
+                (self._deepgemm_w2, self.w2_scale),
+                output,
+                expert_num_tokens,
+                expected_m,
+            )
+        elif self.quant_config.use_int8_w8a8:
             if activation != MoEActivation.SILU:
                 raise ValueError(
                     "HCU Channel INT8 batched DeepGEMM supports only SiLU activation"

--- a/vllm_hcu/model_executor/layers/fused_moe/experts/dpsk_v4_deep_gemm_moe.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/experts/dpsk_v4_deep_gemm_moe.py
@@ -43,6 +43,10 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kInt8StaticChannelSym,
 )
 from vllm.model_executor.utils import replace_parameter
+from vllm_hcu.model_executor.layers.quantization.slimquant_w4a8_deepgemm_runtime import (
+    DeepEPDeepGemmW4A8ContiguousExperts,
+    DeepEPDeepGemmW4A8MaskedExperts,
+)
 
 # Use vLLM's configured logger hierarchy so worker-side backend evidence is
 # present in the normal engine log (``vllm_hcu.*`` has no configured handler).
@@ -945,6 +949,57 @@ class DeepEPAutoDeepGemmExperts(mk.FusedMoEExpertsModular):
             workspace2=workspace2,
             expert_tokens_meta=expert_tokens_meta,
             apply_router_weight_on_input=apply_router_weight_on_input,
+        )
+
+
+class DeepEPAutoW4A8Experts(DeepEPAutoDeepGemmExperts):
+    """Select the W4A8 HIPC layout captured by ``deepep_auto``."""
+
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig,
+        max_num_tokens: int,
+        num_dispatchers: int,
+        fixed_use_low_latency: bool | None = None,
+    ):
+        self.moe_config = moe_config
+        self.quant_config = quant_config
+        self.max_num_tokens = max_num_tokens
+        self.num_dispatchers = num_dispatchers
+        self._fixed_use_low_latency = fixed_use_low_latency
+        self._use_low_latency_snapshot = False
+        if fixed_use_low_latency is not True:
+            self.ht_experts = DeepEPDeepGemmW4A8ContiguousExperts(
+                moe_config=moe_config,
+                quant_config=quant_config,
+            )
+        if fixed_use_low_latency is not False:
+            self.ll_experts = DeepEPDeepGemmW4A8MaskedExperts(
+                moe_config=moe_config,
+                quant_config=quant_config,
+                max_num_tokens=max_num_tokens,
+                num_dispatchers=num_dispatchers,
+            )
+        if fixed_use_low_latency is True:
+            self.ht_experts = self.ll_experts
+        elif fixed_use_low_latency is False:
+            self.ll_experts = self.ht_experts
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if self._fixed_use_low_latency is not None:
+            self._current().process_weights_after_loading(layer)
+            return
+        self.ht_experts.process_weights_after_loading(layer)
+        self.ll_experts.process_weights_after_loading(layer)
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        return DeepEPDeepGemmW4A8ContiguousExperts._supports_quant_scheme(
+            weight_key, activation_key
         )
 
 

--- a/vllm_hcu/model_executor/layers/fused_moe/experts/dpsk_v4_deep_gemm_moe.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/experts/dpsk_v4_deep_gemm_moe.py
@@ -1007,6 +1007,7 @@ def _make_deepep_auto_deepgemm_moe_kernel(
     moe_quant_config: FusedMoEQuantConfig,
     moe_config: FusedMoEConfig,
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+    experts_cls: type[DeepEPAutoDeepGemmExperts] | None = None,
 ) -> mk.FusedMoEKernel:
     from vllm.model_executor.layers.fused_moe.all2all_utils import (
         maybe_make_prepare_finalize,
@@ -1032,7 +1033,9 @@ def _make_deepep_auto_deepgemm_moe_kernel(
     fixed_use_low_latency = dspark_mooncake_pd_use_low_latency(
         get_current_vllm_config_or_none()
     )
-    experts = DeepEPAutoDeepGemmExperts(
+    if experts_cls is None:
+        experts_cls = DeepEPAutoDeepGemmExperts
+    experts = experts_cls(
         moe_config=moe_config,
         quant_config=moe_quant_config,
         max_num_tokens=max_num_tokens,
@@ -1075,4 +1078,21 @@ def make_deepep_auto_deepgemm_int8_moe_kernel(
         moe_quant_config=moe_quant_config,
         moe_config=moe_config,
         routing_tables=routing_tables,
+    )
+
+
+def make_deepep_auto_deepgemm_w4a8_moe_kernel(
+    moe_quant_config: FusedMoEQuantConfig,
+    moe_config: FusedMoEConfig,
+    routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+) -> mk.FusedMoEKernel:
+    """Build the unified DeepEP HT/LL kernel for SlimQuant W4A8."""
+
+    if moe_quant_config.weight_quant_dtype != "int4":
+        raise ValueError("SlimQuant auto factory requires INT4 W4A8 quantization")
+    return _make_deepep_auto_deepgemm_moe_kernel(
+        moe_quant_config=moe_quant_config,
+        moe_config=moe_config,
+        routing_tables=routing_tables,
+        experts_cls=DeepEPAutoW4A8Experts,
     )

--- a/vllm_hcu/model_executor/layers/fused_moe/experts/dpsk_v4_deep_gemm_moe.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/experts/dpsk_v4_deep_gemm_moe.py
@@ -958,6 +958,8 @@ class DeepEPAutoW4A8Experts(DeepEPAutoDeepGemmExperts):
     _LAYOUT_MARKER = "_slimquant_w4a8_deepep_auto_layout"
     _PACKED_W13 = "_slimquant_w4a8_deepep_auto_packed_w13"
     _PACKED_W2 = "_slimquant_w4a8_deepep_auto_packed_w2"
+    _PACKING_LAYOUT = "packing"
+    _REPACKING_LAYOUT = "repacking"
 
     def __init__(
         self,
@@ -1027,6 +1029,7 @@ class DeepEPAutoW4A8Experts(DeepEPAutoDeepGemmExperts):
             # v0.25.1 layerwise reload processes temporary raw Parameters and
             # then restores the original kernel storage. Reuse that storage so
             # the temporary allocation cannot become a second resident owner.
+            setattr(layer, self._LAYOUT_MARKER, self._REPACKING_LAYOUT)
             reloaded = self._pack_in_place(runtime, weights)
             with torch.no_grad():
                 for owner, weight in zip(owners, reloaded):
@@ -1034,14 +1037,18 @@ class DeepEPAutoW4A8Experts(DeepEPAutoDeepGemmExperts):
             replace_parameter(layer, "w13_weight", owners[0])
             replace_parameter(layer, "w2_weight", owners[1])
             self._bind_packed_owners(runtime, *owners)
+            setattr(layer, self._LAYOUT_MARKER, expected_layout)
             return
 
+        # The packer mutates each registered Parameter in sequence. Mark the
+        # transition first so a partial failure can never be retried as raw.
+        setattr(layer, self._LAYOUT_MARKER, self._PACKING_LAYOUT)
         self._pack_in_place(runtime, weights)
         owners = tuple(weight.detach() for weight in weights)
         setattr(layer, self._PACKED_W13, owners[0])
         setattr(layer, self._PACKED_W2, owners[1])
-        setattr(layer, self._LAYOUT_MARKER, expected_layout)
         self._bind_packed_owners(runtime, *owners)
+        setattr(layer, self._LAYOUT_MARKER, expected_layout)
 
     @staticmethod
     def _same_storage(left: torch.Tensor, right: torch.Tensor) -> bool:

--- a/vllm_hcu/model_executor/layers/fused_moe/experts/dpsk_v4_deep_gemm_moe.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/experts/dpsk_v4_deep_gemm_moe.py
@@ -1188,6 +1188,44 @@ def make_deepep_auto_deepgemm_w4a8_moe_kernel(
 
     if moe_quant_config.weight_quant_dtype != "int4":
         raise ValueError("SlimQuant auto factory requires INT4 W4A8 quantization")
+    if (
+        moe_quant_config.quant_dtype != torch.int8
+        or not moe_quant_config.is_per_act_token
+        or moe_quant_config.is_block_quantized
+    ):
+        raise ValueError(
+            "SlimQuant auto factory requires dynamic per-token INT8 "
+            "activation quantization"
+        )
+    if (
+        moe_quant_config.per_out_ch_quant
+        or moe_quant_config.w1_scale is None
+        or moe_quant_config.w2_scale is None
+    ):
+        raise ValueError(
+            "SlimQuant auto factory requires symmetric INT4 channel weight "
+            "scales for both MoE GEMMs"
+        )
+    unsupported_metadata = (
+        moe_quant_config.a1_scale,
+        moe_quant_config.a2_scale,
+        moe_quant_config.a1_gscale,
+        moe_quant_config.a2_gscale,
+        moe_quant_config.w1_zp,
+        moe_quant_config.w2_zp,
+        moe_quant_config.g1_alphas,
+        moe_quant_config.g2_alphas,
+        moe_quant_config.w1_bias,
+        moe_quant_config.w2_bias,
+        moe_quant_config.gemm1_alpha,
+        moe_quant_config.gemm1_beta,
+        moe_quant_config.gemm1_clamp_limit,
+    )
+    if any(value is not None for value in unsupported_metadata):
+        raise ValueError(
+            "SlimQuant auto factory requires symmetric W4A8 without "
+            "auxiliary scales, zero points, biases, or clamps"
+        )
     return _make_deepep_auto_deepgemm_moe_kernel(
         moe_quant_config=moe_quant_config,
         moe_config=moe_config,

--- a/vllm_hcu/model_executor/layers/fused_moe/experts/dpsk_v4_deep_gemm_moe.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/experts/dpsk_v4_deep_gemm_moe.py
@@ -953,7 +953,11 @@ class DeepEPAutoDeepGemmExperts(mk.FusedMoEExpertsModular):
 
 
 class DeepEPAutoW4A8Experts(DeepEPAutoDeepGemmExperts):
-    """Select the W4A8 HIPC layout captured by ``deepep_auto``."""
+    """Own one in-place W4A8 HIPC layout for strict ``deepep_auto``."""
+
+    _LAYOUT_MARKER = "_slimquant_w4a8_deepep_auto_layout"
+    _PACKED_W13 = "_slimquant_w4a8_deepep_auto_packed_w13"
+    _PACKED_W2 = "_slimquant_w4a8_deepep_auto_packed_w2"
 
     def __init__(
         self,
@@ -987,11 +991,98 @@ class DeepEPAutoW4A8Experts(DeepEPAutoDeepGemmExperts):
             self.ll_experts = self.ht_experts
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        if self._fixed_use_low_latency is not None:
-            self._current().process_weights_after_loading(layer)
+        from vllm_hcu.model_executor.layers.quantization import (
+            slimquant_w4a8_deepgemm_runtime as runtime,
+        )
+
+        expected_layout = {
+            None: "shared_hipc_auto",
+            False: "shared_hipc_contiguous",
+            True: "shared_hipc_n32",
+        }[self._fixed_use_low_latency]
+        marker = getattr(layer, self._LAYOUT_MARKER, None)
+        owners = (
+            getattr(layer, self._PACKED_W13, None),
+            getattr(layer, self._PACKED_W2, None),
+        )
+        if marker is None and any(owner is not None for owner in owners):
+            self._invalid_marker()
+        if marker is not None and marker != expected_layout:
+            self._invalid_marker()
+        runtime._validate_w4a8_channel_weights(layer)
+        weights = (layer.w13_weight, layer.w2_weight)
+        if marker is not None:
+            if any(
+                not isinstance(owner, torch.Tensor)
+                or owner.dtype != torch.int8
+                or owner.ndim != 3
+                or tuple(owner.shape) != tuple(weight.shape)
+                for owner, weight in zip(owners, weights)
+            ):
+                self._invalid_marker()
+            if all(self._same_storage(a, b) for a, b in zip(owners, weights)):
+                self._bind_packed_owners(runtime, *owners)
+                return
+
+            # v0.25.1 layerwise reload processes temporary raw Parameters and
+            # then restores the original kernel storage. Reuse that storage so
+            # the temporary allocation cannot become a second resident owner.
+            reloaded = self._pack_in_place(runtime, weights)
+            with torch.no_grad():
+                for owner, weight in zip(owners, reloaded):
+                    owner.copy_(weight)
+            replace_parameter(layer, "w13_weight", owners[0])
+            replace_parameter(layer, "w2_weight", owners[1])
+            self._bind_packed_owners(runtime, *owners)
             return
-        self.ht_experts.process_weights_after_loading(layer)
-        self.ll_experts.process_weights_after_loading(layer)
+
+        self._pack_in_place(runtime, weights)
+        owners = tuple(weight.detach() for weight in weights)
+        setattr(layer, self._PACKED_W13, owners[0])
+        setattr(layer, self._PACKED_W2, owners[1])
+        setattr(layer, self._LAYOUT_MARKER, expected_layout)
+        self._bind_packed_owners(runtime, *owners)
+
+    @staticmethod
+    def _same_storage(left: torch.Tensor, right: torch.Tensor) -> bool:
+        return (
+            left.untyped_storage().data_ptr()
+            == right.untyped_storage().data_ptr()
+        )
+
+    def _pack_in_place(self, runtime, weights):
+        with torch.no_grad():
+            packed = tuple(
+                runtime.pack_w4a8_moe_hipc_weight(weight).detach()
+                for weight in weights
+            )
+        if any(
+            weight.ndim != 3 or not self._same_storage(weight, source)
+            for weight, source in zip(packed, weights)
+        ):
+            raise RuntimeError(
+                "SlimQuant W4A8 deepep_auto packer must reuse rank-3 "
+                "weight storage"
+            )
+        return packed
+
+    @staticmethod
+    def _invalid_marker() -> None:
+        raise RuntimeError(
+            "invalid SlimQuant W4A8 deepep_auto marker or owner shape state"
+        )
+
+    def _bind_packed_owners(self, runtime, w13, w2) -> None:
+        if self._fixed_use_low_latency is not True:
+            self.ht_experts._deepgemm_w13 = w13
+            self.ht_experts._deepgemm_w2 = w2
+        if self._fixed_use_low_latency is not False:
+            self.ll_experts._deepgemm_w13 = (
+                runtime.view_w4a8_moe_hipc_weight_n32_layout(w13).detach()
+            )
+            self.ll_experts._deepgemm_w2 = (
+                runtime.view_w4a8_moe_hipc_weight_n32_layout(w2).detach()
+            )
 
     @staticmethod
     def _supports_quant_scheme(

--- a/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
+++ b/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
@@ -222,6 +222,7 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
         )
 
         if slimquant_w4a8_uses_deepep_auto(getattr(self, "moe", None)):
+            self.moe_quant_config = self.get_fused_moe_quant_config(layer)
             if self.moe_quant_config is None:
                 raise RuntimeError(
                     "SlimQuant W4A8 deepep_auto requires its MoE quantization "
@@ -234,7 +235,7 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
             self.moe_kernel = make_deepep_auto_deepgemm_w4a8_moe_kernel(
                 moe_quant_config=self.moe_quant_config,
                 moe_config=self.moe,
-                routing_tables=None,
+                routing_tables=layer._expert_routing_tables(),
             )
             fused_experts = getattr(self.moe_kernel, "fused_experts", None)
             experts = getattr(fused_experts, "experts", fused_experts)

--- a/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
+++ b/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
@@ -8,9 +8,9 @@ import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from compressed_tensors.quantization import QuantizationStrategy
 from torch.nn.parameter import Parameter
 from vllm.model_executor.layers.fused_moe import (
-    FusedMoE,
     FusedMoEMethodBase,
     FusedMoeWeightScaleSupported,
+    RoutedExperts,
 )
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
 from vllm.model_executor.layers.linear import LinearBase, LinearMethodBase
@@ -60,7 +60,7 @@ class SlimQuantW4A8Int8Config(QuantizationConfig):
                 QuantizationStrategy.CHANNEL, False, True
             )
             return SlimQuantW4A8Int8LinearMethod(self)
-        if isinstance(layer, FusedMoE):
+        if isinstance(layer, RoutedExperts):
             return SlimQuantW4A8Int8AiterMoEMethod(self, layer.moe_config)
         return None
 
@@ -262,7 +262,7 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
 
     def apply(
         self,
-        layer: FusedMoE,
+        layer: RoutedExperts,
         x: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,

--- a/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
+++ b/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
@@ -292,13 +292,32 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
             slimquant_w4a8_uses_deepep_auto,
         )
 
-        if slimquant_w4a8_uses_deepep_auto(getattr(self, "moe", None)):
-            if self.moe_kernel is None:
+        moe_kernel = getattr(self, "moe_kernel", None)
+        uses_deepep_auto = moe_kernel is not None
+        if not uses_deepep_auto:
+            uses_deepep_auto = slimquant_w4a8_uses_deepep_auto(
+                getattr(self, "moe", None)
+            )
+        if uses_deepep_auto:
+            if moe_kernel is None:
                 raise RuntimeError(
                     "SlimQuant W4A8 deepep_auto kernel was not initialized; "
                     "process_weights_after_loading must run before apply"
                 )
-            return self.moe_kernel.apply(
+            from vllm_hcu.model_executor.layers.fused_moe.aiter_moe_dispatch import (
+                resolve_aiter_expert_maps,
+            )
+
+            global_num_experts = getattr(
+                layer,
+                "global_num_experts",
+                getattr(self.moe, "num_experts", -1),
+            )
+            native_expert_map, _ = resolve_aiter_expert_maps(
+                getattr(layer, "expert_map", None),
+                global_num_experts,
+            )
+            return moe_kernel.apply(
                 hidden_states=x,
                 w1=layer.w13_weight,
                 w2=layer.w2_weight,
@@ -309,12 +328,8 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
                     "activation",
                     getattr(self.moe, "activation", None),
                 ),
-                global_num_experts=getattr(
-                    layer,
-                    "global_num_experts",
-                    getattr(self.moe, "num_experts", -1),
-                ),
-                expert_map=getattr(layer, "expert_map", None),
+                global_num_experts=global_num_experts,
+                expert_map=native_expert_map,
                 apply_router_weight_on_input=getattr(
                     layer,
                     "apply_router_weight_on_input",

--- a/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
+++ b/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
@@ -217,6 +217,35 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
             if not isinstance(parameter, Parameter):
                 raise TypeError(f"SlimQuant W4A8 requires Parameter {name}")
             parameter.requires_grad_(False)
+        from vllm_hcu.model_executor.layers.fused_moe.deepep_runtime import (
+            slimquant_w4a8_uses_deepep_auto,
+        )
+
+        if slimquant_w4a8_uses_deepep_auto(getattr(self, "moe", None)):
+            if self.moe_quant_config is None:
+                raise RuntimeError(
+                    "SlimQuant W4A8 deepep_auto requires its MoE quantization "
+                    "config before weight postprocessing"
+                )
+            from vllm_hcu.model_executor.layers.fused_moe.experts.dpsk_v4_deep_gemm_moe import (
+                make_deepep_auto_deepgemm_w4a8_moe_kernel,
+            )
+
+            self.moe_kernel = make_deepep_auto_deepgemm_w4a8_moe_kernel(
+                moe_quant_config=self.moe_quant_config,
+                moe_config=self.moe,
+                routing_tables=None,
+            )
+            fused_experts = getattr(self.moe_kernel, "fused_experts", None)
+            experts = getattr(fused_experts, "experts", fused_experts)
+            process = getattr(experts, "process_weights_after_loading", None)
+            if not callable(process):
+                raise RuntimeError(
+                    "SlimQuant W4A8 deepep_auto did not construct modular "
+                    "experts before weight postprocessing"
+                )
+            process(layer)
+            return
         if getattr(self.moe, "moe_backend", "auto") == "triton":
             from vllm_hcu.model_executor.layers.quantization.compressed_tensors_moe_runtime import (
                 prepare_vllm_w4a8_moe,
@@ -241,9 +270,6 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
         **_,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
 
-        # RoutedExperts owns shared-expert execution and combines its result.
-        del shared_experts, shared_experts_input
-
         if x.dim() != 2:
             raise ValueError(
                 "SlimQuant W4A8 AITER Triton MoE expects rank-2 hidden states, "
@@ -261,6 +287,44 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
                 f"token count as x, got x={tuple(x.shape)}, "
                 f"topk_ids={tuple(topk_ids.shape)}"
             )
+        from vllm_hcu.model_executor.layers.fused_moe.deepep_runtime import (
+            slimquant_w4a8_uses_deepep_auto,
+        )
+
+        if slimquant_w4a8_uses_deepep_auto(getattr(self, "moe", None)):
+            if self.moe_kernel is None:
+                raise RuntimeError(
+                    "SlimQuant W4A8 deepep_auto kernel was not initialized; "
+                    "process_weights_after_loading must run before apply"
+                )
+            return self.moe_kernel.apply(
+                hidden_states=x,
+                w1=layer.w13_weight,
+                w2=layer.w2_weight,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                activation=getattr(
+                    layer,
+                    "activation",
+                    getattr(self.moe, "activation", None),
+                ),
+                global_num_experts=getattr(
+                    layer,
+                    "global_num_experts",
+                    getattr(self.moe, "num_experts", -1),
+                ),
+                expert_map=getattr(layer, "expert_map", None),
+                apply_router_weight_on_input=getattr(
+                    layer,
+                    "apply_router_weight_on_input",
+                    False,
+                ),
+                shared_experts=shared_experts,
+                shared_experts_input=shared_experts_input,
+            )
+        # Pure TP shared experts remain runner-owned, matching the latest
+        # unified AITER/Triton contract.
+        del shared_experts, shared_experts_input
         from vllm_hcu.model_executor.layers.quantization import (
             compressed_tensors_moe_runtime as moe_runtime,
         )

--- a/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8_deepgemm_runtime.py
+++ b/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8_deepgemm_runtime.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""DeepGEMM expert layouts for canonical SlimQuant W4A8 MoE weights."""
+
+from __future__ import annotations
+
+import functools
+
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEQuantConfig,
+)
+from vllm.model_executor.layers.fused_moe.deep_gemm_utils import (
+    compute_aligned_M,
+    deepgemm_moe_permute,
+    deepgemm_unpermute_and_reduce,
+)
+from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceNoOP,
+)
+from vllm.model_executor.layers.fused_moe.utils import _resize_cache
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kInt4W4A8StaticChannelSym,
+    kInt8DynamicTokenSym,
+)
+from vllm_hcu.model_executor.layers.fused_moe.experts.batched_deep_gemm_moe import (
+    BatchedDeepGemmExperts,
+)
+
+logger = init_logger(__name__)
+
+
+@functools.lru_cache(maxsize=None)
+def _deepgemm_op(name: str):
+    import deepgemm
+
+    return getattr(deepgemm, name)
+
+
+def pack_w4a8_moe_hipc_weight(weight: torch.Tensor) -> torch.Tensor:
+    return _deepgemm_op("pack_w4a8_moe_hipc_weight")(weight)
+
+
+def view_w4a8_moe_hipc_weight_n32_layout(
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    return _deepgemm_op("view_w4a8_moe_hipc_weight_n32_layout")(weight)
+
+
+def m_grouped_w4a8_gemm_nt_contiguous_hipc(*args, **kwargs):
+    return _deepgemm_op("m_grouped_w4a8_gemm_nt_contiguous_hipc")(
+        *args, **kwargs
+    )
+
+
+@functools.lru_cache(maxsize=None)
+def _lightop_op(name: str):
+    import lightop
+
+    return getattr(lightop, name)
+
+
+def fuse_silu_mul_quant(*args, **kwargs):
+    return _lightop_op("fuse_silu_mul_quant")(*args, **kwargs)
+
+
+def _canonical_weight_signature(layer: torch.nn.Module) -> tuple[object, ...]:
+    return (
+        id(layer.w13_weight),
+        layer.w13_weight._version,
+        tuple(layer.w13_weight.shape),
+        id(layer.w2_weight),
+        layer.w2_weight._version,
+        tuple(layer.w2_weight.shape),
+    )
+
+
+def _validate_w4a8_channel_weights(layer: torch.nn.Module) -> None:
+    w13 = layer.w13_weight
+    w2 = layer.w2_weight
+    if (
+        w13.dtype != torch.int8
+        or w2.dtype != torch.int8
+        or w13.ndim != 3
+        or w2.ndim != 3
+        or w13.size(0) != w2.size(0)
+    ):
+        raise RuntimeError(
+            "SlimQuant W4A8 DeepGEMM requires packed INT8 rank-3 weights, "
+            f"got w13={tuple(w13.shape)}/{w13.dtype} "
+            f"w2={tuple(w2.shape)}/{w2.dtype}"
+        )
+
+    logical_hidden = w13.size(2) * 2
+    logical_intermediate = w2.size(2) * 2
+    if w2.size(1) != logical_hidden or w13.size(1) != 2 * logical_intermediate:
+        raise RuntimeError(
+            "SlimQuant W4A8 DeepGEMM packed weight dimensions are inconsistent: "
+            f"w13={tuple(w13.shape)} w2={tuple(w2.shape)}"
+        )
+
+    local_experts = w13.size(0)
+    for name, scale, output_size in (
+        ("w13_weight_scale", layer.w13_weight_scale, w13.size(1)),
+        ("w2_weight_scale", layer.w2_weight_scale, w2.size(1)),
+    ):
+        valid = (
+            scale.dtype == torch.float32
+            and scale.ndim in (2, 3)
+            and scale.size(0) == local_experts
+            and scale.size(1) == output_size
+            and (scale.ndim == 2 or scale.size(2) == 1)
+        )
+        if not valid:
+            raise RuntimeError(
+                f"SlimQuant W4A8 DeepGEMM has invalid {name}: "
+                f"shape={tuple(scale.shape)} dtype={scale.dtype}"
+            )
+
+
+class DeepEPDeepGemmW4A8ContiguousExperts(TritonExperts):
+    """Contiguous HIPC W4A8 experts for DeepEP high-throughput dispatch."""
+
+    ALIGNMENT = 256
+    _CACHE_PREFIX = "_slimquant_w4a8_deepgemm_contiguous"
+
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig,
+    ) -> None:
+        super().__init__(moe_config, quant_config)
+        self._deepgemm_w13: torch.Tensor | None = None
+        self._deepgemm_w2: torch.Tensor | None = None
+        logger.info_once(
+            "Using SlimQuant W4A8 contiguous HIPC DeepGEMM experts."
+        )
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        return (weight_key, activation_key) == (
+            kInt4W4A8StaticChannelSym,
+            kInt8DynamicTokenSym,
+        )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        """Pack clones once while retaining checkpoint parameters as owners."""
+
+        _validate_w4a8_channel_weights(layer)
+        signature = _canonical_weight_signature(layer)
+        cache_signature_name = f"{self._CACHE_PREFIX}_source"
+        cache_w13_name = f"{self._CACHE_PREFIX}_w13"
+        cache_w2_name = f"{self._CACHE_PREFIX}_w2"
+        if getattr(layer, cache_signature_name, None) != signature:
+            with torch.no_grad():
+                packed_w13 = pack_w4a8_moe_hipc_weight(
+                    layer.w13_weight.detach().clone()
+                ).detach()
+                packed_w2 = pack_w4a8_moe_hipc_weight(
+                    layer.w2_weight.detach().clone()
+                ).detach()
+            setattr(layer, cache_w13_name, packed_w13)
+            setattr(layer, cache_w2_name, packed_w2)
+            setattr(layer, cache_signature_name, signature)
+
+        self._deepgemm_w13 = getattr(layer, cache_w13_name)
+        self._deepgemm_w2 = getattr(layer, cache_w2_name)
+
+    def moe_problem_size(
+        self,
+        a1: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> tuple[int, int, int, int, int]:
+        del w1, w2
+        if self.w1_scale is None or self.w2_scale is None:
+            raise RuntimeError("SlimQuant W4A8 DeepGEMM requires weight scales")
+        return (
+            self.w1_scale.size(0),
+            a1.size(0),
+            self.w1_scale.size(1),
+            self.w2_scale.size(1),
+            topk_ids.size(1),
+        )
+
+    def finalize_weight_and_reduce_impl(self):
+        return TopKWeightAndReduceNoOP()
+
+    def workspace_shapes(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        topk: int,
+        global_num_experts: int,
+        local_num_experts: int,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        activation: MoEActivation,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        del global_num_experts
+        m_aligned = compute_aligned_M(
+            M=M,
+            num_topk=topk,
+            local_num_experts=local_num_experts,
+            alignment=self.ALIGNMENT,
+            expert_tokens_meta=expert_tokens_meta,
+        )
+        activation_out_dim = self.adjust_N_for_activation(N, activation)
+        return (
+            (m_aligned, max(activation_out_dim, K)),
+            (m_aligned, max(N, K)),
+            (M, K),
+        )
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool,
+    ) -> None:
+        del global_num_experts, a2_scale, apply_router_weight_on_input
+        if hidden_states.size(0) == 0:
+            return
+        if activation != MoEActivation.SILU:
+            raise NotImplementedError(
+                "SlimQuant W4A8 DeepGEMM supports only SiLU activation"
+            )
+        if a1q_scale is None:
+            raise RuntimeError(
+                "SlimQuant W4A8 DeepGEMM requires per-token activation scales"
+            )
+        if self.w1_scale is None or self.w2_scale is None:
+            raise RuntimeError("SlimQuant W4A8 DeepGEMM requires weight scales")
+        if self._deepgemm_w13 is None or self._deepgemm_w2 is None:
+            raise RuntimeError(
+                "SlimQuant W4A8 DeepGEMM weights were not packed before apply"
+            )
+
+        local_num_experts, _, N, K, _ = self.moe_problem_size(
+            hidden_states, w1, w2, topk_ids
+        )
+        m_aligned = compute_aligned_M(
+            M=topk_ids.size(0),
+            num_topk=topk_ids.size(1),
+            local_num_experts=local_num_experts,
+            alignment=self.ALIGNMENT,
+            expert_tokens_meta=expert_tokens_meta,
+        )
+        input_workspace = _resize_cache(
+            workspace13.view(dtype=hidden_states.dtype), (m_aligned, K)
+        )
+        input_tensor, input_scale, m_indices, inv_perm, _ = (
+            deepgemm_moe_permute(
+                aq=hidden_states,
+                aq_scale=self._ensure_2d_scale(a1q_scale),
+                topk_ids=topk_ids,
+                local_num_experts=local_num_experts,
+                expert_map=expert_map,
+                expert_tokens_meta=expert_tokens_meta,
+                aq_out=input_workspace,
+            )
+        )
+        m_indices = m_indices.to(dtype=torch.int32).contiguous()
+
+        gateup_output = _resize_cache(workspace2, (m_aligned, N))
+        m_grouped_w4a8_gemm_nt_contiguous_hipc(
+            (input_tensor, input_scale),
+            (self._deepgemm_w13, self.w1_scale),
+            gateup_output,
+            m_indices,
+        )
+        activation_out_dim = self.adjust_N_for_activation(N, activation)
+        quant_output = _resize_cache(
+            workspace13.view(dtype=torch.int8),
+            (m_aligned, activation_out_dim),
+        )
+        q_activation, q_activation_scale = fuse_silu_mul_quant(
+            gateup_output,
+            output=quant_output,
+            expert_ids=m_indices,
+        )
+        down_output = _resize_cache(workspace2, (m_aligned, K))
+        m_grouped_w4a8_gemm_nt_contiguous_hipc(
+            (q_activation, q_activation_scale),
+            (self._deepgemm_w2, self.w2_scale),
+            down_output,
+            m_indices,
+        )
+        deepgemm_unpermute_and_reduce(
+            a=down_output,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            inv_perm=inv_perm,
+            expert_map=expert_map,
+            output=output,
+        )
+
+    @staticmethod
+    def _ensure_2d_scale(scale: torch.Tensor) -> torch.Tensor:
+        return scale.unsqueeze(-1) if scale.ndim == 1 else scale
+
+
+class DeepEPDeepGemmW4A8BatchedExperts(BatchedDeepGemmExperts):
+    """N32 HIPC W4A8 experts for DeepEP low-latency dispatch."""
+
+    _CACHE_PREFIX = "_slimquant_w4a8_deepgemm_masked"
+
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig,
+        max_num_tokens: int,
+        num_dispatchers: int,
+    ) -> None:
+        super().__init__(
+            moe_config=moe_config,
+            quant_config=quant_config,
+            max_num_tokens=max_num_tokens,
+            num_dispatchers=num_dispatchers,
+        )
+        self._deepgemm_w13: torch.Tensor | None = None
+        self._deepgemm_w2: torch.Tensor | None = None
+        logger.info_once("Using SlimQuant W4A8 masked N32 HIPC DeepGEMM experts.")
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        """Cache N32 views derived from canonical checkpoint parameters."""
+
+        _validate_w4a8_channel_weights(layer)
+        signature = _canonical_weight_signature(layer)
+        cache_signature_name = f"{self._CACHE_PREFIX}_source"
+        cache_w13_name = f"{self._CACHE_PREFIX}_w13"
+        cache_w2_name = f"{self._CACHE_PREFIX}_w2"
+        if getattr(layer, cache_signature_name, None) != signature:
+            with torch.no_grad():
+                packed_w13 = pack_w4a8_moe_hipc_weight(
+                    layer.w13_weight.detach().clone()
+                )
+                packed_w2 = pack_w4a8_moe_hipc_weight(
+                    layer.w2_weight.detach().clone()
+                )
+                masked_w13 = view_w4a8_moe_hipc_weight_n32_layout(
+                    packed_w13
+                ).detach()
+                masked_w2 = view_w4a8_moe_hipc_weight_n32_layout(
+                    packed_w2
+                ).detach()
+            setattr(layer, cache_w13_name, masked_w13)
+            setattr(layer, cache_w2_name, masked_w2)
+            setattr(layer, cache_signature_name, signature)
+
+        self._deepgemm_w13 = getattr(layer, cache_w13_name)
+        self._deepgemm_w2 = getattr(layer, cache_w2_name)
+
+
+DeepEPDeepGemmW4A8MaskedExperts = DeepEPDeepGemmW4A8BatchedExperts
+
+
+__all__ = [
+    "DeepEPDeepGemmW4A8BatchedExperts",
+    "DeepEPDeepGemmW4A8ContiguousExperts",
+    "DeepEPDeepGemmW4A8MaskedExperts",
+]


### PR DESCRIPTION
## 修改内容 Summary

### 设计边界

本 MR 基于 `v0.25.1@04c7e9d` 重新整理，只补充当前基线缺失的 SlimQuant W4A8 DP+EP DeepGEMM 能力：

- 纯 TP：继续使用 `v0.25.1` 已有的统一 AITER dispatcher，由 AITER runtime 自行选择 ASM/HIPC/Triton 等可用实现；本 MR 不新增竞争路由。
- DP+EP：仅接受 `dp_size > 1`、EP 已启用且 `--all2all-backend deepep_auto` 的严格组合；MoE backend 为 `auto` 或 `deep_gemm` 时进入 W4A8 DeepGEMM。
- `deepep_auto` 根据同步后的 forward snapshot 自动选择：高吞吐使用 contiguous HIPC W4A8 DeepGEMM，低延时使用 masked N32 HIPC W4A8 DeepGEMM。
- 每个本地 W4A8 权重只进行一次原地 HIPC pack；HT rank-3 owner 与 LL N32 view 共享 storage，避免为两种模式各复制一份约 1512 MiB/层/卡的 packed 权重。
- channel scale 仅在量化边界转换一次；补齐 expert map、空 dispatch、固定 Mooncake P/D role、reload/sleep/state-dict 和部分 pack 失败时的 fail-closed 处理。
- 修复 ROCm/AITER `RoutedExperts.expert_map` 返回 `expert_mask` 时被 W4A8 DeepGEMM 当作 global-to-local map 使用的问题；进入 kernel 前统一恢复 `_vllm_hcu_native_expert_map`，HT/LL 的 permute、token count 与 unpermute 使用同一 native map。
- `deepep_auto` 在模型构造阶段对 DeepSeek-V4、SiLU、HCU ROCm、HT/LL HIPC/LightOP 算子和完整 INT4-weight/INT8-dynamic-token scheme 执行 fail-closed；LightOP preflight 同时要求 HT 的 `fuse_silu_mul_quant` 与 LL 的 `fuse_silu_mul_quant_ep`；forward 复用已初始化 kernel，不依赖临时 vLLM config 上下文。
- sampler、DeepSeek-V4/DSpark 公共架构、LightOp/AITER 公共选择均由最新 `v0.25.1` 负责。本 MR 的 `hcu_model_runner.py` 和 `test_hcu_sampler.py` 相对基线为零差异。
- 不包含 `.github`、workflow 或 script 修改。

### 后端路线

| 拓扑 | 配置 | 实际路径 |
| --- | --- | --- |
| TP8 | `--tensor-parallel-size 8 --moe-backend aiter` | 基线统一 AITER runtime |
| DP8+EP8 | `--data-parallel-size 8 --enable-expert-parallel --all2all-backend deepep_auto` | DeepEP + W4A8 DeepGEMM；snapshot 自动选择 HT/LL |
| DP+EP 固定 HT/LL | `deepep_high_throughput` / `deepep_low_latency` | 本 MR 对 W4A8 fail closed，避免绕过 auto ownership |

### 服务端命令

TP8 + AITER + DSpark：

```bash
vllm serve /models/DeepSeek-V4-Pro-0813-INT4-Channel \
  --host 0.0.0.0 --port 10140 --trust-remote-code \
  --tokenizer-mode deepseek_v4 --distributed-executor-backend mp \
  --quantization slimquant_w4a8 --tensor-parallel-size 8 \
  --moe-backend aiter --kv-cache-dtype fp8 --block-size 256 \
  --max-model-len 4096 --max-num-batched-tokens 512 --max-num-seqs 8 \
  --gpu-memory-utilization 0.9 \
  --served-model-name deepseek-v4-pro-int4-channel \
  --speculative-config '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
```

DP8 + EP8 + `deepep_auto` + DSpark（已执行的 0.9 profile 命令）：

```bash
vllm serve /models/DeepSeek-V4-Pro-0813-INT4-Channel \
  --host 0.0.0.0 --port 10137 --trust-remote-code \
  --tokenizer-mode deepseek_v4 --distributed-executor-backend mp \
  --quantization slimquant_w4a8 --tensor-parallel-size 1 \
  --data-parallel-size 8 --enable-expert-parallel \
  --all2all-backend deepep_auto --kv-cache-dtype fp8 --block-size 256 \
  --max-model-len 4096 --max-num-batched-tokens 512 --max-num-seqs 8 \
  --gpu-memory-utilization 0.9 \
  --served-model-name deepseek-v4-pro-int4-channel \
  --speculative-config '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
```

容量重试仅把上一条命令改为 `--gpu-memory-utilization 1.0`，其他参数保持不变。

### 客户端命令

服务 ready 后的确定性请求：

```bash
curl --noproxy '*' -sS http://127.0.0.1:10137/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"deepseek-v4-pro-int4-channel","messages":[{"role":"user","content":"Write a Python hello-world program."}],"temperature":0,"max_tokens":128,"chat_template_kwargs":{"thinking":false}}'
```

### 验证状态

- 静态与完整 runtime 回归：`901 passed, 14 warnings in 225.42s`（vLLM `0.25.1`）。
- 与 required CI 相同的 portable contract：`1168 passed, 90 deselected, 14 warnings in 381.39s`；DeepGEMM/LightOP 真卡数值用例归入已注册的 gfx938 accuracy 模块，不在无卡 static runner 执行。
- 远端 required checks（identity、security/SAST、repository/code quality、static gate）均通过。
- 已授权的真实 HCU jobs 在执行测试前被 CI 镜像门禁拦截：仓库变量 `HCU_CI_IMAGE` 当前为可变标签 `0.25.1-latest`，runner 要求 sha256 digest；本 MR 按范围不修改 workflow/scripts，需由仓库维护者修正变量后 rerun。
- production boundary：248 个 Python 文件通过；patch coverage：96/96，未测试模块 0、无效 contract 0。
- TP8+AITER+DSpark：target/draft 均完成加载并选中 AITER W4A8 `MOE_C`，随后 AITER `need_shuffle=true` 为 64 个 target/draft layer pair 申请约 94.5 GiB 派生布局，模型启动 OOM。此问题属于基线 AITER canonical-layout 能力边界，本 MR 未增加破坏统一 AITER ownership 的 TP 特例。
- DP8+EP8+`deepep_auto`+DSpark：8 个 rank 的 target、post-load、draft 均通过，profile 已进入 DeepEP auto contiguous high-throughput；0.9 配置随后因 KV admission 为 `-13.86 GiB` 未能启动 API。
- `--gpu-memory-utilization 1.0` 容量重试当时被外部占用全部 8 张 HCU 的任务阻塞，未执行；没有重置或终止非本任务进程。
- 因 API 尚未 ready，客户端请求、DSpark acceptance counters 和 HumanEval-32 尚未完成，不能声明精度结果。

### Code review

- 本轮复审发现的 P1（AITER mask/native map 混用导致非 identity EP 静默错路由）和 P2（W4A8 deepep_auto 选择未 fail closed）均已修复并增加回归测试。
- 最新复审发现的 P2（HIPC preflight 漏检 LL `fuse_silu_mul_quant_ep`）已补齐初始化期 fail-closed 和缺失符号回归测试；P3 已把计划文档命令修正为 pytest 收集入口 `tests/accuracy/test_unified_aiter_moe_operator.py`，collect-only 成功收集 23 项。
- Critical：0。
- Important：0。
- Minor：1——真实 CuMem level-1 sleep/wake 尚缺完整设备集成验证；现有覆盖验证了同地址 storage restore 与 layerwise reload contract。
- 已删除自有 dummy sampler 策略并与官方/HYGON `v0.25.1` 保持一致；该问题如需继续处理，将拆分为独立 MR。
