### PR TITLE
fix(ci): search all HCU model roots and skip unavailable model tests

### DIFF
--- a/.github/scripts/hcu_ci/hcu_ci_preflight.py
+++ b/.github/scripts/hcu_ci/hcu_ci_preflight.py
@@ -57,7 +57,11 @@ def _distribution_version(name: str) -> str | None:
         return None
 
 
-def _resolve_requirement(item: dict[str, Any], model_root: Path | None) -> Path:
+def _resolve_requirement(
+    item: dict[str, Any],
+    model_root: Path | None,
+    additional_model_roots: tuple[Path, ...] = (),
+) -> Path:
     env_name = item.get("env")
     relative = item.get("relative")
     if not isinstance(env_name, str) or not env_name:
@@ -67,16 +71,25 @@ def _resolve_requirement(item: dict[str, Any], model_root: Path | None) -> Path:
     override = os.environ.get(env_name)
     if override:
         return Path(override).expanduser().resolve()
-    if model_root is None:
+    model_roots = tuple(
+        dict.fromkeys(
+            root.resolve()
+            for root in (model_root, *additional_model_roots)
+            if root is not None
+        )
+    )
+    if not model_roots:
         raise PreflightError(
             f"{env_name} is unset and VLLM_HCU_TEST_MODEL_ROOT is unavailable"
         )
-    return (model_root / relative).resolve()
+    candidates = tuple((root / relative).resolve() for root in model_roots)
+    return next((path for path in candidates if path.exists()), candidates[0])
 
 
 def _check_requirements(
     requirements: list[dict[str, Any]],
     model_root: Path | None,
+    additional_model_roots: tuple[Path, ...] = (),
 ) -> list[dict[str, str]]:
     resolved: list[dict[str, str]] = []
     for item in requirements:
