### PR TITLE
fix(hcu): resolve MoE aliasing and v0.25.1 startup issues

### DIFF
--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import warnings
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -19,11 +20,17 @@ from vllm.utils import torch_utils
 
 
 @pytest.fixture(scope="module")
-def moe_runner_module() -> ModuleType:
+def moe_op_registrations() -> dict[str, dict]:
+    return {}
+
+
+@pytest.fixture(scope="module")
+def moe_runner_module(moe_op_registrations: dict[str, dict]) -> ModuleType:
     register_custom_op = torch_utils.direct_register_custom_op
 
     def register_without_duplicate_moe_ops(op_name, *args, **kwargs):
         if op_name in {"moe_forward", "moe_forward_shared"}:
+            moe_op_registrations[op_name] = kwargs
             return None
         return register_custom_op(op_name, *args, **kwargs)
 
@@ -36,6 +43,81 @@ def moe_runner_module() -> ModuleType:
         torch_utils.direct_register_custom_op = register_custom_op
     assert module.MoERunner.__module__.startswith("vllm_hcu.")
     return module
+
+
+def test_moe_forward_shared_satisfies_aot_mutation_and_alias_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    moe_runner_module: ModuleType,
+    moe_op_registrations: dict[str, dict],
+) -> None:
+    """AOT must preserve the input mutation without returning an input alias."""
+
+    class Layer:
+        def _forward_impl(self, hidden_states, *_args, **_kwargs):
+            hidden_states.add_(1)
+            return torch.full_like(hidden_states, 7), hidden_states
+
+    monkeypatch.setattr(
+        moe_runner_module,
+        "get_layer_from_name",
+        lambda _name: Layer(),
+    )
+    registration = moe_op_registrations["moe_forward_shared"]
+    test_library = torch.library.Library("vllm_hcu_test_moe", "FRAGMENT")
+    torch_utils.direct_register_custom_op(
+        op_name="moe_forward_shared",
+        op_func=registration["op_func"],
+        mutates_args=registration["mutates_args"],
+        fake_impl=registration["fake_impl"],
+        target_lib=test_library,
+        dispatch_key="CPU",
+        tags=registration["tags"],
+    )
+    torch.library.opcheck(
+        torch.ops.vllm_hcu_test_moe.moe_forward_shared.default,
+        (
+            torch.zeros((2, 2)),
+            None,
+            torch.zeros((2, 2)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            "test-layer",
+            0,
+        ),
+        test_utils=("test_schema",),
+    )
+
+    def invoke(hidden_states):
+        return torch.ops.vllm_hcu_test_moe.moe_forward_shared(
+            hidden_states,
+            None,
+            hidden_states,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "test-layer",
+            0,
+        )
+
+    compiled = torch.compile(invoke, backend="aot_eager", fullgraph=True)
+    hidden_states = torch.zeros((2, 2))
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message=r".*moe_forward_shared.*custom operator.*",
+            category=UserWarning,
+        )
+        shared_output, fused_output = compiled(hidden_states)
+
+    torch.testing.assert_close(hidden_states, torch.ones_like(hidden_states))
+    torch.testing.assert_close(shared_output, torch.full_like(hidden_states, 7))
+    torch.testing.assert_close(fused_output, hidden_states)
+    assert not torch._C._is_alias_of(fused_output, hidden_states)
 
 
 def make_hidden() -> torch.Tensor:

--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -123,6 +123,84 @@ def test_inplace_moe_forward_shared_satisfies_aot_mutation_contract(
     assert not torch._C._is_alias_of(shared_output, hidden_states)
 
 
+def test_fallback_moe_forward_shared_satisfies_aot_mutation_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    moe_runner_module: ModuleType,
+    moe_op_registrations: dict[str, dict],
+) -> None:
+    """The tuple fallback must clone the mutated routed output."""
+
+    class Layer:
+        def _forward_impl(self, hidden_states, *_args, **_kwargs):
+            hidden_states.add_(1)
+            return torch.full_like(hidden_states, 7), hidden_states
+
+    monkeypatch.setattr(
+        moe_runner_module,
+        "get_layer_from_name",
+        lambda _name: Layer(),
+    )
+    registration = moe_op_registrations["moe_forward_shared"]
+    test_library = torch.library.Library(
+        "vllm_hcu_test_moe_fallback", "FRAGMENT"
+    )
+    torch_utils.direct_register_custom_op(
+        op_name="moe_forward_shared",
+        op_func=registration["op_func"],
+        mutates_args=registration["mutates_args"],
+        fake_impl=registration["fake_impl"],
+        target_lib=test_library,
+        dispatch_key="CPU",
+        tags=registration["tags"],
+    )
+    torch.library.opcheck(
+        torch.ops.vllm_hcu_test_moe_fallback.moe_forward_shared.default,
+        (
+            torch.zeros((2, 2)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "test-layer",
+            0,
+        ),
+        test_utils=("test_schema",),
+    )
+
+    def invoke(hidden_states):
+        return torch.ops.vllm_hcu_test_moe_fallback.moe_forward_shared(
+            hidden_states,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "test-layer",
+            0,
+        )
+
+    compiled = torch.compile(invoke, backend="aot_eager", fullgraph=True)
+    hidden_states = torch.zeros((2, 2))
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message=r".*moe_forward_shared.*custom operator.*",
+            category=UserWarning,
+        )
+        shared_output, fused_output = compiled(hidden_states)
+
+    torch.testing.assert_close(hidden_states, torch.ones_like(hidden_states))
+    torch.testing.assert_close(shared_output, torch.full_like(hidden_states, 7))
+    torch.testing.assert_close(fused_output, torch.ones_like(hidden_states))
+    assert not torch._C._is_alias_of(shared_output, hidden_states)
+    assert not torch._C._is_alias_of(fused_output, hidden_states)
+
+
 def make_hidden() -> torch.Tensor:
     return torch.tensor([[10.0, 11.0], [20.0, 21.0]])
 
@@ -166,6 +244,37 @@ def test_inplace_shared_output_requires_local_inplace_kernel(
     )
 
     assert runner._can_use_inplace_shared_output() is expected
