### PR TITLE
fix(hcu): bound AITER MoE layout memory across BF16 and quantized paths

### DIFF
--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -2897,6 +2897,60 @@ def test_aiter_w16a16_rejects_runtime_config_for_different_asm_layout(
         )
 
 
+def test_aiter_w16a16_runtime_selects_with_installed_logical_dimensions(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_fake_aiter(monkeypatch)
+    monkeypatch.setattr(aiter_runtime, "is_aiter_moe_requested", lambda: True)
+    config = SimpleNamespace(
+        quant_type="w16a16",
+        solution_type="asm",
+        need_shuffle=True,
+        config={"ORIGINAL_K": 4, "PADDED_K": 8},
+    )
+    layout = (
+        "w16a16",
+        "ASM",
+        True,
+        8,
+    )
+    w1 = torch.ones(3, 8, 8)
+    w2 = torch.ones(3, 4, 4)
+    for weight in (w1, w2):
+        weight.is_shuffled = True
+        weight._hcu_aiter_moe_solution_type = "asm"
+        weight._hcu_aiter_moe_weight_layout = layout
+        weight._hcu_aiter_moe_logical_shape = (3, 8, 4, 4)
+    selector_calls: list[dict[str, object]] = []
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            get_aiter_moe_config=lambda **kwargs: (
+                selector_calls.append(kwargs) or True,
+                config,
+            ),
+            aiter_moe=lambda **kwargs: kwargs["hidden_states"].clone(),
+        ),
+    )
+
+    aiter_runtime.fused_moe_impl(
+        lambda *_args: pytest.fail("must not delegate"),
+        torch.ones(2, 4),
+        w1,
+        w2,
+        torch.ones(2, 2),
+        torch.zeros(2, 2, dtype=torch.int64),
+        activation_method=0,
+    )
+
+    assert selector_calls[0]["E"] == 3
+    assert selector_calls[0]["N1"] == 8
+    assert selector_calls[0]["N2"] == 4
+    assert selector_calls[0]["K"] == 4
+
+
 def test_aiter_w16a16_installed_native_fallback_bypasses_selector(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -3036,6 +3090,8 @@ def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
         True,
         64,
     )
+    assert layer.w13_weight._hcu_aiter_moe_logical_shape == (2, 8, 4, 4)
+    assert layer.w2_weight._hcu_aiter_moe_logical_shape == (2, 8, 4, 4)
     assert len(kernels) == 1
     assert method.moe_kernel is not None
     assert len(select_calls) == 1