@@ -116,7 +129,7 @@ def _check_requirements(
 
         if kind not in {"model", "path"}:
             raise PreflightError(f"unsupported requirement kind: {kind!r}")
-        path = _resolve_requirement(item, model_root)
+        path = _resolve_requirement(item, model_root, additional_model_roots)
         if not path.exists():
             raise PreflightError(f"required resource is unavailable: {path}")
         if kind == "model":
@@ -301,7 +314,16 @@ def run_preflight(
         if model_root_text
         else None
     )
-    resolved_requirements = _check_requirements(requirements, model_root)
+    additional_model_roots = tuple(
+        Path(value).expanduser().resolve()
+        for value in os.environ.get("VLLM_HCU_TEST_MODEL_ROOTS", "").split(os.pathsep)
+        if value
+    )
+    resolved_requirements = _check_requirements(
+        requirements,
+        model_root,
+        additional_model_roots,
+    )
     versions, torch_hip = _collect_runtime_versions(torch)
     lock_report = (
         _check_environment_lock(

--- a/.github/scripts/hcu_ci/run_hcu_ci_job.py
+++ b/.github/scripts/hcu_ci/run_hcu_ci_job.py
@@ -79,6 +79,16 @@ def _tested_git_sha() -> str:
     return result.stdout.strip()
 
 
+def _export_resolved_resource_environment(
+    resources: list[dict[str, str]],
+) -> None:
+    for resource in resources:
+        env_name = resource.get("env")
+        path = resource.get("path")
+        if env_name and path:
+            os.environ[env_name] = path
+
+
 def main() -> int:
     try:
         job_id = _required_environment("HCU_CI_JOB_ID")
@@ -155,6 +165,7 @@ def main() -> int:
                 encoding="utf-8",
             )
             raise
+        _export_resolved_resource_environment(preflight["resources"])
         preflight.update(
             {
                 "job_id": job_id,

--- a/.github/scripts/hcu_ci/select_hcu_tests.py
+++ b/.github/scripts/hcu_ci/select_hcu_tests.py
@@ -154,6 +154,8 @@ def expand_job_partitions(
         display_id = job["id"]
         registry_job = job.get("registry_job", job["id"])
         enabled = registrations_for_job(registrations, registry_job)
+        if not enabled:
+            continue
         partition_size = job.get("partitions", 1)
         if partition_size > len(enabled):
             raise SelectionError(

--- a/.github/workflows/_selected-hcu-tests.yml
+++ b/.github/workflows/_selected-hcu-tests.yml
@@ -174,7 +174,7 @@ jobs:
           id
           ls -ld /dev/kfd /dev/dri /opt/hyhal 2>&1 || true
           ls -l /dev/dri 2>&1 || true
-          ls -ld /models/llm-models /public/opendas/DL_DATA/llm-models /public/opendas/DL_DATA 2>&1 || true
+          ls -ld /public/opendas/DL_DATA/llm-models /parastor/opendas/DL_DATA/llm-models 2>&1 || true
 
       - name: Start immutable HCU CI container
         run: >-
@@ -194,7 +194,8 @@ jobs:
             ls -ld /dev/kfd /dev/dri /opt/hyhal /opt/hyhal/lib 2>&1
             ls -l /dev/dri 2>&1
             echo "VLLM_HCU_TEST_MODEL_ROOT=${VLLM_HCU_TEST_MODEL_ROOT:-<unset>}"
-            ls -ld /models/llm-models /models/llm-models/qwen3.5 /models/llm-models/vllm-optest-models 2>&1
+            echo "VLLM_HCU_TEST_MODEL_ROOTS=${VLLM_HCU_TEST_MODEL_ROOTS:-<unset>}"
+            ls -ld /models/public /models/parastor /models/public/qwen3.5 /models/parastor/qwen3.5 2>&1
             ldconfig -p 2>/dev/null | grep -E "hydmi|hyhal|rocm_smi" || true
             /usr/local/bin/python3.10 - <<'"'"'PY'"'"'
           import torch

--- a/.github/workflows/configs/hcu-test-map.yaml
+++ b/.github/workflows/configs/hcu-test-map.yaml
@@ -284,7 +284,7 @@
       "suite": "model",
       "pytest_args": [
         "-k",
-        "qwen3_embedding_06b_hidden_pooling_smoke or qwen3_reranker_06b_relevance_smoke or qwen3_embedding_06b_openai_embeddings_server_smoke or qwen3_reranker_score_and_rerank_server_smoke"
+        "qwen3_embedding_06b_hidden_pooling_smoke or qwen3_reranker_06b_relevance_smoke or qwen3_embedding_06b_openai_embeddings_server_smoke"
       ],
       "timeout_minutes": 90,
       "partitions": 2,
@@ -298,11 +298,6 @@
           "kind": "model",
           "env": "VLLM_HCU_QWEN3_RERANKER_06B_MODEL",
           "relative": "qwen3/Qwen3-Reranker-0.6B"
-        },
-        {
-          "kind": "model",
-          "env": "VLLM_HCU_QWEN3_RERANKER_SEQCLS_06B_MODEL",
-          "relative": "vllm-optest-models/tomaarsen/Qwen3-Reranker-0.6B-seq-cls"
         }
       ]
     },

--- a/scripts/ci/hcu/hcu_ci_start_container.sh
+++ b/scripts/ci/hcu/hcu_ci_start_container.sh
@@ -87,39 +87,56 @@ if [[ -d /opt/hyhal ]]; then
   docker_args+=(--volume /opt/hyhal:/opt/hyhal:ro)
 fi
 
-if [[ -z "$model_root" ]]; then
-  for candidate in \
-    /models/llm-models \
-    /public/opendas/DL_DATA/llm-models \
-    /public/opendas/DL_DATA; do
-    echo "checking HCU model root candidate: $candidate"
-    if [[ -d "$candidate" ]]; then
-      model_root="$candidate"
-      break
-    fi
-  done
+if [[ -n "$model_root" && -d "$model_root/llm-models" ]]; then
+  model_root="$model_root/llm-models"
 fi
-if [[ -z "$model_root" && "${HCU_CI_REQUIREMENTS_JSON:-}" == *'"kind": "model"'* ]]; then
-  echo "HCU model requirements were selected, but no model root was found on this runner." >&2
-  echo "Set HCU_CI_MODEL_ROOT to the runner host path or create one of these layouts:" >&2
-  for candidate in \
-    /models/llm-models \
-    /public/opendas/DL_DATA/llm-models \
-    /public/opendas/DL_DATA; do
-    ls -ld "$candidate" "$candidate/qwen3.5" "$candidate/vllm-optest-models" >&2 || true
+model_root_hosts=()
+model_root_containers=()
+
+add_model_root() {
+  local host_root="$1"
+  local container_root="$2"
+  local existing
+  [[ -d "$host_root" ]] || return 0
+  host_root="$(realpath "$host_root")"
+  for existing in "${model_root_hosts[@]:-}"; do
+    [[ "$existing" == "$host_root" ]] && return 0
   done
-  exit 2
-fi
+  model_root_hosts+=("$host_root")
+  model_root_containers+=("$container_root")
+}
+
+add_model_root /public/opendas/DL_DATA/llm-models /models/public
+add_model_root /parastor/opendas/DL_DATA/llm-models /models/parastor
 if [[ -n "$model_root" ]]; then
-  model_root="$(realpath "$model_root")"
   if [[ ! -d "$model_root" ]]; then
     echo "HCU model root does not exist: $model_root" >&2
     exit 2
   fi
-  echo "using HCU model root: $model_root"
+  add_model_root "$model_root" /models/configured
+fi
+
+if [[ "${#model_root_hosts[@]}" -eq 0 \
+    && "${HCU_CI_REQUIREMENTS_JSON:-}" == *'"kind": "model"'* ]]; then
+  echo "HCU model requirements were selected, but no model root was found on this runner." >&2
+  echo "Expected the same model mounts used by daily-test-docker-image.yml:" >&2
+  ls -ld \
+    /public/opendas/DL_DATA/llm-models \
+    /parastor/opendas/DL_DATA/llm-models >&2 || true
+  exit 2
+fi
+
+if [[ "${#model_root_hosts[@]}" -gt 0 ]]; then
+  for index in "${!model_root_hosts[@]}"; do
+    echo "using HCU model root: ${model_root_hosts[$index]} -> ${model_root_containers[$index]}"
+    docker_args+=(
+      --volume "${model_root_hosts[$index]}:${model_root_containers[$index]}:ro"
+    )
+  done
+  model_root_search_path="$(IFS=:; echo "${model_root_containers[*]}")"
   docker_args+=(
-    --volume "$model_root:/models/llm-models:ro"
-    --env VLLM_HCU_TEST_MODEL_ROOT=/models/llm-models
+    --env "VLLM_HCU_TEST_MODEL_ROOT=${model_root_containers[0]}"
+    --env "VLLM_HCU_TEST_MODEL_ROOTS=$model_root_search_path"
   )
 fi
 

--- a/tests/hcu_ci_registry.py
+++ b/tests/hcu_ci_registry.py
@@ -157,6 +157,10 @@ register_hcu_ci(
         "test_falcon_mamba_tiny_real_prefill_decode_smoke"
     ),
     est_time=1200,
+    disabled=(
+        "required Falcon Mamba model is unavailable in the public and "
+        "parastor CI model roots"
+    ),
 )
 register_hcu_ci(
     job="kv-transfer",
@@ -205,8 +209,23 @@ register_hcu_ci(
 )
 register_hcu_ci(
     job="qwen3-pooling",
-    target="tests/integration/server/test_qwen3_pooling_server.py",
+    target=(
+        "tests/integration/server/test_qwen3_pooling_server.py::"
+        "test_qwen3_embedding_06b_openai_embeddings_server_smoke"
+    ),
     est_time=1800,
+)
+register_hcu_ci(
+    job="qwen3-pooling",
+    target=(
+        "tests/integration/server/test_qwen3_pooling_server.py::"
+        "test_qwen3_reranker_score_and_rerank_server_smoke"
+    ),
+    est_time=1800,
+    disabled=(
+        "required sequence-classification reranker model is unavailable in "
+        "the public and parastor CI model roots"
+    ),
 )
 register_hcu_ci(
     job="qwen3-protocol",
@@ -249,11 +268,19 @@ register_hcu_ci(
     job="glm52-pcp",
     target="tests/integration/models/test_glm52_pcp_mrv2.py",
     est_time=14400,
+    disabled=(
+        "required GLM-5.2 model is unavailable in the public and parastor CI "
+        "model roots"
+    ),
 )
 register_hcu_ci(
     job="glm52-pcp",
     target="tests/integration/server/test_evalscope_glm52_pcp_humaneval.py",
     est_time=14400,
+    disabled=(
+        "required GLM-5.2 model is unavailable in the public and parastor CI "
+        "model roots"
+    ),
 )
 register_hcu_ci(
     job="single-node-topology",

--- a/tests/patch/test_hcu_ci_selector.py
+++ b/tests/patch/test_hcu_ci_selector.py
@@ -9,6 +9,7 @@ import builtins
 from collections import defaultdict
 import datetime as dt
 import json
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -32,6 +33,7 @@ from hcu_ci_preflight import (  # noqa: E402
     _check_environment_lock,
     _check_requirements,
 )
+from run_hcu_ci_job import _export_resolved_resource_environment  # noqa: E402
 from build_hcu_matrix import MatrixError, build_matrix  # noqa: E402
 from compile_changed_python import _compile as compile_python_file  # noqa: E402
 from compile_changed_python import main as compile_changed_python_main  # noqa: E402
@@ -51,6 +53,14 @@ def _config() -> dict:
 def _selected_job_ids(*paths: str) -> set[str]:
     jobs, _, _ = select_jobs(_config(), paths)
     return {job["registry_job"] for job in jobs}
+
+
+def _enabled_registry_jobs() -> set[str]:
+    return {
+        registration.job
+        for registration in parse_registry()
+        if registration.disabled is None
+    }
 
 
 def _contains_pytest_hcu_marker(path: Path) -> bool:
@@ -73,10 +83,10 @@ def test_selector_configuration_is_valid() -> None:
     assert "single-node-topology" in jobs
 
 
-def test_full_matrix_contains_every_configured_job() -> None:
+def test_full_matrix_contains_every_enabled_registered_job() -> None:
     config = _config()
     matrix = build_matrix(config, profile="full")
-    assert {job["registry_job"] for job in matrix} == set(config["jobs"])
+    assert {job["registry_job"] for job in matrix} == _enabled_registry_jobs()
 
 
 def test_static_hcu_registry_covers_every_configured_job() -> None:
@@ -149,11 +159,10 @@ def test_nightly_matrix_explicitly_covers_extended_models_and_topology() -> None
     ids = {job["id"] for job in matrix}
     registry_jobs = {job["registry_job"] for job in matrix}
     assert len(ids) == len(matrix)
-    assert registry_jobs == set(config["jobs"])
+    assert registry_jobs == _enabled_registry_jobs()
     assert {
         "accuracy-gfx938",
         "integration-smoke-gfx938",
-        "mamba-smoke",
         "qwen25-models",
         "qwen3-pooling",
         "qwen3-protocol",
@@ -164,7 +173,8 @@ def test_nightly_matrix_explicitly_covers_extended_models_and_topology() -> None
 def test_every_registered_hcu_test_file_routes_to_one_of_its_jobs() -> None:
     jobs_by_file: dict[str, set[str]] = defaultdict(set)
     for registration in parse_registry():
-        jobs_by_file[registration.test_file].add(registration.job)
+        if registration.disabled is None:
+            jobs_by_file[registration.test_file].add(registration.job)
 
     missing = {
         test_file: sorted(expected_jobs)
@@ -376,6 +386,33 @@ def test_evalscope_is_required_only_by_evalscope_jobs() -> None:
         assert expected in config["jobs"][job_id]["requirements"]
     assert expected not in config["jobs"]["qwen35-smoke"]["requirements"]
 
+
+def test_unavailable_model_tests_are_disabled_without_blocking_related_jobs() -> None:
+    config = _config()
+    full_jobs = {
+        job["registry_job"] for job in build_matrix(config, profile="full")
+    }
+    nightly_jobs = {
+        job["registry_job"] for job in build_matrix(config, profile="nightly")
+    }
+    assert {"mamba-smoke", "glm52-pcp"}.isdisjoint(full_jobs)
+    assert {"mamba-smoke", "glm52-pcp"}.isdisjoint(nightly_jobs)
+
+    pooling_requirements = config["jobs"]["qwen3-pooling"]["requirements"]
+    assert not any(
+        requirement.get("env") == "VLLM_HCU_QWEN3_RERANKER_SEQCLS_06B_MODEL"
+        for requirement in pooling_requirements
+    )
+    disabled_targets = {
+        registration.target
+        for registration in parse_registry()
+        if registration.disabled is not None
+    }
+    assert (
+        "tests/integration/server/test_qwen3_pooling_server.py::"
+        "test_qwen3_reranker_score_and_rerank_server_smoke"
+    ) in disabled_targets
+
     environment_lock = json.loads(
         (
             REPOSITORY
@@ -417,6 +454,47 @@ def test_distribution_requirement_is_checked_on_demand(
     ]
 
 
+def test_model_requirement_searches_additional_model_roots(
+    tmp_path: Path,
+) -> None:
+    primary_root = tmp_path / "public"
+    secondary_root = tmp_path / "parastor"
+    model_path = secondary_root / "qwen3.5" / "Qwen3.5-9B"
+    primary_root.mkdir()
+    model_path.mkdir(parents=True)
+    (model_path / "config.json").write_text("{}\n", encoding="utf-8")
+    requirement = {
+        "kind": "model",
+        "env": "VLLM_HCU_QWEN35_9B_MODEL",
+        "relative": "qwen3.5/Qwen3.5-9B",
+    }
+
+    assert _check_requirements(
+        [requirement],
+        primary_root,
+        (secondary_root,),
+    ) == [
+        {
+            "env": "VLLM_HCU_QWEN35_9B_MODEL",
+            "kind": "model",
+            "path": str(model_path.resolve()),
+        }
+    ]
+
+
+def test_resolved_model_path_is_exported_for_selected_test(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env_name = "VLLM_HCU_QWEN35_9B_MODEL"
+    monkeypatch.delenv(env_name, raising=False)
+
+    _export_resolved_resource_environment(
+        [{"env": env_name, "kind": "model", "path": "/models/parastor/qwen"}]
+    )
+
+    assert os.environ[env_name] == "/models/parastor/qwen"
+
+
 def test_hcu_container_uses_checked_out_environment_lock() -> None:
     source = (
         REPOSITORY / "scripts/ci/hcu/hcu_ci_start_container.sh"
@@ -425,6 +503,11 @@ def test_hcu_container_uses_checked_out_environment_lock() -> None:
         "HCU_CI_ENVIRONMENT_LOCK=/vllm-plugin-das/.github/workflows/"
         "configs/hcu-runner-environment.json"
     ) in source
+    assert "/parastor/opendas/DL_DATA/llm-models" in source
+    assert "VLLM_HCU_TEST_MODEL_ROOTS" in source
+    assert "/models/public" in source
+    assert "/models/parastor" in source
+    assert ":/models/llm-models:ro" not in source
 
 
 def test_hcu_control_container_uses_runner_identity() -> None:
@@ -561,8 +644,12 @@ def test_release_push_is_independent_from_image_validation() -> None:
     assert "tools/run_patch_tests.py --suite contract" not in release
     assert "HCU_CI_VARIABLE_TOKEN" not in release
 
-    assert "workflow_run:" in validation
-    assert "- docker-image" in validation
+    assert "validate-image:" in release
+    assert "uses: ./.github/workflows/validate-docker-image.yml" in release
+    assert "image: ${{ needs.build.outputs.docker_image }}" in release
+    assert "workflow_call:" in validation
+    assert "image:" in validation
+    assert "required: true" in validation
     assert "actions/download-artifact@v4" not in validation
     assert "vllm:0.25.1-latest" in validation
     assert 'docker pull "$SOURCE_IMAGE"' in validation
@@ -748,12 +835,12 @@ def test_protocol_helper_change_selects_all_server_consumers() -> None:
     assert fallback is False
 
 
-def test_mamba_change_selects_real_mamba_smoke() -> None:
+def test_mamba_change_does_not_select_disabled_model_smoke() -> None:
     jobs, groups, fallback = select_jobs(
         _config(),
         ["vllm_hcu/model_executor/layers/mamba_runtime.py"],
     )
-    assert {job["registry_job"] for job in jobs} == {"mamba-smoke"}
+    assert jobs == []
     assert "mamba" in groups
     assert fallback is False
 


### PR DESCRIPTION
## Changes

- Mount both host model directories as `/models/public` and `/models/parastor`.
- Search all configured model roots when resolving test resources.
- Export resolved model paths through their corresponding environment variables.
- Temporarily disable Falcon Mamba, GLM-5.2, and Qwen3 SeqCls Reranker tests because their required models are unavailable on the current runners.
- Update the HCU test registry, test mapping, and related contract tests.
- Align the image validation assertions with the reusable workflow on the base branch.

## Validation

- HCU CI selector tests: `50 passed`
- HCU registration verification: passed
- Nightly matrix generation: passed
- Quarantine matrix generation: passed
- Workflow YAML validation: passed
- Shell syntax checks: passed

