### PR TITLE
fix(hcu): avoid double router weighting in DeepEP GEMM

### DIFF
--- a/tests/runtime_patch/test_deep_gemm_utils.py
+++ b/tests/runtime_patch/test_deep_gemm_utils.py
@@ -141,15 +141,25 @@ def _load_deep_gemm_apply():
             torch.zeros_like(kwargs["topk_ids"], dtype=torch.int32),
             256,
         ),
-        "deepgemm_unpermute_and_reduce": lambda **_kwargs: None,
+        "deepgemm_unpermute_and_reduce": lambda **kwargs: namespace[
+            "reduce_calls"
+        ].append(kwargs),
+        "topk_weights_for_unpermute": lambda weights, apply: (
+            torch.ones_like(weights) if apply else weights
+        ),
         "m_grouped_fp8_gemm_nt_contiguous": lambda *_args, **_kwargs: None,
+        "m_grouped_w8a8_gemm_nt_contig_asm": lambda *_args, **_kwargs: None,
+        "reduce_calls": [],
     }
     exec(compile(ast.fix_missing_locations(module), source_path, "exec"), namespace)
     return namespace
 
 
 def _run_w8a8_apply(
-    namespace: dict[str, object], *, packed_weights: bool = False
+    namespace: dict[str, object],
+    *,
+    packed_weights: bool = False,
+    apply_router_weight_on_input: bool = False,
 ) -> None:
     logical_n = 16 if packed_weights else 4
     logical_k = 64 if packed_weights else 4
