### PR TITLE
ci: set Qwen max model length to 32768

### DIFF
--- a/docker/image-citest-conf-hcu.yaml
+++ b/docker/image-citest-conf-hcu.yaml
@@ -22,6 +22,7 @@ Qwen3.5-35B-A3B-W8A8:
   server_args:
     attention-backend: FLASH_ATTN
     kv-cache-dtype: fp8_e4m3
+    max-model-len: 32768
     max-num-batched-tokens: 16384
     max-num-seqs: 128
     quantization: slimquant_marlin
@@ -57,6 +58,7 @@ Qwen3.6-35B-A3B:
   server_args:
     attention-backend: FLASH_ATTN
     kv-cache-dtype: fp8_e4m3
+    max-model-len: 32768
     max-num-batched-tokens: 10240
     moe-backend: aiter
     speculative-config.method: mtp


### PR DESCRIPTION
## Summary
- set `max-model-len: 32768` for `Qwen3.5-35B-A3B-W8A8`
- set `max-model-len: 32768` for `Qwen3.6-35B-A3B`

## Testing
- parsed `docker/image-citest-conf-hcu.yaml` and asserted both values are integer `32768`
- `python tools/run_patch_tests.py --suite contract -- -o cache_dir=/tmp/vllm-plugin-das-pytest-cache` (`1276 passed, 102 deselected`)
