### PR TITLE
fix(hcu): 修正 LightOp 路由缩放与稀疏 MLA Top-K 语义

### DIFF
--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -1539,6 +1539,67 @@ def test_indexer_wrappers_filter_zero_chunks_and_propagate_kv_count():
     assert Builder().build(0, common).num_kv_actual_tokens == 5
 
 
+@pytest.mark.parametrize("transpose_logits", [False, True])
+def test_sparse_indexer_torch_topk_respects_ranges_and_relative_indices(
+    transpose_logits,
+):
+    from vllm_hcu.v1.attention.ops import rocm_aiter_mla_sparse as sparse
+
+    # Out-of-window values must not affect the selected request-local indices.
+    logits = torch.tensor(
+        [
+            [100.0, 2.0, 9.0, 8.0, 7.0, 6.0, 100.0],
+            [100.0, 90.0, 5.0, 4.0, 3.0, 200.0, 100.0],
+        ]
+    )
+    if transpose_logits:
+        logits = logits.transpose(0, 1)
+    actual = sparse._topk_indices_torch(
+        logits,
+        topk_tokens=2,
+        row_starts=torch.tensor([1, 2], dtype=torch.int32),
+        row_ends=torch.tensor([6, 5], dtype=torch.int32),
+    )
+    expected = torch.tensor([[1, 2], [0, 1]], dtype=torch.int32)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sparse_indexer_torch_topk_preserves_short_row_sequence_order():
+    from vllm_hcu.v1.attention.ops import rocm_aiter_mla_sparse as sparse
+
+    logits = torch.tensor(
+        [
+            [99.0, 4.0, 1.0, 88.0, 77.0],
+            [99.0, 98.0, 7.0, 6.0, 5.0],
+        ]
+    )
+    actual = sparse._topk_indices_torch(
+        logits,
+        topk_tokens=4,
+        row_starts=torch.tensor([1, 2], dtype=torch.int32),
+        row_ends=torch.tensor([3, 3], dtype=torch.int32),
+    )
+    expected = torch.tensor(
+        [[0, 1, -1, -1], [0, -1, -1, -1]], dtype=torch.int32
+    )
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sparse_indexer_torch_topk_masks_speculative_decode_row_ends():
+    from vllm_hcu.v1.attention.ops import rocm_aiter_mla_sparse as sparse
+
+    row_ends = sparse._decode_row_ends_from_seq_lens(
+        torch.tensor([4, 2], dtype=torch.int32), next_n=2, num_rows=4
+    )
+    torch.testing.assert_close(
+        row_ends, torch.tensor([3, 4, 1, 2], dtype=torch.int32)
+    )
+    logits = torch.tensor([[1.0, 2.0, 3.0, 4.0, 100.0]]).expand(4, -1)
+    actual = sparse._topk_indices_torch(logits, topk_tokens=2, row_ends=row_ends)
+    expected = torch.tensor([[2, 1], [3, 2], [0, -1], [0, 1]], dtype=torch.int32)
+    torch.testing.assert_close(actual, expected)
+
+
 def test_mla_forward_slices_kv_with_independent_token_count():
     from vllm_hcu.model_executor.layers.mla_runtime import mla_forward_impl
 

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -1600,6 +1600,232 @@ def test_sparse_indexer_torch_topk_masks_speculative_decode_row_ends():
     torch.testing.assert_close(actual, expected)
 
 
