### PR TITLE
fix(hy-v4): support fp8_e4m3 KV cache

### DIFF
--- a/tests/integration/model_runtime.py
+++ b/tests/integration/model_runtime.py
@@ -838,6 +838,49 @@ def _case_mtp_parity(
     }
 
 
+def _case_hy_v4_kv_cache_parity(
+    model_path: Path,
+    *,
+    tensor_parallel_size: int,
+    gpu_memory_utilization: float | None,
+    moe_backend: str,
+    enable_expert_parallel: bool,
+    kv_cache_dtype: str,
+    num_speculative_tokens: int,
+) -> dict[str, Any]:
+    common_kwargs = {
+        "tensor_parallel_size": tensor_parallel_size,
+        "gpu_memory_utilization": gpu_memory_utilization,
+        "moe_backend": moe_backend,
+        "enable_expert_parallel": enable_expert_parallel,
+    }
+    baseline = _generate(
+        model_path,
+        enforce_eager=True,
+        **common_kwargs,
+    )
+    quantized = _generate(
+        model_path,
+        enforce_eager=True,
+        **common_kwargs,
+        kv_cache_dtype=kv_cache_dtype,
+    )
+    quantized_mtp = _generate(
+        model_path,
+        enforce_eager=True,
+        **common_kwargs,
+        kv_cache_dtype=kv_cache_dtype,
+        spec_method="mtp",
+        spec_tokens=num_speculative_tokens,
+    )
+    return {
+        "baseline": baseline,
+        "quantized": quantized,
+        "quantized_mtp": quantized_mtp,
+        "kv_cache_dtype": kv_cache_dtype,
+    }
+
+
 def _case_kv_transfer_smoke(model_path: Path) -> dict[str, Any]:
     from vllm import LLM
     from vllm.config.kv_transfer import KVTransferConfig
@@ -1622,6 +1665,7 @@ def _main(argv: list[str] | None = None) -> int:
             "reranker-smoke",
             "vl-image-smoke",
             "tp-ep-smoke",
+            "hy-v4-kv-cache-parity",
             "deepseek-v4-dspark-smoke",
         ),
     )
@@ -1635,6 +1679,7 @@ def _main(argv: list[str] | None = None) -> int:
     parser.add_argument("--all2all-backend", default=None)
     parser.add_argument("--moe-backend", default="auto")
     parser.add_argument("--num-speculative-tokens", type=int, default=1)