+
+
+@pytest.mark.parametrize(
+    ("use_deepep", "use_aiter", "expected"),
+    [
+        (False, False, True),
+        (True, False, False),
+        (False, True, False),
+        (True, True, False),
+    ],
+)
+def test_slimquant_marlin_only_advertises_local_inplace_output(
+    monkeypatch: pytest.MonkeyPatch,
+    use_deepep: bool,
+    use_aiter: bool,
+    expected: bool,
+) -> None:
+    module = importlib.import_module(
+        "vllm_hcu.model_executor.layers.quantization.compressed_tensors."
+        "compressed_tensors_moe_marlin"
+    )
+    method = object.__new__(module.CompressedTensorsW8A8FP8MarlinMoEMethod)
+    method.moe = object()
+    method.use_deepep = use_deepep
+    monkeypatch.setattr(
+        module,
+        "_is_hcu_aiter_w8a8_moe_requested",
+        lambda moe: use_aiter,
+    )
+
+    assert method.supports_inplace_output is expected
 
 
 def test_forward_entry_refreshes_after_runtime_reconfiguration(

--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -168,6 +168,74 @@ def test_inplace_shared_output_requires_local_inplace_kernel(
     assert runner._can_use_inplace_shared_output() is expected
 
 
+def test_forward_entry_refreshes_after_runtime_reconfiguration(
+    monkeypatch: pytest.MonkeyPatch,
+    moe_runner_module: ModuleType,
+) -> None:
+    """Runtime method/config swaps must not retain a stale in-place entry."""
+
+    class RoutedExperts:
+        def __init__(self) -> None:
+            self.quant_method = SimpleNamespace(
+                supports_inplace_output=True,
+                supports_internal_mk=False,
+            )
+
+        def _replace_quant_method(self, quant_method) -> None:
+            self.quant_method = quant_method
+
+        def _set_moe_config(self, _moe_config) -> None:
+            return None
+
+    class SharedExperts:
+        def _set_moe_config(self, _moe_config) -> None:
+            return None
+
+    monkeypatch.setattr(moe_runner_module.current_platform, "is_cpu", lambda: True)
+    monkeypatch.setattr(moe_runner_module.current_platform, "is_tpu", lambda: False)
+
+    runner = object.__new__(moe_runner_module.MoERunner)
+    runner.routed_experts = RoutedExperts()
+    runner._shared_experts = SharedExperts()
+    runner.moe_config = SimpleNamespace(
+        dp_size=1,
+        is_sequence_parallel=False,
+        pcp_size=1,
+    )
+
+    runner._refresh_forward_entry()
+    assert runner._forward_uses_mutated_hidden_states is True
+    assert runner._forward_entry is moe_runner_module._moe_forward_shared_inplace
+
+    runner._replace_quant_method(
+        SimpleNamespace(
+            supports_inplace_output=False,
+            supports_internal_mk=False,
+        )
+    )
+    assert runner._forward_uses_mutated_hidden_states is False
+    assert runner._forward_entry is moe_runner_module._moe_forward_shared
+
+    runner._replace_quant_method(
+        SimpleNamespace(
+            supports_inplace_output=True,
+            supports_internal_mk=False,
+        )
+    )
+    assert runner._forward_uses_mutated_hidden_states is True
+    assert runner._forward_entry is moe_runner_module._moe_forward_shared_inplace
+
+    runner._set_moe_config(
+        SimpleNamespace(
+            dp_size=1,
+            is_sequence_parallel=False,
+            pcp_size=2,
+        )
+    )
+    assert runner._forward_uses_mutated_hidden_states is False
+    assert runner._forward_entry is moe_runner_module._moe_forward_shared
+
+
 class _PCPCollectives:
     """Two-rank in-memory PCP collective with observable token ordering."""
 

--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -29,7 +29,11 @@ def moe_runner_module(moe_op_registrations: dict[str, dict]) -> ModuleType:
     register_custom_op = torch_utils.direct_register_custom_op
 
     def register_without_duplicate_moe_ops(op_name, *args, **kwargs):
-        if op_name in {"moe_forward", "moe_forward_shared"}:
+        if op_name in {
+            "moe_forward",
+            "moe_forward_shared",
+            "moe_forward_shared_inplace",
+        }:
             moe_op_registrations[op_name] = kwargs
             return None
         return register_custom_op(op_name, *args, **kwargs)
@@ -45,7 +49,7 @@ def moe_runner_module(moe_op_registrations: dict[str, dict]) -> ModuleType:
     return module
 
 
-def test_moe_forward_shared_satisfies_aot_mutation_and_alias_contract(
+def test_inplace_moe_forward_shared_satisfies_aot_mutation_contract(
     monkeypatch: pytest.MonkeyPatch,
     moe_runner_module: ModuleType,
     moe_op_registrations: dict[str, dict],
@@ -62,10 +66,10 @@ def test_moe_forward_shared_satisfies_aot_mutation_and_alias_contract(
         "get_layer_from_name",
         lambda _name: Layer(),
     )
-    registration = moe_op_registrations["moe_forward_shared"]
+    registration = moe_op_registrations["moe_forward_shared_inplace"]
     test_library = torch.library.Library("vllm_hcu_test_moe", "FRAGMENT")
     torch_utils.direct_register_custom_op(
-        op_name="moe_forward_shared",
+        op_name="moe_forward_shared_inplace",
         op_func=registration["op_func"],
         mutates_args=registration["mutates_args"],
         fake_impl=registration["fake_impl"],
@@ -74,7 +78,7 @@ def test_moe_forward_shared_satisfies_aot_mutation_and_alias_contract(
         tags=registration["tags"],
     )
     torch.library.opcheck(
-        torch.ops.vllm_hcu_test_moe.moe_forward_shared.default,
+        torch.ops.vllm_hcu_test_moe.moe_forward_shared_inplace.default,
         (
             torch.zeros((2, 2)),
             None,
@@ -91,7 +95,7 @@ def test_moe_forward_shared_satisfies_aot_mutation_and_alias_contract(
     )
 
     def invoke(hidden_states):
-        return torch.ops.vllm_hcu_test_moe.moe_forward_shared(
+        return torch.ops.vllm_hcu_test_moe.moe_forward_shared_inplace(
             hidden_states,
             None,
             hidden_states,
@@ -112,12 +116,11 @@ def test_moe_forward_shared_satisfies_aot_mutation_and_alias_contract(
             message=r".*moe_forward_shared.*custom operator.*",
             category=UserWarning,
         )
-        shared_output, fused_output = compiled(hidden_states)
+        shared_output = compiled(hidden_states)
 
     torch.testing.assert_close(hidden_states, torch.ones_like(hidden_states))
     torch.testing.assert_close(shared_output, torch.full_like(hidden_states, 7))
-    torch.testing.assert_close(fused_output, hidden_states)
-    assert not torch._C._is_alias_of(fused_output, hidden_states)
+    assert not torch._C._is_alias_of(shared_output, hidden_states)
 
 
 def make_hidden() -> torch.Tensor:
@@ -126,6 +129,43 @@ def make_hidden() -> torch.Tensor:
 
 def make_logits() -> torch.Tensor:
     return torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+
+
+@pytest.mark.parametrize(
+    ("supports_inplace", "dp_size", "sequence_parallel", "pcp_size", "expected"),
+    [
+        (True, 1, False, 1, True),
+        (False, 1, False, 1, False),
+        (True, 2, False, 1, False),
+        (True, 1, True, 1, False),
+        (True, 1, False, 2, False),
+    ],
+)
+def test_inplace_shared_output_requires_local_inplace_kernel(
+    moe_runner_module: ModuleType,
+    supports_inplace: bool,
+    dp_size: int,
+    sequence_parallel: bool,
+    pcp_size: int,
+    expected: bool,
+) -> None:
+    """Dispatch or an out-of-place kernel must retain the tuple-returning op."""
+
+    runner = object.__new__(moe_runner_module.MoERunner)
+    runner._shared_experts = object()
+    runner.routed_experts = SimpleNamespace(
+        quant_method=SimpleNamespace(
+            supports_inplace_output=supports_inplace,
+            supports_internal_mk=False,
+        )
+    )
+    runner.moe_config = SimpleNamespace(
+        dp_size=dp_size,
+        is_sequence_parallel=sequence_parallel,
+        pcp_size=pcp_size,
+    )
+
+    assert runner._can_use_inplace_shared_output() is expected
 
 
 class _PCPCollectives:
@@ -219,9 +259,11 @@ def test_pcp_dispatch_requires_router_logits(
         runner._maybe_dispatch(make_hidden(), None)
 
 
+@pytest.mark.parametrize("uses_mutated_output", [False, True])
 def test_shared_and_routed_outputs_keep_local_token_order_before_addition(
     monkeypatch: pytest.MonkeyPatch,
     moe_runner_module: ModuleType,
+    uses_mutated_output: bool,
 ) -> None:
     """Reordering either local output before the shared+routed add is a bug."""
 
@@ -235,10 +277,21 @@ def test_shared_and_routed_outputs_keep_local_token_order_before_addition(
     runner.routed_scaling_factor = 1.0
     runner._shared_experts = object()
     runner.router = object()
-    runner.__dict__["_forward_entry"] = lambda *_args: (
-        torch.tensor([[100.0, 101.0], [200.0, 201.0]]),
-        torch.tensor([[10.0, 11.0], [20.0, 21.0]]),
-    )
+    shared_output = torch.tensor([[100.0, 101.0], [200.0, 201.0]])
+    fused_output = torch.tensor([[10.0, 11.0], [20.0, 21.0]])
+    runner._forward_uses_mutated_hidden_states = uses_mutated_output
+    if uses_mutated_output:
+
+        def forward_entry(hidden_states, *_args):
+            hidden_states.copy_(fused_output)
+            return shared_output
+
+        runner.__dict__["_forward_entry"] = forward_entry
+    else:
+        runner.__dict__["_forward_entry"] = lambda *_args: (
+            shared_output,
+            fused_output,
+        )
     monkeypatch.setattr(
         moe_runner_module.MoERunner,
         "_maybe_pad_hidden_states",

--- a/tests/runtime_patch/test_model_expert_mapping_api.py
+++ b/tests/runtime_patch/test_model_expert_mapping_api.py
@@ -188,6 +188,83 @@ def test_hy_v3_mtp_precomputes_expert_mapping_with_vllm_0251_api() -> None:
     ]
 
 
+def test_hy_v3_mtp_loads_local_redundant_expert_weights() -> None:
+    loaded_shards: dict[tuple[int, str], float] = {}
+
+    class ExpertParam:
+        def weight_loader(
+            self,
+            _param: object,
+            loaded_weight: torch.Tensor,
+            _weight_name: str,
+            *,
+            shard_id: str,
+            expert_id: int,
+            return_success: bool = False,
+        ) -> bool | None:
+            if expert_id not in (2, 3):
+                return False if return_success else None
+            loaded_shards[expert_id, shard_id] = loaded_weight.item()
+            return True if return_success else None
+
+    load_weights = _load_method(
+        "vllm_hcu/models/hy_v3_mtp.py",
+        "HYV3MTP",
+        "load_weights",
+        {
+            "fused_moe_make_expert_params_mapping": (
+                fused_moe.fused_moe_make_expert_params_mapping
+            ),
+            "_get_cla_factor": lambda _config: 1,
+            "_is_moe": lambda _config: True,
+            "get_spec_layer_idx_from_weight_name": lambda _config, _name: 1,
+            "is_pp_missing_parameter": lambda _name, _model: False,
+            "torch": torch,
+        },
+    )
+    expert_param = ExpertParam()
+    params = {
+        "model.layers.1.mlp.experts.routed_experts.w13_weight": expert_param,
+        "model.layers.1.mlp.experts.routed_experts.w2_weight": expert_param,
+    }
+    model = SimpleNamespace(
+        config=SimpleNamespace(
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            hidden_size=8,
+            num_experts=2,
+            num_hidden_layers=1,
+            tie_word_embeddings=False,
+        ),
+        quant_config=None,
+        use_pp=False,
+        num_redundant_experts=2,
+        named_parameters=lambda: params.items(),
+        _split_qkv_weight=lambda value: value,
+        _rewrite_spec_layer_name=lambda _spec_layer, name: name,
+    )
+    weights = [
+        (
+            f"model.layers.1.mlp.experts.{logical_id}.{projection}.weight",
+            torch.tensor(value),
+        )
+        for logical_id, values in enumerate(((10.0, 11.0, 12.0), (20.0, 21.0, 22.0)))
+        for projection, value in zip(
+            ("gate_proj", "down_proj", "up_proj"), values, strict=True
+        )
+    ]
+
+    assert load_weights(model, weights) is None
+    assert loaded_shards == {
+        (2, "w1"): 10.0,
+        (2, "w2"): 11.0,
+        (2, "w3"): 12.0,
+        (3, "w1"): 20.0,
+        (3, "w2"): 21.0,
+        (3, "w3"): 22.0,
+    }
+
+
 def test_deepseek_v4_mtp_precomputes_expert_mapping_with_vllm_0251_api() -> None:
     mapping_calls: list[dict[str, object]] = []
 

--- a/tests/runtime_patch/test_model_expert_mapping_api.py
+++ b/tests/runtime_patch/test_model_expert_mapping_api.py
@@ -51,6 +51,7 @@ def _load_method(
     return namespace[method_name]
 
 
+@pytest.mark.parametrize("num_redundant_experts", [0, 1])
 @pytest.mark.parametrize(
     ("relative_path", "class_name", "config", "expert_names"),
     [
@@ -73,6 +74,7 @@ def test_model_expert_mapping_uses_vllm_0251_function_api(
     class_name: str,
     config: SimpleNamespace,
     expert_names: tuple[str, str, str],
+    num_redundant_experts: int,
 ) -> None:
     get_expert_mapping = _load_method(
         relative_path,
@@ -91,13 +93,22 @@ def test_model_expert_mapping_uses_vllm_0251_function_api(
     if class_name == "DeepseekV4Model":
         model.start_layer = 0
         model.end_layer = 1
-        model.layers = [SimpleNamespace(ffn=SimpleNamespace(use_mega_moe=False))]
+        model.layers = [
+            SimpleNamespace(
+                ffn=SimpleNamespace(
+                    use_mega_moe=False,
+                    n_redundant_experts=num_redundant_experts,
+                )
+            )
+        ]
+    else:
+        model.num_redundant_experts = num_redundant_experts
     model.named_parameters = lambda: []
 
     mapping = get_expert_mapping(model)
 
     gate_name, down_name, up_name = expert_names
-    assert mapping == [
+    expected_mapping = [
         ("experts.routed_experts.w13_", f"experts.0.{gate_name}.", 0, "w1"),
         ("experts.routed_experts.w2_", f"experts.0.{down_name}.", 0, "w2"),
         ("experts.routed_experts.w13_", f"experts.0.{up_name}.", 0, "w3"),
@@ -105,18 +116,46 @@ def test_model_expert_mapping_uses_vllm_0251_function_api(
         ("experts.routed_experts.w2_", f"experts.1.{down_name}.", 1, "w2"),
         ("experts.routed_experts.w13_", f"experts.1.{up_name}.", 1, "w3"),
     ]
+    if num_redundant_experts == 1:
+        expected_mapping.extend(
+            [
+                (
+                    "experts.routed_experts.w13_",
+                    f"experts.0.{gate_name}.",
+                    2,
+                    "w1",
+                ),
+                (
+                    "experts.routed_experts.w2_",
+                    f"experts.0.{down_name}.",
+                    2,
+                    "w2",
+                ),
+                (
+                    "experts.routed_experts.w13_",
+                    f"experts.0.{up_name}.",
+                    2,
+                    "w3",
+                ),
+            ]
+        )
+    assert mapping == expected_mapping
 
 
 def test_hy_v3_mtp_precomputes_expert_mapping_with_vllm_0251_api() -> None:
+    mapping_calls: list[dict[str, object]] = []
+
+    def record_expert_mapping(model: object, **kwargs: object):
+        mapping_calls.append(kwargs)
+        return fused_moe.fused_moe_make_expert_params_mapping(model, **kwargs)
+
     load_weights = _load_method(
         "vllm_hcu/models/hy_v3_mtp.py",
         "HYV3MTP",
         "load_weights",
         {
             "FusedMoE": fused_moe.FusedMoE,
-            "fused_moe_make_expert_params_mapping": (
-                fused_moe.fused_moe_make_expert_params_mapping
-            ),
+            "fused_moe_make_expert_params_mapping": record_expert_mapping,
             "_get_cla_factor": lambda _config: 1,
             "_is_moe": lambda _config: True,
             "torch": torch,
@@ -132,23 +171,37 @@ def test_hy_v3_mtp_precomputes_expert_mapping_with_vllm_0251_api() -> None:
         ),
         quant_config=None,
         use_pp=False,
+        num_redundant_experts=1,
         named_parameters=lambda: [],
         _split_qkv_weight=lambda value: value,
     )
 
     assert load_weights(model, []) is None
+    assert mapping_calls == [
+        {
+            "ckpt_gate_proj_name": "gate_proj",
+            "ckpt_down_proj_name": "down_proj",
+            "ckpt_up_proj_name": "up_proj",
+            "num_experts": 2,
+            "num_redundant_experts": 1,
+        }
+    ]
 
 
 def test_deepseek_v4_mtp_precomputes_expert_mapping_with_vllm_0251_api() -> None:
+    mapping_calls: list[dict[str, object]] = []
+
+    def record_expert_mapping(model: object, **kwargs: object):
+        mapping_calls.append(kwargs)
+        return fused_moe.fused_moe_make_expert_params_mapping(model, **kwargs)
+
     load_weights = _load_method(
         "vllm_hcu/models/deepseek_v4_mtp.py",
         "DeepSeekV4MTP",
         "load_weights",
         {
             "FusedMoE": fused_moe.FusedMoE,
-            "fused_moe_make_expert_params_mapping": (
-                fused_moe.fused_moe_make_expert_params_mapping
-            ),
+            "fused_moe_make_expert_params_mapping": record_expert_mapping,
             "get_tensor_model_parallel_world_size": lambda: 1,
             "get_tensor_model_parallel_rank": lambda: 0,
             "make_deepseek_v4_expert_params_mapping": lambda _count: [],
@@ -163,6 +216,7 @@ def test_deepseek_v4_mtp_precomputes_expert_mapping_with_vllm_0251_api() -> None
             expert_dtype="fp8",
         ),
         quant_config=None,
+        num_redundant_experts=1,
         named_parameters=lambda: [],
         model=SimpleNamespace(
             layers={
@@ -179,3 +233,12 @@ def test_deepseek_v4_mtp_precomputes_expert_mapping_with_vllm_0251_api() -> None
     )
 
     assert load_weights(model, []) == set()
+    assert mapping_calls == [
+        {
+            "ckpt_gate_proj_name": "w1",
+            "ckpt_down_proj_name": "w2",
+            "ckpt_up_proj_name": "w3",
+            "num_experts": 2,
+            "num_redundant_experts": 1,
+        }
+    ]

--- a/tests/runtime_patch/test_model_expert_mapping_api.py
+++ b/tests/runtime_patch/test_model_expert_mapping_api.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+
+from __future__ import annotations
+
+import ast
+from itertools import islice
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.model_executor.layers import fused_moe
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_method(
+    relative_path: str,
+    class_name: str,
+    method_name: str,
+    namespace: dict[str, object],
+):
+    path = REPO_ROOT / relative_path
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    class_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    method = next(
+        node
+        for node in class_node.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == method_name
+    )
+    function_module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias("annotations")],
+                level=0,
+            ),
+            method,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(function_module)
+    exec(compile(function_module, str(path), "exec"), namespace)
+    return namespace[method_name]
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "class_name", "config", "expert_names"),
+    [
+        (
+            "vllm_hcu/models/hy_v3.py",
+            "HYV3Model",
+            SimpleNamespace(num_experts=2),
+            ("gate_proj", "down_proj", "up_proj"),
+        ),
+        (
+            "vllm_hcu/models/deepseek_v4.py",
+            "DeepseekV4Model",
+            SimpleNamespace(n_routed_experts=2),
+            ("w1", "w2", "w3"),
+        ),
+    ],
+)
+def test_model_expert_mapping_uses_vllm_0251_function_api(
+    relative_path: str,
+    class_name: str,
+    config: SimpleNamespace,
+    expert_names: tuple[str, str, str],
+) -> None:
+    get_expert_mapping = _load_method(
+        relative_path,
+        class_name,
+        "get_expert_mapping",
+        {
+            "FusedMoE": fused_moe.FusedMoE,
+            "fused_moe_make_expert_params_mapping": (
+                fused_moe.fused_moe_make_expert_params_mapping
+            ),
+            "islice": islice,
+            "make_deepseek_v4_expert_params_mapping": lambda _count: [],
+        },
+    )
+    model = SimpleNamespace(config=config)
+    if class_name == "DeepseekV4Model":
+        model.start_layer = 0
+        model.end_layer = 1
+        model.layers = [SimpleNamespace(ffn=SimpleNamespace(use_mega_moe=False))]
+    model.named_parameters = lambda: []
+
+    mapping = get_expert_mapping(model)
+
+    gate_name, down_name, up_name = expert_names
+    assert mapping == [
+        ("experts.routed_experts.w13_", f"experts.0.{gate_name}.", 0, "w1"),
+        ("experts.routed_experts.w2_", f"experts.0.{down_name}.", 0, "w2"),
+        ("experts.routed_experts.w13_", f"experts.0.{up_name}.", 0, "w3"),
+        ("experts.routed_experts.w13_", f"experts.1.{gate_name}.", 1, "w1"),
+        ("experts.routed_experts.w2_", f"experts.1.{down_name}.", 1, "w2"),
+        ("experts.routed_experts.w13_", f"experts.1.{up_name}.", 1, "w3"),
+    ]
+
+
+def test_hy_v3_mtp_precomputes_expert_mapping_with_vllm_0251_api() -> None:
+    load_weights = _load_method(
+        "vllm_hcu/models/hy_v3_mtp.py",
+        "HYV3MTP",
+        "load_weights",
+        {
+            "FusedMoE": fused_moe.FusedMoE,
+            "fused_moe_make_expert_params_mapping": (
+                fused_moe.fused_moe_make_expert_params_mapping
+            ),
+            "_get_cla_factor": lambda _config: 1,
+            "_is_moe": lambda _config: True,
+            "torch": torch,
+        },
+    )
+    model = SimpleNamespace(
+        config=SimpleNamespace(
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            hidden_size=8,
+            num_experts=2,
+            num_hidden_layers=1,
+        ),
+        quant_config=None,
+        use_pp=False,
+        named_parameters=lambda: [],
+        _split_qkv_weight=lambda value: value,
+    )
+
+    assert load_weights(model, []) is None
+
+
+def test_deepseek_v4_mtp_precomputes_expert_mapping_with_vllm_0251_api() -> None:
+    load_weights = _load_method(
+        "vllm_hcu/models/deepseek_v4_mtp.py",
+        "DeepSeekV4MTP",
+        "load_weights",
+        {
+            "FusedMoE": fused_moe.FusedMoE,
+            "fused_moe_make_expert_params_mapping": (
+                fused_moe.fused_moe_make_expert_params_mapping
+            ),
+            "get_tensor_model_parallel_world_size": lambda: 1,
+            "get_tensor_model_parallel_rank": lambda: 0,
+            "make_deepseek_v4_expert_params_mapping": lambda _count: [],
+            "logger": SimpleNamespace(info_once=lambda *_args: None),
+            "torch": torch,
+        },
+    )
+    model = SimpleNamespace(
+        config=SimpleNamespace(
+            num_attention_heads=4,
+            n_routed_experts=2,
+            expert_dtype="fp8",
+        ),
+        quant_config=None,
+        named_parameters=lambda: [],
+        model=SimpleNamespace(
+            layers={
+                "1": SimpleNamespace(
+                    mtp_block=SimpleNamespace(
+                        ffn=SimpleNamespace(use_mega_moe=False)
+                    )
+                )
+            },
+            mtp_start_layer_idx=1,
+            num_mtp_layers=0,
+        ),
+        finalize_mega_moe_weights=lambda: None,
+    )
+
+    assert load_weights(model, []) == set()

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -1496,6 +1496,132 @@ def test_varlen_flash_attention_uses_64_token_cache_blocks(
     assert config.cache_config.block_size == 64
 
 
+@pytest.mark.parametrize(
+    ("backend_name", "expected_path"),
+    [
+        (
+            "FLASH_ATTN",
+            "vllm_hcu.v1.attention.backends.flash_attn."
+            "HcuFlashAttentionBackend",
+        ),
+        (
+            "TRITON_ATTN",
+            "vllm_hcu.v1.attention.backends.triton_attn."
+            "HcuTritonAttentionBackend",
+        ),
+    ],
+)
+def test_explicit_attention_backend_restores_hcu_registration(
+    monkeypatch: pytest.MonkeyPatch,
+    backend_name: str,
+    expected_path: str,
+) -> None:
+    from vllm.platforms.interface import DeviceCapability
+    from vllm.v1.attention.backends.registry import (
+        AttentionBackendEnum,
+        register_backend,
+    )
+    from vllm.v1.attention.selector import AttentionSelectorConfig
+    from vllm_hcu.platforms.hcu import HCUPlatform
+
+    class AvailableBackend:
+        @classmethod
+        def validate_configuration(cls, **_kwargs) -> list[str]:
+            return []
+
+    backend = AttentionBackendEnum[backend_name]
+    was_overridden = backend.is_overridden()
+    previous_path = backend.get_path()
+    # The source worktree does not contain the installed hcu_ops extension.
+    # Keep class validation available while exercising the real registry path.
+    def get_available_hcu_backend(selected_backend):
+        assert selected_backend.get_path() == expected_path
+        return AvailableBackend
+
+    monkeypatch.setattr(
+        AttentionBackendEnum,
+        "get_class",
+        get_available_hcu_backend,
+    )
+    monkeypatch.setattr(
+        HCUPlatform,
+        "get_device_capability",
+        classmethod(lambda _cls: DeviceCapability(9, 3)),
+    )
+    selector_config = AttentionSelectorConfig(
+        head_size=128,
+        dtype=torch.bfloat16,
+        kv_cache_dtype=None,
+        block_size=None,
+    )
+
+    try:
+        backend.clear_override()
+        selected_path = HCUPlatform.get_attn_backend_cls(
+            backend,
+            selector_config,
+        )
+    finally:
+        backend.clear_override()
+        if was_overridden:
+            register_backend(backend, previous_path)
+
+    assert selected_path == expected_path
+
+
+@pytest.mark.parametrize("explicit", [True, False])
+def test_attention_selection_preserves_third_party_override(
+    monkeypatch: pytest.MonkeyPatch,
+    explicit: bool,
+) -> None:
+    from vllm.platforms.interface import DeviceCapability
+    from vllm.v1.attention.backends.registry import (
+        AttentionBackendEnum,
+        register_backend,
+    )
+    from vllm.v1.attention.selector import AttentionSelectorConfig
+    from vllm_hcu.platforms.hcu import HCUPlatform
+
+    class AvailableBackend:
+        @classmethod
+        def validate_configuration(cls, **_kwargs) -> list[str]:
+            return []
+
+    backend = AttentionBackendEnum.FLASH_ATTN
+    was_overridden = backend.is_overridden()
+    previous_path = backend.get_path()
+    third_party_path = "third_party.attention.CustomFlashAttentionBackend"
+    monkeypatch.setattr(
+        AttentionBackendEnum,
+        "get_class",
+        lambda _self: AvailableBackend,
+    )
+    monkeypatch.setattr(
+        HCUPlatform,
+        "get_device_capability",
+        classmethod(lambda _cls: DeviceCapability(9, 3)),
+    )
+    selector_config = AttentionSelectorConfig(
+        head_size=128,
+        dtype=torch.bfloat16,
+        kv_cache_dtype=None,
+        block_size=None,
+    )
+
+    try:
+        register_backend(backend, third_party_path)
+        selected_path = HCUPlatform.get_attn_backend_cls(
+            backend if explicit else None,
+            selector_config,
+        )
+    finally:
+        backend.clear_override()
+        if was_overridden:
+            register_backend(backend, previous_path)
+
+    assert selected_path == third_party_path
+
+
 def test_cutlass_block_first_mooncake_defers_to_worker_capability_gates() -> None:
     config = _validation_config(HcuFeatureConfig(hcu_flash_attn_mode="cutlass"))
     config.kv_transfer_config = SimpleNamespace(

--- a/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
@@ -220,6 +220,54 @@ def _moe_forward_shared_fake(
     return shared_out, fused_out
 
 
+def _moe_forward_shared_inplace(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor | None,
+    shared_experts_input: torch.Tensor | None,
+    input_ids: torch.Tensor | None,
+    quanted_hidden_states: torch.Tensor | None,
+    scale: torch.Tensor | None,
+    topk_weights: torch.Tensor | None,
+    topk_ids: torch.Tensor | None,
+    layer_name: _layer_name_type,
+    hidden_dim_unpadded: int,
+) -> torch.Tensor:
+    layer = get_layer_from_name(_resolve_layer_name(layer_name))
+    shared_output, fused_output = layer._forward_impl(
+        hidden_states,
+        router_logits,
+        shared_experts_input,
+        input_ids,
+        quanted_hidden_states=quanted_hidden_states,
+        scale=scale,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+    if fused_output is not hidden_states:
+        raise RuntimeError(
+            "In-place shared MoE path requires the routed kernel to return "
+            "the hidden_states input"
+        )
+    return shared_output
+
+
+def _moe_forward_shared_inplace_fake(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor | None,
+    shared_experts_input: torch.Tensor | None,
+    input_ids: torch.Tensor | None,
+    quanted_hidden_states: torch.Tensor | None,
+    scale: torch.Tensor | None,
+    topk_weights: torch.Tensor | None,
+    topk_ids: torch.Tensor | None,
+    layer_name: _layer_name_type,
+    hidden_dim_unpadded: int,
+) -> torch.Tensor:
+    if shared_experts_input is not None:
+        return torch.empty_like(shared_experts_input)
+    return torch.empty_like(hidden_states)
+
+
 # NOTE: `moe_forward` and `moe_forward_shared` being opaque custom ops is a
 # load-bearing assumption for the MoE-LoRA dual-stream path.
 direct_register_custom_op(
@@ -236,6 +284,15 @@ direct_register_custom_op(
     op_func=_moe_forward_shared,
     mutates_args=["hidden_states"],
     fake_impl=_moe_forward_shared_fake,
+    tags=(torch.Tag.needs_fixed_stride_order,),
+)
+
+
+direct_register_custom_op(
+    op_name="moe_forward_shared_inplace",
+    op_func=_moe_forward_shared_inplace,
+    mutates_args=["hidden_states"],
+    fake_impl=_moe_forward_shared_inplace_fake,
     tags=(torch.Tag.needs_fixed_stride_order,),
 )
 
@@ -318,6 +375,9 @@ class MoERunner(MoERunnerInterface):
         # Needed for string -> MoERunner layer lookup in custom ops.
         self.layer_name = layer_name
 
+        self._forward_uses_mutated_hidden_states = (
+            self._can_use_inplace_shared_output()
+        )
         self._forward_entry = self._select_forward()
 
         # For smuggling this layer into the fused moe custom op
@@ -329,6 +389,11 @@ class MoERunner(MoERunnerInterface):
         return self.routed_experts.load_weights(weights)
 
     def _select_forward(self) -> Callable:
+        if self._forward_uses_mutated_hidden_states:
+            if current_platform.is_tpu() or current_platform.is_cpu():
+                return _moe_forward_shared_inplace
+            return torch.ops.vllm.moe_forward_shared_inplace
+
         if current_platform.is_tpu() or current_platform.is_cpu():
             # TODO: Once the OOM issue for the TPU backend is resolved, we
             # will switch to using the moe_forward custom op.
@@ -339,6 +404,14 @@ class MoERunner(MoERunnerInterface):
             torch.ops.vllm.moe_forward
             if self._shared_experts is None
             else torch.ops.vllm.moe_forward_shared
+        )
+
+    def _can_use_inplace_shared_output(self) -> bool:
+        return bool(
+            self._shared_experts is not None
+            and getattr(self._quant_method, "supports_inplace_output", False)
+            and not self.do_naive_dispatch_combine
+            and self.moe_config.pcp_size == 1
         )
 
     @property
@@ -830,8 +903,12 @@ class MoERunner(MoERunnerInterface):
         #  - When False: neither output is reduced yet, so we combine
         #    them first and all-reduce the sum in _maybe_reduce_final_output.
 
-        # Extract outputs from result
-        shared_output, fused_output = _unpack(result)
+        # Extract outputs from result. The mutation-only custom op returns
+        # shared output and exposes routed output through hidden_states.
+        if self._forward_uses_mutated_hidden_states:
+            shared_output, fused_output = result, hidden_states
+        else:
+            shared_output, fused_output = _unpack(result)
 
         if og_hidden_dim_pre_xform is not None:
             fused_output = fused_output[..., :og_hidden_dim_pre_xform]

--- a/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
@@ -179,7 +179,7 @@ def _moe_forward_shared(
     hidden_dim_unpadded: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     layer = get_layer_from_name(_resolve_layer_name(layer_name))
-    return layer._forward_impl(
+    shared_output, fused_output = layer._forward_impl(
         hidden_states,
         router_logits,
         shared_experts_input,
@@ -189,6 +189,7 @@ def _moe_forward_shared(
         topk_weights=topk_weights,
         topk_ids=topk_ids,
     )
+    return shared_output, fused_output.clone()
 
 
 def _moe_forward_shared_fake(
@@ -233,6 +234,7 @@ direct_register_custom_op(
 direct_register_custom_op(
     op_name="moe_forward_shared",
     op_func=_moe_forward_shared,
+    mutates_args=["hidden_states"],
     fake_impl=_moe_forward_shared_fake,
     tags=(torch.Tag.needs_fixed_stride_order,),
 )

--- a/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
@@ -375,10 +375,7 @@ class MoERunner(MoERunnerInterface):
         # Needed for string -> MoERunner layer lookup in custom ops.
         self.layer_name = layer_name
 
-        self._forward_uses_mutated_hidden_states = (
-            self._can_use_inplace_shared_output()
-        )
-        self._forward_entry = self._select_forward()
+        self._refresh_forward_entry()
 
         # For smuggling this layer into the fused moe custom op
         register_layer_for_moe_forward_op(get_current_vllm_config(), self)
@@ -387,6 +384,12 @@ class MoERunner(MoERunnerInterface):
         self, weights: Iterable[tuple[str, torch.Tensor]]
     ) -> Iterable[str]:
         return self.routed_experts.load_weights(weights)
+
+    def _refresh_forward_entry(self) -> None:
+        self._forward_uses_mutated_hidden_states = (
+            self._can_use_inplace_shared_output()
+        )
+        self._forward_entry = self._select_forward()
 
     def _select_forward(self) -> Callable:
         if self._forward_uses_mutated_hidden_states:
@@ -426,6 +429,7 @@ class MoERunner(MoERunnerInterface):
     def _replace_quant_method(self, quant_method: FusedMoEMethodBase):
         self.routed_experts._replace_quant_method(quant_method)
         self.__dict__.pop("_supports_quanted_inputs", None)
+        self._refresh_forward_entry()
 
     # TODO(bnell): Hack for elastic_ep. Get rid of this
     def _set_moe_config(self, new_moe_config: FusedMoEConfig):
@@ -433,6 +437,7 @@ class MoERunner(MoERunnerInterface):
         self.routed_experts._set_moe_config(new_moe_config)
         if self._shared_experts is not None:
             self._shared_experts._set_moe_config(new_moe_config)
+        self._refresh_forward_entry()
 
     def _maybe_fuse_gate_weights(self):
         """Fuse router and shared expert gate weights on first call.

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
@@ -130,6 +130,12 @@ class CompressedTensorsMarlinMoEMethod(FusedMoEMethodBase):
     def __init_(self, moe: FusedMoEConfig):
         super().__init__(moe)
 
+    @property
+    def supports_inplace_output(self) -> bool:
+        return not self.use_deepep and not _is_hcu_aiter_w8a8_moe_requested(
+            self.moe
+        )
+
     @staticmethod
     def get_moe_method(
         quant_config: "SlimQuantCompressedTensorsMarlinConfig",  # type: ignore # noqa E501

--- a/vllm_hcu/models/deepseek_v4.py
+++ b/vllm_hcu/models/deepseek_v4.py
@@ -27,7 +27,11 @@ from vllm.model_executor.layers.deepseek_v4_attention import (
     DeepseekV4MLAModules,
     DeepseekV4MultiHeadLatentAttentionWrapper,
 )
-from vllm.model_executor.layers.fused_moe import FusedMoE, GateLinear
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoE,
+    GateLinear,
+    fused_moe_make_expert_params_mapping,
+)
 from vllm.model_executor.layers.fused_moe.layer import UnquantizedFusedMoEMethod
 from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
     fused_topk_bias,
@@ -1636,7 +1640,7 @@ class DeepseekV4Model(nn.Module):
             return make_deepseek_v4_expert_params_mapping(self.config.n_routed_experts)
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
-        return FusedMoE.make_expert_params_mapping(
+        return fused_moe_make_expert_params_mapping(
             self,
             ckpt_gate_proj_name="w1",
             ckpt_down_proj_name="w2",

--- a/vllm_hcu/models/deepseek_v4.py
+++ b/vllm_hcu/models/deepseek_v4.py
@@ -1646,6 +1646,7 @@ class DeepseekV4Model(nn.Module):
             ckpt_down_proj_name="w2",
             ckpt_up_proj_name="w3",
             num_experts=self.config.n_routed_experts,
+            num_redundant_experts=first_layer.ffn.n_redundant_experts,
         )
 
     def finalize_mega_moe_weights(self) -> None:

--- a/vllm_hcu/models/deepseek_v4_mtp.py
+++ b/vllm_hcu/models/deepseek_v4_mtp.py
@@ -418,6 +418,7 @@ class DeepSeekV4MTP(nn.Module):
                 ckpt_down_proj_name="w2",
                 ckpt_up_proj_name="w3",
                 num_experts=self.config.n_routed_experts,
+                num_redundant_experts=self.num_redundant_experts,
             )
 
         # FP8 experts register ``..._weight_scale_inv`` (block_quant) while

--- a/vllm_hcu/models/deepseek_v4_mtp.py
+++ b/vllm_hcu/models/deepseek_v4_mtp.py
@@ -29,7 +29,9 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.logger import init_logger
-from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.fused_moe import (
+    fused_moe_make_expert_params_mapping,
+)
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -410,7 +412,7 @@ class DeepSeekV4MTP(nn.Module):
                 self.config.n_routed_experts
             )
         else:
-            expert_mapping = FusedMoE.make_expert_params_mapping(
+            expert_mapping = fused_moe_make_expert_params_mapping(
                 self,
                 ckpt_gate_proj_name="w1",
                 ckpt_down_proj_name="w2",

--- a/vllm_hcu/models/hy_v3.py
+++ b/vllm_hcu/models/hy_v3.py
@@ -45,7 +45,11 @@ from vllm.distributed import (
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.attention import Attention, FusedQkvSplitRmsNormRopeAttention
-from vllm.model_executor.layers.fused_moe import FusedMoE, GateLinear
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoE,
+    GateLinear,
+    fused_moe_make_expert_params_mapping,
+)
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
@@ -652,7 +656,7 @@ class HYV3Model(nn.Module):
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
-        return FusedMoE.make_expert_params_mapping(
+        return fused_moe_make_expert_params_mapping(
             self,
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",

--- a/vllm_hcu/models/hy_v3.py
+++ b/vllm_hcu/models/hy_v3.py
@@ -662,6 +662,7 @@ class HYV3Model(nn.Module):
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
             num_experts=self.config.num_experts,
+            num_redundant_experts=self.num_redundant_experts,
         )
 
     def forward(

--- a/vllm_hcu/models/hy_v3_mtp.py
+++ b/vllm_hcu/models/hy_v3_mtp.py
@@ -407,6 +407,7 @@ class HYV3MTP(nn.Module, SupportsPP):
                 ckpt_down_proj_name="down_proj",
                 ckpt_up_proj_name="up_proj",
                 num_experts=self.config.num_experts,
+                num_redundant_experts=self.num_redundant_experts,
             )
         else:
             expert_params_mapping = {}

--- a/vllm_hcu/models/hy_v3_mtp.py
+++ b/vllm_hcu/models/hy_v3_mtp.py
@@ -34,7 +34,9 @@ from torch import nn
 from transformers import PretrainedConfig
 
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
-from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.fused_moe import (
+    fused_moe_make_expert_params_mapping,
+)
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
@@ -399,7 +401,7 @@ class HYV3MTP(nn.Module, SupportsPP):
         ]
 
         if _is_moe(self.config):
-            expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            expert_params_mapping = fused_moe_make_expert_params_mapping(
                 self,
                 ckpt_gate_proj_name="gate_proj",
                 ckpt_down_proj_name="down_proj",

--- a/vllm_hcu/models/hy_v3_mtp.py
+++ b/vllm_hcu/models/hy_v3_mtp.py
@@ -536,24 +536,31 @@ class HYV3MTP(nn.Module, SupportsPP):
             else:
                 if name.endswith(".bias") and name not in params_dict:
                     continue
+                is_expert_weight = False
                 for mapping in expert_params_mapping:
                     param_name, weight_name, expert_id, shard_id = mapping
                     if weight_name not in name:
                         continue
-                    name = name.replace(weight_name, param_name)
-                    if is_pp_missing_parameter(name, self):
+                    is_expert_weight = True
+                    name_mapped = name.replace(weight_name, param_name)
+                    if is_pp_missing_parameter(name_mapped, self):
                         continue
-                    param = params_dict[name]
+                    param = params_dict[name_mapped]
                     weight_loader = param.weight_loader
-                    weight_loader(
+                    success = weight_loader(
                         param,
                         loaded_weight,
-                        name,
+                        name_mapped,
                         shard_id=shard_id,
                         expert_id=expert_id,
+                        return_success=True,
                     )
-                    break
+                    if success:
+                        name = name_mapped
+                        break
                 else:
+                    if is_expert_weight:
+                        continue
                     if is_pp_missing_parameter(name, self):
                         continue
 

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -129,6 +129,8 @@ _MOE_REPLACEMENTS: tuple[_ReplacementSpec, ...] = (
             f"{_MOE_RUNNER_MODULE}._moe_forward_fake",
             f"{_MOE_RUNNER_MODULE}._moe_forward_shared",
             f"{_MOE_RUNNER_MODULE}._moe_forward_shared_fake",
+            f"{_MOE_RUNNER_MODULE}._moe_forward_shared_inplace",
+            f"{_MOE_RUNNER_MODULE}._moe_forward_shared_inplace_fake",
             f"{_MOE_RUNNER_MODULE}.MoERunner._maybe_apply_shared_experts",
             f"{_MOE_RUNNER_MODULE}.MoERunner._quant_method_supports_quanted_inputs",
             f"{_MOE_RUNNER_MODULE}.MoERunner._apply_quant_method",

--- a/vllm_hcu/patch/worker/op_opt/moe/patch_moe_runner.py
+++ b/vllm_hcu/patch/worker/op_opt/moe/patch_moe_runner.py
@@ -24,6 +24,8 @@ TARGETS = (
     f"{TARGET_MODULE}._moe_forward_fake",
     f"{TARGET_MODULE}._moe_forward_shared",
     f"{TARGET_MODULE}._moe_forward_shared_fake",
+    f"{TARGET_MODULE}._moe_forward_shared_inplace",
+    f"{TARGET_MODULE}._moe_forward_shared_inplace_fake",
     f"{TARGET_MODULE}.MoERunner._maybe_apply_shared_experts",
     f"{TARGET_MODULE}.MoERunner._quant_method_supports_quanted_inputs",
     f"{TARGET_MODULE}.MoERunner._apply_quant_method",
@@ -60,6 +62,16 @@ def apply_to_module(module: ModuleType) -> bool:
             "layer_name", "hidden_dim_unpadded",
         ),
         "_moe_forward_shared_fake": (
+            "hidden_states", "router_logits", "shared_experts_input", "input_ids",
+            "quanted_hidden_states", "scale", "topk_weights", "topk_ids",
+            "layer_name", "hidden_dim_unpadded",
+        ),
+        "_moe_forward_shared_inplace": (
+            "hidden_states", "router_logits", "shared_experts_input", "input_ids",
+            "quanted_hidden_states", "scale", "topk_weights", "topk_ids",
+            "layer_name", "hidden_dim_unpadded",
+        ),
+        "_moe_forward_shared_inplace_fake": (
             "hidden_states", "router_logits", "shared_experts_input", "input_ids",
             "quanted_hidden_states", "scale", "topk_weights", "topk_ids",
             "layer_name", "hidden_dim_unpadded",

--- a/vllm_hcu/platforms/hcu.py
+++ b/vllm_hcu/platforms/hcu.py
@@ -162,27 +162,37 @@ def _get_backend_priorities(
 
 
 def register_attention_backends() -> None:
-    # Pre-register all attention backends
-    register_backend(
-        AttentionBackendEnum.TRITON_ATTN,
-        class_path="vllm_hcu.v1.attention.backends.triton_attn.HcuTritonAttentionBackend",
+    # Install HCU defaults without replacing user or third-party overrides.
+    backends = (
+        (
+            AttentionBackendEnum.TRITON_ATTN,
+            "vllm_hcu.v1.attention.backends.triton_attn."
+            "HcuTritonAttentionBackend",
+        ),
+        (
+            AttentionBackendEnum.FLASH_ATTN,
+            "vllm_hcu.v1.attention.backends.flash_attn."
+            "HcuFlashAttentionBackend",
+        ),
+        (
+            AttentionBackendEnum.FLASHMLA_SPARSE,
+            "vllm_hcu.v1.attention.backends.mla.flashmla_sparse."
+            "HcuFlashMLASparseBackend",
+        ),
+        (
+            AttentionBackendEnum.FLASHMLA,
+            "vllm_hcu.v1.attention.backends.mla.flashmla."
+            "HcuFlashMLABackend",
+        ),
+        (
+            AttentionBackendEnum.TRITON_MLA,
+            "vllm_hcu.v1.attention.backends.mla.triton_mla."
+            "HcuTritonMLABackend",
+        ),
     )
-    register_backend(
-        AttentionBackendEnum.FLASH_ATTN,
-        class_path="vllm_hcu.v1.attention.backends.flash_attn.HcuFlashAttentionBackend",
-    )
-    register_backend(
-        AttentionBackendEnum.FLASHMLA_SPARSE,
-        class_path="vllm_hcu.v1.attention.backends.mla.flashmla_sparse.HcuFlashMLASparseBackend",
-    )
-    register_backend(
-        AttentionBackendEnum.FLASHMLA,
-        class_path="vllm_hcu.v1.attention.backends.mla.flashmla.HcuFlashMLABackend",
-    )
-    register_backend(
-        AttentionBackendEnum.TRITON_MLA,
-        class_path="vllm_hcu.v1.attention.backends.mla.triton_mla.HcuTritonMLABackend",
-    )
+    for backend, class_path in backends:
+        if not backend.is_overridden():
+            register_backend(backend, class_path=class_path)
 
 
 class HCUPlatform(Platform):
@@ -285,6 +295,7 @@ class HCUPlatform(Platform):
         assert device_capability is not None
 
         attn_selector_config = attn_selector_config._replace(block_size=None)
+        register_attention_backends()
 
         # First try checking just the selected backend, if there is one.
         if selected_backend is not None:


### PR DESCRIPTION
## Summary
- declare the shared MoE custom-op mutation and keep the cloned tuple-returning op as a safe fallback
- add a mutation-only custom op for the local SlimQuant Marlin kernel: routed output remains in `hidden_states`, while the op returns only the non-aliasing shared output
- refresh the selected forward entry after quant-method or MoE-config changes so DeepEP, AITER, DP/sequence-parallel, and PCP paths cannot retain a stale in-place entry
- ensure HCU attention backend defaults are registered before explicit `FLASH_ATTN` / `TRITON_ATTN` validation, while preserving user and third-party overrides
- add dispatcher/schema/AOT, runtime-reconfiguration, and attention-registry regression tests

## Root cause
The local shared MoE kernel mutates and returns `hidden_states`, but the original custom-op registration neither declared that mutation nor avoided returning an input alias. PyTorch AOT functionalization rejects this contract.

The explicit attention selection path could also call `get_class()` before the HCU registry overrides were present, resolving `FLASH_ATTN` or `TRITON_ATTN` to upstream classes. The selection path now ensures missing HCU defaults before validation; existing registry overrides remain untouched.

## Performance approach
The optimized local SlimQuant Marlin path no longer clones the routed activation. Its custom op declares `hidden_states` as mutable and returns only `shared_output`; the caller consumes the mutated input as the routed output. Paths whose kernels are not guaranteed in-place retain the clone-based fallback for correctness.

In the Qwen3.5-35B-A3B smoke run, available KV-cache memory was 90.49 GiB versus 89.65 GiB with the clone-only fix (about +0.84 GiB observed). This is a memory observation, not a throughput benchmark. Attention backend registration occurs during configuration selection, not in the inference hot path.

## Validation
- `VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 pytest -q tests/runtime_patch/test_platform_hcu_config.py tests/runtime_patch/test_flash_attention_and_pp.py tests/runtime_patch/test_moe_deepep.py tests/runtime_patch/test_glm52_pcp_moe.py` — 220 passed
- `torch.library.opcheck(..., test_schema)` and `torch.compile(..., backend="aot_eager", fullgraph=True)` pass for the mutation-only op
- Qwen3.5-35B-A3B W8A8 with v2 runner, HND KV layout, SlimQuant Marlin, 3-token MTP, and explicit `--attention-backend FLASH_ATTN` completed AOT/profile, graph capture, server startup, health, and chat; runtime logged `[HCU FLASH_ATTN PATH] flash_attn_varlen`
- the same model with explicit `--attention-backend TRITON_ATTN` completed startup, health, and chat
- the same model without `--attention-backend` completed startup, health, and chat, and selected `[HCU FLASH_ATTN PATH] flash_attn_varlen`
- all health and chat requests returned HTTP 200
- `python -m compileall` and `git diff --check` pass

## Environment note
Full 262144 context exceeded available KV-cache memory by about 1.9 GiB on the validation device, so end-to-end smoke runs used `--max-model-len 131072`.

## Review
Independent code review: Ready to merge; no Critical or Important findings. Reviewer-identified stale MoE forward selection and third-party attention override compatibility issues were fixed and re-reviewed.

## HY3 / DeepSeek V4 expert mapping compatibility
- replace four stale `FusedMoE.make_expert_params_mapping(...)` calls with vLLM 0.25.1's public module-level `fused_moe_make_expert_params_mapping(...)` API
- cover HYV3Model, HYV3MTP, DeepseekV4Model, and DeepSeekV4MTP; no forward, kernel, MoE dispatch, or AITER path is changed
- propagate `num_redundant_experts` so EPLB physical expert slots load the correct logical checkpoint weights; preserve the Mega-MoE mapping branch

The vLLM 0.25.1 `FusedMoE` export is a factory function, so the former class-style attribute access failed during HY3 weight loading with `AttributeError: 'function' object has no attribute 'make_expert_params_mapping'`.

Additional validation:
- regression tests demonstrated RED on all four stale call sites, then GREEN after the API migration; EPLB tests additionally cover 0/1 redundant experts and validate complete 6/9-entry mappings
- the tuple-returning fallback now has direct production-registration `opcheck(test_schema)` and AOT coverage; removing its clone reproduces the alias-contract failure
- direct SlimQuant capability tests cover local, DeepEP, AITER, and combined states; forcing in-place eligibility globally fails the three unsafe cases
- HY3 MTP EPLB loading is covered with 2 logical + 2 redundant experts on a rank that owns only physical slots 2/3: the old control flow loads 0/6 checkpoint shards, while the fixed `return_success` loop loads 6/6
- updated focused regression suite — 119 passed
- `VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 pytest -q -m 'not hcu' tests/patch tests/runtime_patch` — 1211 passed, 49 deselected
- an unfiltered run reached 1251 passed with one environment-only failure: the source worktree does not contain a locally built `vllm_hcu.hcu_ops` extension required by the HCU bootstrap smoke test
- focused model/API suite — 127 passed
- `python -m compileall`, `git diff --check`, and repository search for remaining stale calls pass
- independent review: Ready to merge, with no Critical or Important findings