+def test_sparse_indexer_padded_decode_scratch_preserves_prefill_row():
+    """Regression test for mixed decode/prefill buffer aliasing.
+
+    ``decode_lens=[1, 2]`` produces four rectangular kernel rows but only
+    three actual decode rows.  The fourth row must be staged separately so it
+    cannot overwrite the first prefill row at the end of the decode prefix.
+    """
+    from vllm_hcu.v1.attention.ops.decode_topk import (
+        get_decode_topk_output_buffer,
+    )
+
+    # The shared buffer contains three decode rows followed by one prefill
+    # row.  Use a distinctive value so an accidental alias is observable.
+    shared = torch.tensor([[0], [2], [3], [1]], dtype=torch.int32)
+    staged = get_decode_topk_output_buffer(
+        shared,
+        num_padded_tokens=4,
+        topk_tokens=1,
+        requires_padding=True,
+    )
+    assert staged.shape == (4, 1)
+    assert staged.data_ptr() != shared.data_ptr()
+    torch.testing.assert_close(staged, torch.full((4, 1), -1, dtype=torch.int32))
+
+    # Simulate the padded Top-K result and the subsequent unpack.  The
+    # padding row (index 1) is discarded; only actual decode rows are copied
+    # back to the shared prefix.
+    staged.copy_(torch.tensor([[0], [99], [2], [3]], dtype=torch.int32))
+    decode_lens = [1, 2]
+    compact = torch.cat(
+        [
+            staged[batch_start : batch_start + length]
+            for batch_start, length in ((0, 1), (2, 2))
+        ]
+    )
+    shared[: sum(decode_lens)] = compact
+
+    torch.testing.assert_close(
+        shared,
+        torch.tensor([[0], [2], [3], [1]], dtype=torch.int32),
+    )
+
+    # Uniform decode keeps the existing fast path and may use the shared
+    # prefix because it has no surplus padded rows.
+    uniform = get_decode_topk_output_buffer(
+        shared,
+        num_padded_tokens=3,
+        topk_tokens=1,
+        requires_padding=False,
+    )
+    assert uniform.data_ptr() == shared.data_ptr()
+
+
+@pytest.mark.parametrize("use_lightop", [False, True])
+def test_sparse_indexer_mixed_padding_keeps_prefill_for_both_topk_paths(
+    monkeypatch, use_lightop
+):
+    """Exercise the real native indexer around the shared output buffer.
+
+    Both the LightOp and Torch selectors receive four padded rows, while the
+    shared buffer contains only three decode rows followed by one prefill row.
+    The selector output must be staged independently in either implementation
+    path before ``unpack_seq_triton`` writes the compact decode prefix back.
+    """
+    from vllm_hcu.v1.attention.ops import rocm_aiter_mla_sparse as sparse
+
+    decode_topk_targets = []
+
+    monkeypatch.setattr(sparse, "DeepseekV32IndexerMetadata", SimpleNamespace)
+    original_get_decode_topk_output_buffer = sparse.get_decode_topk_output_buffer
+
+    def capture_decode_topk_output_buffer(*args, **kwargs):
+        target = original_get_decode_topk_output_buffer(*args, **kwargs)
+        decode_topk_targets.append(target)
+        return target
+
+    monkeypatch.setattr(
+        sparse,
+        "get_decode_topk_output_buffer",
+        capture_decode_topk_output_buffer,
+    )
+
+    class _Platform:
+        @staticmethod
+        def is_rocm():
+            return True
+
+        @staticmethod
+        def fp8_dtype():
+            return torch.float32
+
+    monkeypatch.setattr(sparse, "current_platform", _Platform)
+    monkeypatch.setattr(sparse, "on_gfx938", lambda: False)
+    monkeypatch.setattr(
+        sparse,
+        "get_forward_context",
+        lambda: SimpleNamespace(
+            attn_metadata={
+                "layer": SimpleNamespace(
+                    slot_mapping=torch.arange(4, dtype=torch.int32),
+                    num_kv_actual_tokens=4,
+                    num_decodes=2,
+                    num_decode_tokens=3,
+                    num_prefills=1,
+                    num_prefill_tokens=1,
+                    prefill=SimpleNamespace(
+                        chunks=[
+                            SimpleNamespace(
+                                total_seq_lens=1,
+                                block_table=torch.zeros((1, 1), dtype=torch.int32),
+                                cu_seq_lens=torch.tensor(
+                                    [0, 1], dtype=torch.int32
+                                ),
+                                cu_seqlen_ks=torch.tensor(
+                                    [0], dtype=torch.int32
+                                ),
+                                cu_seqlen_ke=torch.tensor(
+                                    [1], dtype=torch.int32
+                                ),
+                                token_start=3,
+                                token_end=4,
+                            )
+                        ]
+                    ),
+                    decode=SimpleNamespace(
+                        decode_lens=torch.tensor([1, 2], dtype=torch.int32),
+                        requires_padding=True,
+                        seq_lens=torch.tensor([4, 2], dtype=torch.int32),
+                        block_table=torch.zeros((2, 1), dtype=torch.int32),
+                        schedule_metadata=torch.zeros(1, dtype=torch.int32),
+                    ),
+                )
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        sparse,
+        "cp_gather_indexer_k_bf16_cache_triton",
+        lambda *args, **kwargs: None,
+    )
+
+    def fake_prefill_logits(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke):
+        del q, kv, weights, cu_seqlen_ks, cu_seqlen_ke
+        return torch.zeros((1, 1), dtype=torch.float32)
+
+    def fake_decode_logits(*args, **kwargs):
+        del args, kwargs
+        return torch.zeros((4, 4), dtype=torch.float32)
+
+    monkeypatch.setattr(sparse, "rocm_fp8_mqa_logits", fake_prefill_logits)
+    monkeypatch.setattr(
+        sparse, "rocm_fp8_paged_mqa_logits", fake_decode_logits
+    )
+
+    def fake_pack(x, lengths):
+        del x
+        return torch.zeros((2, 2, 1), dtype=torch.float32)
+
+    def fake_unpack(packed, lengths):
+        assert tuple(packed.shape) == (2, 2, 1)
+        assert lengths.tolist() == [1, 2]
+        return torch.cat((packed[0, :1], packed[1, :2]), dim=0)
+
+    monkeypatch.setattr(sparse, "pack_seq_triton", fake_pack)
+    monkeypatch.setattr(sparse, "unpack_seq_triton", fake_unpack)
+    monkeypatch.setattr(
+        sparse, "_use_lightop_sparse_mla_topk", lambda: use_lightop
+    )
+
+    def fake_torch_topk(logits, topk_tokens, row_starts=None, row_ends=None):
+        del topk_tokens, row_starts, row_ends
+        if logits.shape[0] == 1:
+            return torch.tensor([[1]], dtype=torch.int32)
+        return torch.tensor([[0], [99], [2], [3]], dtype=torch.int32)
+
+    def fake_lightop_prefill(
+        logits, row_starts, row_ends, topk_indices, topk_tokens
+    ):
+        del logits, row_starts, row_ends, topk_tokens
+        topk_indices.fill_(1)
+
+    def fake_lightop_decode(logits, seq_lens, next_n, topk_indices, topk_tokens):
+        del logits, seq_lens, next_n, topk_tokens
+        decode_topk_targets.append(topk_indices)
+        topk_indices.copy_(torch.tensor([[0], [99], [2], [3]], dtype=torch.int32))
+
+    monkeypatch.setattr(sparse, "_topk_indices_torch", fake_torch_topk)
+    monkeypatch.setattr(
+        sparse, "_lightop_topk_indices_prefill", fake_lightop_prefill
+    )
+    monkeypatch.setattr(
+        sparse, "_lightop_topk_indices_decode", fake_lightop_decode
+    )
+
+    import vllm.utils.torch_utils as torch_utils
+
+    monkeypatch.setattr(torch_utils, "_resolve_layer_name", lambda value: value)
+
+    shared = torch.full((4, 1), -1, dtype=torch.int32)
+    result = sparse.rocm_aiter_sparse_attn_indexer_native(
+        hidden_states=torch.zeros((4, 1), dtype=torch.float32),
+        k_cache_prefix="layer",
+        kv_cache=torch.zeros((1, 2, 1), dtype=torch.float32),
+        q_fp8=torch.zeros((4, 1, 1), dtype=torch.float32),
+        k=torch.zeros((4, 1), dtype=torch.float32),
+        weights=torch.ones((4, 1), dtype=torch.float32),
+        quant_block_size=1,
+        scale_fmt="e4m3",
+        topk_tokens=1,
+        head_dim=1,
+        max_model_len=4,
+        total_seq_lens=1,
+        topk_indices_buffer=shared,
+        skip_k_cache_insert=True,
+    )
+
+    assert decode_topk_targets
+    assert all(
+        target.data_ptr() != shared.data_ptr() for target in decode_topk_targets
+    )
+    torch.testing.assert_close(
+        result,
+        torch.tensor([[0], [2], [3], [1]], dtype=torch.int32),
+    )
+
+
 def test_mla_forward_slices_kv_with_independent_token_count():
     from vllm_hcu.model_executor.layers.mla_runtime import mla_forward_impl
 

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -3943,13 +3943,15 @@ def test_router_factory_feature_gated_hcu_subclass_contract(
 
     routed: list[tuple[torch.Tensor, torch.Tensor]] = []
     lightop_calls: list[tuple[object, ...]] = []
+    lightop_gate_kwargs: list[dict[str, object]] = []
 
-    def moe_fused_gate(router_logits, *args):
+    def moe_fused_gate(router_logits, *args, **kwargs):
         lightop_calls.append((router_logits, *args))
+        lightop_gate_kwargs.append(kwargs)
         routed.append((router_logits, torch.tensor([[3]], dtype=torch.int64)))
         return torch.ones((1, 1)), routed[-1][1]
 
-    _install_lightop_moe(
+    lightop_moe = _install_lightop_moe(
         monkeypatch,
         moe_fused_gate=moe_fused_gate,
     )
@@ -3961,19 +3963,50 @@ def test_router_factory_feature_gated_hcu_subclass_contract(
     assert ids.item() == 3
     assert routed[0][0] is logits
     assert lightop_calls[-1][-2:] == (1.0, False)
+    assert lightop_gate_kwargs[-1] == {}
 
     # FusedMoE normalizes the router factor to 1.0 when MoERunner owns the
     # scale; otherwise LightOp must apply the effective router factor.
     router.routed_scaling_factor = 2.827
     router._compute_routing(None, logits, torch.int32)
     assert lightop_calls[-1][-2:] == (2.827, True)
+    assert lightop_gate_kwargs[-1] == {}
 
-    # Do not hard-code the selected backend's capability boundary in vLLM.
-    # This verifies adapter dispatch, not support in a real LightOp kernel.
+    # The installed LightOp has no routing-capability hook, so an unsupported
+    # mode must use the official router and must not invoke the fixed
+    # sigmoid+renormalize kernel.
+    calls_before_fallback = len(lightop_calls)
+    for unsupported_scoring_func, unsupported_renormalize in (
+        ("softmax", False),
+        ("sigmoid", False),
+        ("softmax", True),
+    ):
+        router.scoring_func = unsupported_scoring_func
+        router.renormalize = unsupported_renormalize
+        assert router._compute_routing(None, logits, torch.int32) == "official"
+        assert len(lightop_calls) == calls_before_fallback
+
+    # A future LightOp can opt into the mode through the documented hook.  In
+    # that case the adapter forwards the routing options instead of requiring
+    # another vLLM condition change.
     router.scoring_func = "softmax"
     router.renormalize = False
+    lightop_moe.supports_moe_fused_gate_routing = (
+        lambda *, scoring_func, renormalize: (
+            scoring_func == "softmax" and not renormalize
+        )
+    )
     router._compute_routing(None, logits, torch.int32)
+    assert len(lightop_calls) == calls_before_fallback + 1
+    assert lightop_gate_kwargs[-1] == {
+        "scoring_func": "softmax",
+        "renormalize": False,
+    }
 
+    # Restore the legacy mode so the next check exercises the categorized
+    # export ABI itself rather than the intentional routing fallback.
+    router.scoring_func = "sigmoid"
+    router.renormalize = True
     lightop = sys.modules["lightop"]
     incomplete_moe = _module("lightop.moe")
     lightop.moe = incomplete_moe
@@ -4004,8 +4037,10 @@ import torch
 from vllm_hcu.platforms import envs as henvs
 
 calls = []
-def moe_fused_gate(*args):
+gate_kwargs = []
+def moe_fused_gate(*args, **kwargs):
     calls.append(args)
+    gate_kwargs.append(kwargs)
     return torch.full((1, 1), 0.5), torch.tensor([[2]], dtype=torch.int64)
 
 lightop = ModuleType("lightop")
@@ -4022,6 +4057,11 @@ spec = importlib.util.spec_from_file_location(
 assert spec is not None and spec.loader is not None
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
+
+# Make the inherited official router observable for the fallback assertion.
+module.GroupedTopKRouter._compute_routing = (
+    lambda self, hidden_states, router_logits, indices_type, input_ids=None: "official"
+)
 
 router = object.__new__(module.HcuGroupedTopKRouter)
 router.num_expert_group = 2
@@ -4040,12 +4080,34 @@ torch.testing.assert_close(weights, torch.full((1, 1), 0.5))
 assert ids.item() == 2
 assert calls[0][0] is logits
 assert calls[-1][-2:] == (1.0, False)
+assert gate_kwargs[-1] == {{}}
 router.routed_scaling_factor = 2.827
 router._compute_routing(None, logits, torch.int32)
 assert calls[-1][-2:] == (2.827, True)
+assert gate_kwargs[-1] == {{}}
+calls_before_fallback = len(calls)
+for unsupported_scoring_func, unsupported_renormalize in (
+    ("softmax", False),
+    ("sigmoid", False),
+    ("softmax", True),
+):
+    router.scoring_func = unsupported_scoring_func
+    router.renormalize = unsupported_renormalize
+    assert router._compute_routing(None, logits, torch.int32) == "official"
+    assert len(calls) == calls_before_fallback
 router.scoring_func = "softmax"
 router.renormalize = False
+moe.supports_moe_fused_gate_routing = (
+    lambda *, scoring_func, renormalize: (
+        scoring_func == "softmax" and not renormalize
+    )
+)
 router._compute_routing(None, logits, torch.int32)
+assert len(calls) == calls_before_fallback + 1
+assert gate_kwargs[-1] == {{
+    "scoring_func": "softmax",
+    "renormalize": False,
+}}
 """
     env = dict(os.environ)
     env["VLLM_PLUGINS"] = "__disabled__"
@@ -4099,6 +4161,8 @@ router.top_k = 1
 router.num_fused_shared_experts = 0
 router.e_score_correction_bias = torch.ones(4)
 router.routed_scaling_factor = 1.0
+router.scoring_func = "sigmoid"
+router.renormalize = True
 logits = torch.ones((1, 4))
 henvs.VLLM_HCU_USE_CUSTOM_OPS = True
 henvs.VLLM_HCU_USE_FUSE_MOE_GATE = True

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -3932,6 +3932,8 @@ def test_router_factory_feature_gated_hcu_subclass_contract(
     router.top_k = 1
     router.e_score_correction_bias = torch.ones(4)
     router.routed_scaling_factor = 1.0
+    router.scoring_func = "sigmoid"
+    router.renormalize = True
 
     from vllm_hcu.platforms import envs as henvs
 
@@ -3940,9 +3942,10 @@ def test_router_factory_feature_gated_hcu_subclass_contract(
     assert router._compute_routing(None, logits, torch.int32) == "official"
 
     routed: list[tuple[torch.Tensor, torch.Tensor]] = []
+    lightop_calls: list[tuple[object, ...]] = []
 
     def moe_fused_gate(router_logits, *args):
-        del args
+        lightop_calls.append((router_logits, *args))
         routed.append((router_logits, torch.tensor([[3]], dtype=torch.int64)))
         return torch.ones((1, 1)), routed[-1][1]
 
@@ -3957,6 +3960,19 @@ def test_router_factory_feature_gated_hcu_subclass_contract(
     assert ids.dtype == torch.int32
     assert ids.item() == 3
     assert routed[0][0] is logits
+    assert lightop_calls[-1][-2:] == (1.0, False)
+
+    # FusedMoE normalizes the router factor to 1.0 when MoERunner owns the
+    # scale; otherwise LightOp must apply the effective router factor.
+    router.routed_scaling_factor = 2.827
+    router._compute_routing(None, logits, torch.int32)
+    assert lightop_calls[-1][-2:] == (2.827, True)
+
+    # Do not hard-code the selected backend's capability boundary in vLLM.
+    # This verifies adapter dispatch, not support in a real LightOp kernel.
+    router.scoring_func = "softmax"
+    router.renormalize = False
+    router._compute_routing(None, logits, torch.int32)
 
     lightop = sys.modules["lightop"]
     incomplete_moe = _module("lightop.moe")
@@ -4014,6 +4030,8 @@ router.top_k = 1
 router.num_fused_shared_experts = 0
 router.e_score_correction_bias = torch.ones(4)
 router.routed_scaling_factor = 1.0
+router.scoring_func = "sigmoid"
+router.renormalize = True
 logits = torch.ones((1, 4))
 henvs.VLLM_HCU_USE_CUSTOM_OPS = True
 henvs.VLLM_HCU_USE_FUSE_MOE_GATE = True
@@ -4021,6 +4039,13 @@ weights, ids = router._compute_routing(None, logits, torch.int32)
 torch.testing.assert_close(weights, torch.full((1, 1), 0.5))
 assert ids.item() == 2
 assert calls[0][0] is logits
+assert calls[-1][-2:] == (1.0, False)
+router.routed_scaling_factor = 2.827
+router._compute_routing(None, logits, torch.int32)
+assert calls[-1][-2:] == (2.827, True)
+router.scoring_func = "softmax"
+router.renormalize = False
+router._compute_routing(None, logits, torch.int32)
 """
     env = dict(os.environ)
     env["VLLM_PLUGINS"] = "__disabled__"

--- a/vllm_hcu/model_executor/layers/fused_moe/lightop_routing.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/lightop_routing.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Compatibility checks for the LightOp fused-MoE routing ABI.
+
+The original ``lightop.moe.moe_fused_gate`` ABI has no arguments for the
+router scoring function or for top-k renormalization.  The kernel therefore
+has one fixed semantic contract (sigmoid scoring followed by
+renormalization).  Keeping that fact in one small helper prevents the two HCU
+router entry points from drifting apart.
+
+Newer LightOp versions can extend the contract without a vLLM change by
+exporting ``supports_moe_fused_gate_routing`` from ``lightop.moe``.  The hook
+must have the following keyword-only shape::
+
+    supports_moe_fused_gate_routing(
+        *, scoring_func: str, renormalize: bool
+    ) -> bool
+
+When it returns ``True`` for a non-legacy mode, the corresponding
+``moe_fused_gate`` wrapper must also accept ``scoring_func=`` and
+``renormalize=`` keyword arguments.  A missing hook is deliberately treated
+as an old LightOp build, so unsupported modes fail safe by using the official
+router instead of silently changing expert IDs or weights.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_LEGACY_SCORING_FUNC = "sigmoid"
+
+
+def lightop_moe_gate_kwargs(
+    lightop_moe: Any,
+    scoring_func: str | None,
+    renormalize: bool | None,
+) -> dict[str, Any] | None:
+    """Return LightOp routing kwargs, or ``None`` for standard-router fallback.
+
+    ``{}`` means that the existing positional ABI is safe to call.  A
+    non-empty mapping is used only after a newer backend explicitly advertises
+    support through the capability hook described in this module.
+    """
+
+    if scoring_func == _LEGACY_SCORING_FUNC and bool(renormalize):
+        return {}
+
+    capability = getattr(lightop_moe, "supports_moe_fused_gate_routing", None)
+    if capability is None:
+        # Older LightOp releases have no way to receive these options and
+        # always execute sigmoid + renormalize.  Do not call them for another
+        # vLLM routing configuration.
+        return None
+    if not callable(capability):
+        raise RuntimeError(
+            "lightop.moe.supports_moe_fused_gate_routing must be callable"
+        )
+
+    try:
+        supported = capability(
+            scoring_func=scoring_func,
+            renormalize=bool(renormalize),
+        )
+    except TypeError as exc:
+        raise RuntimeError(
+            "lightop.moe.supports_moe_fused_gate_routing must accept "
+            "scoring_func= and renormalize= keyword arguments"
+        ) from exc
+    if not bool(supported):
+        return None
+
+    # The capability hook and this keyword forwarding form a versioned
+    # protocol: a backend opting in must implement the matching gate ABI.
+    return {
+        "scoring_func": scoring_func,
+        "renormalize": bool(renormalize),
+    }
+
+
+__all__ = ["lightop_moe_gate_kwargs"]

--- a/vllm_hcu/model_executor/layers/fused_moe/router_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/router_runtime.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+from .lightop_routing import lightop_moe_gate_kwargs
+
+
 def eplb_map_to_physical_and_record(
     module,
     original,
@@ -89,7 +92,38 @@ def make_hcu_grouped_topk_router(base_class):
                     indices_type,
                     input_ids=input_ids,
                 )
+            # Import the module first so a newer LightOp can advertise extra
+            # scoring/normalization modes without a vLLM condition change.
+            # If the optional backend is unavailable, retain the historical
+            # fail-fast behavior for the legacy mode but let unsupported modes
+            # use the official router.
+            scoring_func = getattr(self, "scoring_func", None)
+            renormalize = getattr(self, "renormalize", None)
+            try:
+                import lightop.moe as lightop_moe
+            except ImportError:
+                if scoring_func != "sigmoid" or not bool(renormalize):
+                    return super()._compute_routing(
+                        hidden_states,
+                        router_logits,
+                        indices_type,
+                        input_ids=input_ids,
+                    )
+                raise
+            gate_kwargs = lightop_moe_gate_kwargs(
+                lightop_moe,
+                scoring_func,
+                renormalize,
+            )
+            if gate_kwargs is None:
+                return super()._compute_routing(
+                    hidden_states,
+                    router_logits,
+                    indices_type,
+                    input_ids=input_ids,
+                )
             from lightop.moe import moe_fused_gate
+
             topk_weights, topk_ids = moe_fused_gate(
                 router_logits,
                 self.e_score_correction_bias,
@@ -102,6 +136,7 @@ def make_hcu_grouped_topk_router(base_class):
                 # output scaling. Otherwise this is the effective router
                 # scale and LightOp must apply it to the routing weights.
                 self.routed_scaling_factor != 1.0,
+                **gate_kwargs,
             )
             if indices_type is not None and topk_ids.dtype != indices_type:
                 topk_ids = topk_ids.to(indices_type)

--- a/vllm_hcu/model_executor/layers/fused_moe/router_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/router_runtime.py
@@ -98,6 +98,10 @@ def make_hcu_grouped_topk_router(base_class):
                 self.top_k,
                 0,
                 self.routed_scaling_factor,
+                # FusedMoE passes 1.0 to the router when MoERunner owns
+                # output scaling. Otherwise this is the effective router
+                # scale and LightOp must apply it to the routing weights.
+                self.routed_scaling_factor != 1.0,
             )
             if indices_type is not None and topk_ids.dtype != indices_type:
                 topk_ids = topk_ids.to(indices_type)

--- a/vllm_hcu/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm_hcu/model_executor/layers/sparse_attn_indexer.py
@@ -41,6 +41,7 @@ from vllm_hcu.model_executor.layers.attention.pcp import (
     effective_pcp_world_size,
     maybe_gather_indexer_k,
 )
+from vllm_hcu.v1.attention.ops.decode_topk import get_decode_topk_output_buffer
 
 logger = init_logger(__name__)
 
@@ -578,7 +579,15 @@ def sparse_attn_indexer(
                 clean_logits=False,
             )
         num_rows = logits.shape[0]
-        topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
+        # Variable-length decode is computed in a rectangular padded layout.
+        # The extra rows must be staged outside the shared decode/prefill
+        # buffer; prefill starts at num_decode_tokens in that buffer.
+        topk_indices = get_decode_topk_output_buffer(
+            topk_indices_buffer,
+            num_padded_tokens,
+            topk_tokens,
+            decode_metadata.requires_padding,
+        )
 
         use_cooperative_topk = (
             current_platform.is_cuda()
@@ -642,8 +651,9 @@ def sparse_attn_indexer(
             )
 
         if decode_metadata.requires_padding:
-            # if padded, we need to unpack
-            # the topk indices removing padded tokens
+            # ``topk_indices`` is a disjoint scratch tensor in this case.
+            # Unpack only actual decode rows into the shared prefix so the
+            # prefill suffix remains untouched.
             topk_indices = unpack_seq_triton(
                 topk_indices.reshape(batch_size, -1, topk_indices.shape[-1]),
                 decode_lens,

--- a/vllm_hcu/ops/fuse_moe_gate.py
+++ b/vllm_hcu/ops/fuse_moe_gate.py
@@ -5,6 +5,10 @@ import torch
 import vllm_hcu.platforms.envs as henvs
 from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import GroupedTopKRouter
 
+from vllm_hcu.model_executor.layers.fused_moe.lightop_routing import (
+    lightop_moe_gate_kwargs,
+)
+
 class HcuGroupedTopKRouter(GroupedTopKRouter):
     def _valid_grouping(self, router_logits: torch.Tensor) -> bool:
         """Mirror GroupedTopKRouter._compute_routing.<locals>.valid_grouping (not accessible from outside)."""
@@ -20,9 +24,43 @@ class HcuGroupedTopKRouter(GroupedTopKRouter):
         indices_type: torch.dtype | None,
         input_ids: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        condition = self._valid_grouping(router_logits) and self.e_score_correction_bias is not None and henvs.VLLM_HCU_USE_FUSE_MOE_GATE and henvs.VLLM_HCU_USE_CUSTOM_OPS
+        condition = (
+            self._valid_grouping(router_logits)
+            and self.e_score_correction_bias is not None
+            and henvs.VLLM_HCU_USE_FUSE_MOE_GATE
+            and henvs.VLLM_HCU_USE_CUSTOM_OPS
+        )
         enable_shared_experts_fusion = False
         if condition:
+            # Keep this entry point in lock-step with router_runtime.py.  The
+            # current LightOp ABI is limited to sigmoid + renormalize; a
+            # future backend can opt into more modes through the capability
+            # hook without requiring another vLLM condition change.
+            scoring_func = getattr(self, "scoring_func", None)
+            renormalize = getattr(self, "renormalize", None)
+            try:
+                import lightop.moe as lightop_moe
+            except ImportError:
+                if scoring_func != "sigmoid" or not bool(renormalize):
+                    return super()._compute_routing(
+                        hidden_states,
+                        router_logits,
+                        indices_type,
+                        input_ids=input_ids,
+                    )
+                raise
+            gate_kwargs = lightop_moe_gate_kwargs(
+                lightop_moe,
+                scoring_func,
+                renormalize,
+            )
+            if gate_kwargs is None:
+                return super()._compute_routing(
+                    hidden_states,
+                    router_logits,
+                    indices_type,
+                    input_ids=input_ids,
+                )
             from lightop.moe import moe_fused_gate as lightop_moe_fused_gate
 
             topk_weights, topk_ids = lightop_moe_fused_gate(
@@ -36,7 +74,8 @@ class HcuGroupedTopKRouter(GroupedTopKRouter):
                 # FusedMoE gives the router 1.0 when MoERunner owns output
                 # scaling; otherwise LightOp must scale the routing weights.
                 self.routed_scaling_factor != 1.0,
-            )       
+                **gate_kwargs,
+            )
             return topk_weights, topk_ids
         else:
             return super()._compute_routing(hidden_states, router_logits, indices_type, input_ids=input_ids)

--- a/vllm_hcu/ops/fuse_moe_gate.py
+++ b/vllm_hcu/ops/fuse_moe_gate.py
@@ -33,6 +33,9 @@ class HcuGroupedTopKRouter(GroupedTopKRouter):
                 self.top_k,
                 self.num_fused_shared_experts if enable_shared_experts_fusion else 0,
                 self.routed_scaling_factor,
+                # FusedMoE gives the router 1.0 when MoERunner owns output
+                # scaling; otherwise LightOp must scale the routing weights.
+                self.routed_scaling_factor != 1.0,
             )       
             return topk_weights, topk_ids
         else:

--- a/vllm_hcu/v1/attention/ops/decode_topk.py
+++ b/vllm_hcu/v1/attention/ops/decode_topk.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Utilities for staging sparse-MLA decode Top-K results.
+
+The sparse indexer stores decode and prefill results in one logical output
+buffer.  A variable-length decode batch is temporarily expanded to a
+rectangular ``[batch, max_decode_len]`` layout, so its Top-K kernel can produce
+more rows than there are actual decode tokens.  The padded rows must never be
+written into the shared output buffer: the rows immediately following the
+decode prefix belong to prefill.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def get_decode_topk_output_buffer(
+    topk_indices_buffer: torch.Tensor,
+    num_padded_tokens: int,
+    topk_tokens: int,
+    requires_padding: bool,
+) -> torch.Tensor:
+    """Return storage for a decode Top-K kernel result.
+
+    For a uniform/flattened decode batch, the number of kernel rows equals the
+    number of actual decode rows and the shared prefix can be used directly.
+    For a padded batch, allocate a disjoint temporary tensor.  The caller must
+    compact that tensor with :func:`unpack_seq_triton` before copying the
+    actual rows back to ``topk_indices_buffer``.
+
+    ``topk_indices_buffer`` is deliberately not used as the padded scratch
+    target.  Its rows after ``num_decode_tokens`` may contain prefill results.
+    ``new_empty`` preserves the dtype and device while avoiding assumptions
+    about the physical capacity or layout of the shared buffer.
+    """
+    if not requires_padding:
+        return topk_indices_buffer[:num_padded_tokens, :topk_tokens]
+
+    padded_topk = topk_indices_buffer.new_empty(
+        (num_padded_tokens, topk_tokens)
+    )
+    # Top-K kernels generally write valid entries only.  Keep the same -1
+    # sentinel contract as the shared buffer for invalid/padded entries.
+    padded_topk.fill_(-1)
+    return padded_topk
+
+
+__all__ = ["get_decode_topk_output_buffer"]

--- a/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -949,9 +949,62 @@ def rocm_fp8_mqa_logits(
         return fp8_mqa_logits_torch(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke)
 
 
-def _topk_indices_torch(logits: torch.Tensor, topk_tokens: int) -> torch.Tensor:
+def _topk_indices_torch(
+    logits: torch.Tensor,
+    topk_tokens: int,
+    row_starts: torch.Tensor | None = None,
+    row_ends: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Torch fallback matching sparse-MLA top-k range/index semantics.
+
+    The native prefill selector receives [row_start, row_end) and returns
+    positions relative to row_start. LightOp MQA can leave values outside
+    that interval finite when clean_logits is disabled, so mask them before
+    selecting. For rows shorter than topk, the native selector returns all
+    valid positions in sequence order.
+    """
+    if logits.dim() != 2:
+        raise RuntimeError(
+            f"Torch sparse-MLA topk expects 2D logits, got {logits.shape}"
+        )
+
+    if row_ends is None:
+        num_rows = logits.shape[0]
+        starts = torch.zeros(num_rows, dtype=torch.int64, device=logits.device)
+        ends = torch.full(
+            (num_rows,), logits.shape[1], dtype=torch.int64, device=logits.device
+        )
+    else:
+        num_rows = int(row_ends.numel())
+        if logits.shape[0] != num_rows:
+            if logits.shape[1] == num_rows:
+                logits = logits.transpose(0, 1)
+            else:
+                raise RuntimeError(
+                    "Torch sparse-MLA topk logits/query row mismatch: "
+                    f"logits={tuple(logits.shape)}, rows={num_rows}"
+                )
+        starts = (
+            torch.zeros_like(row_ends)
+            if row_starts is None
+            else row_starts
+        )
+        starts = starts.to(device=logits.device, dtype=torch.int64).reshape(-1)
+        ends = row_ends.to(device=logits.device, dtype=torch.int64).reshape(-1)
+        starts = starts[:num_rows].clamp(0, logits.shape[1])
+        ends = ends[:num_rows].clamp(0, logits.shape[1])
+        ends = torch.maximum(ends, starts)
+
+    row_lens = (ends - starts).clamp_min(0)
+    cols = torch.arange(logits.shape[1], device=logits.device)
+    valid = (cols.unsqueeze(0) >= starts.unsqueeze(1)) & (
+        cols.unsqueeze(0) < ends.unsqueeze(1)
+    )
+    masked_logits = logits.masked_fill(~valid, float("-inf"))
+
     k = min(topk_tokens, logits.shape[-1])
-    values, indices = torch.topk(logits, k=k, dim=-1)
+    values, indices = torch.topk(masked_logits, k=k, dim=-1)
+    indices = indices.to(torch.int64) - starts.unsqueeze(1)
     indices = indices.to(torch.int32)
     indices = torch.where(
         values == float("-inf"),
@@ -959,15 +1012,30 @@ def _topk_indices_torch(logits: torch.Tensor, topk_tokens: int) -> torch.Tensor:
         indices,
     )
     if k == topk_tokens:
-        return indices
-    padded = torch.full(
-        (logits.shape[0], topk_tokens),
-        -1,
-        dtype=torch.int32,
-        device=logits.device,
+        selected = indices
+    else:
+        selected = torch.full(
+            (num_rows, topk_tokens),
+            -1,
+            dtype=torch.int32,
+            device=logits.device,
+        )
+        selected[:, :k] = indices
+
+    # When every valid position is requested, preserve the native selector's
+    # deterministic sequence order instead of sorting by score.
+    seq = torch.arange(topk_tokens, device=logits.device, dtype=torch.int32)
+    seq = seq.unsqueeze(0).expand(num_rows, -1)
+    all_valid = torch.where(
+        seq < row_lens.unsqueeze(1),
+        seq,
+        torch.full_like(seq, -1),
     )
-    padded[:, :k] = indices
-    return padded
+    return torch.where(
+        (row_lens <= topk_tokens).unsqueeze(1),
+        all_valid,
+        selected,
+    )
 
 
 def _decode_row_ends_from_seq_lens(
@@ -1239,7 +1307,14 @@ def rocm_aiter_sparse_attn_indexer_native(
                     topk_tokens,
                 )
             else:
-                topk_indices.copy_(_topk_indices_torch(logits, topk_tokens))
+                topk_indices.copy_(
+                    _topk_indices_torch(
+                        logits,
+                        topk_tokens,
+                        chunk.cu_seqlen_ks,
+                        chunk.cu_seqlen_ke,
+                    )
+                )
 
     if has_decode:
         decode_metadata = layer_attn_metadata.decode
@@ -1288,8 +1363,16 @@ def rocm_aiter_sparse_attn_indexer_native(
                 logits, seq_lens, next_n, topk_indices, topk_tokens
             )
         else:
-            topk_indices = topk_indices_buffer[:num_decode_tokens, :topk_tokens]
-            topk_indices.copy_(_topk_indices_torch(logits, topk_tokens)[:num_decode_tokens]
+            row_ends = _decode_row_ends_from_seq_lens(
+                seq_lens, next_n, logits.shape[0]
+            )
+            topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
+            topk_indices.copy_(
+                _topk_indices_torch(
+                    logits,
+                    topk_tokens,
+                    row_ends=row_ends,
+                )
             )
 
         if decode_metadata.requires_padding:

--- a/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -25,6 +25,7 @@ else:
 from vllm.v1.attention.backends.mla.indexer import DeepseekV32IndexerPrefillMetadata
 import vllm_hcu.platforms.envs as henvs 
 from vllm_hcu.platforms.hcu import on_gfx938
+from vllm_hcu.v1.attention.ops.decode_topk import get_decode_topk_output_buffer
 
 
 lightop_attention = None
@@ -1165,6 +1166,24 @@ def rocm_aiter_sparse_attn_indexer_fake(
     fp8_dtype = current_platform.fp8_dtype()
     _k_fp8 = _flattened_kv[..., :head_dim].view(fp8_dtype).contiguous()
     _k_scale = _flattened_kv[..., head_dim:].view(torch.float32).contiguous()
+    # Account for the maximum padded Top-K staging allocation during memory
+    # profiling.  The runtime scratch is allocated only for variable-length
+    # decode batches, but its peak size is bounded by max_num_batched_tokens.
+    scratch_device = (
+        topk_indices_buffer.device
+        if topk_indices_buffer is not None
+        else hidden_states.device
+    )
+    scratch_dtype = (
+        topk_indices_buffer.dtype
+        if topk_indices_buffer is not None
+        else torch.int32
+    )
+    _padded_topk = torch.empty(
+        (hidden_states.shape[0], topk_tokens),
+        dtype=scratch_dtype,
+        device=scratch_device,
+    )
     return topk_indices_buffer
 
 
@@ -1357,8 +1376,17 @@ def rocm_aiter_sparse_attn_indexer_native(
             max_model_len=max_model_len,
         )
 
+        # A padded decode batch has more kernel rows than actual decode
+        # tokens.  Do not point those extra rows at the shared output buffer:
+        # rows immediately after num_decode_tokens belong to prefill.
+        topk_indices = get_decode_topk_output_buffer(
+            topk_indices_buffer,
+            num_padded_tokens,
+            topk_tokens,
+            decode_metadata.requires_padding,
+        )
+
         if use_lightop_sparse_mla_topk:
-            topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
             _lightop_topk_indices_decode(
                 logits, seq_lens, next_n, topk_indices, topk_tokens
             )
@@ -1366,7 +1394,6 @@ def rocm_aiter_sparse_attn_indexer_native(
             row_ends = _decode_row_ends_from_seq_lens(
                 seq_lens, next_n, logits.shape[0]
             )
-            topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
             topk_indices.copy_(
                 _topk_indices_torch(
                     logits,
@@ -1376,8 +1403,9 @@ def rocm_aiter_sparse_attn_indexer_native(
             )
 
         if decode_metadata.requires_padding:
-            # if padded, we need to unpack
-            # the topk indices removing padded tokens
+            # ``topk_indices`` is a disjoint scratch tensor in this case.
+            # Unpack only the actual decode rows into the shared prefix so
+            # the prefill suffix remains untouched.
             topk_indices = unpack_seq_triton(
                 topk_indices.reshape(batch_size, -1, topk_indices.shape[-1]),
                 decode_lens,


### PR DESCRIPTION
## 背景与范围

从最新 `v0.25.1` 主分支（`dc27551`）独立整理本次 LightOp / HY4 精度排查涉及的 vLLM-HCU 适配修复，便于单独审查与合入。

本 MR 只修改 6 个文件：两个 MoE router 入口、LightOp 路由 ABI 能力检查 helper、稀疏 MLA Top-K 的 Torch fallback，以及对应的两份测试文件。不包含 #34 中的 HY4 模型、MTP、PCP、EPLB 等整套功能变更；原 HY4 分支保持不变。

## 修改内容

### 1. 明确 LightOp gate 与 MoERunner 的缩放分工

- 保留主分支最新的 `lightop.moe.moe_fused_gate` 分类接口，不恢复旧的 `lightop.op` 导入方式。
- 两个 router 入口都显式传入第 8 个参数 `apply_routed_scaling_factor_on_output`，其值取自 `self.routed_scaling_factor != 1.0`，不无条件写死为 `True`。
- vLLM 的 `FusedMoE.apply_routed_scale_to_output` 决定缩放发生的位置，并在构造 router / runner 时将另一侧的 factor 归一为 `1.0`。

| FusedMoE 配置 | Router factor | MoERunner factor | LightOp gate 缩放 |
| --- | --- | --- | --- |
| `apply_routed_scale_to_output=False` | 模型 factor `s` | `1.0` | `s != 1.0` 时启用 |
| `apply_routed_scale_to_output=True` | `1.0` | 模型 factor `s` | 关闭，由 runner 处理 |

LightOp 参数中的 output 指 gate 返回的 routing weights，不是 MoE 最终 hidden states。以 HY4 的 `s=2.827` 为例，当前模型默认由 router 缩放，runner 收到 `1.0`，因此 gate 必须保留这一次缩放。对于由 runner 缩放的模型，gate 不再承担缩放。

这项修改明确现有 factory 契约；不能将它表述为正常 factory 路径此前必然重复缩放，因为此前 runner-owned 路径的 router factor 已是 `1.0`。

### 2. 不兼容 routing 模式安全回退，并保留后端扩展点

- 当前 `moe_fused_gate` API 尚未接收 `scoring_func` / `renormalize`，现有 kernel 固定执行 sigmoid + 归一化。两个 HCU router 因此只在这组语义下调用旧 ABI；`softmax`、`renormalize=False` 以及其他未声明模式统一调用 `super()._compute_routing`，不会再静默改变 expert IDs 或权重。
- 不使用框架级 `ValueError`，所以不会把后端能力边界永久写死，也不会因不兼容模型直接中断服务。未知的 router 属性同样按不支持处理，默认走标准 router。
- 为避免未来 LightOp 增加模式时还要修改 vLLM 条件，适配层支持可选的 `lightop.moe.supports_moe_fused_gate_routing(*, scoring_func, renormalize) -> bool` 能力接口。后端声明支持后，适配层会把两个选项以关键字转发给 `moe_fused_gate`；旧版本没有该接口时保持保守回退。
- 单测覆盖三条契约：旧 ABI 的 `sigmoid + renormalize=True` 正常调用；没有能力声明的 `softmax`/非归一化组合回退且 gate 调用次数不增加；后端声明能力后重新调用并核对参数转发。这样未来只需在 LightOp 中实现并测试该能力接口，不需要再次改 vLLM router 判断。
- 专家数、group、top-k、dtype 等 kernel 支持范围仍由 LightOp 自身的参数检查负责，本 MR 不移除 LightOp 内的检查。

### 3. 对齐稀疏 MLA Torch Top-K fallback 的区间与索引语义

- Prefill 显式传递每行的 `[row_start, row_end)` KV 区间，在 Top-K 前屏蔽区间外的 logits，避免未清理的有限值参与选择。
- 输出索引转换为相对 `row_start` 的请求内位置，与 native selector 的语义一致。
- 有效区间长度不超过 Top-K 时，按原序输出所有有效位置，剩余位置填 `-1`。
- Decode 使用 `_decode_row_ends_from_seq_lens` 计算每个 speculative token 的有效长度。
- 对需要 padding 的 decode，先处理完整 `num_padded_tokens`，再按已有流程 unpack，避免提前截断实际 token 数导致行错位。

## 验证

- [x] 修改文件的 `compileall` 语法检查通过。
- [x] `git diff --check` 通过。
- [x] 通过独立 mock 自测执行两个生产 router 入口：factor `1.0 -> False`、`2.827 -> True`、关闭 fused gate 回到标准 router，以及不兼容 routing 模式的安全回退/能力声明转发。
- [x] 新增或扩展回归测试：两个 router 入口、非零 KV 起点、区间外大值、转置 logits、短行顺序与 `-1` padding、speculative decode 的逐行有效长度。
- [ ] 当前本地环境没有 Torch / vLLM / pytest，未执行完整 pytest。
- [ ] 本次移植未重跑 DCU kernel 数值对照；HumanEval 实测截图由用户提供，见下图。

### 精度验证（用户提供的实测截图）

![HY4 HumanEval pass@1 95.12](https://raw.githubusercontent.com/HYGON-AI/vllm-plugin-das/38c8d26ae9c415cdc62c30d791a783cb5abbb25e/docs/accuracy/hy4-humaneval-20260903.png)

## 依赖与兼容性

需要使用支持 `lightop.moe.moe_fused_gate` 分类接口以及第 8 个缩放参数的 LightOp 版本。仅支持旧七参数 ABI 的二进制不满足本次适配要求。若要启用非 sigmoid/归一化路由，还需由 LightOp 提供上文约定的能力函数和对应关键字参数；否则 vLLM 会自动回退标准 router。

本 MR 不修改模型配置、MoERunner 的缩放策略、环境变量默认值，也不修改或重启任何服务器上的服务。
