### PR TITLE
fix(hcu): avoid gfx936 LightOp FP8 MQA zero logits

### DIFF
--- a/tests/runtime_patch/test_lightop_attention_api.py
+++ b/tests/runtime_patch/test_lightop_attention_api.py
@@ -342,3 +342,132 @@ def test_sparse_mla_topk_helpers_use_categorized_attention_kernels(
 
     assert len(prefill_calls) == 1
     assert len(decode_calls) == 1
+
+
+def test_fp8_mqa_logits_gfx936_prefers_aiter_over_lightop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime()
+    aiter_calls: list[tuple[object, ...]] = []
+    lightop_calls: list[tuple[object, ...]] = []
+    sentinel = object()
+
+    monkeypatch.setattr(runtime.current_platform, "is_rocm", lambda: True)
+    monkeypatch.setattr(runtime, "on_gfx93x", lambda: True)
+    monkeypatch.setattr(runtime, "on_gfx938", lambda: False)
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    monkeypatch.setattr(rocm_aiter_ops, "is_enabled", lambda: True)
+    monkeypatch.setattr(
+        runtime,
+        "mqa_logits_module",
+        lambda: SimpleNamespace(
+            fp8_mqa_logits=lambda *args: (
+                aiter_calls.append(args),
+                sentinel,
+            )[1]
+        ),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "lightop_attention",
+        SimpleNamespace(
+            mqa_logits=lambda *args: (
+                lightop_calls.append(args),
+                None,
+            )[1]
+        ),
+        raising=False,
+    )
+
+    result = runtime.rocm_fp8_mqa_logits(
+        torch.ones((2, 1, 4)),
+        (torch.ones((3, 4), dtype=torch.bfloat16), torch.ones(3)),
+        torch.ones((2, 1)),
+        torch.zeros(2, dtype=torch.int32),
+        torch.full((2,), 3, dtype=torch.int32),
+    )
+
+    assert result is sentinel
+    assert len(aiter_calls) == 1
+    assert lightop_calls == []
+
+
+def test_fp8_mqa_logits_gfx936_without_aiter_uses_bf16_lightop_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime()
+    calls: list[tuple[object, ...]] = []
+    sentinel = object()
+    k_bf16 = torch.full((3, 4), 2.0, dtype=torch.bfloat16)
+
+    monkeypatch.setattr(runtime.current_platform, "is_rocm", lambda: True)
+    monkeypatch.setattr(runtime, "on_gfx93x", lambda: True)
+    monkeypatch.setattr(runtime, "on_gfx938", lambda: False)
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    monkeypatch.setattr(rocm_aiter_ops, "is_enabled", lambda: True)
+    monkeypatch.setattr(runtime, "mqa_logits_module", lambda: None)
+
+    def capture_mqa(*args):
+        calls.append(args)
+        return sentinel
+
+    monkeypatch.setattr(
+        runtime,
+        "lightop_attention",
+        SimpleNamespace(mqa_logits=capture_mqa),
+        raising=False,
+    )
+
+    result = runtime.rocm_fp8_mqa_logits(
+        torch.ones((2, 1, 4)),
+        (k_bf16, torch.full((3,), float("nan"))),
+        torch.ones((2, 1)),
+        torch.zeros(2, dtype=torch.int32),
+        torch.full((2,), 3, dtype=torch.int32),
+    )
+
+    assert result is sentinel
+    assert len(calls) == 1
+    assert calls[0][0].dtype is torch.bfloat16
+    assert calls[0][1] is k_bf16
+    assert calls[0][5] is None
+
+
+def test_fp8_mqa_logits_gfx938_without_aiter_keeps_lightop_fp8_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime()
+    calls: list[tuple[object, ...]] = []
+    sentinel = object()
+    scale = torch.full((3,), 0.5)
+
+    monkeypatch.setattr(runtime.current_platform, "is_rocm", lambda: True)
+    monkeypatch.setattr(runtime, "on_gfx93x", lambda: True)
+    monkeypatch.setattr(runtime, "on_gfx938", lambda: True)
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    monkeypatch.setattr(rocm_aiter_ops, "is_enabled", lambda: False)
+    monkeypatch.setattr(
+        runtime,
+        "lightop_attention",
+        SimpleNamespace(
+            mqa_logits=lambda *args: (calls.append(args), sentinel)[1]
+        ),
+        raising=False,
+    )
+
+    q = torch.ones((2, 1, 4))
+    result = runtime.rocm_fp8_mqa_logits(
+        q,
+        (torch.ones((3, 4)), scale),
+        torch.ones((2, 1)),
+        torch.zeros(2, dtype=torch.int32),
+        torch.full((2,), 3, dtype=torch.int32),
+    )
+
+    assert result is sentinel
+    assert len(calls) == 1
+    assert calls[0][0] is q
+    assert calls[0][5] is scale

--- a/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -24,7 +24,7 @@ else:
     
 from vllm.v1.attention.backends.mla.indexer import DeepseekV32IndexerPrefillMetadata
 import vllm_hcu.platforms.envs as henvs 
-from vllm_hcu.platforms.hcu import on_gfx938
+from vllm_hcu.platforms.hcu import on_gfx93x, on_gfx938
 
 
 lightop_attention = None
@@ -888,6 +888,30 @@ def mqa_logits_module():
     return None
 
 
+def _rocm_fp8_mqa_logits_gfx936_bf16_fallback(
+    q: torch.Tensor,
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+) -> torch.Tensor:
+    """Run the gfx936 LightOp compatibility path with BF16 Q/K inputs.
+
+    The gfx936 sparse-indexer cache path gathers K as BF16 and does not produce
+    a valid per-token FP8 scale.  LightOp 0.6.0 returns zero logits for FP8 Q/K
+    inputs on gfx936, so discard the unused scale and use the BF16 ABI instead.
+    """
+    k_bf16, _uninitialized_scale = kv
+    return _get_lightop_attention().mqa_logits(
+        q.to(torch.bfloat16),
+        k_bf16,
+        weights.float().contiguous(),
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        None,
+    )
+
+
 def rocm_fp8_mqa_logits(
     q: torch.Tensor,
     kv: tuple[torch.Tensor, torch.Tensor],
@@ -900,9 +924,10 @@ def rocm_fp8_mqa_logits(
     Args:
         q: Query tensor of shape [M, H, D]. Casted to
             `torch.float8_e4m3fn` by caller.
-        kv: Tuple `(k_fp8, k_scales)` where `k_fp8` has shape [N, D] with
-            dtype `torch.float8_e4m3fn` and `k_scales` has shape [N] (or
-            [N, 1]) with dtype `torch.float32`.
+        kv: Tuple ``(k_tensor, k_scales)``. On gfx938, ``k_tensor`` is FP8
+            and ``k_scales`` contains valid float32 scales. On gfx936,
+            ``k_tensor`` is BF16 from the compatibility cache path and
+            ``k_scales`` is uninitialized and discarded by the fallback.
         weights: weights of shape [M, H], dtype `torch.float32`.
         cu_seqlen_ks: Start indices (inclusive) for valid K per query position,
             shape [M], dtype int32.
@@ -925,6 +950,20 @@ def rocm_fp8_mqa_logits(
         fp8_mqa_logits = aiter_mqa_logits_module.fp8_mqa_logits
         k_fp8, scale = kv
         return fp8_mqa_logits(q, k_fp8, scale, weights, cu_seqlen_ks, cu_seqlen_ke)
+    elif current_platform.is_rocm() and on_gfx938():
+        k_fp8, scale = kv
+        return _get_lightop_attention().mqa_logits(
+            q,
+            k_fp8,
+            weights.float().contiguous(),
+            cu_seqlen_ks,
+            cu_seqlen_ke,
+            scale,
+        )
+    elif current_platform.is_rocm() and on_gfx93x() and not on_gfx938():
+        return _rocm_fp8_mqa_logits_gfx936_bf16_fallback(
+            q, kv, weights, cu_seqlen_ks, cu_seqlen_ke
+        )
     elif current_platform.is_rocm():
         k_fp8, scale = kv
         return _get_lightop_attention().mqa_logits(
@@ -935,15 +974,6 @@ def rocm_fp8_mqa_logits(
             cu_seqlen_ke,
             scale,
         )
-        # mqa_logits_inner_chunked(
-        #     chunk,
-        #     q_fp8,
-        #     k_fp8,
-        #     weights,
-        #     scale,
-        #     topk_indices_buffer,
-        #     topk_tokens,
-        # )
     else:
         return fp8_mqa_logits_torch(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke)
 


### PR DESCRIPTION
## Summary

- Prefer the validated AITER Triton `fp8_mqa_logits` kernel when available.
- Keep the native LightOp FP8 path on gfx938.
- On gfx936, use BF16 Q/K with `kv_scale=None` when the AITER module is unavailable, avoiding LightOp 0.6.0's all-zero FP8 result.
- Keep paged `fp8_ds_mla` handling unchanged.

## Validation

- `python -m py_compile vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py tests/runtime_patch/test_lightop_attention_api.py`
- `pytest -q tests/runtime_patch/test_lightop_attention_api.py tests/runtime_patch/test_sparse_indexer_loading.py tests/runtime_patch/test_lightop_categorized_api.py`
  - 33 passed
- gfx936 live BF16 fallback numerical check: max absolute error 0.10995, mean absolute error 0.01322 against BF16 reference.
- gfx936 live AITER FP8 check: max absolute error 0.09244, mean absolute error 0.01538 against BF16 reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)