+    parser.add_argument("--kv-cache-dtype", default="fp8_e4m3")
     parser.add_argument(
         "--disable-expert-parallel",
         action="store_true",
@@ -1701,6 +1746,16 @@ def _main(argv: list[str] | None = None) -> int:
             all2all_backend=args.all2all_backend,
             moe_backend=args.moe_backend,
             enable_expert_parallel=not args.disable_expert_parallel,
+        )
+    elif args.case == "hy-v4-kv-cache-parity":
+        payload = _case_hy_v4_kv_cache_parity(
+            args.model,
+            tensor_parallel_size=args.tensor_parallel_size,
+            gpu_memory_utilization=args.gpu_memory_utilization,
+            moe_backend=args.moe_backend,
+            enable_expert_parallel=not args.disable_expert_parallel,
+            kv_cache_dtype=args.kv_cache_dtype,
+            num_speculative_tokens=args.num_speculative_tokens,
         )
     else:
         payload = _case_deepseek_v4_dspark(

--- a/tests/integration/models/test_hy_v4_smoke.py
+++ b/tests/integration/models/test_hy_v4_smoke.py
@@ -113,3 +113,54 @@ def test_hy_v4_blockwise_pure_tp8_mtp_three_token_parity(
     assert all(speculative_tokens)
     for record in [*result["baseline"], *result["speculative"]]:
         _assert_completion(record)
+
+
+def test_hy_v4_fp8_e4m3_kv_cache_prefill_decode_and_mtp_parity(
+    hcu_test_resources: HcuTestResources,
+) -> None:
+    model_path = require_model_runtime(
+        hcu_test_resources,
+        env_name="VLLM_HCU_HY_V4_MODEL",
+        relative_path=HY_V4_MODEL,
+        label="HY V4 FP8 E4M3 KV-cache parity",
+        hcu_count=8,
+    )
+
+    result = run_vllm_case(
+        "hy-v4-kv-cache-parity",
+        model_path,
+        timeout_s=7200,
+        gpu_memory_utilization=0.95,
+        log_label="hy-v4-fp8-e4m3-kv-cache-parity",
+        extra_env={
+            "VLLM_USE_V2_MODEL_RUNNER": "1",
+            "VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD": "0",
+        },
+        extra_args=[
+            "--tensor-parallel-size",
+            "8",
+            "--disable-expert-parallel",
+            "--moe-backend",
+            "triton",
+            "--kv-cache-dtype",
+            "fp8_e4m3",
+            "--num-speculative-tokens",
+            "3",
+        ],
+    )
+
+    baseline_tokens = [record["token_ids"] for record in result["baseline"]]
+    quantized_tokens = [record["token_ids"] for record in result["quantized"]]
+    quantized_mtp_tokens = [
+        record["token_ids"] for record in result["quantized_mtp"]
+    ]
+    assert result["kv_cache_dtype"] == "fp8_e4m3"
+    assert quantized_tokens == baseline_tokens
+    assert quantized_mtp_tokens == baseline_tokens
+    assert all(baseline_tokens)
+    for record in [
+        *result["baseline"],
+        *result["quantized"],
+        *result["quantized_mtp"],
+    ]:
+        _assert_completion(record)

--- a/tests/integration/test_model_runtime_cli.py
+++ b/tests/integration/test_model_runtime_cli.py
@@ -13,6 +13,105 @@ from tests.integration import model_runtime
 
 
 DEEPSEEK_V4_MODEL = Path("/models/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8")
+HY_V4_MODEL = Path("/models/Hy4-preview-FP8-Testing")
+
+
+def test_hy_v4_kv_cache_parity_exercises_baseline_quantized_and_mtp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_generate(model_path: Path, **kwargs):
+        calls.append({"model_path": model_path, **kwargs})
+        return [{"token_ids": [len(calls)]}]
+
+    monkeypatch.setattr(model_runtime, "_generate", fake_generate)
+
+    result = model_runtime._case_hy_v4_kv_cache_parity(
+        HY_V4_MODEL,
+        tensor_parallel_size=8,
+        gpu_memory_utilization=0.95,
+        moe_backend="triton",
+        enable_expert_parallel=False,
+        kv_cache_dtype="fp8_e4m3",
+        num_speculative_tokens=3,
+    )
+
+    common = {
+        "model_path": HY_V4_MODEL,
+        "enforce_eager": True,
+        "tensor_parallel_size": 8,
+        "gpu_memory_utilization": 0.95,
+        "moe_backend": "triton",
+        "enable_expert_parallel": False,
+    }
+    assert calls == [
+        common,
+        {**common, "kv_cache_dtype": "fp8_e4m3"},
+        {
+            **common,
+            "kv_cache_dtype": "fp8_e4m3",
+            "spec_method": "mtp",
+            "spec_tokens": 3,
+        },
+    ]
+    assert result == {
+        "baseline": [{"token_ids": [1]}],
+        "quantized": [{"token_ids": [2]}],
+        "quantized_mtp": [{"token_ids": [3]}],
+        "kv_cache_dtype": "fp8_e4m3",
+    }
+
+
+def test_hy_v4_kv_cache_parity_cli_forwards_runtime_options(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_case(model_path: Path, **kwargs):
+        captured["model_path"] = model_path
+        captured.update(kwargs)
+        return {"baseline": [], "quantized": [], "quantized_mtp": []}
+
+    monkeypatch.setattr(
+        model_runtime,
+        "_case_hy_v4_kv_cache_parity",
+        fake_case,
+        raising=False,
+    )
+
+    assert (
+        model_runtime._main(
+            [
+                "hy-v4-kv-cache-parity",
+                "--model",
+                str(HY_V4_MODEL),
+                "--tensor-parallel-size",
+                "8",
+                "--gpu-memory-utilization",
+                "0.95",
+                "--moe-backend",
+                "triton",
+                "--disable-expert-parallel",
+                "--kv-cache-dtype",
+                "fp8_e4m3",
+                "--num-speculative-tokens",
+                "3",
+            ]
+        )
+        == 0
+    )
+    assert captured == {
+        "model_path": HY_V4_MODEL,
+        "tensor_parallel_size": 8,
+        "gpu_memory_utilization": 0.95,
+        "moe_backend": "triton",
+        "enable_expert_parallel": False,
+        "kv_cache_dtype": "fp8_e4m3",
+        "num_speculative_tokens": 3,
+    }
+    assert "VLLM_HCU_RESULT=" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(

--- a/tests/models/hy_v4/test_attention.py
+++ b/tests/models/hy_v4/test_attention.py
@@ -10,6 +10,7 @@ import torch
 
 from vllm_hcu.models.hy_v4 import hcu_sparse
 from vllm_hcu.models.hy_v4.attention import (
+    _normalize_hy_v4_kv_cache_dtype,
     _require_accuracy_safe_kv_cache_dtype,
     _require_sparse_mqa_backend,
     compute_skip_topk_layers,
@@ -23,17 +24,28 @@ from vllm_hcu.models.hy_v4.hcu_sparse import (
 )
 
 
-@pytest.mark.parametrize("cache_dtype", ["fp8", "fp8_e4m3", "fp8_ds_mla"])
+@pytest.mark.parametrize("cache_dtype", ["fp8"])
 def test_hy_v4_rejects_accuracy_unsafe_kv_cache_dtype(
     cache_dtype: str,
 ) -> None:
-    with pytest.raises(RuntimeError, match="use --kv-cache-dtype auto"):
+    with pytest.raises(RuntimeError, match="--kv-cache-dtype fp8_e4m3"):
         _require_accuracy_safe_kv_cache_dtype(cache_dtype)
 
 
-@pytest.mark.parametrize("cache_dtype", ["auto", "bfloat16"])
+@pytest.mark.parametrize(
+    "cache_dtype", ["auto", "bfloat16", "fp8_e4m3", "fp8_ds_mla"]
+)
 def test_hy_v4_accepts_accuracy_safe_kv_cache_dtype(cache_dtype: str) -> None:
     _require_accuracy_safe_kv_cache_dtype(cache_dtype)
+
+
+def test_hy_v4_normalizes_fp8_e4m3_for_sparse_flashmla_selection() -> None:
+    assert _normalize_hy_v4_kv_cache_dtype("fp8_e4m3") == "fp8_ds_mla"
+
+
+@pytest.mark.parametrize("cache_dtype", ["auto", "bfloat16", "fp8_ds_mla"])
+def test_hy_v4_preserves_native_kv_cache_dtype(cache_dtype: str) -> None:
+    assert _normalize_hy_v4_kv_cache_dtype(cache_dtype) == cache_dtype
 
 
 def test_full_and_shared_indexer_pattern() -> None:

--- a/tests/models/hy_v4/test_attention.py
+++ b/tests/models/hy_v4/test_attention.py
@@ -40,12 +40,25 @@ def test_hy_v4_accepts_accuracy_safe_kv_cache_dtype(cache_dtype: str) -> None:
 
 
 def test_hy_v4_normalizes_fp8_e4m3_for_sparse_flashmla_selection() -> None:
-    assert _normalize_hy_v4_kv_cache_dtype("fp8_e4m3") == "fp8_ds_mla"
+    assert (
+        _normalize_hy_v4_kv_cache_dtype("fp8_e4m3", use_sparse=True)
+        == "fp8_ds_mla"
+    )
+
+
+def test_hy_v4_preserves_fp8_e4m3_for_dense_flashmla_selection() -> None:
+    assert (
+        _normalize_hy_v4_kv_cache_dtype("fp8_e4m3", use_sparse=False)
+        == "fp8_e4m3"
+    )
 
 
 @pytest.mark.parametrize("cache_dtype", ["auto", "bfloat16", "fp8_ds_mla"])
 def test_hy_v4_preserves_native_kv_cache_dtype(cache_dtype: str) -> None:
-    assert _normalize_hy_v4_kv_cache_dtype(cache_dtype) == cache_dtype
+    assert (
+        _normalize_hy_v4_kv_cache_dtype(cache_dtype, use_sparse=True)
+        == cache_dtype
+    )
 
 
 def test_full_and_shared_indexer_pattern() -> None:

--- a/vllm_hcu/models/hy_v4/attention.py
+++ b/vllm_hcu/models/hy_v4/attention.py
@@ -50,13 +50,27 @@ _WEIGHT_LAYER_INDEX_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
 
 def _require_accuracy_safe_kv_cache_dtype(kv_cache_dtype: str) -> None:
     """Reject HY V4 KV-cache formats without verified output parity."""
-    if kv_cache_dtype not in ("auto", "bfloat16"):
+    if kv_cache_dtype not in (
+        "auto",
+        "bfloat16",
+        "fp8_e4m3",
+        "fp8_ds_mla",
+    ):
         raise RuntimeError(
-            "HY V4 accuracy-first inference currently supports only auto or "
-            f"bfloat16 KV cache; got {kv_cache_dtype!r}. "
-            "use --kv-cache-dtype auto until quantized KV-cache parity is "
-            "restored."
+            "HY V4 accuracy-first inference supports auto, bfloat16, "
+            "fp8_e4m3, or fp8_ds_mla KV cache; "
+            f"got {kv_cache_dtype!r}. "
+            "use --kv-cache-dtype fp8_e4m3 or fp8_ds_mla for quantized "
+            "KV cache."
         )
+
+
+def _normalize_hy_v4_kv_cache_dtype(kv_cache_dtype: str) -> str:
+    """Normalize HY V4's E4M3 alias to the sparse FlashMLA cache layout."""
+    _require_accuracy_safe_kv_cache_dtype(kv_cache_dtype)
+    if kv_cache_dtype == "fp8_e4m3":
+        return "fp8_ds_mla"
+    return kv_cache_dtype
 
 
 def require_hyv4_sink_backend(
@@ -397,7 +411,9 @@ class HYV4MLAAttention(nn.Module):
         # Do not silently degrade sparse layers into dense attention. Probe the
         # sparse MLA backend directly and fail fast with the real error.
         kv_cache_dtype = cache_config.cache_dtype if cache_config else "auto"
-        _require_accuracy_safe_kv_cache_dtype(kv_cache_dtype)
+        kv_cache_dtype = _normalize_hy_v4_kv_cache_dtype(kv_cache_dtype)
+        if cache_config is not None:
+            cache_config.cache_dtype = cast(CacheDType, kv_cache_dtype)
         if self.is_sparse:
             try:
                 get_attn_backend(

--- a/vllm_hcu/models/hy_v4/attention.py
+++ b/vllm_hcu/models/hy_v4/attention.py
@@ -65,10 +65,14 @@ def _require_accuracy_safe_kv_cache_dtype(kv_cache_dtype: str) -> None:
         )
 
 
-def _normalize_hy_v4_kv_cache_dtype(kv_cache_dtype: str) -> str:
+def _normalize_hy_v4_kv_cache_dtype(
+    kv_cache_dtype: str,
+    *,
+    use_sparse: bool,
+) -> str:
     """Normalize HY V4's E4M3 alias to the sparse FlashMLA cache layout."""
     _require_accuracy_safe_kv_cache_dtype(kv_cache_dtype)
-    if kv_cache_dtype == "fp8_e4m3":
+    if use_sparse and kv_cache_dtype == "fp8_e4m3":
         return "fp8_ds_mla"
     return kv_cache_dtype
 
@@ -410,9 +414,17 @@ class HYV4MLAAttention(nn.Module):
 
         # Do not silently degrade sparse layers into dense attention. Probe the
         # sparse MLA backend directly and fail fast with the real error.
-        kv_cache_dtype = cache_config.cache_dtype if cache_config else "auto"
-        kv_cache_dtype = _normalize_hy_v4_kv_cache_dtype(kv_cache_dtype)
-        if cache_config is not None:
+        requested_kv_cache_dtype = (
+            cache_config.cache_dtype if cache_config else "auto"
+        )
+        kv_cache_dtype = _normalize_hy_v4_kv_cache_dtype(
+            requested_kv_cache_dtype,
+            use_sparse=self.is_sparse,
+        )
+        if (
+            cache_config is not None
+            and kv_cache_dtype != requested_kv_cache_dtype
+        ):
             cache_config.cache_dtype = cast(CacheDType, kv_cache_dtype)
         if self.is_sparse:
             try:


### PR DESCRIPTION
## Summary
- allow HY4 to use `fp8_ds_mla` KV cache directly
- normalize `fp8_e4m3` to the sparse FlashMLA `fp8_ds_mla` layout only for sparse layers
- preserve standard `fp8_e4m3` for non-sparse FlashMLA layers
- keep ambiguous `fp8` rejected with an actionable error
- add real HCU parity coverage for BF16/auto, FP8 E4M3, and FP8 E4M3 + MTP

## Tests
- `python -m pytest tests/models/hy_v4 tests/integration/test_model_runtime_cli.py -q` (129 passed)
- `VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 python -m pytest -q --ignore=tests/integration` (1368 passed)
- `python .github/scripts/hcu_ci/verify_hcu_registration.py --format summary` (39 registrations, 23 jobs)
- Python compile checks and `git diff --check`
- `tests/integration/models/test_hy_v4_smoke.py` collects successfully and skips locally because no HY4 checkpoint is mounted. The new real-model parity test is registered under `hy-v4-tp8`; note that PR workflows currently listen only to base branch `v0.25.1`, so PR #61 targeting the feature branch does not auto-run that hardware job.