### PR TITLE
fix(hcu): bound AITER BF16 MoE shuffle memory

### DIFF
--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -179,6 +179,46 @@ def test_aiter_dispatch_selector_passes_problem_without_forcing_solution(
     assert "device" not in captured
 
 
+def test_aiter_dispatch_can_pin_asm_shuffle_solution(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, object] = {}
+    expected = SimpleNamespace(solution_type="asm", need_shuffle=True)
+
+    def get_config(**kwargs: object):
+        captured.update(kwargs)
+        return True, expected
+
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module("aiter.moe", get_aiter_moe_config=get_config),
+    )
+    problem = AiterMoeProblem(
+        M=1,
+        E=2,
+        N1=8,
+        N2=4,
+        K=4,
+        top_k=2,
+        block_size=0,
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+        quant_type="w16a16",
+        use_shuffle=True,
+    )
+
+    actual = select_aiter_moe_config(
+        problem,
+        cache_owner=torch.empty(1),
+        solution_type="asm",
+    )
+
+    assert actual is expected
+    assert captured["spec_sol_type"] == "asm"
+    assert captured["use_shuffle"] == 1
+
+
 def test_aiter_dispatch_selector_returns_none_only_for_explicit_no_solution(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -2640,7 +2680,93 @@ def test_aiter_w16a16_routes_public_api_with_canonical_weights(
     assert execute_calls[0]["gemm1_limit"] == 7.5
 
 
-def test_aiter_w16a16_post_load_preserves_canonical_parameters(
+def test_aiter_w16a16_reuses_installed_asm_layout_without_reshuffle(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_fake_aiter(monkeypatch)
+    monkeypatch.setattr(aiter_runtime, "is_aiter_moe_requested", lambda: True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_AITER_MOE_SHUFFLE", True)
+    w1 = torch.ones(3, 8, 4)
+    w2 = torch.ones(3, 4, 4)
+    w1.is_shuffled = True
+    w2.is_shuffled = True
+    selector_calls: list[dict[str, object]] = []
+    execute_calls: list[dict[str, object]] = []
+    config = SimpleNamespace(
+        quant_type="w16a16",
+        solution_type="asm",
+        need_shuffle=True,
+        config={},
+    )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            get_aiter_moe_config=lambda **kwargs: (
+                selector_calls.append(kwargs) or True,
+                config,
+            ),
+            aiter_moe_shfl_weight=lambda *_args, **_kwargs: pytest.fail(
+                "installed ASM weights must not be shuffled again"
+            ),
+            aiter_moe=lambda **kwargs: execute_calls.append(kwargs)
+            or kwargs["hidden_states"].clone(),
+        ),
+    )
+
+    aiter_runtime.fused_moe_impl(
+        lambda *_args: pytest.fail("must not delegate"),
+        torch.ones(2, 4),
+        w1,
+        w2,
+        torch.ones(2, 2),
+        torch.zeros(2, 2, dtype=torch.int64),
+        activation_method=0,
+    )
+
+    assert selector_calls[0]["spec_sol_type"] == "asm"
+    assert execute_calls[0]["w1"] is w1
+    assert execute_calls[0]["w2"] is w2
+    assert execute_calls[0]["use_weight_shuffle"] is True
+
+
+def test_aiter_w16a16_shuffled_weights_never_fall_back_to_triton(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_fake_aiter(monkeypatch)
+    monkeypatch.setattr(aiter_runtime, "is_aiter_moe_requested", lambda: True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_AITER_MOE_SHUFFLE", True)
+    w1 = torch.ones(3, 8, 4)
+    w2 = torch.ones(3, 4, 4)
+    w1.is_shuffled = True
+    w2.is_shuffled = True
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            get_aiter_moe_config=lambda **_kwargs: (False, None),
+        ),
+    )
+
+    with pytest.raises(
+        aiter_runtime.HcuAiterRuntimeError,
+        match="no ASM solution",
+    ):
+        aiter_runtime.fused_moe_impl(
+            lambda *_args: pytest.fail("must not delegate"),
+            torch.ones(2, 4),
+            w1,
+            w2,
+            torch.ones(2, 2),
+            torch.zeros(2, 2, dtype=torch.int64),
+            activation_method=0,
+        )
+
+
+def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
     monkeypatch: pytest.MonkeyPatch,
 ):
     from vllm_hcu.model_executor.layers.fused_moe import (
@@ -2681,30 +2807,52 @@ def test_aiter_w16a16_post_load_preserves_canonical_parameters(
         "make_unquantized_moe_kernel",
         lambda **kwargs: kernels.append(kwargs) or object(),
     )
-    prewarm_calls: list[tuple[AiterMoeProblem, object]] = []
     monkeypatch.setattr(
         hcu_unquantized,
-        "prewarm_aiter_moe_config",
-        lambda problem, cache_owner: prewarm_calls.append(
-            (problem, cache_owner)
+        "replace_parameter",
+        lambda owner, name, value, **_kwargs: setattr(
+            owner,
+            name,
+            torch.nn.Parameter(value, requires_grad=False),
         ),
-        raising=False,
     )
+    select_calls: list[tuple[AiterMoeProblem, object, object]] = []
+    config = SimpleNamespace(
+        quant_type="w16a16",
+        solution_type="asm",
+        need_shuffle=True,
+        config={},
+    )
+    monkeypatch.setattr(
+        hcu_unquantized,
+        "select_aiter_moe_config",
+        lambda problem, cache_owner, solution_type=None: select_calls.append(
+            (problem, cache_owner, solution_type)
+        ) or config,
+    )
+    shuffled_w13 = torch.full_like(w13, 13)
+    shuffled_w2 = torch.full_like(w2, 2)
     monkeypatch.setitem(
         sys.modules,
-        "aiter.moe",
-        _module("aiter.moe"),
+        "aiter.moe", _module(
+            "aiter.moe",
+            aiter_moe_shfl_weight=lambda *_args: (shuffled_w13, shuffled_w2),
+        ),
     )
 
     method.process_weights_after_loading(layer)
     method.process_weights_after_loading(layer)
 
-    assert layer.w13_weight is w13
-    assert layer.w2_weight is w2
+    assert layer.w13_weight is not w13
+    assert layer.w2_weight is not w2
+    torch.testing.assert_close(layer.w13_weight, shuffled_w13)
+    torch.testing.assert_close(layer.w2_weight, shuffled_w2)
+    assert layer.w13_weight.is_shuffled is True
+    assert layer.w2_weight.is_shuffled is True
     assert len(kernels) == 1
     assert method.moe_kernel is not None
-    assert len(prewarm_calls) == 1
-    problem, cache_owner = prewarm_calls[0]
+    assert len(select_calls) == 1
+    problem, cache_owner, solution_type = select_calls[0]
     assert problem == AiterMoeProblem(
         M=1,
         E=2,
@@ -2720,6 +2868,46 @@ def test_aiter_w16a16_post_load_preserves_canonical_parameters(
         use_shuffle=True,
     )
     assert cache_owner is w13
+    assert solution_type == "asm"
+
+
+def test_aiter_w16a16_post_load_keeps_canonical_weights_when_shuffle_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm_hcu.model_executor.layers.fused_moe import (
+        unquantized_fused_moe_method as hcu_unquantized,
+    )
+
+    w13 = torch.nn.Parameter(torch.ones(2, 8, 4), requires_grad=False)
+    w2 = torch.nn.Parameter(torch.ones(2, 4, 4), requires_grad=False)
+    layer = SimpleNamespace(w13_weight=w13, w2_weight=w2)
+    method = object.__new__(hcu_unquantized.HcuUnquantizedFusedMoEMethod)
+    method.moe = SimpleNamespace(
+        num_experts=2,
+        experts_per_token=2,
+        in_dtype=torch.bfloat16,
+        activation=SimpleNamespace(value="silu"),
+    )
+    method.unquantized_backend = hcu_unquantized.UnquantizedMoeBackend.AITER
+    method.experts_cls = object
+    method.get_fused_moe_quant_config = lambda _layer: object()
+    monkeypatch.setattr(hcu_unquantized, "_is_hcu_aiter_moe_requested", lambda *_: True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_AITER_MOE_SHUFFLE", False)
+    monkeypatch.setattr(
+        hcu_unquantized,
+        "select_aiter_moe_config",
+        lambda *_args, **_kwargs: pytest.fail("disabled shuffle must not be selected"),
+    )
+    monkeypatch.setattr(
+        hcu_unquantized,
+        "make_unquantized_moe_kernel",
+        lambda **_kwargs: object(),
+    )
+
+    method.process_weights_after_loading(layer)
+
+    assert layer.w13_weight is w13
+    assert layer.w2_weight is w2
 
 
 def test_explicit_aiter_backend_uses_public_router_without_auto_env_gate(

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -2627,6 +2627,10 @@ def test_aiter_w16a16_routes_public_api_with_canonical_weights(
     x = torch.ones(2, 4)
     w1 = torch.ones(3, 8, 4)
     w2 = torch.ones(3, 4, 4)
+    w1.is_shuffled = False
+    w2.is_shuffled = False
+    w1._hcu_aiter_moe_solution_type = "moe_c"
+    w2._hcu_aiter_moe_solution_type = "moe_c"
     topk_weight = torch.ones(2, 2)
     topk_ids = torch.zeros(2, 2, dtype=torch.int64)
     expected = torch.full_like(x, 7)
@@ -2673,7 +2677,7 @@ def test_aiter_w16a16_routes_public_api_with_canonical_weights(
     assert selector_calls[0]["N2"] == 4
     assert selector_calls[0]["K"] == 4
     assert selector_calls[0]["use_shuffle"] == 1
-    assert "spec_sol_type" not in selector_calls[0]
+    assert selector_calls[0]["spec_sol_type"] == "moe_c"
     assert execute_calls[0]["w1"] is w1
     assert execute_calls[0]["w2"] is w2
     assert execute_calls[0]["activation"] == "gelu_tanh"
@@ -2690,6 +2694,8 @@ def test_aiter_w16a16_reuses_installed_asm_layout_without_reshuffle(
     w2 = torch.ones(3, 4, 4)
     w1.is_shuffled = True
     w2.is_shuffled = True
+    w1._hcu_aiter_moe_solution_type = "asm"
+    w2._hcu_aiter_moe_solution_type = "asm"
     selector_calls: list[dict[str, object]] = []
     execute_calls: list[dict[str, object]] = []
     config = SimpleNamespace(
@@ -2766,6 +2772,137 @@ def test_aiter_w16a16_shuffled_weights_never_fall_back_to_triton(
         )
 
 
+def test_aiter_w16a16_installed_canonical_layout_never_runtime_shuffles(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_fake_aiter(monkeypatch)
+    monkeypatch.setattr(aiter_runtime, "is_aiter_moe_requested", lambda: True)
+    w1 = torch.ones(3, 8, 4)
+    w2 = torch.ones(3, 4, 4)
+    for weight in (w1, w2):
+        weight.is_shuffled = False
+        weight._hcu_aiter_moe_solution_type = "triton"
+    config = SimpleNamespace(
+        quant_type="w16a16",
+        solution_type="triton",
+        need_shuffle=True,
+        config={},
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            get_aiter_moe_config=lambda **_kwargs: (True, config),
+            aiter_moe_shfl_weight=lambda *_args: pytest.fail(
+                "installed canonical weights must not be shuffled at runtime"
+            ),
+        ),
+    )
+
+    with pytest.raises(
+        aiter_runtime.HcuAiterRuntimeError,
+        match="layout does not match",
+    ):
+        aiter_runtime.fused_moe_impl(
+            lambda *_args: pytest.fail("must not delegate"),
+            torch.ones(2, 4),
+            w1,
+            w2,
+            torch.ones(2, 2),
+            torch.zeros(2, 2, dtype=torch.int64),
+            activation_method=0,
+        )
+
+
+def test_aiter_w16a16_rejects_runtime_config_for_different_asm_layout(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_fake_aiter(monkeypatch)
+    monkeypatch.setattr(aiter_runtime, "is_aiter_moe_requested", lambda: True)
+    w1 = torch.ones(3, 8, 4)
+    w2 = torch.ones(3, 4, 4)
+    for weight in (w1, w2):
+        weight.is_shuffled = True
+        weight._hcu_aiter_moe_solution_type = "asm"
+        weight._hcu_aiter_moe_weight_layout = (
+            "w16a16",
+            "ASM",
+            True,
+            64,
+        )
+    runtime_config = SimpleNamespace(
+        quant_type="w16a16",
+        solution_type="asm",
+        need_shuffle=True,
+        config={"PADDED_K": 128},
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            get_aiter_moe_config=lambda **_kwargs: (True, runtime_config),
+        ),
+    )
+
+    with pytest.raises(
+        aiter_runtime.HcuAiterRuntimeError,
+        match="physical layout",
+    ):
+        aiter_runtime.fused_moe_impl(
+            lambda *_args: pytest.fail("must not delegate"),
+            torch.ones(2, 4),
+            w1,
+            w2,
+            torch.ones(2, 2),
+            torch.zeros(2, 2, dtype=torch.int64),
+            activation_method=0,
+        )
+
+
+def test_aiter_w16a16_installed_native_fallback_bypasses_selector(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fused_moe_module = __import__(
+        "vllm.model_executor.layers.fused_moe.fused_moe",
+        fromlist=["fused_experts_impl"],
+    )
+    _install_fake_aiter(monkeypatch)
+    monkeypatch.setattr(aiter_runtime, "is_aiter_moe_requested", lambda: True)
+
+    expected = torch.full((2, 4), 5.0)
+    monkeypatch.setattr(
+        aiter_runtime,
+        "select_aiter_moe_config",
+        lambda *_args, **_kwargs: pytest.fail(
+            "native fallback must not reselect AITER at runtime"
+        ),
+    )
+    monkeypatch.setattr(
+        fused_moe_module,
+        "fused_experts_impl",
+        lambda *_args, **_kwargs: expected,
+    )
+    w1 = torch.ones(3, 8, 4)
+    w2 = torch.ones(3, 4, 4)
+    for weight in (w1, w2):
+        weight.is_shuffled = False
+        weight._hcu_aiter_moe_solution_type = "native"
+
+    actual = aiter_runtime.fused_moe_impl(
+        lambda *_args: pytest.fail("must not delegate"),
+        torch.ones(2, 4),
+        w1,
+        w2,
+        torch.ones(2, 2),
+        torch.zeros(2, 2, dtype=torch.int64),
+        activation_method=0,
+    )
+
+    assert actual is expected
+
+
 def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -2821,7 +2958,7 @@ def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
         quant_type="w16a16",
         solution_type="asm",
         need_shuffle=True,
-        config={},
+        config={"PADDED_K": 64},
     )
     monkeypatch.setattr(
         hcu_unquantized,
@@ -2849,6 +2986,20 @@ def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
     torch.testing.assert_close(layer.w2_weight, shuffled_w2)
     assert layer.w13_weight.is_shuffled is True
     assert layer.w2_weight.is_shuffled is True
+    assert layer.w13_weight._hcu_aiter_moe_solution_type == "asm"
+    assert layer.w2_weight._hcu_aiter_moe_solution_type == "asm"
+    assert layer.w13_weight._hcu_aiter_moe_weight_layout == (
+        "w16a16",
+        "ASM",
+        True,
+        64,
+    )
+    assert layer.w2_weight._hcu_aiter_moe_weight_layout == (
+        "w16a16",
+        "ASM",
+        True,
+        64,
+    )
     assert len(kernels) == 1
     assert method.moe_kernel is not None
     assert len(select_calls) == 1
@@ -2871,7 +3022,62 @@ def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
     assert solution_type == "asm"
 
 
-def test_aiter_w16a16_post_load_keeps_canonical_weights_when_shuffle_disabled(
+def test_aiter_w16a16_post_load_locks_canonical_triton_layout(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm_hcu.model_executor.layers.fused_moe import (
+        unquantized_fused_moe_method as hcu_unquantized,
+    )
+
+    w13 = torch.nn.Parameter(torch.ones(2, 8, 4), requires_grad=False)
+    w2 = torch.nn.Parameter(torch.ones(2, 4, 4), requires_grad=False)
+    layer = SimpleNamespace(w13_weight=w13, w2_weight=w2)
+    method = object.__new__(hcu_unquantized.HcuUnquantizedFusedMoEMethod)
+    method.moe = SimpleNamespace(
+        num_experts=2,
+        experts_per_token=2,
+        in_dtype=torch.bfloat16,
+        activation=SimpleNamespace(value="silu"),
+    )
+    method.unquantized_backend = hcu_unquantized.UnquantizedMoeBackend.AITER
+    method.experts_cls = object
+    method.get_fused_moe_quant_config = lambda _layer: object()
+    monkeypatch.setattr(hcu_unquantized, "_is_hcu_aiter_moe_requested", lambda *_: True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_AITER_MOE_SHUFFLE", False)
+    select_calls: list[tuple[AiterMoeProblem, object, object]] = []
+    config = SimpleNamespace(
+        quant_type="w16a16",
+        solution_type="triton",
+        need_shuffle=False,
+        config={},
+    )
+    monkeypatch.setattr(
+        hcu_unquantized,
+        "select_aiter_moe_config",
+        lambda problem, cache_owner, solution_type=None: select_calls.append(
+            (problem, cache_owner, solution_type)
+        ) or config,
+    )
+    monkeypatch.setattr(
+        hcu_unquantized,
+        "make_unquantized_moe_kernel",
+        lambda **_kwargs: object(),
+    )
+
+    method.process_weights_after_loading(layer)
+
+    assert layer.w13_weight is w13
+    assert layer.w2_weight is w2
+    assert layer.w13_weight.is_shuffled is False
+    assert layer.w2_weight.is_shuffled is False
+    assert layer.w13_weight._hcu_aiter_moe_solution_type == "triton"
+    assert layer.w2_weight._hcu_aiter_moe_solution_type == "triton"
+    assert len(select_calls) == 1
+    assert select_calls[0][1] is w13
+    assert select_calls[0][2] is None
+
+
+def test_aiter_w16a16_post_load_locks_native_fallback_on_m1_miss(
     monkeypatch: pytest.MonkeyPatch,
 ):
     from vllm_hcu.model_executor.layers.fused_moe import (
@@ -2896,7 +3102,7 @@ def test_aiter_w16a16_post_load_keeps_canonical_weights_when_shuffle_disabled(
     monkeypatch.setattr(
         hcu_unquantized,
         "select_aiter_moe_config",
-        lambda *_args, **_kwargs: pytest.fail("disabled shuffle must not be selected"),
+        lambda *_args, **_kwargs: None,
     )
     monkeypatch.setattr(
         hcu_unquantized,
@@ -2908,6 +3114,10 @@ def test_aiter_w16a16_post_load_keeps_canonical_weights_when_shuffle_disabled(
 
     assert layer.w13_weight is w13
     assert layer.w2_weight is w2
+    assert layer.w13_weight.is_shuffled is False
+    assert layer.w2_weight.is_shuffled is False
+    assert layer.w13_weight._hcu_aiter_moe_solution_type == "native"
+    assert layer.w2_weight._hcu_aiter_moe_solution_type == "native"
 
 
 def test_explicit_aiter_backend_uses_public_router_without_auto_env_gate(

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -2861,6 +2861,60 @@ def test_aiter_w16a16_rejects_runtime_config_for_different_asm_layout(
         )
 
 
+def test_aiter_w16a16_runtime_selects_with_installed_logical_dimensions(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_fake_aiter(monkeypatch)
+    monkeypatch.setattr(aiter_runtime, "is_aiter_moe_requested", lambda: True)
+    config = SimpleNamespace(
+        quant_type="w16a16",
+        solution_type="asm",
+        need_shuffle=True,
+        config={"ORIGINAL_K": 4, "PADDED_K": 8},
+    )
+    layout = (
+        "w16a16",
+        "ASM",
+        True,
+        8,
+    )
+    w1 = torch.ones(3, 8, 8)
+    w2 = torch.ones(3, 4, 4)
+    for weight in (w1, w2):
+        weight.is_shuffled = True
+        weight._hcu_aiter_moe_solution_type = "asm"
+        weight._hcu_aiter_moe_weight_layout = layout
+        weight._hcu_aiter_moe_logical_shape = (3, 8, 4, 4)
+    selector_calls: list[dict[str, object]] = []
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            get_aiter_moe_config=lambda **kwargs: (
+                selector_calls.append(kwargs) or True,
+                config,
+            ),
+            aiter_moe=lambda **kwargs: kwargs["hidden_states"].clone(),
+        ),
+    )
+
+    aiter_runtime.fused_moe_impl(
+        lambda *_args: pytest.fail("must not delegate"),
+        torch.ones(2, 4),
+        w1,
+        w2,
+        torch.ones(2, 2),
+        torch.zeros(2, 2, dtype=torch.int64),
+        activation_method=0,
+    )
+
+    assert selector_calls[0]["E"] == 3
+    assert selector_calls[0]["N1"] == 8
+    assert selector_calls[0]["N2"] == 4
+    assert selector_calls[0]["K"] == 4
+
+
 def test_aiter_w16a16_installed_native_fallback_bypasses_selector(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -3000,6 +3054,8 @@ def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
         True,
         64,
     )
+    assert layer.w13_weight._hcu_aiter_moe_logical_shape == (2, 8, 4, 4)
+    assert layer.w2_weight._hcu_aiter_moe_logical_shape == (2, 8, 4, 4)
     assert len(kernels) == 1
     assert method.moe_kernel is not None
     assert len(select_calls) == 1
@@ -3098,7 +3154,7 @@ def test_aiter_w16a16_post_load_locks_native_fallback_on_m1_miss(
     method.experts_cls = object
     method.get_fused_moe_quant_config = lambda _layer: object()
     monkeypatch.setattr(hcu_unquantized, "_is_hcu_aiter_moe_requested", lambda *_: True)
-    monkeypatch.setattr(henvs, "VLLM_HCU_USE_AITER_MOE_SHUFFLE", False)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_AITER_MOE_SHUFFLE", True)
     monkeypatch.setattr(
         hcu_unquantized,
         "select_aiter_moe_config",

--- a/tests/runtime_patch/test_worker_framework_opt.py
+++ b/tests/runtime_patch/test_worker_framework_opt.py
@@ -1264,11 +1264,14 @@ def test_proposer_sidecar_init_cplb_fix_rocm_preservation_and_custom_sp_padding(
     assert prepared.num_kv_actual_tokens == 5
 
 
-def test_proposer_registers_flashmla_sparse_metadata_once() -> None:
+def test_proposer_registers_hcu_spec_decode_metadata_once() -> None:
     from vllm.v1.attention.backends.mla.flashmla_sparse import (
         FlashMLASparseMetadata,
     )
     from vllm_hcu.v1.spec_decode import proposer_runtime
+    from vllm_hcu.v1.attention.backends.flash_attn import (
+        FlashAttentionMetadata,
+    )
 
     proposer = SimpleNamespace(allowed_attn_types=(str,))
     config = _proposer_config()
@@ -1280,7 +1283,11 @@ def test_proposer_registers_flashmla_sparse_metadata_once() -> None:
         SimpleNamespace(), proposer, config, "cpu", None
     )
 
-    assert proposer.allowed_attn_types == (str, FlashMLASparseMetadata)
+    assert proposer.allowed_attn_types == (
+        str,
+        FlashMLASparseMetadata,
+        FlashAttentionMetadata,
+    )
 
 
 def test_proposer_lightly_cp_atomic_metadata_and_forward_context_chain(

--- a/vllm_hcu/model_executor/layers/fused_moe/aiter_moe_dispatch.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/aiter_moe_dispatch.py
@@ -213,13 +213,15 @@ def _validate_derived_tensor(
 def select_aiter_moe_config(
     problem: AiterMoeProblem,
     cache_owner: object,
+    solution_type: object | None = None,
 ) -> object | None:
     """Ask AITER to route the problem, preserving explicit no-solution status."""
 
     cache = _owner_cache(cache_owner, _SELECTION_CACHE_ATTR)
-    if problem in cache:
-        cache.move_to_end(problem)
-        return cache[problem]
+    cache_key = (problem, _freeze(solution_type))
+    if cache_key in cache:
+        cache.move_to_end(cache_key)
+        return cache[cache_key]
 
     moe_module = import_module("aiter.moe")
     selector = getattr(moe_module, "get_aiter_moe_config", None)
@@ -229,7 +231,11 @@ def select_aiter_moe_config(
             + problem.describe()
         )
 
-    result = selector(
+    # A pinned solution is used when weights have already been converted to
+    # that solution's physical layout.  It must not be silently rerouted.
+    use_shuffle = problem.use_shuffle
+
+    selector_kwargs = dict(
         M=problem.M,
         E=problem.E,
         N1=problem.N1,
@@ -240,8 +246,11 @@ def select_aiter_moe_config(
         dtype=problem.dtype,
         quant_type=problem.quant_type,
         activation=problem.activation,
-        use_shuffle=int(problem.use_shuffle),
+        use_shuffle=int(use_shuffle),
     )
+    if solution_type is not None:
+        selector_kwargs["spec_sol_type"] = solution_type
+    result = selector(**selector_kwargs)
     if not isinstance(result, tuple) or len(result) != 2:
         raise HcuAiterMoeDispatchError(
             "get_aiter_moe_config must return (status, config); "
@@ -260,14 +269,13 @@ def select_aiter_moe_config(
                 "Triton MoE for %s",
                 problem.describe(),
             )
-        _cache_put(cache, problem, None, limit=_SELECTION_CACHE_LIMIT)
+        _cache_put(cache, cache_key, None, limit=_SELECTION_CACHE_LIMIT)
         return None
     if config is None:
         raise HcuAiterMoeDispatchError(
             "get_aiter_moe_config returned status=True without a config; "
             + problem.describe()
         )
-
     solution = _solution_token(config)
     if _mark_route_logged(problem):
         logger.debug(
@@ -275,7 +283,14 @@ def select_aiter_moe_config(
             solution,
             problem.describe(),
         )
-    _cache_put(cache, problem, config, limit=_SELECTION_CACHE_LIMIT)
+    if solution_type is not None and _solution_token(config) != str(
+        getattr(solution_type, "value", solution_type)
+    ).rsplit(".", 1)[-1].upper():
+        raise HcuAiterMoeDispatchError(
+            "AITER ignored the requested MoE solution layout; requested="
+            f"{solution_type!r}, returned={_solution_token(config)}"
+        )
+    _cache_put(cache, cache_key, config, limit=_SELECTION_CACHE_LIMIT)
     return config
 
 

--- a/vllm_hcu/model_executor/layers/fused_moe/aiter_moe_dispatch.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/aiter_moe_dispatch.py
@@ -119,7 +119,9 @@ def _solution_token(config: object) -> str:
     return str(solution).rsplit(".", 1)[-1].upper()
 
 
-def _weight_layout_generation(config: object) -> tuple[Any, ...]:
+def aiter_moe_weight_layout_signature(config: object) -> tuple[Any, ...]:
+    """Return the physical weight-layout contract selected by AITER."""
+
     config_values = getattr(config, "config", None)
     padded_k = (
         config_values.get("PADDED_K")
@@ -321,7 +323,7 @@ def prepare_aiter_moe_weights(
     cache_key = (
         _tensor_generation(w1),
         _tensor_generation(w2),
-        _weight_layout_generation(config),
+        aiter_moe_weight_layout_signature(config),
         _freeze(block_shape),
         preserve_inputs,
     )

--- a/vllm_hcu/model_executor/layers/fused_moe/aiter_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/aiter_runtime.py
@@ -880,8 +880,21 @@ def fused_moe_impl(
         activation=activation,
         use_shuffle=use_shuffle,
     )
-    aiter_config = select_aiter_moe_config(problem, cache_owner=w1)
+    weights_are_shuffled = bool(getattr(w1, "is_shuffled", False))
+    if weights_are_shuffled != bool(getattr(w2, "is_shuffled", False)):
+        raise HcuAiterRuntimeError(
+            "HCU AITER W16A16 weights have inconsistent shuffle state"
+        )
+    aiter_config = select_aiter_moe_config(
+        problem,
+        cache_owner=w1,
+        solution_type="asm" if weights_are_shuffled else None,
+    )
     if aiter_config is None:
+        if weights_are_shuffled:
+            raise HcuAiterRuntimeError(
+                "AITER has no ASM solution for installed ASM-layout weights"
+            )
         native_expert_map, _ = resolve_aiter_expert_maps(
             expert_mask,
             global_num_experts,
@@ -914,12 +927,19 @@ def fused_moe_impl(
             expert_map=native_expert_map,
         )
 
-    prepared_w1, prepared_w2 = prepare_aiter_moe_weights(
-        w1,
-        w2,
-        aiter_config,
-        cache_owner=w1,
-    )
+    if weights_are_shuffled:
+        if not bool(getattr(aiter_config, "need_shuffle", False)):
+            raise HcuAiterRuntimeError(
+                "AITER returned a non-shuffle config for ASM-layout weights"
+            )
+        prepared_w1, prepared_w2 = w1, w2
+    else:
+        prepared_w1, prepared_w2 = prepare_aiter_moe_weights(
+            w1,
+            w2,
+            aiter_config,
+            cache_owner=w1,
+        )
     solution = getattr(aiter_config, "solution_type", None)
     solution = getattr(solution, "value", solution)
     if str(solution).rsplit(".", 1)[-1].upper() == "ASM":

--- a/vllm_hcu/model_executor/layers/fused_moe/aiter_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/aiter_runtime.py
@@ -21,6 +21,7 @@ import torch
 
 from vllm_hcu.model_executor.layers.fused_moe.aiter_moe_dispatch import (
     AiterMoeProblem,
+    aiter_moe_weight_layout_signature,
     execute_aiter_moe,
     prepare_aiter_moe_weights,
     resolve_aiter_expert_maps,
@@ -885,11 +886,29 @@ def fused_moe_impl(
         raise HcuAiterRuntimeError(
             "HCU AITER W16A16 weights have inconsistent shuffle state"
         )
-    aiter_config = select_aiter_moe_config(
-        problem,
-        cache_owner=w1,
-        solution_type="asm" if weights_are_shuffled else None,
-    )
+    installed_solution = getattr(w1, "_hcu_aiter_moe_solution_type", None)
+    if installed_solution != getattr(
+        w2, "_hcu_aiter_moe_solution_type", None
+    ):
+        raise HcuAiterRuntimeError(
+            "HCU AITER W16A16 weights have inconsistent installed solutions"
+        )
+    if installed_solution == "native":
+        if weights_are_shuffled:
+            raise HcuAiterRuntimeError(
+                "HCU AITER native fallback cannot use shuffled W16A16 weights"
+            )
+        aiter_config = None
+    else:
+        aiter_config = select_aiter_moe_config(
+            problem,
+            cache_owner=w1,
+            solution_type=(
+                installed_solution
+                if installed_solution is not None
+                else ("asm" if weights_are_shuffled else None)
+            ),
+        )
     if aiter_config is None:
         if weights_are_shuffled:
             raise HcuAiterRuntimeError(
@@ -927,6 +946,44 @@ def fused_moe_impl(
             expert_map=native_expert_map,
         )
 
+    selected_solution = getattr(aiter_config, "solution_type", None)
+    selected_solution = getattr(selected_solution, "value", selected_solution)
+    if selected_solution is None:
+        raise HcuAiterRuntimeError(
+            "AITER selected a W16A16 config without a solution type"
+        )
+    selected_solution = str(selected_solution).rsplit(".", 1)[-1].lower()
+    if not selected_solution:
+        raise HcuAiterRuntimeError(
+            "AITER selected a W16A16 config without a solution type"
+        )
+    if (
+        installed_solution is not None
+        and selected_solution != installed_solution
+    ):
+        raise HcuAiterRuntimeError(
+            "AITER selected a solution incompatible with installed W16A16 weights"
+        )
+    if installed_solution is not None and bool(
+        getattr(aiter_config, "need_shuffle", False)
+    ) != weights_are_shuffled:
+        raise HcuAiterRuntimeError(
+            "AITER config layout does not match installed W16A16 weights"
+        )
+    installed_layout = getattr(w1, "_hcu_aiter_moe_weight_layout", None)
+    if installed_layout != getattr(
+        w2, "_hcu_aiter_moe_weight_layout", None
+    ):
+        raise HcuAiterRuntimeError(
+            "HCU AITER W16A16 weights have inconsistent physical layouts"
+        )
+    if (
+        installed_layout is not None
+        and aiter_moe_weight_layout_signature(aiter_config) != installed_layout
+    ):
+        raise HcuAiterRuntimeError(
+            "AITER config physical layout does not match installed W16A16 weights"
+        )
     if weights_are_shuffled:
         if not bool(getattr(aiter_config, "need_shuffle", False)):
             raise HcuAiterRuntimeError(
@@ -940,9 +997,7 @@ def fused_moe_impl(
             aiter_config,
             cache_owner=w1,
         )
-    solution = getattr(aiter_config, "solution_type", None)
-    solution = getattr(solution, "value", solution)
-    if str(solution).rsplit(".", 1)[-1].upper() == "ASM":
+    if selected_solution == "asm":
         aiter_expert_map = expert_mask
     else:
         aiter_expert_map, _ = resolve_aiter_expert_maps(

--- a/vllm_hcu/model_executor/layers/fused_moe/aiter_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/aiter_runtime.py
@@ -853,26 +853,54 @@ def fused_moe_impl(
             f"{moe_sorting_dispatch_policy}"
         )
 
-    # HCU AITER consumes vLLM's canonical w1=[E, N1, K] and
-    # w2=[E, N2, K2]. N2 is GEMM2's hidden/output dimension at w2.shape[1].
-    if (
-        w1.dim() != 3
-        or w2.dim() != 3
-        or int(w1.shape[0]) != int(w2.shape[0])
-        or int(w1.shape[1]) != 2 * int(w2.shape[2])
-        or int(w1.shape[2]) != int(w2.shape[1])
-    ):
+    logical_shape = getattr(w1, "_hcu_aiter_moe_logical_shape", None)
+    if logical_shape != getattr(w2, "_hcu_aiter_moe_logical_shape", None):
+        raise HcuAiterRuntimeError(
+            "HCU AITER W16A16 weights have inconsistent logical dimensions"
+        )
+    if w1.dim() != 3 or w2.dim() != 3 or w1.shape[0] != w2.shape[0]:
         raise ValueError(
             f"unexpected MoE weight layout: w1.shape={tuple(w1.shape)}, "
             f"w2.shape={tuple(w2.shape)}"
         )
+    if logical_shape is None:
+        if (
+            int(w1.shape[1]) != 2 * int(w2.shape[2])
+            or int(w1.shape[2]) != int(w2.shape[1])
+        ):
+            raise ValueError(
+                f"unexpected MoE weight layout: w1.shape={tuple(w1.shape)}, "
+                f"w2.shape={tuple(w2.shape)}"
+            )
+        logical_e = global_num_experts
+        logical_n1 = int(w1.shape[1])
+        logical_n2 = int(w2.shape[1])
+        logical_k = int(w1.shape[2])
+    else:
+        if (
+            not isinstance(logical_shape, tuple)
+            or len(logical_shape) != 4
+            or not all(isinstance(value, int) and value > 0 for value in logical_shape)
+        ):
+            raise HcuAiterRuntimeError(
+                "HCU AITER W16A16 weights have invalid logical dimensions"
+            )
+        logical_e, logical_n1, logical_n2, logical_k = logical_shape
+        if logical_e != global_num_experts:
+            raise HcuAiterRuntimeError(
+                "HCU AITER W16A16 logical expert count does not match routing"
+            )
+    if int(hidden_states.shape[1]) != logical_k:
+        raise HcuAiterRuntimeError(
+            "HCU AITER W16A16 hidden states do not match logical K"
+        )
 
     problem = AiterMoeProblem(
         M=int(hidden_states.shape[0]),
-        E=global_num_experts,
-        N1=int(w1.shape[1]),
-        N2=int(w2.shape[1]),
-        K=int(w1.shape[2]),
+        E=logical_e,
+        N1=logical_n1,
+        N2=logical_n2,
+        K=logical_k,
         top_k=int(topk_ids.shape[1]),
         block_size=0,
         dtype=hidden_states.dtype,

--- a/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -3,11 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
 # Modified by Hygon Information Technology Co., Ltd., 2026.
 
-"""
-HCU version of UnquantizedFusedMoEMethod.
-Inherits from vllm's version and overrides process_weights_after_loading
-to preserve canonical AITER weights while initializing the MoE kernel.
-"""
+"""HCU unquantized MoE integration."""
 
 from __future__ import annotations
 
@@ -20,9 +16,12 @@ from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
     UnquantizedFusedMoEMethod as _Original,
 )
+from vllm.model_executor.utils import replace_parameter
 from vllm_hcu.model_executor.layers.fused_moe.aiter_moe_dispatch import (
     AiterMoeProblem,
-    prewarm_aiter_moe_config,
+    HcuAiterMoeDispatchError,
+    prepare_aiter_moe_weights,
+    select_aiter_moe_config,
 )
 from vllm_hcu.platforms import envs as henvs
 
@@ -48,11 +47,9 @@ def _expert_routing_tables(
 
     return None
 
-class HcuUnquantizedFusedMoEMethod(_Original):
-    """HCU version of UnquantizedFusedMoEMethod.
 
-    Initializes the AITER runner without replacing canonical model weights.
-    """
+class HcuUnquantizedFusedMoEMethod(_Original):
+    """Install the AITER ASM layout once instead of caching a second copy."""
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if (
@@ -65,6 +62,45 @@ class HcuUnquantizedFusedMoEMethod(_Original):
         if getattr(layer, "_hcu_aiter_moe_initialized", False):
             return
 
+        original_w13 = layer.w13_weight
+        original_w2 = layer.w2_weight
+        activation = getattr(self.moe.activation, "value", self.moe.activation)
+        problem = AiterMoeProblem(
+            M=1,
+            E=int(self.moe.num_experts),
+            N1=int(original_w13.shape[1]),
+            N2=int(original_w2.shape[1]),
+            K=int(original_w13.shape[2]),
+            top_k=int(self.moe.experts_per_token),
+            block_size=0,
+            dtype=self.moe.in_dtype,
+            device=original_w13.device,
+            quant_type="w16a16",
+            activation=str(activation),
+            use_shuffle=bool(henvs.VLLM_HCU_USE_AITER_MOE_SHUFFLE),
+        )
+        if problem.use_shuffle:
+            config = select_aiter_moe_config(
+                problem,
+                cache_owner=original_w13,
+                solution_type="asm",
+            )
+            if config is None or not bool(getattr(config, "need_shuffle", False)):
+                raise HcuAiterMoeDispatchError(
+                    "HCU AITER BF16 MoE requires an ASM shuffle solution before "
+                    "installing the runtime weight layout; " + problem.describe()
+                )
+            shuffled_w13, shuffled_w2 = prepare_aiter_moe_weights(
+                original_w13,
+                original_w2,
+                config,
+                cache_owner=object(),
+            )
+            replace_parameter(layer, "w13_weight", shuffled_w13)
+            replace_parameter(layer, "w2_weight", shuffled_w2)
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
+
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         self.moe_kernel = make_unquantized_moe_kernel(
             quant_config=self.moe_quant_config,
@@ -72,23 +108,5 @@ class HcuUnquantizedFusedMoEMethod(_Original):
             backend=self.unquantized_backend,
             experts_cls=self.experts_cls,
             routing_tables=_expert_routing_tables(layer),
-        )
-        activation = getattr(self.moe.activation, "value", self.moe.activation)
-        prewarm_aiter_moe_config(
-            AiterMoeProblem(
-                M=1,
-                E=int(self.moe.num_experts),
-                N1=int(layer.w13_weight.shape[1]),
-                N2=int(layer.w2_weight.shape[1]),
-                K=int(layer.w13_weight.shape[2]),
-                top_k=int(self.moe.experts_per_token),
-                block_size=0,
-                dtype=self.moe.in_dtype,
-                device=layer.w13_weight.device,
-                quant_type="w16a16",
-                activation=str(activation),
-                use_shuffle=bool(henvs.VLLM_HCU_USE_AITER_MOE_SHUFFLE),
-            ),
-            cache_owner=layer.w13_weight,
         )
         layer._hcu_aiter_moe_initialized = True

--- a/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -20,6 +20,7 @@ from vllm.model_executor.utils import replace_parameter
 from vllm_hcu.model_executor.layers.fused_moe.aiter_moe_dispatch import (
     AiterMoeProblem,
     HcuAiterMoeDispatchError,
+    aiter_moe_weight_layout_signature,
     prepare_aiter_moe_weights,
     select_aiter_moe_config,
 )
@@ -79,12 +80,12 @@ class HcuUnquantizedFusedMoEMethod(_Original):
             activation=str(activation),
             use_shuffle=bool(henvs.VLLM_HCU_USE_AITER_MOE_SHUFFLE),
         )
+        config = select_aiter_moe_config(
+            problem,
+            cache_owner=original_w13,
+            solution_type="asm" if problem.use_shuffle else None,
+        )
         if problem.use_shuffle:
-            config = select_aiter_moe_config(
-                problem,
-                cache_owner=original_w13,
-                solution_type="asm",
-            )
             if config is None or not bool(getattr(config, "need_shuffle", False)):
                 raise HcuAiterMoeDispatchError(
                     "HCU AITER BF16 MoE requires an ASM shuffle solution before "
@@ -98,8 +99,33 @@ class HcuUnquantizedFusedMoEMethod(_Original):
             )
             replace_parameter(layer, "w13_weight", shuffled_w13)
             replace_parameter(layer, "w2_weight", shuffled_w2)
-            layer.w13_weight.is_shuffled = True
-            layer.w2_weight.is_shuffled = True
+        elif config is not None and bool(getattr(config, "need_shuffle", False)):
+            raise HcuAiterMoeDispatchError(
+                "HCU AITER selected a shuffle solution for canonical BF16 "
+                "weights; " + problem.describe()
+            )
+
+        if config is not None:
+            solution = getattr(config, "solution_type", None)
+            solution = getattr(solution, "value", solution)
+            if solution is None:
+                raise HcuAiterMoeDispatchError(
+                    "HCU AITER selected a BF16 MoE config without a solution type"
+                )
+            solution = str(solution).rsplit(".", 1)[-1].lower()
+            if not solution:
+                raise HcuAiterMoeDispatchError(
+                    "HCU AITER selected a BF16 MoE config without a solution type"
+                )
+            layout = aiter_moe_weight_layout_signature(config)
+        else:
+            solution = "native"
+            layout = None
+        for weight in (layer.w13_weight, layer.w2_weight):
+            weight.is_shuffled = bool(problem.use_shuffle)
+            weight._hcu_aiter_moe_solution_type = solution
+            if layout is not None:
+                weight._hcu_aiter_moe_weight_layout = layout
 
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         self.moe_kernel = make_unquantized_moe_kernel(

--- a/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -85,8 +85,8 @@ class HcuUnquantizedFusedMoEMethod(_Original):
             cache_owner=original_w13,
             solution_type="asm" if problem.use_shuffle else None,
         )
-        if problem.use_shuffle:
-            if config is None or not bool(getattr(config, "need_shuffle", False)):
+        if config is not None and problem.use_shuffle:
+            if not bool(getattr(config, "need_shuffle", False)):
                 raise HcuAiterMoeDispatchError(
                     "HCU AITER BF16 MoE requires an ASM shuffle solution before "
                     "installing the runtime weight layout; " + problem.describe()
@@ -121,9 +121,12 @@ class HcuUnquantizedFusedMoEMethod(_Original):
         else:
             solution = "native"
             layout = None
+        installed_shuffle = bool(config is not None and problem.use_shuffle)
+        logical_shape = (problem.E, problem.N1, problem.N2, problem.K)
         for weight in (layer.w13_weight, layer.w2_weight):
-            weight.is_shuffled = bool(problem.use_shuffle)
+            weight.is_shuffled = installed_shuffle
             weight._hcu_aiter_moe_solution_type = solution
+            weight._hcu_aiter_moe_logical_shape = logical_shape
             if layout is not None:
                 weight._hcu_aiter_moe_weight_layout = layout
 

--- a/vllm_hcu/v1/spec_decode/proposer_runtime.py
+++ b/vllm_hcu/v1/spec_decode/proposer_runtime.py
@@ -22,10 +22,9 @@ def initialize_proposer(
     proposer._hcu_feature_config = config
     proposer.runner = runner
 
-    # HCU FlashMLA sparse explicitly supports speculative tokens as decode
-    # queries, but target vLLM v0.25.1 does not include its metadata class in
-    # the ROCm multi-step drafting allowlist.  Keep the target proposer and
-    # extend only the HCU-owned backend capability registration.
+    # HCU attention backends support speculative tokens as decode queries,
+    # but target vLLM v0.25.1 cannot discover plugin-owned metadata classes
+    # for its ROCm multi-step drafting allowlist.
     try:
         from vllm.v1.attention.backends.mla.flashmla_sparse import (
             FlashMLASparseMetadata,
@@ -40,6 +39,17 @@ def initialize_proposer(
             and FlashMLASparseMetadata not in allowed_attn_types
         ):
             proposer.allowed_attn_types += (FlashMLASparseMetadata,)
+
+    from vllm_hcu.v1.attention.backends.flash_attn import (
+        FlashAttentionMetadata,
+    )
+
+    allowed_attn_types = getattr(proposer, "allowed_attn_types", None)
+    if (
+        allowed_attn_types is not None
+        and FlashAttentionMetadata not in allowed_attn_types
+    ):
+        proposer.allowed_attn_types += (FlashAttentionMetadata,)
 
     proposer.enable_multi_layers_mtp = config.enable_multi_layers_mtp
     proposer.enable_lightly_cp = config.enable_lightly_cp


### PR DESCRIPTION
## Summary

- install the selected BF16/W16A16 AITER weight layout once during per-layer post-load processing
- replace canonical Parameters after ASM shuffle instead of retaining a second persistent weight copy
- persist and validate the exact physical layout signature, including PADDED_K
- pin runtime routing to the installed solution and lock M=1 misses to the native Triton fallback
- fix HCU MTP FlashAttention metadata compatibility

## Verification

- pytest: 181 passed in tests/runtime_patch/test_quant_gemm_aiter.py
- compileall and git diff check passed
- real TP2 validation on HIP devices 5 and 6 with Qwen3.5-35B-A3B, BF16, AITER and MTP=3
- CUDA graphs completed, no OOM, and /v1/completions returned HTTP 200