### PR TITLE
fix: exclude gfx938-only test from gfx936 CI

### DIFF
--- a/.github/workflows/configs/hcu-test-map.yaml
+++ b/.github/workflows/configs/hcu-test-map.yaml
@@ -34,7 +34,10 @@
       "arch": "gfx936",
       "cards": 1,
       "suite": "accuracy-hcu",
-      "pytest_args": [],
+      "pytest_args": [
+        "--deselect",
+        "tests/accuracy/test_hcu_kernel_accuracy.py::test_lightop_deepseek_v4_fused_insert_updates_q_and_cache"
+      ],
       "timeout_minutes": 30,
       "requirements": []
     },


### PR DESCRIPTION
## Summary

- deselect the gfx938-only DeepSeek V4 fused-insert accuracy test from `accuracy-gfx936`
- keep the test enabled for `accuracy-gfx938`
- preserve fail-closed handling for unexpected skipped/xfail tests

## Validation

- HCU test map JSON validation passed
- `tests/patch/test_hcu_ci_selector.py`: 47 passed
- `git diff --check` passed