@@ -187,7 +197,32 @@ def _run_w8a8_apply(
         workspace13=torch.empty(32, dtype=torch.int8),
         workspace2=torch.empty(32),
         expert_tokens_meta=None,
-        apply_router_weight_on_input=False,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+    )
+
+
+def test_w8a8_apply_uses_uniform_reduce_weights_after_input_weighting(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_categorized_lightop(
+        monkeypatch,
+        activation_name="fuse_silu_mul_quant",
+        activation_kernel=lambda tensor, **kwargs: (
+            kwargs["output"],
+            torch.ones((tensor.shape[0], 1)),
+        ),
+        gemm_name="m_grouped_w8a8_gemm_nt_contig_asm",
+        gemm_kernel=lambda *_args: None,
+    )
+    namespace = _load_deep_gemm_apply()
+    namespace["current_platform"] = SimpleNamespace(is_rocm=lambda: True)
+    _run_w8a8_apply(namespace, apply_router_weight_on_input=True)
+
+    reduce_calls = namespace["reduce_calls"]
+    assert len(reduce_calls) == 1
+    torch.testing.assert_close(
+        reduce_calls[0]["topk_weights"],
+        torch.ones((2, 1)),
     )
 
 
@@ -446,8 +481,10 @@ def test_w4a8_contiguous_rejects_invalid_channel_scale_before_packing(
     assert pack_calls == 0
 
 
+@pytest.mark.parametrize("apply_router_weight_on_input", [False, True])
 def test_w4a8_contiguous_runs_two_hipc_gemms_with_expert_map_and_scales(
     monkeypatch: pytest.MonkeyPatch,
+    apply_router_weight_on_input: bool,
 ):
     """Both GEMM stages must retain scale and expert-map ownership."""
 
@@ -470,7 +507,7 @@ def test_w4a8_contiguous_runs_two_hipc_gemms_with_expert_map_and_scales(
     hidden_states = torch.arange(8, dtype=torch.int8).reshape(2, 4)
     input_scale = torch.ones((2, 1), dtype=torch.float32)
     topk_ids = torch.tensor([[0], [1]], dtype=torch.int32)
-    topk_weights = torch.ones((2, 1), dtype=torch.float32)
+    topk_weights = torch.tensor([[0.25], [0.75]], dtype=torch.float32)
     expert_map = torch.tensor([1, 0], dtype=torch.int32)
     m_indices = torch.tensor([0, 1], dtype=torch.int64)
     inv_perm = torch.tensor([1, 0], dtype=torch.int32)
@@ -540,7 +577,7 @@ def test_w4a8_contiguous_runs_two_hipc_gemms_with_expert_map_and_scales(
         workspace13=torch.empty(32, dtype=torch.int8),
         workspace2=torch.empty(32, dtype=torch.bfloat16),
         expert_tokens_meta=expert_tokens_meta,
-        apply_router_weight_on_input=False,
+        apply_router_weight_on_input=apply_router_weight_on_input,
     )
 
     assert len(gemm_calls) == 2
@@ -551,6 +588,10 @@ def test_w4a8_contiguous_runs_two_hipc_gemms_with_expert_map_and_scales(
     assert permute_call["expert_map"] is expert_map
     assert permute_call["expert_tokens_meta"] is expert_tokens_meta
     assert reduce_call["expert_map"] is expert_map
+    expected_weights = (
+        torch.ones_like(topk_weights) if apply_router_weight_on_input else topk_weights
+    )
+    torch.testing.assert_close(reduce_call["topk_weights"], expected_weights)
     torch.testing.assert_close(output, torch.full_like(output, 2))
 
 

--- a/vllm_hcu/model_executor/layers/fused_moe/deep_gemm_utils.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/deep_gemm_utils.py
@@ -637,6 +637,20 @@ def deepgemm_moe_permute(
     return aq_out, aq_scale_out, expert_ids, inv_perm, align_used
 
 
+def topk_weights_for_unpermute(
+    topk_weights: torch.Tensor,
+    apply_router_weight_on_input: bool,
+) -> torch.Tensor:
+    """Return reduction weights for an input-weighted expert computation.
+
+    The modular MoE contract applies router weights either before dispatch or
+    during unpermute/reduce, but never at both stages.
+    """
+    if apply_router_weight_on_input:
+        return torch.ones_like(topk_weights)
+    return topk_weights
+
+
 def deepgemm_unpermute_and_reduce(
     a: torch.Tensor,  # Grouped gemm output
     topk_ids: torch.Tensor,

--- a/vllm_hcu/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
@@ -20,6 +20,9 @@ from vllm.model_executor.layers.fused_moe.deep_gemm_utils import (
     deepgemm_moe_permute,
     deepgemm_unpermute_and_reduce,
 )
+from vllm_hcu.model_executor.layers.fused_moe.deep_gemm_utils import (
+    topk_weights_for_unpermute,
+)
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )

--- a/vllm_hcu/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
@@ -498,8 +498,10 @@ class DeepGemmExperts(mk.FusedMoEExpertsModular):
                     **gemm_kwargs,
                 )
 
-        if apply_router_weight_on_input:
-            topk_weights = torch.ones_like(topk_weights)
+        topk_weights = topk_weights_for_unpermute(
+            topk_weights,
+            apply_router_weight_on_input,
+        )
 
         deepgemm_unpermute_and_reduce(
             a=mm2_out,
@@ -722,8 +724,10 @@ class DeepGemmFP4Experts(mk.FusedMoEExpertsModular):
                 recipe_b=(1, self._WEIGHT_BLOCK_K),
             )
 
-        if apply_router_weight_on_input:
-            topk_weights = torch.ones_like(topk_weights)
+        topk_weights = topk_weights_for_unpermute(
+            topk_weights,
+            apply_router_weight_on_input,
+        )
 
         deepgemm_unpermute_and_reduce(
             a=mm2_out,

--- a/vllm_hcu/model_executor/layers/fused_moe/experts/dpsk_v4_deep_gemm_moe.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/experts/dpsk_v4_deep_gemm_moe.py
@@ -27,6 +27,9 @@ from vllm.model_executor.layers.fused_moe.deep_gemm_utils import (
     deepgemm_moe_permute,
     deepgemm_unpermute_and_reduce,
 )
+from vllm_hcu.model_executor.layers.fused_moe.deep_gemm_utils import (
+    topk_weights_for_unpermute,
+)
 from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceDelegate,
@@ -341,7 +344,6 @@ class DeepEPDeepGemmContiguousExperts(TritonExperts):
         expert_tokens_meta: mk.ExpertTokensMetadata | None,
         apply_router_weight_on_input: bool,
     ):
-        del apply_router_weight_on_input
         if activation != MoEActivation.SILU:
             raise NotImplementedError(
                 "DeepEP DeepGEMM HT path currently mirrors SGLang's silu-only "
@@ -435,6 +437,10 @@ class DeepEPDeepGemmContiguousExperts(TritonExperts):
             m_indices,
         )
 
+        topk_weights = topk_weights_for_unpermute(
+            topk_weights,
+            apply_router_weight_on_input,
+        )
         deepgemm_unpermute_and_reduce(
             a=down_output,
             topk_ids=topk_ids,

--- a/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8_deepgemm_runtime.py
+++ b/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8_deepgemm_runtime.py
@@ -20,6 +20,9 @@ from vllm.model_executor.layers.fused_moe.deep_gemm_utils import (
     deepgemm_moe_permute,
     deepgemm_unpermute_and_reduce,
 )
+from vllm_hcu.model_executor.layers.fused_moe.deep_gemm_utils import (
+    topk_weights_for_unpermute,
+)
 from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
@@ -236,9 +239,13 @@ class DeepEPDeepGemmW4A8ContiguousExperts(TritonExperts):
         expert_tokens_meta: mk.ExpertTokensMetadata | None,
         apply_router_weight_on_input: bool,
     ) -> None:
-        del global_num_experts, a2_scale, apply_router_weight_on_input
+        del global_num_experts, a2_scale
         if hidden_states.size(0) == 0:
             return
+        topk_weights = topk_weights_for_unpermute(
+            topk_weights,
+            apply_router_weight_on_input,
+        )
         if activation != MoEActivation.SILU:
             raise NotImplementedError(
                 "SlimQuant W4A8 DeepGEMM supports only SiLU activation"


### PR DESCRIPTION
## Summary

- align HCU DeepGEMM and DeepEP HT reduction with the official vLLM `apply_router_weight_on_input` contract
- apply router weights exactly once: at input or during unpermute/reduce
- share the reduction-weight helper across native DeepGEMM, Channel-FP8/INT8 DeepEP HT, and SlimQuant W4A8 HT
- keep DeepEP LL masked/N32, pure-TP AITER, and other quantization ownership boundaries unchanged

## Reference

This follows the official vLLM modular MoE design:

- prepare/dispatch may apply router weights to the input
- expert execution produces unweighted expert results
- finalize/unpermute/reduce must use uniform weights when input weighting already occurred

Reference repository: https://github.com/vllm-project/vllm

## Validation

Passed before opening this MR:

- `tests/runtime_patch/test_deep_gemm_utils.py`: 13 passed
- `tests/runtime_patch/test_quant_gemm_aiter.py`: 195 passed
- `tests/runtime_patch/test_moe_deepep.py`: 84 passed
- Python AST/bytecode compilation for modified modules
- `git diff --check`
- Qwen3.5-9B and Qwen3.5-35B-A3B integration test collection executed successfully

Additional real-model validation on 2026-09-03 using 8 gfx936 devices:

- Qwen3.5-35B-A3B-W8A8, TP8/EP8 smoke: passed with `allgather_reducescatter`
- Qwen3.5-35B-A3B-W8A8, DP8/EP8 with explicit DeepEP high-throughput: passed; selected `DeepEPHTPrepareAndFinalize`
- Qwen3.5-35B-A3B BF16, DP8/EP8 with explicit DeepEP high-throughput: passed; selected `DeepEPHTPrepareAndFinalize`
- Qwen3.5-35B-A3B BF16, DP8/EP8 with explicit DeepEP low-latency: passed; selected `DeepEPLLPrepareAndFinalize`

Environment-limited or unsupported configurations:

- Qwen3.5-9B smoke: skipped because the HCU model runtime resource was unavailable
- Qwen3.5-9B graph parity: skipped because the HCU model runtime resource was unavailable
- Qwen3.5-35B-A3B TP+EP matrix: 6 skipped because the test requires gfx938 and the available devices are gfx936
- Qwen3.5-35B-A3B-W8A8 with `deepep_auto`: rejected by the existing HCU guard because this Channel-INT8 auto path is validated only for DeepSeek-V4; explicit DeepEP HT is the supported Qwen3.5 route
- Qwen3.5-35B-A3B-W8A8 with explicit DeepEP LL: rejected because no Int8 MoE backend supports this deployment configuration
- Qwen3.5-35B-A3B-W8A8: no dedicated upstream local integration test was present in this v0.25.1 test tree

Known unrelated test prerequisite:

- the full `test_moe_deepep.py` module has one existing environment failure in `test_moe_runner_and_shared_experts_cold_replacement_contract` because `/models/vllm_0251` is not available; the remaining 84 tests passed.