@@ -3134,7 +3190,7 @@ def test_aiter_w16a16_post_load_locks_native_fallback_on_m1_miss(
     method.experts_cls = object
     method.get_fused_moe_quant_config = lambda _layer: object()
     monkeypatch.setattr(hcu_unquantized, "_is_hcu_aiter_moe_requested", lambda *_: True)
-    monkeypatch.setattr(henvs, "VLLM_HCU_USE_AITER_MOE_SHUFFLE", False)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_AITER_MOE_SHUFFLE", True)
     monkeypatch.setattr(
         hcu_unquantized,
         "select_aiter_moe_config",

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -4509,11 +4509,10 @@ def test_slimquant_w4a8_installs_moe_c_layout_at_load(
         w2_weight_scale=torch.nn.Parameter(
             torch.ones(2, 4, 1), requires_grad=False
         ),
+        w13_input_scale=None,
+        w2_input_scale=None,
     )
-    method.moe_quant_config = SimpleNamespace(
-        w1_scale=layer.w13_weight_scale * 16.0,
-        w2_scale=layer.w2_weight_scale * 16.0,
-    )
+    assert method.moe_quant_config is None
 
     method.process_weights_after_loading(layer)
 
@@ -4537,6 +4536,7 @@ def test_slimquant_w4a8_installs_moe_c_layout_at_load(
     assert layer.w2_weight.is_shuffled is True
     assert layer.w13_weight._hcu_aiter_moe_solution_type == "moe_c"
     assert layer.w2_weight._hcu_aiter_moe_solution_type == "moe_c"
+    assert method.moe_quant_config is not None
     torch.testing.assert_close(
         method.moe_quant_config.w1_scale,
         torch.full_like(method.moe_quant_config.w1_scale, 16.0),
@@ -4645,7 +4645,7 @@ def test_w8a8_padded_layout_keeps_original_logical_problem_dimensions(
     def shuffle_weights(w1, w2, _config):
         return (
             torch.zeros((w1.shape[0], w1.shape[1], 8), dtype=w1.dtype),
-            torch.zeros((w2.shape[0], w2.shape[1], 8), dtype=w2.dtype),
+            torch.zeros((w2.shape[0], 8, w2.shape[2]), dtype=w2.dtype),
         )
 
     monkeypatch.setitem(
@@ -4693,10 +4693,45 @@ def test_w8a8_padded_layout_keeps_original_logical_problem_dimensions(
     )
 
     assert layer.w13_weight.shape[2] == 8
-    assert layer.w2_weight.shape[2] == 8
+    assert layer.w2_weight.shape[1] == 8
     assert config_calls[1]["K"] == 4
     assert config_calls[1]["N1"] == 8
     assert config_calls[1]["N2"] == 4
+
+
+def test_padded_layout_validation_rejects_wrong_w2_axis(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    config = SimpleNamespace(
+        quant_type="fp8_w8a8",
+        solution_type="moe_c",
+        need_shuffle=True,
+        config={"PADDED_K": 8, "ORIGINAL_K": 4},
+    )
+    w1 = torch.zeros((2, 8, 4))
+    w2 = torch.zeros((2, 4, 4))
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            aiter_moe_shfl_weight=lambda *_args: (
+                torch.zeros((2, 8, 8)),
+                torch.zeros((2, 4, 8)),
+            ),
+        ),
+    )
+
+    with pytest.raises(
+        HcuAiterMoeDispatchError,
+        match="incompatible w2 shape",
+    ):
+        prepare_aiter_moe_weights(
+            w1,
+            w2,
+            config,
+            cache_owner=object(),
+        )
 
 
 def test_w8a8_m1_miss_locks_native_weights_without_runtime_relayout(
@@ -5004,6 +5039,8 @@ def test_slimquant_w4a8_m1_miss_installs_single_native_triton_layout(
         w2_weight_scale=torch.nn.Parameter(
             torch.ones(1, 4, 1), requires_grad=False
         ),
+        w13_input_scale=None,
+        w2_input_scale=None,
     )
 
     method.process_weights_after_loading(layer)
@@ -5724,6 +5761,121 @@ def test_moe_fp8_aiter_route_is_layer_aware_and_cached(
     assert calls[0]["quant_type"] == "fp8_w8a8"
     assert calls[0]["M"] == 2 and calls[0]["top_k"] == 2
     assert calls[0]["use_shuffle"] == 1
+
+
+def test_moe_fp8_padded_layout_routes_with_installed_logical_dimensions(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[dict[str, object]] = []
+    config = SimpleNamespace(
+        quant_type="fp8_w8a8",
+        solution_type="moe_c",
+        need_shuffle=True,
+        need_shuffle_scale=False,
+        config={"PADDED_K": 8, "ORIGINAL_K": 4},
+    )
+
+    class MoeQuantType:
+        FP8_W8A8 = "fp8_w8a8"
+
+    def get_config(**kwargs):
+        calls.append(kwargs)
+        return True, config
+
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            MoeQuantType=MoeQuantType,
+            get_aiter_moe_config=get_config,
+            aiter_moe=lambda **kwargs: kwargs["hidden_states"],
+        ),
+    )
+    layer = _fp8_moe_layer()
+    layer.w13_weight = torch.zeros((3, 8, 8))
+    layer.w2_weight = torch.zeros((3, 8, 4))
+    logical_shape = (3, 8, 4, 4)
+    layout = ("fp8_w8a8", "MOE_C", True, 8)
+    for weight in (layer.w13_weight, layer.w2_weight):
+        weight._hcu_aiter_moe_solution_type = "moe_c"
+        weight._hcu_aiter_moe_logical_shape = logical_shape
+        weight._hcu_aiter_moe_weight_layout = layout
+        weight.is_shuffled = True
+
+    compressed_tensors_moe_runtime.apply_aiter_w8a8_fp8_moe(
+        SimpleNamespace(moe=object()),
+        layer,
+        torch.ones((2, 4)),
+        torch.ones((2, 2)),
+        torch.zeros((2, 2), dtype=torch.int64),
+        None,
+        None,
+    )
+
+    assert calls[0]["E"] == 3
+    assert calls[0]["N1"] == 8
+    assert calls[0]["N2"] == 4
+    assert calls[0]["K"] == 4
+
+
+def test_quantized_installed_logical_contract_rejects_invalid_dimensions():
+    w1 = torch.zeros((3, 8, 4))
+    w2 = torch.zeros((3, 4, 4))
+    w1._hcu_aiter_moe_logical_shape = (3, 8, 4, -1)
+    w2._hcu_aiter_moe_logical_shape = (3, 8, 4, -1)
+
+    with pytest.raises(
+        compressed_tensors_moe_runtime.HcuCompressedTensorsMoeError,
+        match="invalid logical dimensions",
+    ):
+        compressed_tensors_moe_runtime._installed_weight_logical_shape(w1, w2)
+
+
+def test_quantized_installed_logical_contract_rejects_invalid_layout_signature():
+    w1 = torch.zeros((3, 8, 4))
+    w2 = torch.zeros((3, 4, 4))
+    for weight in (w1, w2):
+        weight._hcu_aiter_moe_logical_shape = (3, 8, 4, 4)
+        weight._hcu_aiter_moe_weight_layout = ("fp8_w8a8",)
+
+    with pytest.raises(
+        compressed_tensors_moe_runtime.HcuCompressedTensorsMoeError,
+        match="invalid physical layout signature",
+    ):
+        compressed_tensors_moe_runtime._installed_weight_logical_shape(w1, w2)
+
+
+def test_moe_fp8_installed_layout_rejects_hidden_width_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class MoeQuantType:
+        FP8_W8A8 = "fp8_w8a8"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module("aiter.moe", MoeQuantType=MoeQuantType),
+    )
+    layer = _fp8_moe_layer()
+    for weight in (layer.w13_weight, layer.w2_weight):
+        weight._hcu_aiter_moe_solution_type = "native"
+        weight._hcu_aiter_moe_logical_shape = (3, 8, 4, 4)
+        weight.is_shuffled = False
+
+    with pytest.raises(
+        compressed_tensors_moe_runtime.HcuCompressedTensorsMoeError,
+        match="hidden states do not match logical K",
+    ):
+        compressed_tensors_moe_runtime.apply_aiter_w8a8_fp8_moe(
+            SimpleNamespace(moe=object()),
+            layer,
+            torch.ones((2, 5)),
+            torch.ones((2, 2)),
+            torch.zeros((2, 2), dtype=torch.int64),
+            None,
+            None,
+        )
 
 
 def test_moe_fp8_uses_unified_shuffle_cache_and_invalidates_on_weight_change(

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -3048,7 +3048,7 @@ def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
         quant_type="w16a16",
         solution_type="asm",
         need_shuffle=True,
-        config={"PADDED_K": 64},
+        config={"PADDED_K": 64, "ORIGINAL_K": 4},
     )
     monkeypatch.setattr(
         hcu_unquantized,
@@ -3057,17 +3057,32 @@ def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
             (problem, cache_owner, solution_type)
         ) or config,
     )
-    shuffled_w13 = torch.full_like(w13, 13)
-    shuffled_w2 = torch.full_like(w2, 2)
+    shuffled_w13 = torch.full((2, 8, 64), 13.0)
+    shuffled_w2 = torch.full((2, 64, 4), 2.0)
+    shuffle_calls: list[tuple[torch.Tensor, torch.Tensor]] = []
+
+    def shuffle_weights(current_w13, current_w2, _config):
+        shuffle_calls.append((current_w13, current_w2))
+        return shuffled_w13.clone(), shuffled_w2.clone()
+
     monkeypatch.setitem(
         sys.modules,
         "aiter.moe", _module(
             "aiter.moe",
-            aiter_moe_shfl_weight=lambda *_args: (shuffled_w13, shuffled_w2),
+            aiter_moe_shfl_weight=shuffle_weights,
         ),
     )
 
     method.process_weights_after_loading(layer)
+    method.process_weights_after_loading(layer)
+
+    # Upstream layerwise reload restores new canonical Parameters but does not
+    # know about legacy HCU-owned layer markers.
+    layer._hcu_aiter_moe_initialized = True
+    reloaded_w13 = torch.nn.Parameter(torch.full_like(w13, 5), requires_grad=False)
+    reloaded_w2 = torch.nn.Parameter(torch.full_like(w2, 6), requires_grad=False)
+    layer.w13_weight = reloaded_w13
+    layer.w2_weight = reloaded_w2
     method.process_weights_after_loading(layer)
 
     assert layer.w13_weight is not w13
@@ -3092,9 +3107,14 @@ def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
     )
     assert layer.w13_weight._hcu_aiter_moe_logical_shape == (2, 8, 4, 4)
     assert layer.w2_weight._hcu_aiter_moe_logical_shape == (2, 8, 4, 4)
-    assert len(kernels) == 1
+    assert len(kernels) == 2
     assert method.moe_kernel is not None
-    assert len(select_calls) == 1
+    assert len(select_calls) == 2
+    assert len(shuffle_calls) == 2
+    assert shuffle_calls[0][0] is w13
+    assert shuffle_calls[0][1] is w2
+    assert shuffle_calls[1][0] is reloaded_w13
+    assert shuffle_calls[1][1] is reloaded_w2
     problem, cache_owner, solution_type = select_calls[0]
     assert problem == AiterMoeProblem(
         M=1,
@@ -4569,6 +4589,12 @@ def test_w8a8_prewarm_replaces_raw_weights_with_selected_layout(
     class MoeQuantType:
         W8A8 = "w8a8"
 
+    shuffle_calls: list[tuple[torch.Tensor, torch.Tensor]] = []
+
+    def shuffle_weights(w1, w2, _config):
+        shuffle_calls.append((w1, w2))
+        return w1.clone().add_(3), w2.clone().add_(4)
+
     monkeypatch.setitem(
         sys.modules,
         "aiter.moe",
@@ -4576,10 +4602,7 @@ def test_w8a8_prewarm_replaces_raw_weights_with_selected_layout(
             "aiter.moe",
             MoeQuantType=MoeQuantType,
             get_aiter_moe_config=lambda **_kwargs: (True, config),
-            aiter_moe_shfl_weight=lambda w1, w2, _config: (
-                w1.clone().add_(3),
-                w2.clone().add_(4),
-            ),
+            aiter_moe_shfl_weight=shuffle_weights,
         ),
     )
     layer = _fp8_moe_layer()
@@ -4604,6 +4627,15 @@ def test_w8a8_prewarm_replaces_raw_weights_with_selected_layout(
         ),
         quant_config,
     )
+    compressed_tensors_moe_runtime.prewarm_aiter_quantized_moe(
+        layer,
+        SimpleNamespace(
+            experts_per_token=2,
+            in_dtype=torch.bfloat16,
+            activation=SimpleNamespace(value="silu"),
+        ),
+        quant_config,
+    )
 
     assert layer.w13_weight._hcu_aiter_moe_solution_type == "asm"
     assert layer.w2_weight._hcu_aiter_moe_solution_type == "asm"
@@ -4619,6 +4651,31 @@ def test_w8a8_prewarm_replaces_raw_weights_with_selected_layout(
         True,
         None,
     )
+    torch.testing.assert_close(layer.w13_weight, torch.full_like(layer.w13_weight, 3))
+    torch.testing.assert_close(layer.w2_weight, torch.full_like(layer.w2_weight, 4))
+    assert len(shuffle_calls) == 1
+
+    reloaded_w13 = torch.nn.Parameter(
+        torch.zeros((3, 8, 4), dtype=torch.int8), requires_grad=False
+    )
+    reloaded_w2 = torch.nn.Parameter(
+        torch.zeros((3, 4, 4), dtype=torch.int8), requires_grad=False
+    )
+    layer.w13_weight = reloaded_w13
+    layer.w2_weight = reloaded_w2
+    compressed_tensors_moe_runtime.prewarm_aiter_quantized_moe(
+        layer,
+        SimpleNamespace(
+            experts_per_token=2,
+            in_dtype=torch.bfloat16,
+            activation=SimpleNamespace(value="silu"),
+        ),
+        quant_config,
+    )
+
+    assert len(shuffle_calls) == 2
+    assert shuffle_calls[1][0] is reloaded_w13
+    assert shuffle_calls[1][1] is reloaded_w2
     torch.testing.assert_close(layer.w13_weight, torch.full_like(layer.w13_weight, 3))
     torch.testing.assert_close(layer.w2_weight, torch.full_like(layer.w2_weight, 4))
 
@@ -4732,6 +4789,63 @@ def test_padded_layout_validation_rejects_wrong_w2_axis(
             config,
             cache_owner=object(),
         )
+
+
+def test_padded_scale_layout_accepts_weight_matching_k_axes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    config = SimpleNamespace(
+        quant_type="fp8_w8a8",
+        solution_type="moe_c",
+        need_shuffle_scale=True,
+        config={"PADDED_K": 8, "ORIGINAL_K": 4},
+    )
+    scale1 = torch.ones((2, 8, 4))
+    scale2 = torch.ones((2, 4, 4))
+    expected1 = torch.full((2, 8, 8), 3.0)
+    expected2 = torch.full((2, 8, 4), 4.0)
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            aiter_moe_shfl_scale=lambda *_args: (expected1, expected2),
+        ),
+    )
+
+    actual1, actual2 = prepare_aiter_moe_scales(
+        scale1, scale2, config, cache_owner=object()
+    )
+
+    assert actual1 is expected1
+    assert actual2 is expected2
+
+
+def test_padded_scale_layout_rejects_wrong_w2_axis(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    config = SimpleNamespace(
+        quant_type="fp8_w8a8",
+        solution_type="moe_c",
+        need_shuffle_scale=True,
+        config={"PADDED_K": 8, "ORIGINAL_K": 4},
+    )
+    scale1 = torch.ones((2, 8, 4))
+    scale2 = torch.ones((2, 4, 4))
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            aiter_moe_shfl_scale=lambda *_args: (
+                torch.zeros((2, 8, 8)),
+                torch.zeros((2, 4, 8)),
+            ),
+        ),
+    )
+
+    with pytest.raises(HcuAiterMoeDispatchError, match="incompatible w2_scale shape"):
+        prepare_aiter_moe_scales(scale1, scale2, config, cache_owner=object())
 
 
 def test_w8a8_m1_miss_locks_native_weights_without_runtime_relayout(
@@ -4854,6 +4968,15 @@ def test_w8a8_prewarm_installs_selected_scale_layout_once(
         ),
         quant_config,
     )
+    compressed_tensors_moe_runtime.prewarm_aiter_quantized_moe(
+        layer,
+        SimpleNamespace(
+            experts_per_token=2,
+            in_dtype=torch.bfloat16,
+            activation=SimpleNamespace(value="silu"),
+        ),
+        quant_config,
+    )
 
     assert len(scale_calls) == 1
     assert layer.w13_weight_scale is not original_w1_scale
@@ -4864,12 +4987,68 @@ def test_w8a8_prewarm_installs_selected_scale_layout_once(
         "w8a8",
         "MOE_C",
         True,
+        None,
+        None,
     )
     assert layer.w2_weight_scale._hcu_aiter_moe_scale_layout == (
         "w8a8",
         "MOE_C",
         True,
+        None,
+        None,
     )
+
+
+def test_installed_scale_layout_rejects_different_padded_k(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class MoeQuantType:
+        W8A8 = "w8a8"
+
+    first_config = SimpleNamespace(
+        quant_type="w8a8",
+        solution_type="moe_c",
+        need_shuffle_scale=True,
+        config={"PADDED_K": 8, "ORIGINAL_K": 4},
+    )
+    second_config = SimpleNamespace(
+        quant_type="w8a8",
+        solution_type="moe_c",
+        need_shuffle_scale=True,
+        config={"PADDED_K": 16, "ORIGINAL_K": 4},
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            MoeQuantType=MoeQuantType,
+            aiter_moe_shfl_scale=lambda scale1, scale2, _config: (
+                torch.zeros((2, 8, 8), dtype=scale1.dtype),
+                torch.zeros((2, 8, 4), dtype=scale2.dtype),
+            ),
+        ),
+    )
+    layer = SimpleNamespace(
+        w13_weight_scale=torch.ones((2, 8, 4)),
+        w2_weight_scale=torch.ones((2, 4, 4)),
+    )
+    quant_config = SimpleNamespace(
+        w1_scale=layer.w13_weight_scale,
+        w2_scale=layer.w2_weight_scale,
+    )
+
+    compressed_tensors_moe_runtime.install_aiter_moe_scale_layout(
+        layer, quant_config, first_config
+    )
+
+    with pytest.raises(
+        compressed_tensors_moe_runtime.HcuCompressedTensorsMoeError,
+        match="selected layout",
+    ):
+        compressed_tensors_moe_runtime.install_aiter_moe_scale_layout(
+            layer, quant_config, second_config
+        )
 
 
 @pytest.mark.hcu

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -2663,6 +2663,10 @@ def test_aiter_w16a16_routes_public_api_with_canonical_weights(
     x = torch.ones(2, 4)
     w1 = torch.ones(3, 8, 4)
     w2 = torch.ones(3, 4, 4)
+    w1.is_shuffled = False
+    w2.is_shuffled = False
+    w1._hcu_aiter_moe_solution_type = "moe_c"
+    w2._hcu_aiter_moe_solution_type = "moe_c"
     topk_weight = torch.ones(2, 2)
     topk_ids = torch.zeros(2, 2, dtype=torch.int64)
     expected = torch.full_like(x, 7)
@@ -2709,7 +2713,7 @@ def test_aiter_w16a16_routes_public_api_with_canonical_weights(
     assert selector_calls[0]["N2"] == 4
     assert selector_calls[0]["K"] == 4
     assert selector_calls[0]["use_shuffle"] == 1
-    assert "spec_sol_type" not in selector_calls[0]
+    assert selector_calls[0]["spec_sol_type"] == "moe_c"
     assert execute_calls[0]["w1"] is w1
     assert execute_calls[0]["w2"] is w2
     assert execute_calls[0]["activation"] == "gelu_tanh"
@@ -2726,6 +2730,8 @@ def test_aiter_w16a16_reuses_installed_asm_layout_without_reshuffle(
     w2 = torch.ones(3, 4, 4)
     w1.is_shuffled = True
     w2.is_shuffled = True
+    w1._hcu_aiter_moe_solution_type = "asm"
+    w2._hcu_aiter_moe_solution_type = "asm"
     selector_calls: list[dict[str, object]] = []
     execute_calls: list[dict[str, object]] = []
     config = SimpleNamespace(
@@ -2802,6 +2808,137 @@ def test_aiter_w16a16_shuffled_weights_never_fall_back_to_triton(
         )
 
 
+def test_aiter_w16a16_installed_canonical_layout_never_runtime_shuffles(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_fake_aiter(monkeypatch)
+    monkeypatch.setattr(aiter_runtime, "is_aiter_moe_requested", lambda: True)
+    w1 = torch.ones(3, 8, 4)
+    w2 = torch.ones(3, 4, 4)
+    for weight in (w1, w2):
+        weight.is_shuffled = False
+        weight._hcu_aiter_moe_solution_type = "triton"
+    config = SimpleNamespace(
+        quant_type="w16a16",
+        solution_type="triton",
+        need_shuffle=True,
+        config={},
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            get_aiter_moe_config=lambda **_kwargs: (True, config),
+            aiter_moe_shfl_weight=lambda *_args: pytest.fail(
+                "installed canonical weights must not be shuffled at runtime"
+            ),
+        ),
+    )
+
+    with pytest.raises(
+        aiter_runtime.HcuAiterRuntimeError,
+        match="layout does not match",
+    ):
+        aiter_runtime.fused_moe_impl(
+            lambda *_args: pytest.fail("must not delegate"),
+            torch.ones(2, 4),
+            w1,
+            w2,
+            torch.ones(2, 2),
+            torch.zeros(2, 2, dtype=torch.int64),
+            activation_method=0,
+        )
+
+
+def test_aiter_w16a16_rejects_runtime_config_for_different_asm_layout(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_fake_aiter(monkeypatch)
+    monkeypatch.setattr(aiter_runtime, "is_aiter_moe_requested", lambda: True)
+    w1 = torch.ones(3, 8, 4)
+    w2 = torch.ones(3, 4, 4)
+    for weight in (w1, w2):
+        weight.is_shuffled = True
+        weight._hcu_aiter_moe_solution_type = "asm"
+        weight._hcu_aiter_moe_weight_layout = (
+            "w16a16",
+            "ASM",
+            True,
+            64,
+        )
+    runtime_config = SimpleNamespace(
+        quant_type="w16a16",
+        solution_type="asm",
+        need_shuffle=True,
+        config={"PADDED_K": 128},
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            get_aiter_moe_config=lambda **_kwargs: (True, runtime_config),
+        ),
+    )
+
+    with pytest.raises(
+        aiter_runtime.HcuAiterRuntimeError,
+        match="physical layout",
+    ):
+        aiter_runtime.fused_moe_impl(
+            lambda *_args: pytest.fail("must not delegate"),
+            torch.ones(2, 4),
+            w1,
+            w2,
+            torch.ones(2, 2),
+            torch.zeros(2, 2, dtype=torch.int64),
+            activation_method=0,
+        )
+
+
+def test_aiter_w16a16_installed_native_fallback_bypasses_selector(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fused_moe_module = __import__(
+        "vllm.model_executor.layers.fused_moe.fused_moe",
+        fromlist=["fused_experts_impl"],
+    )
+    _install_fake_aiter(monkeypatch)
+    monkeypatch.setattr(aiter_runtime, "is_aiter_moe_requested", lambda: True)
+
+    expected = torch.full((2, 4), 5.0)
+    monkeypatch.setattr(
+        aiter_runtime,
+        "select_aiter_moe_config",
+        lambda *_args, **_kwargs: pytest.fail(
+            "native fallback must not reselect AITER at runtime"
+        ),
+    )
+    monkeypatch.setattr(
+        fused_moe_module,
+        "fused_experts_impl",
+        lambda *_args, **_kwargs: expected,
+    )
+    w1 = torch.ones(3, 8, 4)
+    w2 = torch.ones(3, 4, 4)
+    for weight in (w1, w2):
+        weight.is_shuffled = False
+        weight._hcu_aiter_moe_solution_type = "native"
+
+    actual = aiter_runtime.fused_moe_impl(
+        lambda *_args: pytest.fail("must not delegate"),
+        torch.ones(2, 4),
+        w1,
+        w2,
+        torch.ones(2, 2),
+        torch.zeros(2, 2, dtype=torch.int64),
+        activation_method=0,
+    )
+
+    assert actual is expected
+
+
 def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -2857,7 +2994,7 @@ def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
         quant_type="w16a16",
         solution_type="asm",
         need_shuffle=True,
-        config={},
+        config={"PADDED_K": 64},
     )
     monkeypatch.setattr(
         hcu_unquantized,
@@ -2885,6 +3022,20 @@ def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
     torch.testing.assert_close(layer.w2_weight, shuffled_w2)
     assert layer.w13_weight.is_shuffled is True
     assert layer.w2_weight.is_shuffled is True
+    assert layer.w13_weight._hcu_aiter_moe_solution_type == "asm"
+    assert layer.w2_weight._hcu_aiter_moe_solution_type == "asm"
+    assert layer.w13_weight._hcu_aiter_moe_weight_layout == (
+        "w16a16",
+        "ASM",
+        True,
+        64,
+    )
+    assert layer.w2_weight._hcu_aiter_moe_weight_layout == (
+        "w16a16",
+        "ASM",
+        True,
+        64,
+    )
     assert len(kernels) == 1
     assert method.moe_kernel is not None
     assert len(select_calls) == 1
@@ -2907,7 +3058,62 @@ def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
     assert solution_type == "asm"
 
 
-def test_aiter_w16a16_post_load_keeps_canonical_weights_when_shuffle_disabled(
+def test_aiter_w16a16_post_load_locks_canonical_triton_layout(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm_hcu.model_executor.layers.fused_moe import (
+        unquantized_fused_moe_method as hcu_unquantized,
+    )
+
+    w13 = torch.nn.Parameter(torch.ones(2, 8, 4), requires_grad=False)
+    w2 = torch.nn.Parameter(torch.ones(2, 4, 4), requires_grad=False)
+    layer = SimpleNamespace(w13_weight=w13, w2_weight=w2)
+    method = object.__new__(hcu_unquantized.HcuUnquantizedFusedMoEMethod)
+    method.moe = SimpleNamespace(
+        num_experts=2,
+        experts_per_token=2,
+        in_dtype=torch.bfloat16,
+        activation=SimpleNamespace(value="silu"),
+    )
+    method.unquantized_backend = hcu_unquantized.UnquantizedMoeBackend.AITER
+    method.experts_cls = object
+    method.get_fused_moe_quant_config = lambda _layer: object()
+    monkeypatch.setattr(hcu_unquantized, "_is_hcu_aiter_moe_requested", lambda *_: True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_AITER_MOE_SHUFFLE", False)
+    select_calls: list[tuple[AiterMoeProblem, object, object]] = []
+    config = SimpleNamespace(
+        quant_type="w16a16",
+        solution_type="triton",
+        need_shuffle=False,
+        config={},
+    )
+    monkeypatch.setattr(
+        hcu_unquantized,
+        "select_aiter_moe_config",
+        lambda problem, cache_owner, solution_type=None: select_calls.append(
+            (problem, cache_owner, solution_type)
+        ) or config,
+    )
+    monkeypatch.setattr(
+        hcu_unquantized,
+        "make_unquantized_moe_kernel",
+        lambda **_kwargs: object(),
+    )
+
+    method.process_weights_after_loading(layer)
+
+    assert layer.w13_weight is w13
+    assert layer.w2_weight is w2
+    assert layer.w13_weight.is_shuffled is False
+    assert layer.w2_weight.is_shuffled is False
+    assert layer.w13_weight._hcu_aiter_moe_solution_type == "triton"
+    assert layer.w2_weight._hcu_aiter_moe_solution_type == "triton"
+    assert len(select_calls) == 1
+    assert select_calls[0][1] is w13
+    assert select_calls[0][2] is None
+
+
+def test_aiter_w16a16_post_load_locks_native_fallback_on_m1_miss(
     monkeypatch: pytest.MonkeyPatch,
 ):
     from vllm_hcu.model_executor.layers.fused_moe import (
@@ -2932,7 +3138,7 @@ def test_aiter_w16a16_post_load_keeps_canonical_weights_when_shuffle_disabled(
     monkeypatch.setattr(
         hcu_unquantized,
         "select_aiter_moe_config",
-        lambda *_args, **_kwargs: pytest.fail("disabled shuffle must not be selected"),
+        lambda *_args, **_kwargs: None,
     )
     monkeypatch.setattr(
         hcu_unquantized,
@@ -2944,6 +3150,10 @@ def test_aiter_w16a16_post_load_keeps_canonical_weights_when_shuffle_disabled(
 
     assert layer.w13_weight is w13
     assert layer.w2_weight is w2
+    assert layer.w13_weight.is_shuffled is False
+    assert layer.w2_weight.is_shuffled is False
+    assert layer.w13_weight._hcu_aiter_moe_solution_type == "native"
+    assert layer.w2_weight._hcu_aiter_moe_solution_type == "native"
 
 
 def test_explicit_aiter_backend_uses_public_router_without_auto_env_gate(

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -4453,7 +4453,7 @@ def test_slimquant_w4a8_deepep_routing_fails_closed_before_tp_fallback(
 
 
 @pytest.mark.hcu
-def test_slimquant_w4a8_prewarms_m1_with_logical_packed_dimensions(
+def test_slimquant_w4a8_installs_moe_c_layout_at_load(
     monkeypatch: pytest.MonkeyPatch,
 ):
     from vllm_hcu.model_executor.layers.quantization import slimquant_w4a8
@@ -4462,7 +4462,7 @@ def test_slimquant_w4a8_prewarms_m1_with_logical_packed_dimensions(
     selected = SimpleNamespace(
         quant_type="w4a8",
         solution_type="moe_c",
-        need_shuffle=False,
+        need_shuffle=True,
         need_shuffle_scale=False,
     )
 
@@ -4480,6 +4480,10 @@ def test_slimquant_w4a8_prewarms_m1_with_logical_packed_dimensions(
             "aiter.moe",
             MoeQuantType=MoeQuantType,
             get_aiter_moe_config=get_config,
+            aiter_moe_shfl_weight=lambda w1, w2, _config: (
+                w1.clone().add_(1),
+                w2.clone().add_(2),
+            ),
         ),
     )
     method = slimquant_w4a8.SlimQuantW4A8Int8AiterMoEMethod(
@@ -4522,9 +4526,71 @@ def test_slimquant_w4a8_prewarms_m1_with_logical_packed_dimensions(
             "quant_type": "w4a8",
             "activation": "silu",
             "use_shuffle": 1,
+            "spec_sol_type": "moe_c",
         }
     ]
-    assert not hasattr(layer.w13_weight, "_hcu_aiter_moe_m1_supported")
+    assert layer.w13_weight.is_shuffled is True
+    assert layer.w2_weight.is_shuffled is True
+    assert layer.w13_weight._hcu_aiter_moe_solution_type == "moe_c"
+    assert layer.w2_weight._hcu_aiter_moe_solution_type == "moe_c"
+    torch.testing.assert_close(layer.w13_weight, torch.ones_like(layer.w13_weight))
+    torch.testing.assert_close(layer.w2_weight, torch.full_like(layer.w2_weight, 2))
+
+
+def test_w8a8_prewarm_replaces_raw_weights_with_selected_layout(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    config = SimpleNamespace(
+        quant_type="w8a8",
+        solution_type="asm",
+        need_shuffle=True,
+        need_shuffle_scale=False,
+        config={},
+    )
+
+    class MoeQuantType:
+        W8A8 = "w8a8"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            MoeQuantType=MoeQuantType,
+            get_aiter_moe_config=lambda **_kwargs: (True, config),
+            aiter_moe_shfl_weight=lambda w1, w2, _config: (
+                w1.clone().add_(3),
+                w2.clone().add_(4),
+            ),
+        ),
+    )
+    layer = _fp8_moe_layer()
+    layer.w13_weight = torch.nn.Parameter(
+        torch.zeros((3, 8, 4), dtype=torch.int8), requires_grad=False
+    )
+    layer.w2_weight = torch.nn.Parameter(
+        torch.zeros((3, 4, 4), dtype=torch.int8), requires_grad=False
+    )
+    quant_config = SimpleNamespace(
+        use_fp8_w8a8=False,
+        use_int8_w8a8=True,
+        block_shape=None,
+    )
+
+    compressed_tensors_moe_runtime.prewarm_aiter_quantized_moe(
+        layer,
+        SimpleNamespace(
+            experts_per_token=2,
+            in_dtype=torch.bfloat16,
+            activation=SimpleNamespace(value="silu"),
+        ),
+        quant_config,
+    )
+
+    assert layer.w13_weight._hcu_aiter_moe_solution_type == "asm"
+    assert layer.w2_weight._hcu_aiter_moe_solution_type == "asm"
+    torch.testing.assert_close(layer.w13_weight, torch.full_like(layer.w13_weight, 3))
+    torch.testing.assert_close(layer.w2_weight, torch.full_like(layer.w2_weight, 4))
 
 
 @pytest.mark.hcu
@@ -4622,11 +4688,11 @@ def test_slimquant_w4a8_explicit_triton_prepares_only_vllm_weights(
 
     method.process_weights_after_loading(layer)
 
-    fallback_w1, fallback_w2 = (
-        layer.w13_weight._hcu_vllm_w4a8_fallback_weights
-    )
-    assert fallback_w1.shape == (1, 4, 4)
-    assert fallback_w2.shape == (1, 4, 2)
+    assert layer.w13_weight.shape == (1, 4, 4)
+    assert layer.w2_weight.shape == (1, 4, 2)
+    assert layer.w13_weight._hcu_vllm_w4a8_unpacked is True
+    assert layer.w2_weight._hcu_vllm_w4a8_unpacked is True
+    assert not hasattr(layer.w13_weight, "_hcu_vllm_w4a8_fallback_weights")
     assert not hasattr(layer.w13_weight, "_hcu_aiter_moe_m1_supported")
 
 

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -5878,6 +5878,85 @@ def test_moe_fp8_installed_layout_rejects_hidden_width_mismatch(
         )
 
 
+@pytest.mark.parametrize("entrypoint", ["generic", "explicit"])
+def test_quantized_native_layout_accepts_non_gated_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+    entrypoint: str,
+):
+    class MoeQuantType:
+        FP8_W8A8 = "fp8_w8a8"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module("aiter.moe", MoeQuantType=MoeQuantType),
+    )
+    expected = torch.ones((2, 4))
+    fused_moe_module = __import__(
+        "vllm.model_executor.layers.fused_moe.fused_moe",
+        fromlist=["fused_experts_impl"],
+    )
+    monkeypatch.setattr(
+        fused_moe_module,
+        "fused_experts_impl",
+        lambda *_args, **_kwargs: expected,
+    )
+    w1 = torch.zeros((2, 6, 4))
+    w2 = torch.zeros((2, 4, 6))
+    for weight in (w1, w2):
+        weight._hcu_aiter_moe_solution_type = "native"
+        weight._hcu_aiter_moe_logical_shape = (2, 6, 4, 4)
+        weight.is_shuffled = False
+    hidden_states = torch.ones((2, 4))
+    topk_weights = torch.ones((2, 1))
+    topk_ids = torch.zeros((2, 1), dtype=torch.int64)
+    if entrypoint == "generic":
+        quant_config = SimpleNamespace(
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            block_shape=None,
+            w1_scale=torch.ones((2, 6, 1)),
+            w2_scale=torch.ones((2, 4, 1)),
+            a1_scale=None,
+            a2_scale=None,
+        )
+        actual = compressed_tensors_moe_runtime.apply_aiter_quantized_moe(
+            hidden_states,
+            w1,
+            w2,
+            topk_weights,
+            topk_ids,
+            SimpleNamespace(num_experts=2),
+            SimpleNamespace(value="relu2"),
+            False,
+            None,
+            quant_config,
+        )
+    else:
+        layer = SimpleNamespace(
+            activation=SimpleNamespace(value="relu2"),
+            apply_router_weight_on_input=False,
+            w13_weight=w1,
+            w2_weight=w2,
+            w13_weight_scale=torch.ones((2, 6, 1)),
+            w2_weight_scale=torch.ones((2, 4, 1)),
+            w13_input_scale=None,
+            w2_input_scale=None,
+            global_num_experts=2,
+            expert_map=None,
+        )
+        actual = compressed_tensors_moe_runtime.apply_aiter_w8a8_fp8_moe(
+            SimpleNamespace(moe=object()),
+            layer,
+            hidden_states,
+            topk_weights,
+            topk_ids,
+            None,
+            None,
+        )
+    assert actual is expected
+
+
 def test_moe_fp8_uses_unified_shuffle_cache_and_invalidates_on_weight_change(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -215,6 +215,46 @@ def test_aiter_dispatch_selector_passes_problem_without_forcing_solution(
     assert "device" not in captured
 
 
+def test_aiter_dispatch_can_pin_asm_shuffle_solution(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, object] = {}
+    expected = SimpleNamespace(solution_type="asm", need_shuffle=True)
+
+    def get_config(**kwargs: object):
+        captured.update(kwargs)
+        return True, expected
+
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module("aiter.moe", get_aiter_moe_config=get_config),
+    )
+    problem = AiterMoeProblem(
+        M=1,
+        E=2,
+        N1=8,
+        N2=4,
+        K=4,
+        top_k=2,
+        block_size=0,
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+        quant_type="w16a16",
+        use_shuffle=True,
+    )
+
+    actual = select_aiter_moe_config(
+        problem,
+        cache_owner=torch.empty(1),
+        solution_type="asm",
+    )
+
+    assert actual is expected
+    assert captured["spec_sol_type"] == "asm"
+    assert captured["use_shuffle"] == 1
+
+
 def test_aiter_dispatch_selector_returns_none_only_for_explicit_no_solution(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -2676,7 +2716,93 @@ def test_aiter_w16a16_routes_public_api_with_canonical_weights(
     assert execute_calls[0]["gemm1_limit"] == 7.5
 
 
-def test_aiter_w16a16_post_load_preserves_canonical_parameters(
+def test_aiter_w16a16_reuses_installed_asm_layout_without_reshuffle(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_fake_aiter(monkeypatch)
+    monkeypatch.setattr(aiter_runtime, "is_aiter_moe_requested", lambda: True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_AITER_MOE_SHUFFLE", True)
+    w1 = torch.ones(3, 8, 4)
+    w2 = torch.ones(3, 4, 4)
+    w1.is_shuffled = True
+    w2.is_shuffled = True
+    selector_calls: list[dict[str, object]] = []
+    execute_calls: list[dict[str, object]] = []
+    config = SimpleNamespace(
+        quant_type="w16a16",
+        solution_type="asm",
+        need_shuffle=True,
+        config={},
+    )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            get_aiter_moe_config=lambda **kwargs: (
+                selector_calls.append(kwargs) or True,
+                config,
+            ),
+            aiter_moe_shfl_weight=lambda *_args, **_kwargs: pytest.fail(
+                "installed ASM weights must not be shuffled again"
+            ),
+            aiter_moe=lambda **kwargs: execute_calls.append(kwargs)
+            or kwargs["hidden_states"].clone(),
+        ),
+    )
+
+    aiter_runtime.fused_moe_impl(
+        lambda *_args: pytest.fail("must not delegate"),
+        torch.ones(2, 4),
+        w1,
+        w2,
+        torch.ones(2, 2),
+        torch.zeros(2, 2, dtype=torch.int64),
+        activation_method=0,
+    )
+
+    assert selector_calls[0]["spec_sol_type"] == "asm"
+    assert execute_calls[0]["w1"] is w1
+    assert execute_calls[0]["w2"] is w2
+    assert execute_calls[0]["use_weight_shuffle"] is True
+
+
+def test_aiter_w16a16_shuffled_weights_never_fall_back_to_triton(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_fake_aiter(monkeypatch)
+    monkeypatch.setattr(aiter_runtime, "is_aiter_moe_requested", lambda: True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_AITER_MOE_SHUFFLE", True)
+    w1 = torch.ones(3, 8, 4)
+    w2 = torch.ones(3, 4, 4)
+    w1.is_shuffled = True
+    w2.is_shuffled = True
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            get_aiter_moe_config=lambda **_kwargs: (False, None),
+        ),
+    )
+
+    with pytest.raises(
+        aiter_runtime.HcuAiterRuntimeError,
+        match="no ASM solution",
+    ):
+        aiter_runtime.fused_moe_impl(
+            lambda *_args: pytest.fail("must not delegate"),
+            torch.ones(2, 4),
+            w1,
+            w2,
+            torch.ones(2, 2),
+            torch.zeros(2, 2, dtype=torch.int64),
+            activation_method=0,
+        )
+
+
+def test_aiter_w16a16_post_load_replaces_parameters_with_asm_layout(
     monkeypatch: pytest.MonkeyPatch,
 ):
     from vllm_hcu.model_executor.layers.fused_moe import (
@@ -2717,30 +2843,52 @@ def test_aiter_w16a16_post_load_preserves_canonical_parameters(
         "make_unquantized_moe_kernel",
         lambda **kwargs: kernels.append(kwargs) or object(),
     )
-    prewarm_calls: list[tuple[AiterMoeProblem, object]] = []
     monkeypatch.setattr(
         hcu_unquantized,
-        "prewarm_aiter_moe_config",
-        lambda problem, cache_owner: prewarm_calls.append(
-            (problem, cache_owner)
+        "replace_parameter",
+        lambda owner, name, value, **_kwargs: setattr(
+            owner,
+            name,
+            torch.nn.Parameter(value, requires_grad=False),
         ),
-        raising=False,
     )
+    select_calls: list[tuple[AiterMoeProblem, object, object]] = []
+    config = SimpleNamespace(
+        quant_type="w16a16",
+        solution_type="asm",
+        need_shuffle=True,
+        config={},
+    )
+    monkeypatch.setattr(
+        hcu_unquantized,
+        "select_aiter_moe_config",
+        lambda problem, cache_owner, solution_type=None: select_calls.append(
+            (problem, cache_owner, solution_type)
+        ) or config,
+    )
+    shuffled_w13 = torch.full_like(w13, 13)
+    shuffled_w2 = torch.full_like(w2, 2)
     monkeypatch.setitem(
         sys.modules,
-        "aiter.moe",
-        _module("aiter.moe"),
+        "aiter.moe", _module(
+            "aiter.moe",
+            aiter_moe_shfl_weight=lambda *_args: (shuffled_w13, shuffled_w2),
+        ),
     )
 
     method.process_weights_after_loading(layer)
     method.process_weights_after_loading(layer)
 
-    assert layer.w13_weight is w13
-    assert layer.w2_weight is w2
+    assert layer.w13_weight is not w13
+    assert layer.w2_weight is not w2
+    torch.testing.assert_close(layer.w13_weight, shuffled_w13)
+    torch.testing.assert_close(layer.w2_weight, shuffled_w2)
+    assert layer.w13_weight.is_shuffled is True
+    assert layer.w2_weight.is_shuffled is True
     assert len(kernels) == 1
     assert method.moe_kernel is not None
-    assert len(prewarm_calls) == 1
-    problem, cache_owner = prewarm_calls[0]
+    assert len(select_calls) == 1
+    problem, cache_owner, solution_type = select_calls[0]
     assert problem == AiterMoeProblem(
         M=1,
         E=2,
@@ -2756,6 +2904,46 @@ def test_aiter_w16a16_post_load_preserves_canonical_parameters(
         use_shuffle=True,
     )
     assert cache_owner is w13
+    assert solution_type == "asm"
+
+
+def test_aiter_w16a16_post_load_keeps_canonical_weights_when_shuffle_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm_hcu.model_executor.layers.fused_moe import (
+        unquantized_fused_moe_method as hcu_unquantized,
+    )
+
+    w13 = torch.nn.Parameter(torch.ones(2, 8, 4), requires_grad=False)
+    w2 = torch.nn.Parameter(torch.ones(2, 4, 4), requires_grad=False)
+    layer = SimpleNamespace(w13_weight=w13, w2_weight=w2)
+    method = object.__new__(hcu_unquantized.HcuUnquantizedFusedMoEMethod)
+    method.moe = SimpleNamespace(
+        num_experts=2,
+        experts_per_token=2,
+        in_dtype=torch.bfloat16,
+        activation=SimpleNamespace(value="silu"),
+    )
+    method.unquantized_backend = hcu_unquantized.UnquantizedMoeBackend.AITER
+    method.experts_cls = object
+    method.get_fused_moe_quant_config = lambda _layer: object()
+    monkeypatch.setattr(hcu_unquantized, "_is_hcu_aiter_moe_requested", lambda *_: True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_AITER_MOE_SHUFFLE", False)
+    monkeypatch.setattr(
+        hcu_unquantized,
+        "select_aiter_moe_config",
+        lambda *_args, **_kwargs: pytest.fail("disabled shuffle must not be selected"),
+    )
+    monkeypatch.setattr(
+        hcu_unquantized,
+        "make_unquantized_moe_kernel",
+        lambda **_kwargs: object(),
+    )
+
+    method.process_weights_after_loading(layer)
+
+    assert layer.w13_weight is w13
+    assert layer.w2_weight is w2
 
 
 def test_explicit_aiter_backend_uses_public_router_without_auto_env_gate(

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -4510,6 +4510,10 @@ def test_slimquant_w4a8_installs_moe_c_layout_at_load(
             torch.ones(2, 4, 1), requires_grad=False
         ),
     )
+    method.moe_quant_config = SimpleNamespace(
+        w1_scale=layer.w13_weight_scale * 16.0,
+        w2_scale=layer.w2_weight_scale * 16.0,
+    )
 
     method.process_weights_after_loading(layer)
 
@@ -4533,6 +4537,20 @@ def test_slimquant_w4a8_installs_moe_c_layout_at_load(
     assert layer.w2_weight.is_shuffled is True
     assert layer.w13_weight._hcu_aiter_moe_solution_type == "moe_c"
     assert layer.w2_weight._hcu_aiter_moe_solution_type == "moe_c"
+    torch.testing.assert_close(
+        method.moe_quant_config.w1_scale,
+        torch.full_like(method.moe_quant_config.w1_scale, 16.0),
+    )
+    torch.testing.assert_close(
+        method.moe_quant_config.w2_scale,
+        torch.full_like(method.moe_quant_config.w2_scale, 16.0),
+    )
+    torch.testing.assert_close(
+        layer.w13_weight_scale, torch.ones_like(layer.w13_weight_scale)
+    )
+    torch.testing.assert_close(
+        layer.w2_weight_scale, torch.ones_like(layer.w2_weight_scale)
+    )
     torch.testing.assert_close(layer.w13_weight, torch.ones_like(layer.w13_weight))
     torch.testing.assert_close(layer.w2_weight, torch.full_like(layer.w2_weight, 2))
 
@@ -4589,8 +4607,234 @@ def test_w8a8_prewarm_replaces_raw_weights_with_selected_layout(
 
     assert layer.w13_weight._hcu_aiter_moe_solution_type == "asm"
     assert layer.w2_weight._hcu_aiter_moe_solution_type == "asm"
+    assert layer.w13_weight._hcu_aiter_moe_weight_layout == (
+        "w8a8",
+        "ASM",
+        True,
+        None,
+    )
+    assert layer.w2_weight._hcu_aiter_moe_weight_layout == (
+        "w8a8",
+        "ASM",
+        True,
+        None,
+    )
     torch.testing.assert_close(layer.w13_weight, torch.full_like(layer.w13_weight, 3))
     torch.testing.assert_close(layer.w2_weight, torch.full_like(layer.w2_weight, 4))
+
+
+def test_w8a8_padded_layout_keeps_original_logical_problem_dimensions(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    config = SimpleNamespace(
+        quant_type="fp8_w8a8",
+        solution_type="moe_c",
+        need_shuffle=True,
+        need_shuffle_scale=False,
+        config={"PADDED_K": 8, "ORIGINAL_K": 4},
+    )
+    config_calls: list[dict[str, object]] = []
+
+    class MoeQuantType:
+        FP8_W8A8 = "fp8_w8a8"
+
+    def get_config(**kwargs):
+        config_calls.append(kwargs)
+        return True, config
+
+    def shuffle_weights(w1, w2, _config):
+        return (
+            torch.zeros((w1.shape[0], w1.shape[1], 8), dtype=w1.dtype),
+            torch.zeros((w2.shape[0], w2.shape[1], 8), dtype=w2.dtype),
+        )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            MoeQuantType=MoeQuantType,
+            get_aiter_moe_config=get_config,
+            aiter_moe_shfl_weight=shuffle_weights,
+            aiter_moe=lambda **kwargs: kwargs["hidden_states"],
+        ),
+    )
+    layer = _fp8_moe_layer()
+    quant_config = SimpleNamespace(
+        use_fp8_w8a8=True,
+        use_int8_w8a8=False,
+        block_shape=None,
+        w1_scale=layer.w13_weight_scale,
+        w2_scale=layer.w2_weight_scale,
+        a1_scale=None,
+        a2_scale=None,
+    )
+    moe_config = SimpleNamespace(
+        experts_per_token=2,
+        in_dtype=torch.bfloat16,
+        activation=SimpleNamespace(value="silu"),
+        num_experts=3,
+    )
+
+    compressed_tensors_moe_runtime.prewarm_aiter_quantized_moe(
+        layer, moe_config, quant_config
+    )
+    compressed_tensors_moe_runtime.apply_aiter_quantized_moe(
+        hidden_states=torch.ones((2, 4), dtype=torch.bfloat16),
+        w1=layer.w13_weight,
+        w2=layer.w2_weight,
+        topk_weights=torch.ones((2, 2), dtype=torch.bfloat16),
+        topk_ids=torch.zeros((2, 2), dtype=torch.int64),
+        vllm_moe_config=moe_config,
+        activation=SimpleNamespace(value="silu"),
+        apply_router_weight_on_input=False,
+        expert_map=None,
+        quant_config=quant_config,
+    )
+
+    assert layer.w13_weight.shape[2] == 8
+    assert layer.w2_weight.shape[2] == 8
+    assert config_calls[1]["K"] == 4
+    assert config_calls[1]["N1"] == 8
+    assert config_calls[1]["N2"] == 4
+
+
+def test_w8a8_m1_miss_locks_native_weights_without_runtime_relayout(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class MoeQuantType:
+        W8A8 = "w8a8"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            MoeQuantType=MoeQuantType,
+            get_aiter_moe_config=lambda **_kwargs: (False, None),
+        ),
+    )
+    layer = _fp8_moe_layer()
+    layer.w13_weight = torch.nn.Parameter(
+        torch.zeros((3, 8, 4), dtype=torch.int8), requires_grad=False
+    )
+    layer.w2_weight = torch.nn.Parameter(
+        torch.zeros((3, 4, 4), dtype=torch.int8), requires_grad=False
+    )
+
+    compressed_tensors_moe_runtime.prewarm_aiter_quantized_moe(
+        layer,
+        SimpleNamespace(
+            experts_per_token=2,
+            in_dtype=torch.bfloat16,
+            activation=SimpleNamespace(value="silu"),
+        ),
+        SimpleNamespace(
+            use_fp8_w8a8=False,
+            use_int8_w8a8=True,
+            block_shape=None,
+        ),
+    )
+
+    assert layer.w13_weight._hcu_aiter_moe_solution_type == "native"
+    assert layer.w2_weight._hcu_aiter_moe_solution_type == "native"
+    assert layer.w13_weight.is_shuffled is False
+    assert layer.w2_weight.is_shuffled is False
+
+
+def test_quantized_installed_weights_reject_different_physical_layout():
+    w1 = torch.zeros((2, 8, 4), dtype=torch.int8)
+    w2 = torch.zeros((2, 4, 4), dtype=torch.int8)
+    installed_layout = ("w8a8", "MOE_C", True, 64)
+    for weight in (w1, w2):
+        weight.is_shuffled = True
+        weight._hcu_aiter_moe_solution_type = "moe_c"
+        weight._hcu_aiter_moe_weight_layout = installed_layout
+    runtime_config = SimpleNamespace(
+        quant_type="w8a8",
+        solution_type="moe_c",
+        need_shuffle=True,
+        config={"PADDED_K": 128},
+    )
+
+    with pytest.raises(
+        compressed_tensors_moe_runtime.HcuCompressedTensorsMoeError,
+        match="physical layout",
+    ):
+        compressed_tensors_moe_runtime._weights_for_selected_config(
+            w1,
+            w2,
+            runtime_config,
+            installed_solution="moe_c",
+        )
+
+
+def test_w8a8_prewarm_installs_selected_scale_layout_once(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    config = SimpleNamespace(
+        quant_type="w8a8",
+        solution_type="moe_c",
+        need_shuffle=False,
+        need_shuffle_scale=True,
+        config={},
+    )
+
+    class MoeQuantType:
+        W8A8 = "w8a8"
+
+    scale_calls: list[tuple[torch.Tensor, torch.Tensor]] = []
+
+    def shuffle_scales(scale1, scale2, _config):
+        scale_calls.append((scale1, scale2))
+        return scale1.clone().add_(3), scale2.clone().add_(4)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.moe",
+        _module(
+            "aiter.moe",
+            MoeQuantType=MoeQuantType,
+            get_aiter_moe_config=lambda **_kwargs: (True, config),
+            aiter_moe_shfl_scale=shuffle_scales,
+        ),
+    )
+    layer = _fp8_moe_layer()
+    original_w1_scale = layer.w13_weight_scale
+    original_w2_scale = layer.w2_weight_scale
+    quant_config = SimpleNamespace(
+        use_fp8_w8a8=False,
+        use_int8_w8a8=True,
+        block_shape=None,
+        w1_scale=original_w1_scale,
+        w2_scale=original_w2_scale,
+    )
+
+    compressed_tensors_moe_runtime.prewarm_aiter_quantized_moe(
+        layer,
+        SimpleNamespace(
+            experts_per_token=2,
+            in_dtype=torch.bfloat16,
+            activation=SimpleNamespace(value="silu"),
+        ),
+        quant_config,
+    )
+
+    assert len(scale_calls) == 1
+    assert layer.w13_weight_scale is not original_w1_scale
+    assert layer.w2_weight_scale is not original_w2_scale
+    assert quant_config.w1_scale is layer.w13_weight_scale
+    assert quant_config.w2_scale is layer.w2_weight_scale
+    assert layer.w13_weight_scale._hcu_aiter_moe_scale_layout == (
+        "w8a8",
+        "MOE_C",
+        True,
+    )
+    assert layer.w2_weight_scale._hcu_aiter_moe_scale_layout == (
+        "w8a8",
+        "MOE_C",
+        True,
+    )
 
 
 @pytest.mark.hcu
@@ -4697,7 +4941,7 @@ def test_slimquant_w4a8_explicit_triton_prepares_only_vllm_weights(
 
 
 @pytest.mark.hcu
-def test_slimquant_w4a8_unsupported_m1_does_not_expand_weights_at_load(
+def test_slimquant_w4a8_m1_miss_installs_single_native_triton_layout(
     monkeypatch: pytest.MonkeyPatch,
 ):
     from vllm_hcu.model_executor.layers.quantization import slimquant_w4a8
@@ -4748,12 +4992,16 @@ def test_slimquant_w4a8_unsupported_m1_does_not_expand_weights_at_load(
 
     method.process_weights_after_loading(layer)
 
-    assert not hasattr(layer.w13_weight, "_hcu_aiter_moe_m1_supported")
-    assert not hasattr(layer.w13_weight, "_hcu_vllm_w4a8_fallback_weights")
+    assert layer.w13_weight.shape == (1, 4, 4)
+    assert layer.w2_weight.shape == (1, 4, 2)
+    assert layer.w13_weight._hcu_vllm_w4a8_unpacked is True
+    assert layer.w2_weight._hcu_vllm_w4a8_unpacked is True
+    assert layer.w13_weight._hcu_aiter_moe_solution_type == "native"
+    assert layer.w2_weight._hcu_aiter_moe_solution_type == "native"
 
 
 @pytest.mark.hcu
-def test_slimquant_w4a8_runtime_rechecks_actual_m_after_m1_miss(
+def test_slimquant_w4a8_legacy_raw_weights_pin_actual_m_to_moe_c(
     monkeypatch: pytest.MonkeyPatch,
 ):
     calls: dict[str, object] = {}
@@ -4827,6 +5075,7 @@ def test_slimquant_w4a8_runtime_rechecks_actual_m_after_m1_miss(
         "quant_type": "w4a8",
         "activation": "silu",
         "use_shuffle": 1,
+        "spec_sol_type": "moe_c",
     }
     execute = calls["execute"]
     assert execute["moe_config"] is selected

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -5080,13 +5080,12 @@ def test_slimquant_w4a8_tp_aiter_keeps_selected_canonical_owner(
         w2_weight_scale=torch.nn.Parameter(
             torch.ones((1, 4, 1), dtype=torch.float32), requires_grad=False
         ),
+        w13_input_scale=None,
+        w2_input_scale=None,
     )
     expected_w13 = w13.detach().clone()
     expected_w2 = w2.detach().clone()
-    method.moe_quant_config = SimpleNamespace(
-        w1_scale=layer.w13_weight_scale * 16.0,
-        w2_scale=layer.w2_weight_scale * 16.0,
-    )
+    assert method.moe_quant_config is None
     selected = SimpleNamespace(
         quant_type="w4a8",
         solution_type="moe_c",
@@ -5108,12 +5107,33 @@ def test_slimquant_w4a8_tp_aiter_keeps_selected_canonical_owner(
 
     method.process_weights_after_loading(layer)
 
+    assert method.moe_quant_config is not None
     assert prewarm_calls == [layer]
     assert layer.w13_weight is w13
     assert layer.w2_weight is w2
     torch.testing.assert_close(layer.w13_weight, expected_w13)
     torch.testing.assert_close(layer.w2_weight, expected_w2)
     assert not hasattr(layer, "_slimquant_w4a8_deepep_auto_layout")
+
+    installed_quant_config = method.moe_quant_config
+    method.process_weights_after_loading(layer)
+    assert method.moe_quant_config is installed_quant_config
+    assert prewarm_calls == [layer]
+
+    with torch.no_grad():
+        layer.w13_weight_scale.add_(1.0)
+        layer.w2_weight_scale.add_(2.0)
+    method.process_weights_after_loading(layer)
+    assert method.moe_quant_config is not installed_quant_config
+    assert prewarm_calls == [layer]
+    torch.testing.assert_close(
+        method.moe_quant_config.w1_scale,
+        torch.full((1, 8, 1), 32.0),
+    )
+    torch.testing.assert_close(
+        method.moe_quant_config.w2_scale,
+        torch.full((1, 4, 1), 48.0),
+    )
 
 
 @pytest.mark.hcu
@@ -5158,7 +5178,12 @@ def test_slimquant_w4a8_explicit_triton_prepares_only_vllm_weights(
         w2_weight_scale=torch.nn.Parameter(
             torch.ones(1, 4, 1), requires_grad=False
         ),
+        w13_input_scale=None,
+        w2_input_scale=None,
     )
+    assert method.moe_quant_config is None
+    packed_w13 = layer.w13_weight.detach().clone()
+    packed_w2 = layer.w2_weight.detach().clone()
 
     method.process_weights_after_loading(layer)
 
@@ -5168,6 +5193,83 @@ def test_slimquant_w4a8_explicit_triton_prepares_only_vllm_weights(
     assert layer.w2_weight._hcu_vllm_w4a8_unpacked is True
     assert not hasattr(layer.w13_weight, "_hcu_vllm_w4a8_fallback_weights")
     assert not hasattr(layer.w13_weight, "_hcu_aiter_moe_m1_supported")
+    assert method.moe_quant_config is not None
+    torch.testing.assert_close(
+        method.moe_quant_config.w1_scale,
+        layer.w13_weight_scale * 16.0,
+    )
+    torch.testing.assert_close(
+        method.moe_quant_config.w2_scale,
+        layer.w2_weight_scale * 16.0,
+    )
+
+    from vllm.model_executor.layers.fused_moe import fused_moe
+
+    kernel_calls: list[dict[str, object]] = []
+
+    def fused_experts_impl(hidden_states, *_args, **kwargs):
+        kernel_calls.append(kwargs)
+        return hidden_states + 1
+
+    monkeypatch.setattr(fused_moe, "fused_experts_impl", fused_experts_impl)
+    hidden_states = torch.zeros((2, 4), dtype=torch.float16)
+    result = method.apply(
+        layer,
+        hidden_states,
+        torch.ones((2, 1), dtype=torch.float32),
+        torch.zeros((2, 1), dtype=torch.int64),
+        None,
+        None,
+    )
+
+    torch.testing.assert_close(result, hidden_states + 1)
+    assert kernel_calls[0]["w1_scale"] is method.moe_quant_config.w1_scale
+    assert kernel_calls[0]["w2_scale"] is method.moe_quant_config.w2_scale
+
+    installed_w13 = layer.w13_weight
+    installed_w2 = layer.w2_weight
+    installed_quant_config = method.moe_quant_config
+    method.process_weights_after_loading(layer)
+    assert layer.w13_weight is installed_w13
+    assert layer.w2_weight is installed_w2
+    assert method.moe_quant_config is installed_quant_config
+
+    with torch.no_grad():
+        layer.w13_weight_scale.add_(1.0)
+        layer.w2_weight_scale.add_(2.0)
+    method.process_weights_after_loading(layer)
+    scale_updated_quant_config = method.moe_quant_config
+    assert layer.w13_weight is installed_w13
+    assert layer.w2_weight is installed_w2
+    assert scale_updated_quant_config is not installed_quant_config
+    torch.testing.assert_close(
+        scale_updated_quant_config.w1_scale,
+        torch.full((1, 4, 1), 32.0),
+    )
+    torch.testing.assert_close(
+        scale_updated_quant_config.w2_scale,
+        torch.full((1, 4, 1), 48.0),
+    )
+
+    layer.w13_weight = torch.nn.Parameter(packed_w13, requires_grad=False)
+    layer.w2_weight = torch.nn.Parameter(packed_w2, requires_grad=False)
+    layer.w13_weight_scale = torch.nn.Parameter(
+        torch.full((1, 4, 1), 2.0), requires_grad=False
+    )
+    layer.w2_weight_scale = torch.nn.Parameter(
+        torch.full((1, 4, 1), 3.0), requires_grad=False
+    )
+    method.process_weights_after_loading(layer)
+
+    assert method.moe_quant_config is not installed_quant_config
+    torch.testing.assert_close(
+        method.moe_quant_config.w1_scale,
+        torch.full((1, 4, 1), 32.0),
+    )
+    torch.testing.assert_close(
+        method.moe_quant_config.w2_scale,
+        torch.full((1, 4, 1), 48.0),
+    )
 
 
 @pytest.mark.hcu
@@ -5224,6 +5326,7 @@ def test_slimquant_w4a8_m1_miss_installs_single_native_triton_layout(
 
     method.process_weights_after_loading(layer)
 
+    assert method.moe_quant_config is not None
     assert layer.w13_weight.shape == (1, 4, 4)
     assert layer.w2_weight.shape == (1, 4, 2)
     assert layer.w13_weight._hcu_vllm_w4a8_unpacked is True

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -4838,10 +4838,10 @@ def test_w8a8_prewarm_installs_selected_scale_layout_once(
 
 
 @pytest.mark.hcu
-def test_slimquant_w4a8_tp_aiter_keeps_raw_canonical_owner(
+def test_slimquant_w4a8_tp_aiter_keeps_selected_canonical_owner(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """The DP auto ownership exception must not mutate pure-TP AITER weights."""
+    """The DP auto ownership exception must not transform pure-TP weights."""
 
     from vllm_hcu.model_executor.layers.quantization import slimquant_w4a8
 
@@ -4869,11 +4869,27 @@ def test_slimquant_w4a8_tp_aiter_keeps_raw_canonical_owner(
     )
     expected_w13 = w13.detach().clone()
     expected_w2 = w2.detach().clone()
+    method.moe_quant_config = SimpleNamespace(
+        w1_scale=layer.w13_weight_scale * 16.0,
+        w2_scale=layer.w2_weight_scale * 16.0,
+    )
+    selected = SimpleNamespace(
+        quant_type="w4a8",
+        solution_type="moe_c",
+        need_shuffle=False,
+        need_shuffle_scale=False,
+        config={},
+    )
     prewarm_calls: list[object] = []
+
+    def prewarm(_method, owner):
+        prewarm_calls.append(owner)
+        return selected
+
     monkeypatch.setattr(
         compressed_tensors_moe_runtime,
         "prewarm_aiter_w4a8_moe",
-        lambda _method, owner: prewarm_calls.append(owner),
+        prewarm,
     )
 
     method.process_weights_after_loading(layer)

--- a/tests/runtime_patch/test_worker_framework_opt.py
+++ b/tests/runtime_patch/test_worker_framework_opt.py
@@ -1290,6 +1290,89 @@ def test_proposer_registers_hcu_spec_decode_metadata_once() -> None:
     )
 
 
+def test_proposer_without_allowlist_does_not_import_optional_flash_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import builtins
+
+    from vllm_hcu.v1.spec_decode import proposer_runtime
+
+    original_import = builtins.__import__
+
+    def import_without_flash_attention(name, *args, **kwargs):
+        if name in {
+            "vllm.v1.attention.backends.mla.flashmla_sparse",
+            "vllm_hcu.v1.attention.backends.flash_attn",
+        }:
+            raise AssertionError("optional attention metadata was imported")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_flash_attention)
+    proposer = SimpleNamespace(allowed_attn_types=None)
+
+    proposer_runtime.initialize_proposer(
+        SimpleNamespace(), proposer, _proposer_config(), "cpu", None
+    )
+
+    assert proposer.allowed_attn_types is None
+
+
+def test_proposer_allows_triton_fallback_when_flash_attn_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import builtins
+
+    from vllm_hcu.v1.spec_decode import proposer_runtime
+
+    original_import = builtins.__import__
+
+    def import_without_flash_attention(name, *args, **kwargs):
+        if name == "vllm_hcu.v1.attention.backends.flash_attn":
+            error = ModuleNotFoundError("No module named 'flash_attn'")
+            error.name = "flash_attn"
+            raise error
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_flash_attention)
+    proposer = SimpleNamespace(allowed_attn_types=(str,))
+
+    proposer_runtime.initialize_proposer(
+        SimpleNamespace(), proposer, _proposer_config(), "cpu", None
+    )
+
+    assert proposer.allowed_attn_types[0] is str
+
+
+def test_proposer_propagates_flash_attention_symbol_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import builtins
+
+    from vllm_hcu.v1.spec_decode import proposer_runtime
+
+    original_import = builtins.__import__
+
+    def import_with_incompatible_flash_attention(name, *args, **kwargs):
+        if name == "vllm_hcu.v1.attention.backends.flash_attn":
+            raise ImportError("cannot import name 'hg_flash_attn_varlen_func'")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(
+        builtins,
+        "__import__",
+        import_with_incompatible_flash_attention,
+    )
+
+    with pytest.raises(ImportError, match="hg_flash_attn_varlen_func"):
+        proposer_runtime.initialize_proposer(
+            SimpleNamespace(),
+            SimpleNamespace(allowed_attn_types=(str,)),
+            _proposer_config(),
+            "cpu",
+            None,
+        )
+
+
 def test_proposer_lightly_cp_atomic_metadata_and_forward_context_chain(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/runtime_patch/test_worker_framework_opt.py
+++ b/tests/runtime_patch/test_worker_framework_opt.py
@@ -1264,11 +1264,14 @@ def test_proposer_sidecar_init_cplb_fix_rocm_preservation_and_custom_sp_padding(
     assert prepared.num_kv_actual_tokens == 5
 
 
-def test_proposer_registers_flashmla_sparse_metadata_once() -> None:
+def test_proposer_registers_hcu_spec_decode_metadata_once() -> None:
     from vllm.v1.attention.backends.mla.flashmla_sparse import (
         FlashMLASparseMetadata,
     )
     from vllm_hcu.v1.spec_decode import proposer_runtime
+    from vllm_hcu.v1.attention.backends.flash_attn import (
+        FlashAttentionMetadata,
+    )
 
     proposer = SimpleNamespace(allowed_attn_types=(str,))
     config = _proposer_config()
@@ -1280,7 +1283,11 @@ def test_proposer_registers_flashmla_sparse_metadata_once() -> None:
         SimpleNamespace(), proposer, config, "cpu", None
     )
 
-    assert proposer.allowed_attn_types == (str, FlashMLASparseMetadata)
+    assert proposer.allowed_attn_types == (
+        str,
+        FlashMLASparseMetadata,
+        FlashAttentionMetadata,
+    )
 
 
 def test_proposer_lightly_cp_atomic_metadata_and_forward_context_chain(

--- a/vllm_hcu/model_executor/layers/fused_moe/aiter_moe_dispatch.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/aiter_moe_dispatch.py
@@ -179,7 +179,7 @@ def _validate_derived_tensor(
         )
     compatible_shape = derived.shape == original.shape
     config_values = getattr(config, "config", None)
-    if not compatible_shape and isinstance(config_values, dict):
+    if isinstance(config_values, dict):
         padded_k = config_values.get("PADDED_K")
         original_k = config_values.get("ORIGINAL_K")
         try:
@@ -187,19 +187,23 @@ def _validate_derived_tensor(
             original_k = int(original_k)
         except (TypeError, ValueError):
             padded_k = original_k = -1
-        padded_axis = {"w1": 2, "w2": 1}.get(label)
-        compatible_shape = (
-            padded_axis is not None
-            and derived.ndim == original.ndim == 3
-            and all(
-                derived.shape[index] == original.shape[index]
-                for index in range(derived.ndim)
-                if index != padded_axis
+        padded_axis = {
+            "w1": 2,
+            "w2": 1,
+            "w1_scale": 2,
+            "w2_scale": 1,
+        }.get(label)
+        if padded_axis is not None and padded_k > original_k > 0:
+            compatible_shape = (
+                derived.ndim == original.ndim == 3
+                and all(
+                    derived.shape[index] == original.shape[index]
+                    for index in range(derived.ndim)
+                    if index != padded_axis
+                )
+                and derived.shape[padded_axis] == padded_k
+                and original.shape[padded_axis] == original_k
             )
-            and derived.shape[padded_axis] == padded_k
-            and original.shape[padded_axis] == original_k
-            and padded_k >= original_k > 0
-        )
     if not compatible_shape:
         raise HcuAiterMoeDispatchError(
             f"AITER returned incompatible {label} shape {tuple(derived.shape)} "

--- a/vllm_hcu/model_executor/layers/fused_moe/aiter_moe_dispatch.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/aiter_moe_dispatch.py
@@ -213,13 +213,15 @@ def _validate_derived_tensor(
 def select_aiter_moe_config(
     problem: AiterMoeProblem,
     cache_owner: object,
+    solution_type: object | None = None,
 ) -> object | None:
     """Ask AITER to route the problem, preserving explicit no-solution status."""
 
     cache = _owner_cache(cache_owner, _SELECTION_CACHE_ATTR)
-    if problem in cache:
-        cache.move_to_end(problem)
-        return cache[problem]
+    cache_key = (problem, _freeze(solution_type))
+    if cache_key in cache:
+        cache.move_to_end(cache_key)
+        return cache[cache_key]
 
     moe_module = import_module("aiter.moe")
     selector = getattr(moe_module, "get_aiter_moe_config", None)
@@ -229,7 +231,11 @@ def select_aiter_moe_config(
             + problem.describe()
         )
 
-    result = selector(
+    # A pinned solution is used when weights have already been converted to
+    # that solution's physical layout.  It must not be silently rerouted.
+    use_shuffle = problem.use_shuffle
+
+    selector_kwargs = dict(
         M=problem.M,
         E=problem.E,
         N1=problem.N1,
@@ -240,8 +246,11 @@ def select_aiter_moe_config(
         dtype=problem.dtype,
         quant_type=problem.quant_type,
         activation=problem.activation,
-        use_shuffle=int(problem.use_shuffle),
+        use_shuffle=int(use_shuffle),
     )
+    if solution_type is not None:
+        selector_kwargs["spec_sol_type"] = solution_type
+    result = selector(**selector_kwargs)
     if not isinstance(result, tuple) or len(result) != 2:
         raise HcuAiterMoeDispatchError(
             "get_aiter_moe_config must return (status, config); "
@@ -260,14 +269,13 @@ def select_aiter_moe_config(
                 "Triton MoE for %s",
                 problem.describe(),
             )
-        _cache_put(cache, problem, None, limit=_SELECTION_CACHE_LIMIT)
+        _cache_put(cache, cache_key, None, limit=_SELECTION_CACHE_LIMIT)
         return None
     if config is None:
         raise HcuAiterMoeDispatchError(
             "get_aiter_moe_config returned status=True without a config; "
             + problem.describe()
         )
-
     solution = _solution_token(config)
     if _mark_route_logged(problem):
         logger.debug(
@@ -275,7 +283,14 @@ def select_aiter_moe_config(
             solution,
             problem.describe(),
         )
-    _cache_put(cache, problem, config, limit=_SELECTION_CACHE_LIMIT)
+    if solution_type is not None and _solution_token(config) != str(
+        getattr(solution_type, "value", solution_type)
+    ).rsplit(".", 1)[-1].upper():
+        raise HcuAiterMoeDispatchError(
+            "AITER ignored the requested MoE solution layout; requested="
+            f"{solution_type!r}, returned={_solution_token(config)}"
+        )
+    _cache_put(cache, cache_key, config, limit=_SELECTION_CACHE_LIMIT)
     return config
 
 

--- a/vllm_hcu/model_executor/layers/fused_moe/aiter_moe_dispatch.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/aiter_moe_dispatch.py
@@ -187,21 +187,17 @@ def _validate_derived_tensor(
             original_k = int(original_k)
         except (TypeError, ValueError):
             padded_k = original_k = -1
-        mismatched_dims = (
-            [
-                index
-                for index, (actual, expected) in enumerate(
-                    zip(derived.shape, original.shape, strict=True)
-                )
-                if actual != expected
-            ]
-            if derived.ndim == original.ndim
-            else []
-        )
+        padded_axis = {"w1": 2, "w2": 1}.get(label)
         compatible_shape = (
-            len(mismatched_dims) == 1
-            and derived.shape[mismatched_dims[0]] == padded_k
-            and original.shape[mismatched_dims[0]] == original_k
+            padded_axis is not None
+            and derived.ndim == original.ndim == 3
+            and all(
+                derived.shape[index] == original.shape[index]
+                for index in range(derived.ndim)
+                if index != padded_axis
+            )
+            and derived.shape[padded_axis] == padded_k
+            and original.shape[padded_axis] == original_k
             and padded_k >= original_k > 0
         )
     if not compatible_shape:

--- a/vllm_hcu/model_executor/layers/fused_moe/aiter_moe_dispatch.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/aiter_moe_dispatch.py
@@ -119,7 +119,9 @@ def _solution_token(config: object) -> str:
     return str(solution).rsplit(".", 1)[-1].upper()
 
 
-def _weight_layout_generation(config: object) -> tuple[Any, ...]:
+def aiter_moe_weight_layout_signature(config: object) -> tuple[Any, ...]:
+    """Return the physical weight-layout contract selected by AITER."""
+
     config_values = getattr(config, "config", None)
     padded_k = (
         config_values.get("PADDED_K")
@@ -321,7 +323,7 @@ def prepare_aiter_moe_weights(
     cache_key = (
         _tensor_generation(w1),
         _tensor_generation(w2),
-        _weight_layout_generation(config),
+        aiter_moe_weight_layout_signature(config),
         _freeze(block_shape),
         preserve_inputs,
     )

--- a/vllm_hcu/model_executor/layers/fused_moe/aiter_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/aiter_runtime.py
@@ -880,8 +880,21 @@ def fused_moe_impl(
         activation=activation,
         use_shuffle=use_shuffle,
     )
-    aiter_config = select_aiter_moe_config(problem, cache_owner=w1)
+    weights_are_shuffled = bool(getattr(w1, "is_shuffled", False))
+    if weights_are_shuffled != bool(getattr(w2, "is_shuffled", False)):
+        raise HcuAiterRuntimeError(
+            "HCU AITER W16A16 weights have inconsistent shuffle state"
+        )
+    aiter_config = select_aiter_moe_config(
+        problem,
+        cache_owner=w1,
+        solution_type="asm" if weights_are_shuffled else None,
+    )
     if aiter_config is None:
+        if weights_are_shuffled:
+            raise HcuAiterRuntimeError(
+                "AITER has no ASM solution for installed ASM-layout weights"
+            )
         native_expert_map, _ = resolve_aiter_expert_maps(
             expert_mask,
             global_num_experts,
@@ -914,12 +927,19 @@ def fused_moe_impl(
             expert_map=native_expert_map,
         )
 
-    prepared_w1, prepared_w2 = prepare_aiter_moe_weights(
-        w1,
-        w2,
-        aiter_config,
-        cache_owner=w1,
-    )
+    if weights_are_shuffled:
+        if not bool(getattr(aiter_config, "need_shuffle", False)):
+            raise HcuAiterRuntimeError(
+                "AITER returned a non-shuffle config for ASM-layout weights"
+            )
+        prepared_w1, prepared_w2 = w1, w2
+    else:
+        prepared_w1, prepared_w2 = prepare_aiter_moe_weights(
+            w1,
+            w2,
+            aiter_config,
+            cache_owner=w1,
+        )
     solution = getattr(aiter_config, "solution_type", None)
     solution = getattr(solution, "value", solution)
     if str(solution).rsplit(".", 1)[-1].upper() == "ASM":

--- a/vllm_hcu/model_executor/layers/fused_moe/aiter_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/aiter_runtime.py
@@ -21,6 +21,7 @@ import torch
 
 from vllm_hcu.model_executor.layers.fused_moe.aiter_moe_dispatch import (
     AiterMoeProblem,
+    aiter_moe_weight_layout_signature,
     execute_aiter_moe,
     prepare_aiter_moe_weights,
     resolve_aiter_expert_maps,
@@ -885,11 +886,29 @@ def fused_moe_impl(
         raise HcuAiterRuntimeError(
             "HCU AITER W16A16 weights have inconsistent shuffle state"
         )
-    aiter_config = select_aiter_moe_config(
-        problem,
-        cache_owner=w1,
-        solution_type="asm" if weights_are_shuffled else None,
-    )
+    installed_solution = getattr(w1, "_hcu_aiter_moe_solution_type", None)
+    if installed_solution != getattr(
+        w2, "_hcu_aiter_moe_solution_type", None
+    ):
+        raise HcuAiterRuntimeError(
+            "HCU AITER W16A16 weights have inconsistent installed solutions"
+        )
+    if installed_solution == "native":
+        if weights_are_shuffled:
+            raise HcuAiterRuntimeError(
+                "HCU AITER native fallback cannot use shuffled W16A16 weights"
+            )
+        aiter_config = None
+    else:
+        aiter_config = select_aiter_moe_config(
+            problem,
+            cache_owner=w1,
+            solution_type=(
+                installed_solution
+                if installed_solution is not None
+                else ("asm" if weights_are_shuffled else None)
+            ),
+        )
     if aiter_config is None:
         if weights_are_shuffled:
             raise HcuAiterRuntimeError(
@@ -927,6 +946,44 @@ def fused_moe_impl(
             expert_map=native_expert_map,
         )
 
+    selected_solution = getattr(aiter_config, "solution_type", None)
+    selected_solution = getattr(selected_solution, "value", selected_solution)
+    if selected_solution is None:
+        raise HcuAiterRuntimeError(
+            "AITER selected a W16A16 config without a solution type"
+        )
+    selected_solution = str(selected_solution).rsplit(".", 1)[-1].lower()
+    if not selected_solution:
+        raise HcuAiterRuntimeError(
+            "AITER selected a W16A16 config without a solution type"
+        )
+    if (
+        installed_solution is not None
+        and selected_solution != installed_solution
+    ):
+        raise HcuAiterRuntimeError(
+            "AITER selected a solution incompatible with installed W16A16 weights"
+        )
+    if installed_solution is not None and bool(
+        getattr(aiter_config, "need_shuffle", False)
+    ) != weights_are_shuffled:
+        raise HcuAiterRuntimeError(
+            "AITER config layout does not match installed W16A16 weights"
+        )
+    installed_layout = getattr(w1, "_hcu_aiter_moe_weight_layout", None)
+    if installed_layout != getattr(
+        w2, "_hcu_aiter_moe_weight_layout", None
+    ):
+        raise HcuAiterRuntimeError(
+            "HCU AITER W16A16 weights have inconsistent physical layouts"
+        )
+    if (
+        installed_layout is not None
+        and aiter_moe_weight_layout_signature(aiter_config) != installed_layout
+    ):
+        raise HcuAiterRuntimeError(
+            "AITER config physical layout does not match installed W16A16 weights"
+        )
     if weights_are_shuffled:
         if not bool(getattr(aiter_config, "need_shuffle", False)):
             raise HcuAiterRuntimeError(
@@ -940,9 +997,7 @@ def fused_moe_impl(
             aiter_config,
             cache_owner=w1,
         )
-    solution = getattr(aiter_config, "solution_type", None)
-    solution = getattr(solution, "value", solution)
-    if str(solution).rsplit(".", 1)[-1].upper() == "ASM":
+    if selected_solution == "asm":
         aiter_expert_map = expert_mask
     else:
         aiter_expert_map, _ = resolve_aiter_expert_maps(

--- a/vllm_hcu/model_executor/layers/fused_moe/aiter_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/aiter_runtime.py
@@ -853,26 +853,54 @@ def fused_moe_impl(
             f"{moe_sorting_dispatch_policy}"
         )
 
-    # HCU AITER consumes vLLM's canonical w1=[E, N1, K] and
-    # w2=[E, N2, K2]. N2 is GEMM2's hidden/output dimension at w2.shape[1].
-    if (
-        w1.dim() != 3
-        or w2.dim() != 3
-        or int(w1.shape[0]) != int(w2.shape[0])
-        or int(w1.shape[1]) != 2 * int(w2.shape[2])
-        or int(w1.shape[2]) != int(w2.shape[1])
-    ):
+    logical_shape = getattr(w1, "_hcu_aiter_moe_logical_shape", None)
+    if logical_shape != getattr(w2, "_hcu_aiter_moe_logical_shape", None):
+        raise HcuAiterRuntimeError(
+            "HCU AITER W16A16 weights have inconsistent logical dimensions"
+        )
+    if w1.dim() != 3 or w2.dim() != 3 or w1.shape[0] != w2.shape[0]:
         raise ValueError(
             f"unexpected MoE weight layout: w1.shape={tuple(w1.shape)}, "
             f"w2.shape={tuple(w2.shape)}"
         )
+    if logical_shape is None:
+        if (
+            int(w1.shape[1]) != 2 * int(w2.shape[2])
+            or int(w1.shape[2]) != int(w2.shape[1])
+        ):
+            raise ValueError(
+                f"unexpected MoE weight layout: w1.shape={tuple(w1.shape)}, "
+                f"w2.shape={tuple(w2.shape)}"
+            )
+        logical_e = global_num_experts
+        logical_n1 = int(w1.shape[1])
+        logical_n2 = int(w2.shape[1])
+        logical_k = int(w1.shape[2])
+    else:
+        if (
+            not isinstance(logical_shape, tuple)
+            or len(logical_shape) != 4
+            or not all(isinstance(value, int) and value > 0 for value in logical_shape)
+        ):
+            raise HcuAiterRuntimeError(
+                "HCU AITER W16A16 weights have invalid logical dimensions"
+            )
+        logical_e, logical_n1, logical_n2, logical_k = logical_shape
+        if logical_e != global_num_experts:
+            raise HcuAiterRuntimeError(
+                "HCU AITER W16A16 logical expert count does not match routing"
+            )
+    if int(hidden_states.shape[1]) != logical_k:
+        raise HcuAiterRuntimeError(
+            "HCU AITER W16A16 hidden states do not match logical K"
+        )
 
     problem = AiterMoeProblem(
         M=int(hidden_states.shape[0]),
-        E=global_num_experts,
-        N1=int(w1.shape[1]),
-        N2=int(w2.shape[1]),
-        K=int(w1.shape[2]),
+        E=logical_e,
+        N1=logical_n1,
+        N2=logical_n2,
+        K=logical_k,
         top_k=int(topk_ids.shape[1]),
         block_size=0,
         dtype=hidden_states.dtype,

--- a/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -3,11 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
 # Modified by Hygon Information Technology Co., Ltd., 2026.
 
-"""
-HCU version of UnquantizedFusedMoEMethod.
-Inherits from vllm's version and overrides process_weights_after_loading
-to preserve canonical AITER weights while initializing the MoE kernel.
-"""
+"""HCU unquantized MoE integration."""
 
 from __future__ import annotations
 
@@ -20,9 +16,12 @@ from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
     UnquantizedFusedMoEMethod as _Original,
 )
+from vllm.model_executor.utils import replace_parameter
 from vllm_hcu.model_executor.layers.fused_moe.aiter_moe_dispatch import (
     AiterMoeProblem,
-    prewarm_aiter_moe_config,
+    HcuAiterMoeDispatchError,
+    prepare_aiter_moe_weights,
+    select_aiter_moe_config,
 )
 from vllm_hcu.platforms import envs as henvs
 
@@ -48,11 +47,9 @@ def _expert_routing_tables(
 
     return None
 
-class HcuUnquantizedFusedMoEMethod(_Original):
-    """HCU version of UnquantizedFusedMoEMethod.
 
-    Initializes the AITER runner without replacing canonical model weights.
-    """
+class HcuUnquantizedFusedMoEMethod(_Original):
+    """Install the AITER ASM layout once instead of caching a second copy."""
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if (
@@ -65,6 +62,45 @@ class HcuUnquantizedFusedMoEMethod(_Original):
         if getattr(layer, "_hcu_aiter_moe_initialized", False):
             return
 
+        original_w13 = layer.w13_weight
+        original_w2 = layer.w2_weight
+        activation = getattr(self.moe.activation, "value", self.moe.activation)
+        problem = AiterMoeProblem(
+            M=1,
+            E=int(self.moe.num_experts),
+            N1=int(original_w13.shape[1]),
+            N2=int(original_w2.shape[1]),
+            K=int(original_w13.shape[2]),
+            top_k=int(self.moe.experts_per_token),
+            block_size=0,
+            dtype=self.moe.in_dtype,
+            device=original_w13.device,
+            quant_type="w16a16",
+            activation=str(activation),
+            use_shuffle=bool(henvs.VLLM_HCU_USE_AITER_MOE_SHUFFLE),
+        )
+        if problem.use_shuffle:
+            config = select_aiter_moe_config(
+                problem,
+                cache_owner=original_w13,
+                solution_type="asm",
+            )
+            if config is None or not bool(getattr(config, "need_shuffle", False)):
+                raise HcuAiterMoeDispatchError(
+                    "HCU AITER BF16 MoE requires an ASM shuffle solution before "
+                    "installing the runtime weight layout; " + problem.describe()
+                )
+            shuffled_w13, shuffled_w2 = prepare_aiter_moe_weights(
+                original_w13,
+                original_w2,
+                config,
+                cache_owner=object(),
+            )
+            replace_parameter(layer, "w13_weight", shuffled_w13)
+            replace_parameter(layer, "w2_weight", shuffled_w2)
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
+
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         self.moe_kernel = make_unquantized_moe_kernel(
             quant_config=self.moe_quant_config,
@@ -72,23 +108,5 @@ class HcuUnquantizedFusedMoEMethod(_Original):
             backend=self.unquantized_backend,
             experts_cls=self.experts_cls,
             routing_tables=_expert_routing_tables(layer),
-        )
-        activation = getattr(self.moe.activation, "value", self.moe.activation)
-        prewarm_aiter_moe_config(
-            AiterMoeProblem(
-                M=1,
-                E=int(self.moe.num_experts),
-                N1=int(layer.w13_weight.shape[1]),
-                N2=int(layer.w2_weight.shape[1]),
-                K=int(layer.w13_weight.shape[2]),
-                top_k=int(self.moe.experts_per_token),
-                block_size=0,
-                dtype=self.moe.in_dtype,
-                device=layer.w13_weight.device,
-                quant_type="w16a16",
-                activation=str(activation),
-                use_shuffle=bool(henvs.VLLM_HCU_USE_AITER_MOE_SHUFFLE),
-            ),
-            cache_owner=layer.w13_weight,
         )
         layer._hcu_aiter_moe_initialized = True

--- a/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -20,6 +20,7 @@ from vllm.model_executor.utils import replace_parameter
 from vllm_hcu.model_executor.layers.fused_moe.aiter_moe_dispatch import (
     AiterMoeProblem,
     HcuAiterMoeDispatchError,
+    aiter_moe_weight_layout_signature,
     prepare_aiter_moe_weights,
     select_aiter_moe_config,
 )
@@ -79,12 +80,12 @@ class HcuUnquantizedFusedMoEMethod(_Original):
             activation=str(activation),
             use_shuffle=bool(henvs.VLLM_HCU_USE_AITER_MOE_SHUFFLE),
         )
+        config = select_aiter_moe_config(
+            problem,
+            cache_owner=original_w13,
+            solution_type="asm" if problem.use_shuffle else None,
+        )
         if problem.use_shuffle:
-            config = select_aiter_moe_config(
-                problem,
-                cache_owner=original_w13,
-                solution_type="asm",
-            )
             if config is None or not bool(getattr(config, "need_shuffle", False)):
                 raise HcuAiterMoeDispatchError(
                     "HCU AITER BF16 MoE requires an ASM shuffle solution before "
@@ -98,8 +99,33 @@ class HcuUnquantizedFusedMoEMethod(_Original):
             )
             replace_parameter(layer, "w13_weight", shuffled_w13)
             replace_parameter(layer, "w2_weight", shuffled_w2)
-            layer.w13_weight.is_shuffled = True
-            layer.w2_weight.is_shuffled = True
+        elif config is not None and bool(getattr(config, "need_shuffle", False)):
+            raise HcuAiterMoeDispatchError(
+                "HCU AITER selected a shuffle solution for canonical BF16 "
+                "weights; " + problem.describe()
+            )
+
+        if config is not None:
+            solution = getattr(config, "solution_type", None)
+            solution = getattr(solution, "value", solution)
+            if solution is None:
+                raise HcuAiterMoeDispatchError(
+                    "HCU AITER selected a BF16 MoE config without a solution type"
+                )
+            solution = str(solution).rsplit(".", 1)[-1].lower()
+            if not solution:
+                raise HcuAiterMoeDispatchError(
+                    "HCU AITER selected a BF16 MoE config without a solution type"
+                )
+            layout = aiter_moe_weight_layout_signature(config)
+        else:
+            solution = "native"
+            layout = None
+        for weight in (layer.w13_weight, layer.w2_weight):
+            weight.is_shuffled = bool(problem.use_shuffle)
+            weight._hcu_aiter_moe_solution_type = solution
+            if layout is not None:
+                weight._hcu_aiter_moe_weight_layout = layout
 
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         self.moe_kernel = make_unquantized_moe_kernel(

--- a/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -85,8 +85,8 @@ class HcuUnquantizedFusedMoEMethod(_Original):
             cache_owner=original_w13,
             solution_type="asm" if problem.use_shuffle else None,
         )
-        if problem.use_shuffle:
-            if config is None or not bool(getattr(config, "need_shuffle", False)):
+        if config is not None and problem.use_shuffle:
+            if not bool(getattr(config, "need_shuffle", False)):
                 raise HcuAiterMoeDispatchError(
                     "HCU AITER BF16 MoE requires an ASM shuffle solution before "
                     "installing the runtime weight layout; " + problem.describe()
@@ -121,9 +121,12 @@ class HcuUnquantizedFusedMoEMethod(_Original):
         else:
             solution = "native"
             layout = None
+        installed_shuffle = bool(config is not None and problem.use_shuffle)
+        logical_shape = (problem.E, problem.N1, problem.N2, problem.K)
         for weight in (layer.w13_weight, layer.w2_weight):
-            weight.is_shuffled = bool(problem.use_shuffle)
+            weight.is_shuffled = installed_shuffle
             weight._hcu_aiter_moe_solution_type = solution
+            weight._hcu_aiter_moe_logical_shape = logical_shape
             if layout is not None:
                 weight._hcu_aiter_moe_weight_layout = layout
 

--- a/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -49,6 +49,59 @@ def _expert_routing_tables(
     return None
 
 
+def _has_installed_aiter_layout(
+    layer: torch.nn.Module,
+    *,
+    activation: object,
+) -> bool:
+    """Return whether the current parameter pair is already runtime-ready."""
+
+    w13 = getattr(layer, "w13_weight", None)
+    w2 = getattr(layer, "w2_weight", None)
+    if not isinstance(w13, torch.Tensor) or not isinstance(w2, torch.Tensor):
+        return False
+    solution = getattr(w13, "_hcu_aiter_moe_solution_type", None)
+    logical_shape = getattr(w13, "_hcu_aiter_moe_logical_shape", None)
+    layout = getattr(w13, "_hcu_aiter_moe_weight_layout", None)
+    shuffled = getattr(w13, "is_shuffled", None)
+    if (
+        solution is None
+        or solution != getattr(w2, "_hcu_aiter_moe_solution_type", None)
+        or logical_shape != getattr(w2, "_hcu_aiter_moe_logical_shape", None)
+        or layout != getattr(w2, "_hcu_aiter_moe_weight_layout", None)
+        or shuffled != getattr(w2, "is_shuffled", None)
+        or not isinstance(logical_shape, tuple)
+        or len(logical_shape) != 4
+    ):
+        return False
+    try:
+        experts, w13_n, _w2_k, logical_k = map(int, logical_shape)
+    except (TypeError, ValueError):
+        return False
+    physical_k = logical_k
+    if shuffled:
+        if not isinstance(layout, tuple) or len(layout) != 4:
+            return False
+        padded_k = layout[3]
+        if padded_k is not None:
+            try:
+                physical_k = int(padded_k)
+            except (TypeError, ValueError):
+                return False
+    activation = str(getattr(activation, "value", activation)).lower()
+    gated = activation in {
+        "silu",
+        "situ",
+        "gelu",
+        "swigluoai",
+        "swiglustep",
+        "gelu_tanh",
+    }
+    expected_w13 = (experts, w13_n, physical_k)
+    expected_w2 = (experts, physical_k, w13_n // 2 if gated else w13_n)
+    return tuple(w13.shape) == expected_w13 and tuple(w2.shape) == expected_w2
+
+
 class HcuUnquantizedFusedMoEMethod(_Original):
     """Install the AITER ASM layout once instead of caching a second copy."""
 
@@ -60,12 +113,12 @@ class HcuUnquantizedFusedMoEMethod(_Original):
         ):
             return super().process_weights_after_loading(layer)
 
-        if getattr(layer, "_hcu_aiter_moe_initialized", False):
+        activation = getattr(self.moe.activation, "value", self.moe.activation)
+        if _has_installed_aiter_layout(layer, activation=activation):
             return
 
         original_w13 = layer.w13_weight
         original_w2 = layer.w2_weight
-        activation = getattr(self.moe.activation, "value", self.moe.activation)
         problem = AiterMoeProblem(
             M=1,
             E=int(self.moe.num_experts),
@@ -138,4 +191,3 @@ class HcuUnquantizedFusedMoEMethod(_Original):
             experts_cls=self.experts_cls,
             routing_tables=_expert_routing_tables(layer),
         )
-        layer._hcu_aiter_moe_initialized = True

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors_moe_runtime.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors_moe_runtime.py
@@ -232,6 +232,8 @@ def install_aiter_moe_weight_layout(
 def _installed_weight_logical_shape(
     w1: torch.Tensor,
     w2: torch.Tensor,
+    *,
+    activation: object = "silu",
 ) -> tuple[int, int, int, int]:
     first = getattr(w1, _WEIGHT_LOGICAL_SHAPE_ATTR, None)
     second = getattr(w2, _WEIGHT_LOGICAL_SHAPE_ATTR, None)
@@ -258,7 +260,15 @@ def _installed_weight_logical_shape(
             "AITER weights have invalid logical dimensions"
         )
     logical_e, logical_n1, logical_n2, logical_k = first
-    if logical_n1 % 2:
+    gated = _enum_token(activation) in {
+        "SILU",
+        "SITU",
+        "GELU",
+        "SWIGLUOAI",
+        "SWIGLUSTEP",
+        "GELU_TANH",
+    }
+    if gated and logical_n1 % 2:
         raise HcuCompressedTensorsMoeError(
             "AITER weights have invalid logical dimensions"
         )
@@ -277,7 +287,8 @@ def _installed_weight_logical_shape(
     padded_k = first_layout[3] if first_layout is not None else None
     physical_k = int(padded_k) if padded_k is not None else logical_k
     expected_w1 = (logical_e, logical_n1, physical_k)
-    expected_w2 = (logical_e, physical_k, logical_n1 // 2)
+    intermediate_size = logical_n1 // 2 if gated else logical_n1
+    expected_w2 = (logical_e, physical_k, intermediate_size)
     if tuple(w1.shape) != expected_w1 or tuple(w2.shape) != expected_w2:
         raise HcuCompressedTensorsMoeError(
             "AITER weights do not match their installed physical layout"
@@ -289,8 +300,14 @@ def _quantized_problem_dimensions(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
     w2: torch.Tensor,
+    *,
+    activation: object,
 ) -> tuple[int, int, int, int]:
-    logical_shape = _installed_weight_logical_shape(w1, w2)
+    logical_shape = _installed_weight_logical_shape(
+        w1,
+        w2,
+        activation=activation,
+    )
     if int(hidden_states.shape[1]) != logical_shape[3]:
         raise HcuCompressedTensorsMoeError(
             "AITER quantized MoE hidden states do not match logical K"
@@ -884,7 +901,10 @@ def apply_aiter_quantized_moe(
         )
     activation_name = str(activation_value)
     logical_e, logical_n1, logical_n2, logical_k = _quantized_problem_dimensions(
-        hidden_states, w1, w2
+        hidden_states,
+        w1,
+        w2,
+        activation=activation_name,
     )
     problem = AiterMoeProblem(
         M=int(hidden_states.shape[0]),
@@ -1082,7 +1102,10 @@ def apply_aiter_w8a8_fp8_moe(
             "AITER does not expose the required FP8_W8A8 MoE quant type"
         )
     logical_e, logical_n1, logical_n2, logical_k = _quantized_problem_dimensions(
-        x, w1, w2
+        x,
+        w1,
+        w2,
+        activation=activation,
     )
     problem = AiterMoeProblem(
         M=int(x.shape[0]),

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors_moe_runtime.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors_moe_runtime.py
@@ -66,10 +66,19 @@ _SCALE_LAYOUT_ATTR = "_hcu_aiter_moe_scale_layout"
 
 
 def _scale_layout_signature(config: object) -> tuple[object, ...]:
+    config_values = getattr(config, "config", None)
+    padded_k = (
+        config_values.get("PADDED_K") if isinstance(config_values, dict) else None
+    )
+    original_k = (
+        config_values.get("ORIGINAL_K") if isinstance(config_values, dict) else None
+    )
     return (
         _enum_token(getattr(config, "quant_type", None)).lower(),
         _enum_token(getattr(config, "solution_type", None)),
         bool(getattr(config, "need_shuffle_scale", False)),
+        padded_k,
+        original_k,
     )
 
 
@@ -108,6 +117,15 @@ def install_aiter_moe_scale_layout(
     )
     scale1 = _required_tensor(owner, first_name)
     scale2 = _required_tensor(owner, second_name)
+    signature = _scale_layout_signature(config)
+    first_layout = getattr(scale1, _SCALE_LAYOUT_ATTR, None)
+    second_layout = getattr(scale2, _SCALE_LAYOUT_ATTR, None)
+    if first_layout is not None or second_layout is not None:
+        if first_layout != signature or second_layout != signature:
+            raise HcuCompressedTensorsMoeError(
+                "AITER installed scales do not match the selected layout"
+            )
+        return scale1, scale2
     installed1, installed2 = prepare_aiter_moe_scales(
         scale1,
         scale2,
@@ -122,7 +140,6 @@ def install_aiter_moe_scale_layout(
     if layer_has_scales and quant_config is not None:
         _replace_tensor_reference(quant_config, "w1_scale", installed1)
         _replace_tensor_reference(quant_config, "w2_scale", installed2)
-    signature = _scale_layout_signature(config)
     for scale in (installed1, installed2):
         setattr(scale, _SCALE_LAYOUT_ATTR, signature)
     return installed1, installed2
@@ -191,6 +208,43 @@ def install_aiter_moe_weight_layout(
 
     w1 = _required_tensor(layer, w1_name)
     w2 = _required_tensor(layer, w2_name)
+    solution = _enum_token(getattr(config, "solution_type", None)).lower()
+    if not solution:
+        raise HcuCompressedTensorsMoeError(
+            "AITER selected a quantized MoE config without a solution type"
+        )
+    layout = aiter_moe_weight_layout_signature(config)
+    installed_solution = getattr(w1, _WEIGHT_SOLUTION_ATTR, None)
+    installed_layout = getattr(w1, _WEIGHT_LAYOUT_ATTR, None)
+    has_installed_state = any(
+        value is not None
+        for value in (
+            installed_solution,
+            getattr(w2, _WEIGHT_SOLUTION_ATTR, None),
+            installed_layout,
+            getattr(w2, _WEIGHT_LAYOUT_ATTR, None),
+        )
+    )
+    if has_installed_state:
+        installed_logical_shape = _installed_weight_logical_shape(w1, w2)
+        if (
+            installed_solution != solution
+            or getattr(w2, _WEIGHT_SOLUTION_ATTR, None) != solution
+            or installed_layout != layout
+            or getattr(w2, _WEIGHT_LAYOUT_ATTR, None) != layout
+            or bool(getattr(w1, "is_shuffled", False))
+            != bool(getattr(config, "need_shuffle", False))
+            or bool(getattr(w2, "is_shuffled", False))
+            != bool(getattr(config, "need_shuffle", False))
+            or (
+                logical_shape is not None
+                and installed_logical_shape != logical_shape
+            )
+        ):
+            raise HcuCompressedTensorsMoeError(
+                "AITER installed weights do not match the selected layout"
+            )
+        return w1, w2
     if logical_shape is None:
         logical_shape = (
             int(w1.shape[0]),
@@ -212,17 +266,12 @@ def install_aiter_moe_weight_layout(
         w1 = _required_tensor(layer, w1_name)
         w2 = _required_tensor(layer, w2_name)
 
-    solution = _enum_token(getattr(config, "solution_type", None)).lower()
-    if not solution:
-        raise HcuCompressedTensorsMoeError(
-            "AITER selected a quantized MoE config without a solution type"
-        )
     for weight in (w1, w2):
         setattr(weight, _WEIGHT_SOLUTION_ATTR, solution)
         setattr(
             weight,
             _WEIGHT_LAYOUT_ATTR,
-            aiter_moe_weight_layout_signature(config),
+            layout,
         )
         setattr(weight, _WEIGHT_LOGICAL_SHAPE_ATTR, logical_shape)
         weight.is_shuffled = need_shuffle
@@ -418,14 +467,19 @@ def prewarm_aiter_quantized_moe(
         raise HcuCompressedTensorsMoeError(
             "AITER quantized MoE prewarm requires an activation"
         )
+    logical_shape = _installed_weight_logical_shape(
+        w1,
+        w2,
+        activation=activation,
+    )
     block_shape = getattr(quant_config, "block_shape", None)
     block_size = int(block_shape[1]) if block_shape else 0
     problem = AiterMoeProblem(
         M=1,
-        E=int(w1.shape[0]),
-        N1=int(w1.shape[1]),
-        N2=int(w2.shape[1]),
-        K=int(w1.shape[2]),
+        E=logical_shape[0],
+        N1=logical_shape[1],
+        N2=logical_shape[2],
+        K=logical_shape[3],
         top_k=top_k,
         block_size=block_size,
         dtype=dtype,
@@ -436,7 +490,11 @@ def prewarm_aiter_quantized_moe(
     )
     config = prewarm_aiter_moe_config(problem, cache_owner=w1)
     if config is not None:
-        install_aiter_moe_weight_layout(layer, config)
+        install_aiter_moe_weight_layout(
+            layer,
+            config,
+            logical_shape=logical_shape,
+        )
         install_aiter_moe_scale_layout(layer, quant_config, config)
     else:
         mark_aiter_moe_native_layout(layer)

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors_moe_runtime.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors_moe_runtime.py
@@ -246,11 +246,56 @@ def _installed_weight_logical_shape(
             int(w2.shape[1]),
             int(w1.shape[2]),
         )
-    if not isinstance(first, tuple) or len(first) != 4:
+    if (
+        not isinstance(first, tuple)
+        or len(first) != 4
+        or not all(
+            isinstance(value, int) and not isinstance(value, bool) and value > 0
+            for value in first
+        )
+    ):
         raise HcuCompressedTensorsMoeError(
             "AITER weights have invalid logical dimensions"
         )
-    return tuple(int(value) for value in first)
+    logical_e, logical_n1, logical_n2, logical_k = first
+    if logical_n1 % 2:
+        raise HcuCompressedTensorsMoeError(
+            "AITER weights have invalid logical dimensions"
+        )
+    first_layout = getattr(w1, _WEIGHT_LAYOUT_ATTR, None)
+    second_layout = getattr(w2, _WEIGHT_LAYOUT_ATTR, None)
+    if first_layout != second_layout:
+        raise HcuCompressedTensorsMoeError(
+            "AITER weights have inconsistent physical layouts"
+        )
+    if first_layout is not None and (
+        not isinstance(first_layout, tuple) or len(first_layout) != 4
+    ):
+        raise HcuCompressedTensorsMoeError(
+            "AITER weights have invalid physical layout signature"
+        )
+    padded_k = first_layout[3] if first_layout is not None else None
+    physical_k = int(padded_k) if padded_k is not None else logical_k
+    expected_w1 = (logical_e, logical_n1, physical_k)
+    expected_w2 = (logical_e, physical_k, logical_n1 // 2)
+    if tuple(w1.shape) != expected_w1 or tuple(w2.shape) != expected_w2:
+        raise HcuCompressedTensorsMoeError(
+            "AITER weights do not match their installed physical layout"
+        )
+    return first
+
+
+def _quantized_problem_dimensions(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+) -> tuple[int, int, int, int]:
+    logical_shape = _installed_weight_logical_shape(w1, w2)
+    if int(hidden_states.shape[1]) != logical_shape[3]:
+        raise HcuCompressedTensorsMoeError(
+            "AITER quantized MoE hidden states do not match logical K"
+        )
+    return logical_shape
 
 
 def _installed_weight_solution(
@@ -838,8 +883,8 @@ def apply_aiter_quantized_moe(
             "AITER quantized MoE requires an activation"
         )
     activation_name = str(activation_value)
-    logical_e, logical_n1, logical_n2, logical_k = _installed_weight_logical_shape(
-        w1, w2
+    logical_e, logical_n1, logical_n2, logical_k = _quantized_problem_dimensions(
+        hidden_states, w1, w2
     )
     problem = AiterMoeProblem(
         M=int(hidden_states.shape[0]),
@@ -1036,12 +1081,15 @@ def apply_aiter_w8a8_fp8_moe(
         raise HcuCompressedTensorsMoeError(
             "AITER does not expose the required FP8_W8A8 MoE quant type"
         )
+    logical_e, logical_n1, logical_n2, logical_k = _quantized_problem_dimensions(
+        x, w1, w2
+    )
     problem = AiterMoeProblem(
         M=int(x.shape[0]),
-        E=int(w1.shape[0]),
-        N1=int(w1.shape[1]),
-        N2=int(w2.shape[1]),
-        K=int(w1.shape[2]),
+        E=logical_e,
+        N1=logical_n1,
+        N2=logical_n2,
+        K=logical_k,
         top_k=int(topk_ids.shape[1]),
         block_size=0,
         dtype=x.dtype,

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors_moe_runtime.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors_moe_runtime.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from typing import Any
 
 import torch
+from vllm.model_executor.utils import replace_parameter
 
 from vllm_hcu.model_executor.layers.fused_moe.aiter_moe_dispatch import (
     AiterMoeProblem,
@@ -55,6 +56,96 @@ def _enum_token(value: object) -> str:
         if token:
             return token
     return ""
+
+
+_WEIGHT_SOLUTION_ATTR = "_hcu_aiter_moe_solution_type"
+
+
+def install_aiter_moe_weight_layout(
+    layer: object,
+    config: object,
+    *,
+    w1_name: str = "w13_weight",
+    w2_name: str = "w2_weight",
+    block_shape: list[int] | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Install one selected AITER layout and record its routing contract."""
+
+    w1 = _required_tensor(layer, w1_name)
+    w2 = _required_tensor(layer, w2_name)
+    need_shuffle = bool(getattr(config, "need_shuffle", False))
+    if need_shuffle:
+        w1, w2 = prepare_aiter_moe_weights(
+            w1,
+            w2,
+            config,
+            cache_owner=object(),
+            block_shape=block_shape,
+        )
+        replace_parameter(layer, w1_name, w1)
+        replace_parameter(layer, w2_name, w2)
+        w1 = _required_tensor(layer, w1_name)
+        w2 = _required_tensor(layer, w2_name)
+
+    solution = _enum_token(getattr(config, "solution_type", None)).lower()
+    if not solution:
+        raise HcuCompressedTensorsMoeError(
+            "AITER selected a quantized MoE config without a solution type"
+        )
+    for weight in (w1, w2):
+        setattr(weight, _WEIGHT_SOLUTION_ATTR, solution)
+        weight.is_shuffled = need_shuffle
+    return w1, w2
+
+
+def _installed_weight_solution(
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    *,
+    label: str,
+) -> str | None:
+    first = getattr(w1, _WEIGHT_SOLUTION_ATTR, None)
+    second = getattr(w2, _WEIGHT_SOLUTION_ATTR, None)
+    if first != second:
+        raise HcuCompressedTensorsMoeError(
+            f"{label} weights have inconsistent installed solutions"
+        )
+    return first
+
+
+def _weights_for_selected_config(
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    config: object,
+    *,
+    installed_solution: str | None,
+    preserve_inputs: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reuse an installed layout or derive a legacy transient layout."""
+
+    if installed_solution is not None:
+        selected = _enum_token(getattr(config, "solution_type", None)).lower()
+        if selected != installed_solution:
+            raise HcuCompressedTensorsMoeError(
+                "AITER selected a solution incompatible with installed weights"
+            )
+        expected_shuffle = bool(getattr(w1, "is_shuffled", False))
+        if expected_shuffle != bool(getattr(w2, "is_shuffled", False)):
+            raise HcuCompressedTensorsMoeError(
+                "AITER weights have inconsistent shuffle state"
+            )
+        if expected_shuffle != bool(getattr(config, "need_shuffle", False)):
+            raise HcuCompressedTensorsMoeError(
+                "AITER config layout does not match installed weights"
+            )
+        return w1, w2
+    return prepare_aiter_moe_weights(
+        w1,
+        w2,
+        config,
+        cache_owner=w1,
+        preserve_inputs=preserve_inputs,
+    )
 
 
 def prewarm_aiter_quantized_moe(
@@ -113,7 +204,10 @@ def prewarm_aiter_quantized_moe(
         activation=str(activation),
         use_shuffle=bool(henvs.VLLM_HCU_USE_AITER_MOE_SHUFFLE),
     )
-    return prewarm_aiter_moe_config(problem, cache_owner=w1)
+    config = prewarm_aiter_moe_config(problem, cache_owner=w1)
+    if config is not None:
+        install_aiter_moe_weight_layout(layer, config)
+    return config
 
 
 def prewarm_aiter_w4a16_moe(
@@ -249,7 +343,11 @@ def prewarm_aiter_w4a8_moe(
         activation=activation,
         use_shuffle=bool(henvs.VLLM_HCU_USE_AITER_MOE_SHUFFLE),
     )
-    config = prewarm_aiter_moe_config(problem, cache_owner=w1)
+    config = select_aiter_moe_config(
+        problem,
+        cache_owner=w1,
+        solution_type="moe_c",
+    )
     return config
 
 
@@ -281,12 +379,15 @@ def prepare_vllm_w4a8_moe(
     method: object,
     layer: object,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Prepare and cache unpacked weights for an explicit vLLM Triton route."""
+    """Replace packed weights with the sole layout used by explicit Triton."""
 
     w1, w2, _, _ = _slimquant_w4a8_metadata(method, layer)
     fallback_weights = _vllm_w4a8_fallback_weights(w1, w2)
-    w1._hcu_vllm_w4a8_fallback_weights = fallback_weights
-    return fallback_weights
+    replace_parameter(layer, "w13_weight", fallback_weights[0])
+    replace_parameter(layer, "w2_weight", fallback_weights[1])
+    layer.w13_weight._hcu_vllm_w4a8_unpacked = True
+    layer.w2_weight._hcu_vllm_w4a8_unpacked = True
+    return layer.w13_weight, layer.w2_weight
 
 
 def apply_aiter_w4a8_moe(
@@ -310,10 +411,51 @@ def apply_aiter_w4a8_moe(
         raise HcuCompressedTensorsMoeError(
             "SlimQuant W4A8 requires matching rank-2 hidden and top-k tensors"
         )
-    w1, w2, logical_k, activation = _slimquant_w4a8_metadata(method, layer)
+    explicit_vllm_layout = not allow_aiter and bool(
+        getattr(
+            getattr(layer, "w13_weight", None),
+            "_hcu_vllm_w4a8_unpacked",
+            False,
+        )
+    )
+    if explicit_vllm_layout:
+        w1 = _required_tensor(layer, "w13_weight")
+        w2 = _required_tensor(layer, "w2_weight")
+        if not bool(getattr(w2, "_hcu_vllm_w4a8_unpacked", False)):
+            raise HcuCompressedTensorsMoeError(
+                "SlimQuant W4A8 Triton weights have inconsistent layouts"
+            )
+        if w1.dtype != torch.int8 or w2.dtype != torch.int8:
+            raise HcuCompressedTensorsMoeError(
+                "SlimQuant W4A8 Triton weights require unpacked INT8 storage"
+            )
+        if (
+            w1.ndim != 3
+            or w2.ndim != 3
+            or w1.shape[0] != w2.shape[0]
+            or w1.shape[2] != w2.shape[1]
+            or w1.shape[1] != 2 * w2.shape[2]
+        ):
+            raise HcuCompressedTensorsMoeError(
+                "SlimQuant W4A8 Triton weight dimensions are inconsistent"
+            )
+        logical_k = int(w1.shape[2])
+        activation = str(
+            getattr(
+                getattr(getattr(method, "moe", None), "activation", None),
+                "value",
+                "silu",
+            )
+        )
+        if activation != "silu":
+            raise HcuCompressedTensorsMoeError(
+                "SlimQuant W4A8 supports only silu activation"
+            )
+    else:
+        w1, w2, logical_k, activation = _slimquant_w4a8_metadata(method, layer)
     if int(hidden_states.shape[1]) != logical_k:
         raise HcuCompressedTensorsMoeError(
-            "SlimQuant W4A8 hidden states do not match the packed logical K"
+            "SlimQuant W4A8 hidden states do not match the weight logical K"
         )
     quant_config = getattr(method, "moe_quant_config", None)
     w1_scale = _required_tensor(quant_config, "w1_scale")
@@ -341,7 +483,16 @@ def apply_aiter_w4a8_moe(
             activation=activation,
             use_shuffle=bool(henvs.VLLM_HCU_USE_AITER_MOE_SHUFFLE),
         )
-        aiter_config = select_aiter_moe_config(problem, cache_owner=w1)
+        installed_solution = _installed_weight_solution(
+            w1, w2, label="SlimQuant W4A8"
+        )
+        aiter_config = select_aiter_moe_config(
+            problem,
+            cache_owner=w1,
+            solution_type=installed_solution,
+        )
+    else:
+        installed_solution = None
     global_num_experts = getattr(
         layer,
         "global_num_experts",
@@ -354,16 +505,13 @@ def apply_aiter_w4a8_moe(
     )
     expert_mask = getattr(layer, "expert_mask", None)
     if aiter_config is None:
-        fallback_weights = getattr(
-            w1, "_hcu_vllm_w4a8_fallback_weights", None
-        )
-        if (
-            not isinstance(fallback_weights, tuple)
-            or len(fallback_weights) != 2
-            or not all(
-                isinstance(weight, torch.Tensor) for weight in fallback_weights
+        if installed_solution is not None:
+            raise HcuCompressedTensorsMoeError(
+                "AITER has no MOE_C solution for installed W4A8 weights"
             )
-        ):
+        if explicit_vllm_layout:
+            fallback_weights = (w1, w2)
+        else:
             fallback_weights = _vllm_w4a8_fallback_weights(w1, w2)
         fallback_w1, fallback_w2 = fallback_weights
         from vllm.model_executor.layers.fused_moe.fused_moe import (
@@ -391,11 +539,11 @@ def apply_aiter_w4a8_moe(
             block_shape=None,
         )
 
-    prepared_w1, prepared_w2 = prepare_aiter_moe_weights(
+    prepared_w1, prepared_w2 = _weights_for_selected_config(
         w1,
         w2,
         aiter_config,
-        cache_owner=w1,
+        installed_solution=installed_solution,
         preserve_inputs=True,
     )
     prepared_w1_scale, prepared_w2_scale = prepare_aiter_moe_scales(
@@ -533,13 +681,24 @@ def apply_aiter_quantized_moe(
         activation=activation_name,
         use_shuffle=bool(henvs.VLLM_HCU_USE_AITER_MOE_SHUFFLE),
     )
-    aiter_config = select_aiter_moe_config(problem, cache_owner=w1)
+    installed_solution = _installed_weight_solution(
+        w1, w2, label="AITER quantized MoE"
+    )
+    aiter_config = select_aiter_moe_config(
+        problem,
+        cache_owner=w1,
+        solution_type=installed_solution,
+    )
     global_num_experts = getattr(vllm_moe_config, "num_experts", w1.shape[0])
     native_expert_map, expert_mask = resolve_aiter_expert_maps(
         expert_map,
         int(global_num_experts),
     )
     if aiter_config is None:
+        if installed_solution is not None:
+            raise HcuCompressedTensorsMoeError(
+                "AITER has no solution compatible with installed quantized weights"
+            )
         from vllm.model_executor.layers.fused_moe.fused_moe import (
             fused_experts_impl,
         )
@@ -572,11 +731,11 @@ def apply_aiter_quantized_moe(
             block_shape=None,
         )
 
-    prepared_w1, prepared_w2 = prepare_aiter_moe_weights(
+    prepared_w1, prepared_w2 = _weights_for_selected_config(
         w1,
         w2,
         aiter_config,
-        cache_owner=w1,
+        installed_solution=installed_solution,
     )
     prepared_w1_scale, prepared_w2_scale = prepare_aiter_moe_scales(
         w1_scale,
@@ -714,13 +873,24 @@ def apply_aiter_w8a8_fp8_moe(
         activation=activation,
         use_shuffle=bool(henvs.VLLM_HCU_USE_AITER_MOE_SHUFFLE),
     )
-    moe_config = select_aiter_moe_config(problem, cache_owner=w1)
+    installed_solution = _installed_weight_solution(
+        w1, w2, label="AITER FP8-W8A8"
+    )
+    moe_config = select_aiter_moe_config(
+        problem,
+        cache_owner=w1,
+        solution_type=installed_solution,
+    )
     w1_scale = _required_tensor(layer, "w13_weight_scale")
     w2_scale = _required_tensor(layer, "w2_weight_scale")
     global_num_experts = getattr(layer, "global_num_experts", -1)
     expert_map = getattr(layer, "_expert_map", None)
     expert_mask = getattr(layer, "expert_mask", None)
     if moe_config is None:
+        if installed_solution is not None:
+            raise HcuCompressedTensorsMoeError(
+                "AITER has no solution compatible with installed FP8 weights"
+            )
         from vllm.model_executor.layers.fused_moe.fused_moe import (
             fused_experts_impl,
         )
@@ -747,11 +917,11 @@ def apply_aiter_w8a8_fp8_moe(
             block_shape=None,
         )
 
-    prepared_w1, prepared_w2 = prepare_aiter_moe_weights(
+    prepared_w1, prepared_w2 = _weights_for_selected_config(
         w1,
         w2,
         moe_config,
-        cache_owner=w1,
+        installed_solution=installed_solution,
     )
     prepared_w1_scale, prepared_w2_scale = prepare_aiter_moe_scales(
         w1_scale,
@@ -939,6 +1109,7 @@ __all__ = [
     "apply_vllm_w4a8_moe",
     "build_aiter_w4a16_quant_config",
     "create_aiter_w4a16_qzeros",
+    "install_aiter_moe_weight_layout",
     "prewarm_aiter_w4a8_moe",
     "prepare_vllm_w4a8_moe",
     "process_dpsk_deepgemm_weights",

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors_moe_runtime.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors_moe_runtime.py
@@ -17,6 +17,7 @@ from vllm.model_executor.utils import replace_parameter
 
 from vllm_hcu.model_executor.layers.fused_moe.aiter_moe_dispatch import (
     AiterMoeProblem,
+    aiter_moe_weight_layout_signature,
     aiter_expert_map_for_solution,
     execute_aiter_moe,
     prewarm_aiter_moe_config,
@@ -59,6 +60,122 @@ def _enum_token(value: object) -> str:
 
 
 _WEIGHT_SOLUTION_ATTR = "_hcu_aiter_moe_solution_type"
+_WEIGHT_LAYOUT_ATTR = "_hcu_aiter_moe_weight_layout"
+_WEIGHT_LOGICAL_SHAPE_ATTR = "_hcu_aiter_moe_logical_shape"
+_SCALE_LAYOUT_ATTR = "_hcu_aiter_moe_scale_layout"
+
+
+def _scale_layout_signature(config: object) -> tuple[object, ...]:
+    return (
+        _enum_token(getattr(config, "quant_type", None)).lower(),
+        _enum_token(getattr(config, "solution_type", None)),
+        bool(getattr(config, "need_shuffle_scale", False)),
+    )
+
+
+def _replace_tensor_reference(owner: object, name: str, value: torch.Tensor) -> None:
+    descriptor_name = {"w1_scale": "_w1", "w2_scale": "_w2"}.get(name)
+    descriptor = getattr(owner, descriptor_name, None) if descriptor_name else None
+    if descriptor is not None and hasattr(descriptor, "scale"):
+        descriptor.scale = value
+    elif isinstance(owner, torch.nn.Module) and name in owner._parameters:
+        replace_parameter(owner, name, value)
+    else:
+        setattr(owner, name, value)
+
+
+def install_aiter_moe_scale_layout(
+    layer: object,
+    quant_config: object | None,
+    config: object,
+    *,
+    prefer_quant_config: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Install the selected scale layout and update every owning reference."""
+
+    layer_has_scales = not prefer_quant_config and isinstance(
+        getattr(layer, "w13_weight_scale", None), torch.Tensor
+    ) and isinstance(getattr(layer, "w2_weight_scale", None), torch.Tensor)
+    owner = layer if layer_has_scales else quant_config
+    if owner is None:
+        raise HcuCompressedTensorsMoeError(
+            "AITER selected scale shuffle without a quantization config"
+        )
+    first_name, second_name = (
+        ("w13_weight_scale", "w2_weight_scale")
+        if layer_has_scales
+        else ("w1_scale", "w2_scale")
+    )
+    scale1 = _required_tensor(owner, first_name)
+    scale2 = _required_tensor(owner, second_name)
+    installed1, installed2 = prepare_aiter_moe_scales(
+        scale1,
+        scale2,
+        config,
+        cache_owner=object(),
+    )
+    assert installed1 is not None and installed2 is not None
+    _replace_tensor_reference(owner, first_name, installed1)
+    _replace_tensor_reference(owner, second_name, installed2)
+    installed1 = _required_tensor(owner, first_name)
+    installed2 = _required_tensor(owner, second_name)
+    if layer_has_scales and quant_config is not None:
+        _replace_tensor_reference(quant_config, "w1_scale", installed1)
+        _replace_tensor_reference(quant_config, "w2_scale", installed2)
+    signature = _scale_layout_signature(config)
+    for scale in (installed1, installed2):
+        setattr(scale, _SCALE_LAYOUT_ATTR, signature)
+    return installed1, installed2
+
+
+def _scales_for_selected_config(
+    scale1: torch.Tensor,
+    scale2: torch.Tensor,
+    config: object,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    first_layout = getattr(scale1, _SCALE_LAYOUT_ATTR, None)
+    second_layout = getattr(scale2, _SCALE_LAYOUT_ATTR, None)
+    if first_layout != second_layout:
+        raise HcuCompressedTensorsMoeError(
+            "AITER scales have inconsistent physical layouts"
+        )
+    if first_layout is not None:
+        if _scale_layout_signature(config) != first_layout:
+            raise HcuCompressedTensorsMoeError(
+                "AITER config scale layout does not match installed scales"
+            )
+        return scale1, scale2
+    prepared1, prepared2 = prepare_aiter_moe_scales(
+        scale1,
+        scale2,
+        config,
+        cache_owner=scale1,
+    )
+    assert prepared1 is not None and prepared2 is not None
+    return prepared1, prepared2
+
+
+def mark_aiter_moe_native_layout(
+    layer: object,
+    *,
+    w1_name: str = "w13_weight",
+    w2_name: str = "w2_weight",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Lock canonical weights to the native fallback without a second layout."""
+
+    w1 = _required_tensor(layer, w1_name)
+    w2 = _required_tensor(layer, w2_name)
+    logical_shape = (
+        int(w1.shape[0]),
+        int(w1.shape[1]),
+        int(w2.shape[1]),
+        int(w1.shape[2]),
+    )
+    for weight in (w1, w2):
+        setattr(weight, _WEIGHT_SOLUTION_ATTR, "native")
+        setattr(weight, _WEIGHT_LOGICAL_SHAPE_ATTR, logical_shape)
+        weight.is_shuffled = False
+    return w1, w2
 
 
 def install_aiter_moe_weight_layout(
@@ -68,11 +185,19 @@ def install_aiter_moe_weight_layout(
     w1_name: str = "w13_weight",
     w2_name: str = "w2_weight",
     block_shape: list[int] | None = None,
+    logical_shape: tuple[int, int, int, int] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Install one selected AITER layout and record its routing contract."""
 
     w1 = _required_tensor(layer, w1_name)
     w2 = _required_tensor(layer, w2_name)
+    if logical_shape is None:
+        logical_shape = (
+            int(w1.shape[0]),
+            int(w1.shape[1]),
+            int(w2.shape[1]),
+            int(w1.shape[2]),
+        )
     need_shuffle = bool(getattr(config, "need_shuffle", False))
     if need_shuffle:
         w1, w2 = prepare_aiter_moe_weights(
@@ -94,8 +219,38 @@ def install_aiter_moe_weight_layout(
         )
     for weight in (w1, w2):
         setattr(weight, _WEIGHT_SOLUTION_ATTR, solution)
+        setattr(
+            weight,
+            _WEIGHT_LAYOUT_ATTR,
+            aiter_moe_weight_layout_signature(config),
+        )
+        setattr(weight, _WEIGHT_LOGICAL_SHAPE_ATTR, logical_shape)
         weight.is_shuffled = need_shuffle
     return w1, w2
+
+
+def _installed_weight_logical_shape(
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+) -> tuple[int, int, int, int]:
+    first = getattr(w1, _WEIGHT_LOGICAL_SHAPE_ATTR, None)
+    second = getattr(w2, _WEIGHT_LOGICAL_SHAPE_ATTR, None)
+    if first != second:
+        raise HcuCompressedTensorsMoeError(
+            "AITER weights have inconsistent logical dimensions"
+        )
+    if first is None:
+        return (
+            int(w1.shape[0]),
+            int(w1.shape[1]),
+            int(w2.shape[1]),
+            int(w1.shape[2]),
+        )
+    if not isinstance(first, tuple) or len(first) != 4:
+        raise HcuCompressedTensorsMoeError(
+            "AITER weights have invalid logical dimensions"
+        )
+    return tuple(int(value) for value in first)
 
 
 def _installed_weight_solution(
@@ -137,6 +292,19 @@ def _weights_for_selected_config(
         if expected_shuffle != bool(getattr(config, "need_shuffle", False)):
             raise HcuCompressedTensorsMoeError(
                 "AITER config layout does not match installed weights"
+            )
+        first_layout = getattr(w1, _WEIGHT_LAYOUT_ATTR, None)
+        second_layout = getattr(w2, _WEIGHT_LAYOUT_ATTR, None)
+        if first_layout != second_layout:
+            raise HcuCompressedTensorsMoeError(
+                "AITER weights have inconsistent physical layouts"
+            )
+        if (
+            first_layout is not None
+            and aiter_moe_weight_layout_signature(config) != first_layout
+        ):
+            raise HcuCompressedTensorsMoeError(
+                "AITER config physical layout does not match installed weights"
             )
         return w1, w2
     return prepare_aiter_moe_weights(
@@ -207,6 +375,9 @@ def prewarm_aiter_quantized_moe(
     config = prewarm_aiter_moe_config(problem, cache_owner=w1)
     if config is not None:
         install_aiter_moe_weight_layout(layer, config)
+        install_aiter_moe_scale_layout(layer, quant_config, config)
+    else:
+        mark_aiter_moe_native_layout(layer)
     return config
 
 
@@ -411,7 +582,7 @@ def apply_aiter_w4a8_moe(
         raise HcuCompressedTensorsMoeError(
             "SlimQuant W4A8 requires matching rank-2 hidden and top-k tensors"
         )
-    explicit_vllm_layout = not allow_aiter and bool(
+    explicit_vllm_layout = bool(
         getattr(
             getattr(layer, "w13_weight", None),
             "_hcu_vllm_w4a8_unpacked",
@@ -486,11 +657,12 @@ def apply_aiter_w4a8_moe(
         installed_solution = _installed_weight_solution(
             w1, w2, label="SlimQuant W4A8"
         )
-        aiter_config = select_aiter_moe_config(
-            problem,
-            cache_owner=w1,
-            solution_type=installed_solution,
-        )
+        if installed_solution != "native":
+            aiter_config = select_aiter_moe_config(
+                problem,
+                cache_owner=w1,
+                solution_type="moe_c",
+            )
     else:
         installed_solution = None
     global_num_experts = getattr(
@@ -505,7 +677,7 @@ def apply_aiter_w4a8_moe(
     )
     expert_mask = getattr(layer, "expert_mask", None)
     if aiter_config is None:
-        if installed_solution is not None:
+        if installed_solution not in (None, "native"):
             raise HcuCompressedTensorsMoeError(
                 "AITER has no MOE_C solution for installed W4A8 weights"
             )
@@ -546,11 +718,10 @@ def apply_aiter_w4a8_moe(
         installed_solution=installed_solution,
         preserve_inputs=True,
     )
-    prepared_w1_scale, prepared_w2_scale = prepare_aiter_moe_scales(
+    prepared_w1_scale, prepared_w2_scale = _scales_for_selected_config(
         w1_scale,
         w2_scale,
         aiter_config,
-        cache_owner=w1_scale,
     )
     aiter_expert_map = aiter_expert_map_for_solution(
         native_expert_map,
@@ -667,12 +838,15 @@ def apply_aiter_quantized_moe(
             "AITER quantized MoE requires an activation"
         )
     activation_name = str(activation_value)
+    logical_e, logical_n1, logical_n2, logical_k = _installed_weight_logical_shape(
+        w1, w2
+    )
     problem = AiterMoeProblem(
         M=int(hidden_states.shape[0]),
-        E=int(w1.shape[0]),
-        N1=int(w1.shape[1]),
-        N2=int(w2.shape[1]),
-        K=int(w1.shape[2]),
+        E=logical_e,
+        N1=logical_n1,
+        N2=logical_n2,
+        K=logical_k,
         top_k=int(topk_ids.shape[1]),
         block_size=0,
         dtype=hidden_states.dtype,
@@ -684,10 +858,14 @@ def apply_aiter_quantized_moe(
     installed_solution = _installed_weight_solution(
         w1, w2, label="AITER quantized MoE"
     )
-    aiter_config = select_aiter_moe_config(
-        problem,
-        cache_owner=w1,
-        solution_type=installed_solution,
+    aiter_config = (
+        None
+        if installed_solution == "native"
+        else select_aiter_moe_config(
+            problem,
+            cache_owner=w1,
+            solution_type=installed_solution,
+        )
     )
     global_num_experts = getattr(vllm_moe_config, "num_experts", w1.shape[0])
     native_expert_map, expert_mask = resolve_aiter_expert_maps(
@@ -695,7 +873,7 @@ def apply_aiter_quantized_moe(
         int(global_num_experts),
     )
     if aiter_config is None:
-        if installed_solution is not None:
+        if installed_solution not in (None, "native"):
             raise HcuCompressedTensorsMoeError(
                 "AITER has no solution compatible with installed quantized weights"
             )
@@ -737,11 +915,10 @@ def apply_aiter_quantized_moe(
         aiter_config,
         installed_solution=installed_solution,
     )
-    prepared_w1_scale, prepared_w2_scale = prepare_aiter_moe_scales(
+    prepared_w1_scale, prepared_w2_scale = _scales_for_selected_config(
         w1_scale,
         w2_scale,
         aiter_config,
-        cache_owner=w1_scale,
     )
 
     from vllm_hcu.model_executor.layers.fused_moe.aiter_runtime import (
@@ -876,10 +1053,14 @@ def apply_aiter_w8a8_fp8_moe(
     installed_solution = _installed_weight_solution(
         w1, w2, label="AITER FP8-W8A8"
     )
-    moe_config = select_aiter_moe_config(
-        problem,
-        cache_owner=w1,
-        solution_type=installed_solution,
+    moe_config = (
+        None
+        if installed_solution == "native"
+        else select_aiter_moe_config(
+            problem,
+            cache_owner=w1,
+            solution_type=installed_solution,
+        )
     )
     w1_scale = _required_tensor(layer, "w13_weight_scale")
     w2_scale = _required_tensor(layer, "w2_weight_scale")
@@ -887,7 +1068,7 @@ def apply_aiter_w8a8_fp8_moe(
     expert_map = getattr(layer, "_expert_map", None)
     expert_mask = getattr(layer, "expert_mask", None)
     if moe_config is None:
-        if installed_solution is not None:
+        if installed_solution not in (None, "native"):
             raise HcuCompressedTensorsMoeError(
                 "AITER has no solution compatible with installed FP8 weights"
             )
@@ -923,11 +1104,10 @@ def apply_aiter_w8a8_fp8_moe(
         moe_config,
         installed_solution=installed_solution,
     )
-    prepared_w1_scale, prepared_w2_scale = prepare_aiter_moe_scales(
+    prepared_w1_scale, prepared_w2_scale = _scales_for_selected_config(
         w1_scale,
         w2_scale,
         moe_config,
-        cache_owner=w1_scale,
     )
     aiter_expert_map = aiter_expert_map_for_solution(
         expert_map,
@@ -1110,6 +1290,8 @@ __all__ = [
     "build_aiter_w4a16_quant_config",
     "create_aiter_w4a16_qzeros",
     "install_aiter_moe_weight_layout",
+    "install_aiter_moe_scale_layout",
+    "mark_aiter_moe_native_layout",
     "prewarm_aiter_w4a8_moe",
     "prepare_vllm_w4a8_moe",
     "process_dpsk_deepgemm_weights",

--- a/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
+++ b/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
@@ -110,6 +110,32 @@ class SlimQuantW4A8Int8LinearMethod(LinearMethodBase):
         return scheme.apply_weights(layer, x, bias=bias)
 
 
+_SLIMQUANT_MOE_LAYOUT_TENSORS = (
+    "w13_weight",
+    "w2_weight",
+    "w13_weight_scale",
+    "w2_weight_scale",
+)
+_SLIMQUANT_MOE_WEIGHT_TENSORS = _SLIMQUANT_MOE_LAYOUT_TENSORS[:2]
+
+
+def _slimquant_moe_tensor_generation(
+    layer: torch.nn.Module,
+    names: tuple[str, ...],
+) -> tuple[object, ...]:
+    return tuple(
+        (
+            id(tensor),
+            tensor.data_ptr(),
+            tensor._version,
+            tuple(tensor.shape),
+            tuple(tensor.stride()),
+        )
+        for name in names
+        if isinstance((tensor := getattr(layer, name, None)), Parameter)
+    )
+
+
 class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
     """Channel-wise SlimQuant W4A8 routed by the shared AITER adapter."""
 
@@ -207,27 +233,61 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
         # / [E, K, N // 2] tensors directly.  Pre-shuffling here routes the
         # weights into the MOE_C/Marlin layout and produces incorrect values
         # for this path.
-        for name in (
-            "w13_weight",
-            "w2_weight",
-            "w13_weight_scale",
-            "w2_weight_scale",
-        ):
+        for name in _SLIMQUANT_MOE_LAYOUT_TENSORS:
             parameter = getattr(layer, name, None)
             if not isinstance(parameter, Parameter):
                 raise TypeError(f"SlimQuant W4A8 requires Parameter {name}")
             parameter.requires_grad_(False)
+        generation = _slimquant_moe_tensor_generation(
+            layer,
+            _SLIMQUANT_MOE_LAYOUT_TENSORS,
+        )
+        if (
+            getattr(layer, "_hcu_slimquant_post_load_generation", None)
+            == generation
+        ):
+            return
         from vllm_hcu.model_executor.layers.fused_moe.deepep_runtime import (
             slimquant_w4a8_uses_deepep_auto,
         )
 
-        if slimquant_w4a8_uses_deepep_auto(getattr(self, "moe", None)):
+        uses_deepep_auto = slimquant_w4a8_uses_deepep_auto(
+            getattr(self, "moe", None)
+        )
+        weight_generation = _slimquant_moe_tensor_generation(
+            layer,
+            _SLIMQUANT_MOE_WEIGHT_TENSORS,
+        )
+        installed_weight_generation = getattr(
+            layer,
+            "_hcu_slimquant_post_load_weight_generation",
+            None,
+        )
+        if not uses_deepep_auto and installed_weight_generation == weight_generation:
             self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-            if self.moe_quant_config is None:
-                raise RuntimeError(
-                    "SlimQuant W4A8 deepep_auto requires its MoE quantization "
-                    "config before weight postprocessing"
+            config = getattr(layer, "_hcu_slimquant_post_load_aiter_config", None)
+            if config is not None:
+                from vllm_hcu.model_executor.layers.quantization.compressed_tensors_moe_runtime import (
+                    install_aiter_moe_scale_layout,
                 )
+
+                install_aiter_moe_scale_layout(
+                    layer,
+                    self.moe_quant_config,
+                    config,
+                    prefer_quant_config=True,
+                )
+            layer._hcu_slimquant_post_load_generation = generation
+            return
+
+        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        if self.moe_quant_config is None:
+            raise RuntimeError(
+                "SlimQuant W4A8 requires its MoE quantization config before "
+                "weight postprocessing"
+            )
+
+        if uses_deepep_auto:
             from vllm_hcu.model_executor.layers.fused_moe.experts.dpsk_v4_deep_gemm_moe import (
                 make_deepep_auto_deepgemm_w4a8_moe_kernel,
             )
@@ -246,6 +306,18 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
                     "experts before weight postprocessing"
                 )
             process(layer)
+            layer._hcu_slimquant_post_load_weight_generation = (
+                _slimquant_moe_tensor_generation(
+                    layer,
+                    _SLIMQUANT_MOE_WEIGHT_TENSORS,
+                )
+            )
+            layer._hcu_slimquant_post_load_generation = (
+                _slimquant_moe_tensor_generation(
+                    layer,
+                    _SLIMQUANT_MOE_LAYOUT_TENSORS,
+                )
+            )
             return
         if getattr(self.moe, "moe_backend", "auto") == "triton":
             from vllm_hcu.model_executor.layers.quantization.compressed_tensors_moe_runtime import (
@@ -253,6 +325,7 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
             )
 
             prepare_vllm_w4a8_moe(self, layer)
+            layer._hcu_slimquant_post_load_aiter_config = None
         else:
             from vllm_hcu.model_executor.layers.quantization.compressed_tensors_moe_runtime import (
                 install_aiter_moe_weight_layout,
@@ -262,13 +335,6 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
                 prepare_vllm_w4a8_moe,
             )
 
-            if self.moe_quant_config is None:
-                self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-            if self.moe_quant_config is None:
-                raise RuntimeError(
-                    "SlimQuant W4A8 AITER requires its MoE quantization "
-                    "config before weight postprocessing"
-                )
             config = prewarm_aiter_w4a8_moe(self, layer)
             if config is not None:
                 install_aiter_moe_weight_layout(
@@ -287,9 +353,23 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
                     config,
                     prefer_quant_config=True,
                 )
+                layer._hcu_slimquant_post_load_aiter_config = config
             else:
                 prepare_vllm_w4a8_moe(self, layer)
                 mark_aiter_moe_native_layout(layer)
+                layer._hcu_slimquant_post_load_aiter_config = None
+        layer._hcu_slimquant_post_load_weight_generation = (
+            _slimquant_moe_tensor_generation(
+                layer,
+                _SLIMQUANT_MOE_WEIGHT_TENSORS,
+            )
+        )
+        layer._hcu_slimquant_post_load_generation = (
+            _slimquant_moe_tensor_generation(
+                layer,
+                _SLIMQUANT_MOE_LAYOUT_TENSORS,
+            )
+        )
 
     def apply(
         self,

--- a/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
+++ b/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
@@ -262,6 +262,13 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
                 prepare_vllm_w4a8_moe,
             )
 
+            if self.moe_quant_config is None:
+                self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+            if self.moe_quant_config is None:
+                raise RuntimeError(
+                    "SlimQuant W4A8 AITER requires its MoE quantization "
+                    "config before weight postprocessing"
+                )
             config = prewarm_aiter_w4a8_moe(self, layer)
             if config is not None:
                 install_aiter_moe_weight_layout(

--- a/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
+++ b/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
@@ -256,12 +256,33 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
         else:
             from vllm_hcu.model_executor.layers.quantization.compressed_tensors_moe_runtime import (
                 install_aiter_moe_weight_layout,
+                install_aiter_moe_scale_layout,
+                mark_aiter_moe_native_layout,
                 prewarm_aiter_w4a8_moe,
+                prepare_vllm_w4a8_moe,
             )
 
             config = prewarm_aiter_w4a8_moe(self, layer)
             if config is not None:
-                install_aiter_moe_weight_layout(layer, config)
+                install_aiter_moe_weight_layout(
+                    layer,
+                    config,
+                    logical_shape=(
+                        int(layer.w13_weight.shape[0]),
+                        int(layer.w13_weight.shape[1]),
+                        int(layer.w2_weight.shape[1]),
+                        int(layer.w13_weight.shape[2]) * 2,
+                    ),
+                )
+                install_aiter_moe_scale_layout(
+                    layer,
+                    self.moe_quant_config,
+                    config,
+                    prefer_quant_config=True,
+                )
+            else:
+                prepare_vllm_w4a8_moe(self, layer)
+                mark_aiter_moe_native_layout(layer)
 
     def apply(
         self,

--- a/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
+++ b/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
@@ -255,10 +255,13 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
             prepare_vllm_w4a8_moe(self, layer)
         else:
             from vllm_hcu.model_executor.layers.quantization.compressed_tensors_moe_runtime import (
+                install_aiter_moe_weight_layout,
                 prewarm_aiter_w4a8_moe,
             )
 
-            prewarm_aiter_w4a8_moe(self, layer)
+            config = prewarm_aiter_w4a8_moe(self, layer)
+            if config is not None:
+                install_aiter_moe_weight_layout(layer, config)
 
     def apply(
         self,

--- a/vllm_hcu/v1/spec_decode/proposer_runtime.py
+++ b/vllm_hcu/v1/spec_decode/proposer_runtime.py
@@ -22,10 +22,9 @@ def initialize_proposer(
     proposer._hcu_feature_config = config
     proposer.runner = runner
 
-    # HCU FlashMLA sparse explicitly supports speculative tokens as decode
-    # queries, but target vLLM v0.25.1 does not include its metadata class in
-    # the ROCm multi-step drafting allowlist.  Keep the target proposer and
-    # extend only the HCU-owned backend capability registration.
+    # HCU attention backends support speculative tokens as decode queries,
+    # but target vLLM v0.25.1 cannot discover plugin-owned metadata classes
+    # for its ROCm multi-step drafting allowlist.
     try:
         from vllm.v1.attention.backends.mla.flashmla_sparse import (
             FlashMLASparseMetadata,
@@ -40,6 +39,17 @@ def initialize_proposer(
             and FlashMLASparseMetadata not in allowed_attn_types
         ):
             proposer.allowed_attn_types += (FlashMLASparseMetadata,)
+
+    from vllm_hcu.v1.attention.backends.flash_attn import (
+        FlashAttentionMetadata,
+    )
+
+    allowed_attn_types = getattr(proposer, "allowed_attn_types", None)
+    if (
+        allowed_attn_types is not None
+        and FlashAttentionMetadata not in allowed_attn_types
+    ):
+        proposer.allowed_attn_types += (FlashAttentionMetadata,)
 
     proposer.enable_multi_layers_mtp = config.enable_multi_layers_mtp
     proposer.enable_lightly_cp = config.enable_lightly_cp

--- a/vllm_hcu/v1/spec_decode/proposer_runtime.py
+++ b/vllm_hcu/v1/spec_decode/proposer_runtime.py
@@ -25,31 +25,29 @@ def initialize_proposer(
     # HCU attention backends support speculative tokens as decode queries,
     # but target vLLM v0.25.1 cannot discover plugin-owned metadata classes
     # for its ROCm multi-step drafting allowlist.
-    try:
-        from vllm.v1.attention.backends.mla.flashmla_sparse import (
-            FlashMLASparseMetadata,
-        )
-    except ModuleNotFoundError as exc:
-        if exc.name != "vllm.v1.attention.backends.mla.flashmla_sparse":
-            raise
-    else:
-        allowed_attn_types = getattr(proposer, "allowed_attn_types", None)
-        if (
-            allowed_attn_types is not None
-            and FlashMLASparseMetadata not in allowed_attn_types
-        ):
-            proposer.allowed_attn_types += (FlashMLASparseMetadata,)
-
-    from vllm_hcu.v1.attention.backends.flash_attn import (
-        FlashAttentionMetadata,
-    )
-
     allowed_attn_types = getattr(proposer, "allowed_attn_types", None)
-    if (
-        allowed_attn_types is not None
-        and FlashAttentionMetadata not in allowed_attn_types
-    ):
-        proposer.allowed_attn_types += (FlashAttentionMetadata,)
+    if allowed_attn_types is not None:
+        try:
+            from vllm.v1.attention.backends.mla.flashmla_sparse import (
+                FlashMLASparseMetadata,
+            )
+        except ModuleNotFoundError as exc:
+            if exc.name != "vllm.v1.attention.backends.mla.flashmla_sparse":
+                raise
+        else:
+            if FlashMLASparseMetadata not in proposer.allowed_attn_types:
+                proposer.allowed_attn_types += (FlashMLASparseMetadata,)
+
+        try:
+            from vllm_hcu.v1.attention.backends.flash_attn import (
+                FlashAttentionMetadata,
+            )
+        except ModuleNotFoundError as exc:
+            if exc.name != "flash_attn":
+                raise
+        else:
+            if FlashAttentionMetadata not in allowed_attn_types:
+                proposer.allowed_attn_types += (FlashAttentionMetadata,)
 
     proposer.enable_multi_layers_mtp = config.enable_multi_layers_mtp
     proposer.enable_lightly_cp = config.enable_lightly_cp


### PR DESCRIPTION
## Summary

- install the selected BF16/W16A16, W8A8, FP8 and SlimQuant W4A8 AITER layouts once during per-layer post-load processing
- replace canonical Parameters after shuffle instead of retaining a second persistent weight copy
- persist and validate physical layout signatures and pre-shuffle logical dimensions, including PADDED_K contracts
- validate gated and non-gated quantized MoE geometry consistently across generic and explicit FP8 entrypoints
- lock M=1 misses to native/Triton fallback and pin W4A8 to its compatible MOE_C route
- preserve SlimQuant W4A8 compensated scales and initialize/install them in the real post-load lifecycle
- preserve the existing specialized W4A16 and DeepGEMM load paths
- fix HCU MTP FlashAttention metadata compatibility

## Verification

- pytest: 211 passed in tests/runtime_patch/test_quant_gemm_aiter.py on the latest v0.25.1 base
- compileall and git diff check passed
- independent final code review: no Critical, Important, or Minor findings
- real TP2 BF16 validation on HIP devices 5 and 6 with AITER and MTP=3 returned HTTP 200
- real TP2 W8A8 validation on HIP devices 5 and 6 with AITER and MTP=3 completed CUDA graph capture and returned HTTP 200

### BF16 server

```bash
HIP_VISIBLE_DEVICES=5,6 PYTHONPATH=/models/vllm-plugin-das \
vllm serve /models/Qwen3.5-35B-A3B \
  --moe-backend aiter -tp 2 \
  --max-model-len 8192 --max-num-batched-tokens 4096 \
  --max-num-seqs 16 --gpu-memory-utilization 0.90 \
  --enforce-eager --port 8015 \
  --speculative_config '{"method":"mtp","num_speculative_tokens":3}'
```

### BF16 client

```bash
curl --noproxy 127.0.0.1 http://127.0.0.1:8015/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"/models/Qwen3.5-35B-A3B","messages":[{"role":"user","content":"Hello"}],"temperature":0,"max_tokens":32,"chat_template_kwargs":{"enable_thinking":false}}'
```

### W8A8 server

```bash
HIP_VISIBLE_DEVICES=5,6 PYTHONPATH=/models/vllm-plugin-das \
vllm serve /models/Qwen3.5-35B-A3B-W8A8 \
  --moe-backend aiter -tp 2 \
  --max-model-len 8192 --max-num-batched-tokens 4096 \
  --max-num-seqs 16 --gpu-memory-utilization 0.90 \
  --enforce-eager --port 8016 \
  --speculative_config '{"method":"mtp","num_speculative_tokens":3}'
```

### W8A8 client

```bash
curl --noproxy 127.0.0.1 http://127.0.0.1:8016/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"/models/Qwen3.5-35B-A3B-W8A8","messages":[{"role":"user","content":"Hello"}],"temperature":0,"max_tokens":32,"chat_template_kwargs":{"enable_thinking":false}}'
```

## Known follow-up: gfx936 LightOp sparse MQA

This PR intentionally does not change sparse-indexer MQA routing.

- On gfx936, LightOp 0.6.0 `mqa_logits` returns all-zero logits for FP8 Q/K inputs; its BF16 input path is correct.
- The available AITER Triton `fp8_mqa_logits` kernel was tested directly on gfx936 and passed the FP32-reference comparison (`max_abs_diff=0.1353`, `mean_abs_diff=0.0160`, `rtol=2e-2`, `atol=2e-1`).
- A future focused fix can prefer the AITER Triton FP8 kernel on gfx936 and use a gfx936-only BF16 LightOp compatibility fallback when that module is unavailable, while retaining the native gfx938 path.
- `fp8_ds_mla` is the downstream paged KV-cache format used by FlashMLA sparse attention. It is not a drop-in replacement for the non-paged sparse-indexer `mqa_logits` computation.

## Supersedes

This PR includes and supersedes #44.