### PR TITLE
[Bugfix] Backport stale multiproc RPC timeout guards (#41357)

### DIFF
--- a/tests/runtime_patch/test_multiproc_executor_timeout.py
+++ b/tests/runtime_patch/test_multiproc_executor_timeout.py
@@ -53,6 +53,39 @@ def _make_executor(hcu_executor):
     return executor
 
 
+def _make_patch_target_module(patch_multiproc_executor):
+    from vllm.distributed.device_communicators.shm_broadcast import (
+        MessageQueue as UpstreamMessageQueue,
+    )
+    from vllm.v1.executor import multiproc_executor as upstream
+
+    class MessageQueue(UpstreamMessageQueue):
+        pass
+
+    class MultiprocExecutor:
+        def _init_executor(self) -> None:
+            pass
+
+        def collective_rpc(
+            self,
+            method,
+            timeout=None,
+            args=(),
+            kwargs=None,
+            non_block=False,
+            unique_reply_rank=None,
+            kv_output_aggregator=None,
+        ):
+            pass
+
+    module = ModuleType(patch_multiproc_executor.TARGET_MODULE)
+    module.FutureWrapper = upstream.FutureWrapper
+    module.MessageQueue = MessageQueue
+    module.MultiprocExecutor = MultiprocExecutor
+    module.WorkerProc = upstream.WorkerProc
+    return module, MessageQueue
+
+
 def test_hcu_collective_rpc_clamps_stale_deadline(monkeypatch) -> None:
     from vllm_hcu.v1.executor import multiproc_executor as hcu_executor
 
@@ -103,21 +136,9 @@ def test_hcu_collective_rpc_preserves_valid_timeout(
 
 
 def test_multiproc_patch_clamps_negative_zmq_poll_timeout() -> None:
-    from vllm.distributed.device_communicators.shm_broadcast import (
-        MessageQueue as UpstreamMessageQueue,
-    )
     from vllm_hcu.patch.platform.framework_opt import patch_multiproc_executor
 
-    class MessageQueue(UpstreamMessageQueue):
-        pass
-
-    class MultiprocExecutor:
-        def _init_executor(self) -> None:
-            pass
-
-    module = ModuleType(patch_multiproc_executor.TARGET_MODULE)
-    module.MessageQueue = MessageQueue
-    module.MultiprocExecutor = MultiprocExecutor
+    module, message_queue = _make_patch_target_module(patch_multiproc_executor)
     assert patch_multiproc_executor.apply_to_module(module) is True
     assert patch_multiproc_executor.apply_to_module(module) is False
 
@@ -132,5 +153,121 @@ def test_multiproc_patch_clamps_negative_zmq_poll_timeout() -> None:
     socket = Socket()
     for timeout in (-1.0, None, 0.001, 2.5):
         with pytest.raises(TimeoutError):
-            MessageQueue.recv(socket, timeout)
+            message_queue.recv(socket, timeout)
     assert socket.poll_timeouts == [0, None, 1, 2500]
+
+
+def test_multiproc_patch_rejects_stale_recv_wrapper() -> None:
+    from vllm_hcu.patch.platform.framework_opt import patch_multiproc_executor
+
+    module, message_queue = _make_patch_target_module(patch_multiproc_executor)
+    assert patch_multiproc_executor.apply_to_module(module) is True
+
+    message_queue.recv = staticmethod(lambda socket, timeout: None)
+
+    with pytest.raises(
+        patch_multiproc_executor.PatchCompatibilityError,
+        match="marker.*stale",
+    ):
+        patch_multiproc_executor.apply_to_module(module)
+
+
+def test_multiproc_patch_rejects_orphan_recv_wrapper() -> None:
+    from vllm_hcu.patch.platform.framework_opt import patch_multiproc_executor
+
+    module, message_queue = _make_patch_target_module(patch_multiproc_executor)
+
+    def orphan_recv(socket, timeout):
+        pass
+
+    setattr(orphan_recv, patch_multiproc_executor._RECV_MARKER, True)
+    message_queue.recv = staticmethod(orphan_recv)
+
+    with pytest.raises(
+        patch_multiproc_executor.PatchCompatibilityError,
+        match="wrapped without its owner marker",
+    ):
+        patch_multiproc_executor.apply_to_module(module)
+
+
+def test_multiproc_patch_rejects_collective_rpc_signature_drift() -> None:
+    from vllm_hcu.patch.platform.framework_opt import patch_multiproc_executor
+
+    module, _ = _make_patch_target_module(patch_multiproc_executor)
+
+    def incompatible_collective_rpc(self, operation, timeout=None):
+        pass
+
+    module.MultiprocExecutor.collective_rpc = incompatible_collective_rpc
+
+    with pytest.raises(
+        patch_multiproc_executor.PatchCompatibilityError,
+        match=patch_multiproc_executor.TARGETS[1],
+    ):
+        patch_multiproc_executor.apply_to_module(module)
+
+
+@pytest.mark.parametrize(
+    ("attribute", "target"),
+    [
+        ("FutureWrapper", "vllm.v1.executor.multiproc_executor.FutureWrapper"),
+        ("WorkerProc", "vllm.v1.executor.multiproc_executor.WorkerProc"),
+    ],
+)
+def test_multiproc_patch_rejects_missing_rpc_dependency(
+    attribute: str,
+    target: str,
+) -> None:
+    from vllm_hcu.patch.platform.framework_opt import patch_multiproc_executor
+
+    module, _ = _make_patch_target_module(patch_multiproc_executor)
+    delattr(module, attribute)
+
+    with pytest.raises(
+        patch_multiproc_executor.PatchCompatibilityError,
+        match=target,
+    ):
+        patch_multiproc_executor.apply_to_module(module)
+
+
+def test_multiproc_patch_rejects_future_wrapper_signature_drift() -> None:
+    from vllm_hcu.patch.platform.framework_opt import patch_multiproc_executor
+
+    module, _ = _make_patch_target_module(patch_multiproc_executor)
+
+    class FutureWrapper:
+        def __init__(self, pending):
+            pass
+
+    module.FutureWrapper = FutureWrapper
+
+    with pytest.raises(
+        patch_multiproc_executor.PatchCompatibilityError,
+        match=patch_multiproc_executor.TARGETS[3],
+    ):
+        patch_multiproc_executor.apply_to_module(module)
+
+
+@pytest.mark.parametrize("include_response_status", [False, True])
+def test_multiproc_patch_rejects_incomplete_worker_status_contract(
+    include_response_status: bool,
+) -> None:
+    from vllm_hcu.patch.platform.framework_opt import patch_multiproc_executor
+
+    module, _ = _make_patch_target_module(patch_multiproc_executor)
+
+    class WorkerProc:
+        pass
+
+    if include_response_status:
+        class ResponseStatus:
+            pass
+
+        WorkerProc.ResponseStatus = ResponseStatus
+    module.WorkerProc = WorkerProc
+
+    with pytest.raises(
+        patch_multiproc_executor.PatchCompatibilityError,
+        match=patch_multiproc_executor.TARGETS[5],
+    ):
+        patch_multiproc_executor.apply_to_module(module)

--- a/tests/runtime_patch/test_multiproc_executor_timeout.py
+++ b/tests/runtime_patch/test_multiproc_executor_timeout.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Regression tests for stale HCU multiprocess RPC deadlines."""
+
+from __future__ import annotations
+
+import os
+from collections import deque
+from types import ModuleType
+
+import pytest
+
+os.environ.setdefault("VLLM_PLUGINS", "__disabled__")
+
+
+class _FakeClock:
+    def __init__(self, now: float) -> None:
+        self.now = now
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+class _FakeBroadcastQueue:
+    def __init__(self) -> None:
+        self.requests: list[object] = []
+
+    def enqueue(self, request: object) -> None:
+        self.requests.append(request)
+
+
+class _FakeResponseQueue:
+    def __init__(self, status: object) -> None:
+        self.status = status
+        self.timeouts: list[float | None] = []
+
+    def dequeue(self, timeout: float | None = None) -> tuple[object, str]:
+        assert timeout is None or timeout >= 0.0, (
+            f"dequeue received negative timeout: {timeout}"
+        )
+        self.timeouts.append(timeout)
+        return self.status, "response"
+
+
+def _make_executor(hcu_executor):
+    executor = object.__new__(hcu_executor.HcuMultiprocExecutor)
+    executor.rpc_broadcast_mq = _FakeBroadcastQueue()
+    executor.response_mqs = [
+        _FakeResponseQueue(hcu_executor._upstream.WorkerProc.ResponseStatus.SUCCESS)
+    ]
+    executor.futures_queue = deque()
+    executor.is_failed = False
+    return executor
+
+
+def test_hcu_collective_rpc_clamps_stale_deadline(monkeypatch) -> None:
+    from vllm_hcu.v1.executor import multiproc_executor as hcu_executor
+
+    clock = _FakeClock(100.0)
+    monkeypatch.setattr(hcu_executor._upstream.time, "monotonic", clock.monotonic)
+
+    executor = _make_executor(hcu_executor)
+
+    future = executor.collective_rpc(
+        "sample_tokens",
+        timeout=1.0,
+        non_block=True,
+    )
+    clock.now += 5.0
+
+    assert future.result() == ["response"]
+    assert executor.response_mqs[0].timeouts == [0.0]
+
+
+@pytest.mark.parametrize(
+    ("timeout", "elapsed", "expected"),
+    [
+        (None, 20.0, None),
+        (5.0, 2.0, 3.0),
+    ],
+)
+def test_hcu_collective_rpc_preserves_valid_timeout(
+    monkeypatch,
+    timeout: float | None,
+    elapsed: float,
+    expected: float | None,
+) -> None:
+    from vllm_hcu.v1.executor import multiproc_executor as hcu_executor
+
+    clock = _FakeClock(100.0)
+    monkeypatch.setattr(hcu_executor._upstream.time, "monotonic", clock.monotonic)
+    executor = _make_executor(hcu_executor)
+
+    future = executor.collective_rpc(
+        "sample_tokens",
+        timeout=timeout,
+        non_block=True,
+    )
+    clock.now += elapsed
+
+    assert future.result() == ["response"]
+    assert executor.response_mqs[0].timeouts == [expected]
+
+
+def test_multiproc_patch_clamps_negative_zmq_poll_timeout() -> None:
+    from vllm.distributed.device_communicators.shm_broadcast import (
+        MessageQueue as UpstreamMessageQueue,
+    )
+    from vllm_hcu.patch.platform.framework_opt import patch_multiproc_executor
+
+    class MessageQueue(UpstreamMessageQueue):
+        pass
+
+    class MultiprocExecutor:
+        def _init_executor(self) -> None:
+            pass
+
+    module = ModuleType(patch_multiproc_executor.TARGET_MODULE)
+    module.MessageQueue = MessageQueue
+    module.MultiprocExecutor = MultiprocExecutor
+    assert patch_multiproc_executor.apply_to_module(module) is True
+    assert patch_multiproc_executor.apply_to_module(module) is False
+
+    class Socket:
+        def __init__(self) -> None:
+            self.poll_timeouts: list[int | None] = []
+
+        def poll(self, timeout: int | None) -> bool:
+            self.poll_timeouts.append(timeout)
+            return False
+
+    socket = Socket()
+    for timeout in (-1.0, None, 0.001, 2.5):
+        with pytest.raises(TimeoutError):
+            MessageQueue.recv(socket, timeout)
+    assert socket.poll_timeouts == [0, None, 1, 2500]

--- a/vllm_hcu/patch/platform/framework_opt/patch_multiproc_executor.py
+++ b/vllm_hcu/patch/platform/framework_opt/patch_multiproc_executor.py
@@ -8,18 +8,28 @@ import functools
 import inspect
 from types import ModuleType
 
-from ._common import PatchCompatibilityError, load_exact_module, require_callable, require_class, require_signature_prefix
+from ._common import (
+    PatchCompatibilityError,
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_signature_prefix,
+)
 
 TARGET_MODULE = "vllm.v1.executor.multiproc_executor"
 PATCH_ID = "platform.framework_opt.hcu_multiproc_executor"
 TARGETS = (
     f"{TARGET_MODULE}.MultiprocExecutor",
+    f"{TARGET_MODULE}.MultiprocExecutor.collective_rpc",
     f"{TARGET_MODULE}.MessageQueue.recv",
+    f"{TARGET_MODULE}.FutureWrapper",
+    f"{TARGET_MODULE}.WorkerProc",
+    f"{TARGET_MODULE}.WorkerProc.ResponseStatus",
     "vllm_hcu.v1.executor.multiproc_executor.HcuMultiprocExecutor",
 )
 _MARKER = "_vllm_hcu_multiproc_contract_validated"
 _RECV_MARKER = "_vllm_hcu_non_negative_timeout"
-_ORIGINAL_RECV = "_vllm_hcu_original_recv"
 HCU_MULTIPROC_EXECUTOR_PATH = (
     "vllm_hcu.v1.executor.multiproc_executor.HcuMultiprocExecutor"
 )
@@ -28,15 +38,49 @@ UPSTREAM_MULTIPROC_EXECUTOR_PATH = TARGET_MODULE + ".MultiprocExecutor"
 
 def apply_to_module(module: ModuleType) -> bool:
     target = load_exact_module(TARGET_MODULE, module)
-    if getattr(target, _MARKER, False):
-        return False
     executor = require_class(target, "MultiprocExecutor", TARGETS[0])
+    message_queue = require_class(
+        target,
+        "MessageQueue",
+        f"{TARGET_MODULE}.MessageQueue",
+    )
+    if already_applied(
+        target,
+        _MARKER,
+        ((message_queue, "recv", _RECV_MARKER),),
+    ):
+        return False
     require_signature_prefix(
         require_callable(executor, "_init_executor", f"{TARGETS[0]}._init_executor"),
         f"{TARGETS[0]}._init_executor",
         ("self",),
     )
-    message_queue = require_class(target, "MessageQueue", f"{TARGET_MODULE}.MessageQueue")
+    require_signature_prefix(
+        require_callable(executor, "collective_rpc", TARGETS[1]),
+        TARGETS[1],
+        (
+            "self",
+            "method",
+            "timeout",
+            "args",
+            "kwargs",
+            "non_block",
+            "unique_reply_rank",
+            "kv_output_aggregator",
+        ),
+    )
+    future_wrapper = require_class(target, "FutureWrapper", TARGETS[3])
+    require_signature_prefix(
+        future_wrapper,
+        TARGETS[3],
+        ("futures_queue", "get_response", "aggregate"),
+    )
+    worker_proc = require_class(target, "WorkerProc", TARGETS[4])
+    response_status = require_class(worker_proc, "ResponseStatus", TARGETS[5])
+    if not hasattr(response_status, "SUCCESS"):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[5]}.SUCCESS is missing"
+        )
     try:
         signature = inspect.signature(message_queue)
     except (TypeError, ValueError) as exc:
@@ -45,10 +89,15 @@ def apply_to_module(module: ModuleType) -> bool:
         raise PatchCompatibilityError(
             f"vLLM MessageQueue lacks required max_chunks parameter: {signature}"
         )
-    original_recv = require_callable(message_queue, "recv", TARGETS[1])
+    original_recv = require_callable(message_queue, "recv", TARGETS[2])
+    if getattr(original_recv, _RECV_MARKER, False):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[2]} is wrapped without "
+            "its owner marker"
+        )
     require_signature_prefix(
         original_recv,
-        TARGETS[1],
+        TARGETS[2],
         ("socket", "timeout"),
     )
 
@@ -58,7 +107,6 @@ def apply_to_module(module: ModuleType) -> bool:
         return original_recv(socket, timeout)
 
     setattr(hcu_recv, _RECV_MARKER, True)
-    setattr(message_queue, _ORIGINAL_RECV, original_recv)
     setattr(message_queue, "recv", staticmethod(hcu_recv))
     setattr(target, _MARKER, True)
     return True

--- a/vllm_hcu/patch/platform/framework_opt/patch_multiproc_executor.py
+++ b/vllm_hcu/patch/platform/framework_opt/patch_multiproc_executor.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import functools
 import inspect
 from types import ModuleType
 
@@ -13,9 +14,12 @@ TARGET_MODULE = "vllm.v1.executor.multiproc_executor"
 PATCH_ID = "platform.framework_opt.hcu_multiproc_executor"
 TARGETS = (
     f"{TARGET_MODULE}.MultiprocExecutor",
+    f"{TARGET_MODULE}.MessageQueue.recv",
     "vllm_hcu.v1.executor.multiproc_executor.HcuMultiprocExecutor",
 )
 _MARKER = "_vllm_hcu_multiproc_contract_validated"
+_RECV_MARKER = "_vllm_hcu_non_negative_timeout"
+_ORIGINAL_RECV = "_vllm_hcu_original_recv"
 HCU_MULTIPROC_EXECUTOR_PATH = (
     "vllm_hcu.v1.executor.multiproc_executor.HcuMultiprocExecutor"
 )
@@ -41,6 +45,21 @@ def apply_to_module(module: ModuleType) -> bool:
         raise PatchCompatibilityError(
             f"vLLM MessageQueue lacks required max_chunks parameter: {signature}"
         )
+    original_recv = require_callable(message_queue, "recv", TARGETS[1])
+    require_signature_prefix(
+        original_recv,
+        TARGETS[1],
+        ("socket", "timeout"),
+    )
+
+    @functools.wraps(original_recv)
+    def hcu_recv(socket, timeout):
+        timeout = None if timeout is None else max(0.0, timeout)
+        return original_recv(socket, timeout)
+
+    setattr(hcu_recv, _RECV_MARKER, True)
+    setattr(message_queue, _ORIGINAL_RECV, original_recv)
+    setattr(message_queue, "recv", staticmethod(hcu_recv))
     setattr(target, _MARKER, True)
     return True
 

--- a/vllm_hcu/v1/executor/multiproc_executor.py
+++ b/vllm_hcu/v1/executor/multiproc_executor.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 import os
 import threading
+import time
+from collections.abc import Callable, Sequence
+from functools import partial
 from typing import Any
 
 from vllm.v1.executor import multiproc_executor as _upstream
@@ -76,6 +79,76 @@ class HcuMultiprocExecutor(_upstream.MultiprocExecutor):
     """
 
     _mq_constructor_lock = threading.RLock()
+
+    def collective_rpc(  # type: ignore[override]
+        self,
+        method: str | Callable,
+        timeout: float | None = None,
+        args: tuple = (),
+        kwargs: dict | None = None,
+        non_block: bool = False,
+        unique_reply_rank: int | None = None,
+        kv_output_aggregator: Any | None = None,
+    ) -> Any:
+        """Call every worker without allowing an expired deadline to go negative."""
+        assert self.rpc_broadcast_mq is not None, (
+            "collective_rpc should not be called on follower node"
+        )
+        if self.is_failed:
+            raise RuntimeError("Executor failed.")
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        kwargs = kwargs or {}
+
+        if kv_output_aggregator is not None:
+            output_rank = None
+            aggregate: Callable[[Any], Any] = partial(
+                kv_output_aggregator.aggregate,
+                output_rank=unique_reply_rank or 0,
+            )
+        else:
+            output_rank = unique_reply_rank
+            aggregate = lambda value: value
+
+        if isinstance(method, str):
+            send_method = method
+        else:
+            send_method = _upstream.cloudpickle.dumps(
+                method,
+                protocol=_upstream.pickle.HIGHEST_PROTOCOL,
+            )
+        self.rpc_broadcast_mq.enqueue((send_method, args, kwargs, output_rank))
+
+        response_mqs: Sequence[_upstream.MessageQueue] = self.response_mqs
+        if output_rank is not None:
+            response_mqs = (response_mqs[output_rank],)
+
+        def get_response() -> Any:
+            responses = []
+            for mq in response_mqs:
+                dequeue_timeout = (
+                    None
+                    if deadline is None
+                    else max(0.0, deadline - time.monotonic())
+                )
+                try:
+                    status, result = mq.dequeue(timeout=dequeue_timeout)
+                except TimeoutError as exc:
+                    raise TimeoutError(f"RPC call to {method} timed out.") from exc
+                if status != _upstream.WorkerProc.ResponseStatus.SUCCESS:
+                    raise RuntimeError(
+                        f"Worker failed with error '{result}', please check the"
+                        " stack trace above for the root cause"
+                    )
+                responses.append(result)
+            return responses[0] if output_rank is not None else responses
+
+        future = _upstream.FutureWrapper(
+            self.futures_queue,
+            get_response=get_response,
+            aggregate=aggregate,
+        )
+        return future if non_block else future.result()
 
     def _init_executor(self) -> None:
         global _FORK_ORIGINAL_MESSAGE_QUEUE, _FORK_PROXY_MESSAGE_QUEUE


### PR DESCRIPTION
## Summary

Backport vllm-project/vllm#41357 to the HCU plugin without patching the installed vLLM source tree.

- clamp expired `collective_rpc` deadlines in `HcuMultiprocExecutor` before dequeuing worker responses
- clamp negative `MessageQueue.recv` timeouts at the existing runtime-patch boundary before conversion to ZMQ milliseconds
- fail closed when the recv wrapper marker is stale/orphaned or required vLLM RPC contracts drift
- add regression coverage for stale, finite, and unbounded deadlines, ZMQ poll conversion, marker integrity, and upstream compatibility contracts

Upstream: https://github.com/vllm-project/vllm/pull/41357

## Tests

```text
VLLM_PLUGINS=__disabled__ PYTHONPATH=$PWD python -m pytest -q \
  tests/runtime_patch/test_multiproc_executor_timeout.py \
  tests/runtime_patch/test_platform_framework_opt.py \
  tests/patch/test_plugin_lifecycle.py \
  tests/patch/test_platform_dispatcher.py

79 passed, 14 warnings
```

Additional checks:

- real installed vLLM 0.25.1 contract and idempotency probe
- `python tools/check_production_boundary.py`
- `python tools/check_patch_test_coverage.py`
- `python -m compileall` on changed Python files
- `git diff --check`