### PR TITLE
feat(hy-v4): integrate PCP+EP and FP8 KV cache into blockwise v0.25.1

### DIFF
--- a/tests/integration/model_runtime.py
+++ b/tests/integration/model_runtime.py
@@ -838,6 +838,49 @@ def _case_mtp_parity(
     }
 
 
+def _case_hy_v4_kv_cache_parity(
+    model_path: Path,
+    *,
+    tensor_parallel_size: int,
+    gpu_memory_utilization: float | None,
+    moe_backend: str,
+    enable_expert_parallel: bool,
+    kv_cache_dtype: str,
+    num_speculative_tokens: int,
+) -> dict[str, Any]:
+    common_kwargs = {
+        "tensor_parallel_size": tensor_parallel_size,
+        "gpu_memory_utilization": gpu_memory_utilization,
+        "moe_backend": moe_backend,
+        "enable_expert_parallel": enable_expert_parallel,
+    }
+    baseline = _generate(
+        model_path,
+        enforce_eager=True,
+        **common_kwargs,
+    )
+    quantized = _generate(
+        model_path,
+        enforce_eager=True,
+        **common_kwargs,
+        kv_cache_dtype=kv_cache_dtype,
+    )
+    quantized_mtp = _generate(
+        model_path,
+        enforce_eager=True,
+        **common_kwargs,
+        kv_cache_dtype=kv_cache_dtype,
+        spec_method="mtp",
+        spec_tokens=num_speculative_tokens,
+    )
+    return {
+        "baseline": baseline,
+        "quantized": quantized,
+        "quantized_mtp": quantized_mtp,
+        "kv_cache_dtype": kv_cache_dtype,
+    }
+
+
 def _case_kv_transfer_smoke(model_path: Path) -> dict[str, Any]:
     from vllm import LLM
     from vllm.config.kv_transfer import KVTransferConfig
@@ -1622,6 +1665,7 @@ def _main(argv: list[str] | None = None) -> int:
             "reranker-smoke",
             "vl-image-smoke",
             "tp-ep-smoke",
+            "hy-v4-kv-cache-parity",
             "deepseek-v4-dspark-smoke",
         ),
     )
@@ -1635,6 +1679,7 @@ def _main(argv: list[str] | None = None) -> int:
     parser.add_argument("--all2all-backend", default=None)
     parser.add_argument("--moe-backend", default="auto")
     parser.add_argument("--num-speculative-tokens", type=int, default=1)
+    parser.add_argument("--kv-cache-dtype", default="fp8_e4m3")
     parser.add_argument(
         "--disable-expert-parallel",
         action="store_true",
@@ -1701,6 +1746,16 @@ def _main(argv: list[str] | None = None) -> int:
             all2all_backend=args.all2all_backend,
             moe_backend=args.moe_backend,
             enable_expert_parallel=not args.disable_expert_parallel,
+        )
+    elif args.case == "hy-v4-kv-cache-parity":
+        payload = _case_hy_v4_kv_cache_parity(
+            args.model,
+            tensor_parallel_size=args.tensor_parallel_size,
+            gpu_memory_utilization=args.gpu_memory_utilization,
+            moe_backend=args.moe_backend,
+            enable_expert_parallel=not args.disable_expert_parallel,
+            kv_cache_dtype=args.kv_cache_dtype,
+            num_speculative_tokens=args.num_speculative_tokens,
         )
     else:
         payload = _case_deepseek_v4_dspark(

--- a/tests/integration/models/test_hy_v4_smoke.py
+++ b/tests/integration/models/test_hy_v4_smoke.py
@@ -113,3 +113,54 @@ def test_hy_v4_blockwise_pure_tp8_mtp_three_token_parity(
     assert all(speculative_tokens)
     for record in [*result["baseline"], *result["speculative"]]:
         _assert_completion(record)
+
+
+def test_hy_v4_fp8_e4m3_kv_cache_prefill_decode_and_mtp_parity(
+    hcu_test_resources: HcuTestResources,
+) -> None:
+    model_path = require_model_runtime(
+        hcu_test_resources,
+        env_name="VLLM_HCU_HY_V4_MODEL",
+        relative_path=HY_V4_MODEL,
+        label="HY V4 FP8 E4M3 KV-cache parity",
+        hcu_count=8,
+    )
+
+    result = run_vllm_case(
+        "hy-v4-kv-cache-parity",
+        model_path,
+        timeout_s=7200,
+        gpu_memory_utilization=0.95,
+        log_label="hy-v4-fp8-e4m3-kv-cache-parity",
+        extra_env={
+            "VLLM_USE_V2_MODEL_RUNNER": "1",
+            "VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD": "0",
+        },
+        extra_args=[
+            "--tensor-parallel-size",
+            "8",
+            "--disable-expert-parallel",
+            "--moe-backend",
+            "triton",
+            "--kv-cache-dtype",
+            "fp8_e4m3",
+            "--num-speculative-tokens",
+            "3",
+        ],
+    )
+
+    baseline_tokens = [record["token_ids"] for record in result["baseline"]]
+    quantized_tokens = [record["token_ids"] for record in result["quantized"]]
+    quantized_mtp_tokens = [
+        record["token_ids"] for record in result["quantized_mtp"]
+    ]
+    assert result["kv_cache_dtype"] == "fp8_e4m3"
+    assert quantized_tokens == baseline_tokens
+    assert quantized_mtp_tokens == baseline_tokens
+    assert all(baseline_tokens)
+    for record in [
+        *result["baseline"],
+        *result["quantized"],
+        *result["quantized_mtp"],
+    ]:
+        _assert_completion(record)

--- a/tests/integration/test_model_runtime_cli.py
+++ b/tests/integration/test_model_runtime_cli.py
@@ -13,6 +13,105 @@ from tests.integration import model_runtime
 
 
 DEEPSEEK_V4_MODEL = Path("/models/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8")
+HY_V4_MODEL = Path("/models/Hy4-preview-FP8-Testing")
+
+
+def test_hy_v4_kv_cache_parity_exercises_baseline_quantized_and_mtp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_generate(model_path: Path, **kwargs):
+        calls.append({"model_path": model_path, **kwargs})
+        return [{"token_ids": [len(calls)]}]
+
+    monkeypatch.setattr(model_runtime, "_generate", fake_generate)
+
+    result = model_runtime._case_hy_v4_kv_cache_parity(
+        HY_V4_MODEL,
+        tensor_parallel_size=8,
+        gpu_memory_utilization=0.95,
+        moe_backend="triton",
+        enable_expert_parallel=False,
+        kv_cache_dtype="fp8_e4m3",
+        num_speculative_tokens=3,
+    )
+
+    common = {
+        "model_path": HY_V4_MODEL,
+        "enforce_eager": True,
+        "tensor_parallel_size": 8,
+        "gpu_memory_utilization": 0.95,
+        "moe_backend": "triton",
+        "enable_expert_parallel": False,
+    }
+    assert calls == [
+        common,
+        {**common, "kv_cache_dtype": "fp8_e4m3"},
+        {
+            **common,
+            "kv_cache_dtype": "fp8_e4m3",
+            "spec_method": "mtp",
+            "spec_tokens": 3,
+        },
+    ]
+    assert result == {
+        "baseline": [{"token_ids": [1]}],
+        "quantized": [{"token_ids": [2]}],
+        "quantized_mtp": [{"token_ids": [3]}],
+        "kv_cache_dtype": "fp8_e4m3",
+    }
+
+
+def test_hy_v4_kv_cache_parity_cli_forwards_runtime_options(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_case(model_path: Path, **kwargs):
+        captured["model_path"] = model_path
+        captured.update(kwargs)
+        return {"baseline": [], "quantized": [], "quantized_mtp": []}
+
+    monkeypatch.setattr(
+        model_runtime,
+        "_case_hy_v4_kv_cache_parity",
+        fake_case,
+        raising=False,
+    )
+
+    assert (
+        model_runtime._main(
+            [
+                "hy-v4-kv-cache-parity",
+                "--model",
+                str(HY_V4_MODEL),
+                "--tensor-parallel-size",
+                "8",
+                "--gpu-memory-utilization",
+                "0.95",
+                "--moe-backend",
+                "triton",
+                "--disable-expert-parallel",
+                "--kv-cache-dtype",
+                "fp8_e4m3",
+                "--num-speculative-tokens",
+                "3",
+            ]
+        )
+        == 0
+    )
+    assert captured == {
+        "model_path": HY_V4_MODEL,
+        "tensor_parallel_size": 8,
+        "gpu_memory_utilization": 0.95,
+        "moe_backend": "triton",
+        "enable_expert_parallel": False,
+        "kv_cache_dtype": "fp8_e4m3",
+        "num_speculative_tokens": 3,
+    }
+    assert "VLLM_HCU_RESULT=" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(

--- a/tests/models/hy_v4/test_attention.py
+++ b/tests/models/hy_v4/test_attention.py
@@ -10,6 +10,7 @@ import torch
 
 from vllm_hcu.models.hy_v4 import hcu_sparse
 from vllm_hcu.models.hy_v4.attention import (
+    _normalize_hy_v4_kv_cache_dtype,
     _require_accuracy_safe_kv_cache_dtype,
     _require_sparse_mqa_backend,
     compute_skip_topk_layers,
@@ -23,17 +24,28 @@ from vllm_hcu.models.hy_v4.hcu_sparse import (
 )
 
 
-@pytest.mark.parametrize("cache_dtype", ["fp8", "fp8_e4m3", "fp8_ds_mla"])
+@pytest.mark.parametrize("cache_dtype", ["fp8"])
 def test_hy_v4_rejects_accuracy_unsafe_kv_cache_dtype(
     cache_dtype: str,
 ) -> None:
-    with pytest.raises(RuntimeError, match="use --kv-cache-dtype auto"):
+    with pytest.raises(RuntimeError, match="--kv-cache-dtype fp8_e4m3"):
         _require_accuracy_safe_kv_cache_dtype(cache_dtype)
 
 
-@pytest.mark.parametrize("cache_dtype", ["auto", "bfloat16"])
+@pytest.mark.parametrize(
+    "cache_dtype", ["auto", "bfloat16", "fp8_e4m3", "fp8_ds_mla"]
+)
 def test_hy_v4_accepts_accuracy_safe_kv_cache_dtype(cache_dtype: str) -> None:
     _require_accuracy_safe_kv_cache_dtype(cache_dtype)
+
+
+def test_hy_v4_normalizes_fp8_e4m3_for_sparse_flashmla_selection() -> None:
+    assert _normalize_hy_v4_kv_cache_dtype("fp8_e4m3") == "fp8_ds_mla"
+
+
+@pytest.mark.parametrize("cache_dtype", ["auto", "bfloat16", "fp8_ds_mla"])
+def test_hy_v4_preserves_native_kv_cache_dtype(cache_dtype: str) -> None:
+    assert _normalize_hy_v4_kv_cache_dtype(cache_dtype) == cache_dtype
 
 
 def test_full_and_shared_indexer_pattern() -> None:

--- a/tests/models/hy_v4/test_attention.py
+++ b/tests/models/hy_v4/test_attention.py
@@ -40,12 +40,25 @@ def test_hy_v4_accepts_accuracy_safe_kv_cache_dtype(cache_dtype: str) -> None:
 
 
 def test_hy_v4_normalizes_fp8_e4m3_for_sparse_flashmla_selection() -> None:
-    assert _normalize_hy_v4_kv_cache_dtype("fp8_e4m3") == "fp8_ds_mla"
+    assert (
+        _normalize_hy_v4_kv_cache_dtype("fp8_e4m3", use_sparse=True)
+        == "fp8_ds_mla"
+    )
+
+
+def test_hy_v4_preserves_fp8_e4m3_for_dense_flashmla_selection() -> None:
+    assert (
+        _normalize_hy_v4_kv_cache_dtype("fp8_e4m3", use_sparse=False)
+        == "fp8_e4m3"
+    )
 
 
 @pytest.mark.parametrize("cache_dtype", ["auto", "bfloat16", "fp8_ds_mla"])
 def test_hy_v4_preserves_native_kv_cache_dtype(cache_dtype: str) -> None:
-    assert _normalize_hy_v4_kv_cache_dtype(cache_dtype) == cache_dtype
+    assert (
+        _normalize_hy_v4_kv_cache_dtype(cache_dtype, use_sparse=True)
+        == cache_dtype
+    )
 
 
 def test_full_and_shared_indexer_pattern() -> None:

--- a/tests/models/hy_v4/test_attention.py
+++ b/tests/models/hy_v4/test_attention.py
@@ -7,9 +7,11 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from vllm.v1.kv_cache_interface import KVQuantMode, MLAAttentionSpec
 
 from vllm_hcu.models.hy_v4 import hcu_sparse
 from vllm_hcu.models.hy_v4.attention import (
+    HYV4MLAAttentionLayer,
     _normalize_hy_v4_kv_cache_dtype,
     _require_accuracy_safe_kv_cache_dtype,
     _require_sparse_mqa_backend,
@@ -59,6 +61,27 @@ def test_hy_v4_preserves_native_kv_cache_dtype(cache_dtype: str) -> None:
         _normalize_hy_v4_kv_cache_dtype(cache_dtype, use_sparse=True)
         == cache_dtype
     )
+
+
+def test_hy_v4_mla_cache_spec_marks_fp8_as_quantized(monkeypatch) -> None:
+    spec = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.uint8,
+        cache_dtype_str="fp8_ds_mla",
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.attention.MLAAttention.get_kv_cache_spec",
+        lambda self, vllm_config: spec,
+    )
+    attention = object.__new__(HYV4MLAAttentionLayer)
+    attention.kv_cache_dtype = "fp8_ds_mla"
+
+    resolved = attention.get_kv_cache_spec(SimpleNamespace())
+
+    assert resolved.kv_quant_mode == KVQuantMode.FP8_PER_TENSOR
+    assert resolved.page_size_bytes == 64 * 656
 
 
 def test_full_and_shared_indexer_pattern() -> None:

--- a/tests/runtime_patch/test_fp8_channel_triton_product.py
+++ b/tests/runtime_patch/test_fp8_channel_triton_product.py
@@ -22,10 +22,12 @@ _TRITON_MODULE = (
     "vllm.model_executor.layers.quantization.compressed_tensors."
     "triton_scaled_mm"
 )
+_LIGHTOP_MODULE = "lightop.gemm_ops"
 _FP8_DTYPE = getattr(torch, "float8_e4m3fnuz", None)
+_LIGHTOP_FP8_DTYPE = getattr(torch, "float8_e4m3fn", None)
 
 pytestmark = pytest.mark.skipif(
-    _FP8_DTYPE is None,
+    _FP8_DTYPE is None or _LIGHTOP_FP8_DTYPE is None,
     reason="the target vLLM Channel-FP8 contract requires torch FP8 dtypes",
 )
 
@@ -67,7 +69,12 @@ def _install_fake_module_tree(
 def fake_product(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
     original_calls: list[dict[str, object]] = []
     triton_calls: list[dict[str, object]] = []
+    lightop_calls: list[dict[str, object]] = []
     state: dict[str, object] = {}
+
+    # Most existing product tests exercise the retained Triton route. Tests
+    # for the default/custom route delete or override this value explicitly.
+    monkeypatch.setenv("VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM", "0")
 
     def original_get_output_padding(self):
         return "target-padding"
@@ -130,11 +137,48 @@ def fake_product(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
     )
     triton = ModuleType(_TRITON_MODULE)
     triton.triton_scaled_mm = triton_scaled_mm
+    lightop = ModuleType(_LIGHTOP_MODULE)
+
+    def hipblaslt_w8a8_channelwise_gemm(
+        a,
+        b,
+        scale_a,
+        scale_b,
+        m,
+        n,
+        k,
+        transpose_flag,
+        out_dtype,
+        bias=None,
+    ):
+        values = torch.arange(m * n, dtype=torch.float32).reshape(1, m, n)
+        result = values.to(out_dtype)
+        lightop_calls.append(
+            {
+                "a": a,
+                "b": b,
+                "scale_a": scale_a,
+                "scale_b": scale_b,
+                "m": m,
+                "n": n,
+                "k": k,
+                "transpose_flag": transpose_flag,
+                "out_dtype": out_dtype,
+                "bias": bias,
+                "result": result,
+            }
+        )
+        return True, result
+
+    lightop.hipblaslt_w8a8_channelwise_gemm = (
+        hipblaslt_w8a8_channelwise_gemm
+    )
     _install_fake_module_tree(
         monkeypatch,
         {
             _TARGET_MODULE: target,
             _TRITON_MODULE: triton,
+            _LIGHTOP_MODULE: lightop,
         },
     )
     # Ordinary product tests exercise adapter ownership and eager contracts.
@@ -155,6 +199,7 @@ def fake_product(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
         original_apply_scaled_mm=original_apply_scaled_mm,
         original_calls=original_calls,
         triton_calls=triton_calls,
+        lightop_calls=lightop_calls,
         state=state,
     )
 
@@ -485,7 +530,7 @@ def test_existing_marker_without_reviewed_wrapper_identity_fails_closed(
 ):
     fake_product.channel_class._hcu_fp8_patch_applied = True
     fake_product.channel_class._hcu_fp8_backend = "target-triton"
-    with pytest.raises(RuntimeError, match="without the reviewed target Triton"):
+    with pytest.raises(RuntimeError, match="without the reviewed HCU wrapper"):
         scaled_mm.install_fp8_scaled_mm_compat(fake_product.target)
 
 
@@ -534,6 +579,104 @@ def test_channelwise_route_calls_target_triton_and_reshapes_output(
     ].untyped_storage().data_ptr()
     assert kwargs["B"].stride() == (1, kwargs["A"].shape[1])
     assert fake_product.original_calls == []
+
+
+@pytest.mark.parametrize("value", [None, "1", "true"])
+def test_channelwise_route_uses_lightop_by_default_or_when_enabled(
+    fake_product: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    value: str | None,
+):
+    if value is None:
+        monkeypatch.delenv(
+            "VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM",
+            raising=False,
+        )
+    else:
+        monkeypatch.setenv("VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM", value)
+    kernel = _install_and_make_kernel(fake_product)
+    kwargs = _valid_call(output_shape=(2, 3, 5))
+    kwargs["A"] = kwargs["A"].to(_LIGHTOP_FP8_DTYPE)
+    kwargs["B"] = _column_major_weight(4, 5, dtype=_LIGHTOP_FP8_DTYPE)
+
+    output = kernel.apply_scaled_mm(**kwargs)
+
+    assert tuple(output.shape) == (2, 3, 5)
+    assert fake_product.triton_calls == []
+    assert len(fake_product.lightop_calls) == 1
+    call = fake_product.lightop_calls[0]
+    assert call["a"] is kwargs["A"]
+    assert tuple(call["b"].shape) == (
+        kwargs["B"].shape[1],
+        kwargs["B"].shape[0],
+    )
+    assert call["b"].is_contiguous()
+    assert call["b"].untyped_storage().data_ptr() == (
+        kwargs["B"].untyped_storage().data_ptr()
+    )
+    assert call["scale_a"] is kwargs["As"]
+    assert call["scale_b"] is kwargs["Bs"]
+    assert (call["m"], call["n"], call["k"]) == (6, 5, 4)
+    assert call["transpose_flag"] == "NT"
+    assert call["out_dtype"] is torch.bfloat16
+    assert call["bias"] is kwargs["bias"]
+    assert output.untyped_storage().data_ptr() == (
+        call["result"].untyped_storage().data_ptr()
+    )
+    assert fake_product.channel_class._hcu_fp8_backend == "lightop"
+
+
+def test_lightop_backend_resolution_returns_stable_adapter(
+    fake_product: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM", "1")
+
+    first_name, first_backend = scaled_mm._resolve_scaled_mm_backend()
+    second_name, second_backend = scaled_mm._resolve_scaled_mm_backend()
+
+    assert first_name == second_name == "lightop"
+    assert first_backend is second_backend
+
+
+@pytest.mark.parametrize(
+    ("case", "match"),
+    [
+        ("fp8-fnuz", "float8_e4m3fn"),
+        ("scale-f16", "float32 scales"),
+        ("output-f32", "float16 or bfloat16"),
+        ("bias-mismatch", "bias dtype"),
+    ],
+)
+def test_lightop_route_rejects_unsupported_dtypes_before_backend(
+    fake_product: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    match: str,
+):
+    monkeypatch.setenv("VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM", "1")
+    kernel = _install_and_make_kernel(fake_product)
+    kwargs = _valid_call()
+    kwargs["A"] = kwargs["A"].to(_LIGHTOP_FP8_DTYPE)
+    kwargs["B"] = _column_major_weight(4, 5, dtype=_LIGHTOP_FP8_DTYPE)
+
+    if case == "fp8-fnuz":
+        kwargs["A"] = kwargs["A"].to(_FP8_DTYPE)
+        kwargs["B"] = _column_major_weight(4, 5, dtype=_FP8_DTYPE)
+    elif case == "scale-f16":
+        kwargs["As"] = kwargs["As"].to(torch.float16)
+        kwargs["Bs"] = kwargs["Bs"].to(torch.float16)
+    elif case == "output-f32":
+        kwargs["out_dtype"] = torch.float32
+        kwargs["bias"] = kwargs["bias"].to(torch.float32)
+    elif case == "bias-mismatch":
+        kwargs["bias"] = kwargs["bias"].to(torch.float16)
+    else:  # pragma: no cover - protects the parameter table itself
+        raise AssertionError(f"unknown test case: {case}")
+
+    with pytest.raises(ValueError, match=match):
+        kernel.apply_scaled_mm(**kwargs)
+    assert fake_product.lightop_calls == []
 
 
 def test_channelwise_route_preserves_target_per_tensor_weight_scale(
@@ -791,6 +934,7 @@ def test_channelwise_custom_op_keeps_full_profile_range_in_one_graph():
             "PYTHONNOUSERSITE": "1",
             "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
             "VLLM_PLUGINS": "__disabled__",
+            "VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM": "0",
         }
     )
     completed = subprocess.run(
@@ -968,7 +1112,7 @@ def test_incompatible_triton_outputs_fail_closed_without_fallback(
         )
 
     fake_product.state["behavior"] = bad_behavior
-    with pytest.raises(RuntimeError, match="target triton_scaled_mm"):
+    with pytest.raises(RuntimeError, match="selected Channel-FP8 backend"):
         kernel.apply_scaled_mm(**kwargs)
     assert len(fake_product.triton_calls) == 1
     assert fake_product.original_calls == []

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -231,6 +231,7 @@ def test_all2all_auto_builds_ht_and_ll_around_one_manager_handle():
         "physical_to_global": "physical-to-global",
         "local_expert_global_ids": "local-ids",
     }
+    assert result.ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer is True
     int8_result = module.maybe_make_prepare_finalize(
         moe,
         SimpleNamespace(quant_dtype=torch.int8),
@@ -245,6 +246,7 @@ def test_all2all_auto_builds_ht_and_ll_around_one_manager_handle():
         "physical_to_global": "physical-to-global",
         "local_expert_global_ids": "local-ids",
     }
+    assert int8_result.ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer is True
     assert module.maybe_roundup_layer_hidden_size(
         10, torch.float16, moe.moe_parallel_config
     ) == 13
@@ -3141,8 +3143,17 @@ def test_deepep_ll_non_hcu_dispatch_signatures_delegate_to_upstream(
     )
 
 
-def test_deepep_ll_fp8_auto_detects_hcu_buffer_dispatch_abi(
+@pytest.mark.parametrize(
+    ("shared_with_high_throughput", "expected_clean_calls"),
+    [
+        (False, []),
+        (True, [(8, 2048, 1, 128), (8, 2048, 1, 128)]),
+    ],
+)
+def test_deepep_ll_fp8_cleans_only_when_buffer_is_shared_with_high_throughput(
     monkeypatch: pytest.MonkeyPatch,
+    shared_with_high_throughput: bool,
+    expected_clean_calls: list[tuple[int, int, int, int]],
 ):
     module = _fake_deepep_ll_module()
     module.torch = torch
@@ -3212,6 +3223,10 @@ def test_deepep_ll_fp8_auto_detects_hcu_buffer_dispatch_abi(
             return expert_x, torch.ones(1, dtype=torch.int32), "handle", None, lambda: None
 
     instance = cls(Buffer(), 8, 1, use_fp8_dispatch=True)
+    if shared_with_high_throughput:
+        instance._vllm_hcu_clean_low_latency_buffer = True
+    else:
+        del instance._vllm_hcu_clean_low_latency_buffer
     instance.handles = [None]
     instance.use_int8_dispatch = False
     instance.use_ue8m0_dispatch = False
@@ -3256,14 +3271,13 @@ def test_deepep_ll_fp8_auto_detects_hcu_buffer_dispatch_abi(
     assert calls["topk_weight"] is topk_weights
     assert calls["quant_type"] == 2
     assert calls["quant_group_size"] == 128
-    assert calls["clean"] == [
-        (8, 2048, 1, 128),
-        (8, 2048, 1, 128),
-    ]
+    assert calls.get("clean", []) == expected_clean_calls
 
 
+@pytest.mark.parametrize("shared_with_high_throughput", [False, True])
 def test_deepep_ll_hcu_int8_dispatch_contract(
     monkeypatch: pytest.MonkeyPatch,
+    shared_with_high_throughput: bool,
 ):
     module = _fake_deepep_ll_module()
 
@@ -3307,6 +3321,7 @@ def test_deepep_ll_hcu_int8_dispatch_contract(
             return expert_x, expert_counts, "handle", None, lambda: None
 
     instance = cls(Buffer(), 8, 1, use_int8_dispatch=True)
+    instance._vllm_hcu_clean_low_latency_buffer = shared_with_high_throughput
     instance.handles = [None, None]
     instance.use_ue8m0_dispatch = False
     quant_config = SimpleNamespace(
@@ -3355,12 +3370,16 @@ def test_deepep_ll_hcu_int8_dispatch_contract(
         False,
         quant_config,
     )
-    assert calls["order"] == [
-        ("clean", (8, 2048, 1, 0)),
-        ("dispatch", 1),
-        ("clean", (8, 2048, 1, 0)),
-        ("dispatch", 1),
-    ]
+    expected_dispatches = [("dispatch", 1), ("dispatch", 1)]
+    if shared_with_high_throughput:
+        assert calls["order"] == [
+            ("clean", (8, 2048, 1, 0)),
+            expected_dispatches[0],
+            ("clean", (8, 2048, 1, 0)),
+            expected_dispatches[1],
+        ]
+    else:
+        assert calls["order"] == expected_dispatches
 
     fp8_instance = cls(None, 8, 1, use_fp8_dispatch=True)
     fp8_instance.use_int8_dispatch = False

--- a/tests/runtime_patch/test_patch_base_communicator_pcp.py
+++ b/tests/runtime_patch/test_patch_base_communicator_pcp.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Tests for patch_base_communicator_pcp: widens use_all2all under PCP + EP."""
+
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from vllm_hcu.patch.worker.framework_opt import patch_base_communicator_pcp
+
+
+# ---------------------------------------------------------------------------
+# Fake vLLM ``base_device_communicator`` module
+# ---------------------------------------------------------------------------
+
+
+def _module(name: str, **attributes: object) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    return module
+
+
+def _fake_base_communicator_module() -> ModuleType:
+    """Reproduce the audited vLLM 0.25.1 DeviceCommunicatorBase surface.
+
+    Only the parts our patch inspects are modeled: the constructor signature,
+    ``is_ep_communicator``/``use_all2all``/``all2all_backend`` attributes.
+    """
+
+    class DeviceCommunicatorBase:
+        def __init__(
+            self,
+            cpu_group,
+            device=None,
+            device_group=None,
+            unique_name: str = "",
+            global_ranks=None,
+            global_world_size=None,
+        ):
+            self.cpu_group = cpu_group
+            self.device = device
+            self.device_group = device_group
+            self.unique_name = unique_name
+            # Reproduce the upstream deduction of these three attributes;
+            # only their final values matter to the patch.
+            self.is_ep_communicator = unique_name.split(":")[0] == "ep"
+            self.use_all2all = False
+            self.all2all_backend = None
+
+    return _module(
+        patch_base_communicator_pcp.TARGET_MODULE,
+        DeviceCommunicatorBase=DeviceCommunicatorBase,
+    )
+
+
+def _install_vllm_config(monkeypatch: pytest.MonkeyPatch, config: object) -> None:
+    import vllm.config
+
+    monkeypatch.setattr(
+        vllm.config, "get_current_vllm_config_or_none", lambda: config
+    )
+
+
+def _pcp_ep_config(
+    *,
+    pcp_size: int = 8,
+    ep_enabled: bool = True,
+    backend: str | None = "deepep_high_throughput",
+) -> SimpleNamespace:
+    parallel = SimpleNamespace(
+        prefill_context_parallel_size=pcp_size,
+        enable_expert_parallel=ep_enabled,
+        all2all_backend=backend,
+        data_parallel_size=1,
+    )
+    return SimpleNamespace(parallel_config=parallel)
+
+
+# ---------------------------------------------------------------------------
+# Positive path: PCP + EP + DeepEP backend forces use_all2all=True
+# ---------------------------------------------------------------------------
+
+
+def test_base_pcp_ep_forces_use_all2all_for_pcp_ep_deepep_ht(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(monkeypatch, _pcp_ep_config())
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.is_ep_communicator is True
+    assert communicator.use_all2all is True
+
+
+def test_base_pcp_ep_forces_use_all2all_for_pcp_ep_deepep_ll(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(
+        monkeypatch, _pcp_ep_config(backend="deepep_low_latency")
+    )
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.use_all2all is True
+
+
+# ---------------------------------------------------------------------------
+# Negative paths: patch must leave use_all2all=False in every other scenario
+# ---------------------------------------------------------------------------
+
+
+def test_base_pcp_ep_ignores_non_ep_communicator(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(monkeypatch, _pcp_ep_config())
+    for unique_name in ("tp:0", "pp:0", "dp:0", "world", ""):
+        communicator = module.DeviceCommunicatorBase(
+            object(), unique_name=unique_name
+        )
+        assert communicator.is_ep_communicator is False
+        assert communicator.use_all2all is False, unique_name
+
+
+def test_base_pcp_ep_ignores_non_deepep_backend(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    for backend in ("naive", "pynccl", "allgather_reducescatter", None):
+        _install_vllm_config(
+            monkeypatch, _pcp_ep_config(backend=backend)
+        )
+        communicator = module.DeviceCommunicatorBase(
+            object(), unique_name="ep:0"
+        )
+        assert communicator.use_all2all is False, backend
+
+
+def test_base_pcp_ep_ignores_pcp_size_one(monkeypatch: pytest.MonkeyPatch):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(monkeypatch, _pcp_ep_config(pcp_size=1))
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.use_all2all is False
+
+
+def test_base_pcp_ep_ignores_expert_parallel_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(monkeypatch, _pcp_ep_config(ep_enabled=False))
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.use_all2all is False
+
+
+def test_base_pcp_ep_preserves_upstream_use_all2all_true(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When upstream already flipped use_all2all=True (DP>1 case), do nothing."""
+    module = _fake_base_communicator_module()
+
+    class UpstreamAlreadyEnabled(module.DeviceCommunicatorBase):
+        def __init__(
+            self,
+            cpu_group,
+            device=None,
+            device_group=None,
+            unique_name: str = "",
+            global_ranks=None,
+            global_world_size=None,
+        ):
+            super().__init__(
+                cpu_group,
+                device=device,
+                device_group=device_group,
+                unique_name=unique_name,
+                global_ranks=global_ranks,
+                global_world_size=global_world_size,
+            )
+            # Simulate upstream having chosen to enable all2all already.
+            self.use_all2all = True
+
+    module.DeviceCommunicatorBase = UpstreamAlreadyEnabled
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    # Even if PCP+EP is off, upstream's True must remain True.
+    _install_vllm_config(
+        monkeypatch, _pcp_ep_config(pcp_size=1, ep_enabled=False)
+    )
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.use_all2all is True
+
+
+def test_base_pcp_ep_tolerates_missing_vllm_config(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(monkeypatch, None)
+    # Should not raise; use_all2all stays False.
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.use_all2all is False
+
+
+def test_base_pcp_ep_tolerates_missing_parallel_config(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(monkeypatch, SimpleNamespace(parallel_config=None))
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.use_all2all is False
+
+
+# ---------------------------------------------------------------------------
+# Contract tests: idempotency, signature validation
+# ---------------------------------------------------------------------------
+
+
+def test_base_pcp_ep_apply_is_idempotent():
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+    # Second call must report no-op via the marker path.
+    assert patch_base_communicator_pcp.apply_to_module(module) is False
+
+
+def test_base_pcp_ep_rejects_incompatible_init_signature():
+    from vllm_hcu.patch.worker.framework_opt._common import (
+        PatchCompatibilityError,
+    )
+
+    class DeviceCommunicatorBase:
+        def __init__(self, cpu_group):  # missing keyword args
+            self.cpu_group = cpu_group
+
+    module = _module(
+        patch_base_communicator_pcp.TARGET_MODULE,
+        DeviceCommunicatorBase=DeviceCommunicatorBase,
+    )
+    with pytest.raises(PatchCompatibilityError):
+        patch_base_communicator_pcp.apply_to_module(module)
+
+
+def test_base_pcp_ep_rejects_missing_class():
+    from vllm_hcu.patch.worker.framework_opt._common import (
+        PatchCompatibilityError,
+    )
+
+    module = _module(patch_base_communicator_pcp.TARGET_MODULE)
+    with pytest.raises(PatchCompatibilityError):
+        patch_base_communicator_pcp.apply_to_module(module)
+
+
+# ---------------------------------------------------------------------------
+# Registration tests
+# ---------------------------------------------------------------------------
+
+
+def test_base_pcp_ep_registered_as_deepep_gated_callback():
+    from vllm_hcu.patch import worker as worker_dispatcher
+
+    names = worker_dispatcher.worker_callback_names()
+    assert (
+        patch_base_communicator_pcp.PATCH_ID,
+        patch_base_communicator_pcp.TARGET_MODULE,
+    ) in names
+
+    features = worker_dispatcher._patch_features()
+    assert features[patch_base_communicator_pcp.PATCH_ID] == "deepep"
+
+
+def test_base_pcp_ep_dispatched_before_deep_ep_runtime():
+    """Must run before patch_all2all so use_all2all is set first."""
+    from vllm_hcu.patch import worker as worker_dispatcher
+
+    order = [
+        patch_id
+        for patch_id, _target in worker_dispatcher.worker_callback_names()
+    ]
+    assert (
+        patch_base_communicator_pcp.PATCH_ID in order
+        and "worker.framework_opt.communicator.deep_ep_runtime" in order
+    )
+    assert order.index(patch_base_communicator_pcp.PATCH_ID) < order.index(
+        "worker.framework_opt.communicator.deep_ep_runtime"
+    )
+
+
+def test_base_pcp_ep_patch_id_matches_adapter():
+    """PATCH_ID string must match the one declared inside the adapter."""
+    assert (
+        patch_base_communicator_pcp.PATCH_ID
+        == "worker.framework_opt.communicator.base_pcp_ep"
+    )
+    assert (
+        patch_base_communicator_pcp.TARGET_MODULE
+        == "vllm.distributed.device_communicators.base_device_communicator"
+    )
+    assert patch_base_communicator_pcp.TARGETS == (
+        f"{patch_base_communicator_pcp.TARGET_MODULE}"
+        ".DeviceCommunicatorBase.__init__",
+    )

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -2493,12 +2493,13 @@ def test_aiter_topk_supports_old_and_new_abi(
     assert len(calls[0]) == (7 if extended else 5)
 
 
-def test_scaled_mm_prequantized_input_bypasses_quantizer():
+@pytest.mark.parametrize("backend", ["lightop", "target-triton"])
+def test_scaled_mm_prequantized_input_bypasses_quantizer(backend: str):
     calls: list[tuple[object, ...]] = []
 
     class FP8ScaledMMLinearKernel:
         _hcu_fp8_patch_applied = True
-        _hcu_fp8_backend = "target-triton"
+        _hcu_fp8_backend = backend
 
         def apply_weights(self, layer, x, bias=None):
             calls.append(("original", layer, x, bias))
@@ -5535,12 +5536,14 @@ def test_fp8_channel_weight_layout_requires_hcu_kernel(monkeypatch: pytest.Monke
     scheme = module.CompressedTensorsW8A8Fp8()
     scheme.strategy = channel
     scheme.fp8_linear = object()
-    with pytest.raises(RuntimeError, match="target Triton scaled-mm adapter"):
+    with pytest.raises(RuntimeError, match="HCU scaled-mm adapter"):
         scheme.process_weights_after_loading(SimpleNamespace(weight=torch.ones(2, 3)))
 
 
-def test_fp8_target_triton_route_is_independent_of_general_custom_gemm_flag(
+@pytest.mark.parametrize("backend", ["lightop", "target-triton"])
+def test_fp8_channel_backend_preserves_weight_layout(
     monkeypatch: pytest.MonkeyPatch,
+    backend: str,
 ):
     from vllm_hcu.platforms import envs as henvs
 
@@ -5550,7 +5553,7 @@ def test_fp8_target_triton_route_is_independent_of_general_custom_gemm_flag(
 
     class Kernel:
         _hcu_fp8_patch_applied = True
-        _hcu_fp8_backend = "target-triton"
+        _hcu_fp8_backend = backend
 
     scheme = module.CompressedTensorsW8A8Fp8()
     scheme.strategy = channel
@@ -5561,14 +5564,18 @@ def test_fp8_target_triton_route_is_independent_of_general_custom_gemm_flag(
     assert layer.weight.stride() == (1, 3)
 
 
-def test_fp8_scheme_forwards_prequantized_input(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize("backend", ["lightop", "target-triton"])
+def test_fp8_scheme_forwards_prequantized_input(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+):
     module, channel = _fake_fp8_scheme_module()
     patch_compressed_tensors_w8a8_fp8.apply_to_module(module)
     calls: list[tuple[object, ...]] = []
 
     class Kernel:
         _hcu_fp8_patch_applied = True
-        _hcu_fp8_backend = "target-triton"
+        _hcu_fp8_backend = backend
 
         def supports_quanted_inputs(self):
             return True

--- a/vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py
@@ -287,6 +287,7 @@ def ll_init(
         local_expert_global_ids,
     )
     self.use_int8_dispatch = bool(use_int8_dispatch)
+    self._vllm_hcu_clean_low_latency_buffer = False
     self._hcu_low_latency_dispatch_abi = _has_hcu_low_latency_dispatch_abi(buffer)
 
 
@@ -472,17 +473,18 @@ def ll_prepare_async(
             if block_k is None and quant_config.per_act_token_quant
             else module.DEEPEP_QUANT_BLOCK_SIZE
         )
-    cleanup = getattr(self.buffer, "clean_low_latency_buffer", None)
-    if not callable(cleanup):
-        raise RuntimeError(
-            "HCU DeepEP LL buffer does not expose clean_low_latency_buffer"
+    if getattr(self, "_vllm_hcu_clean_low_latency_buffer", False):
+        cleanup = getattr(self.buffer, "clean_low_latency_buffer", None)
+        if not callable(cleanup):
+            raise RuntimeError(
+                "HCU DeepEP LL buffer does not expose clean_low_latency_buffer"
+            )
+        cleanup(
+            self.max_tokens_per_rank,
+            hidden_size,
+            num_experts,
+            quant_group_size,
         )
-    cleanup(
-        self.max_tokens_per_rank,
-        hidden_size,
-        num_experts,
-        quant_group_size,
-    )
     try:
         if use_hcu_api:
             result = self.buffer.low_latency_dispatch(

--- a/vllm_hcu/models/hy_v4/attention.py
+++ b/vllm_hcu/models/hy_v4/attention.py
@@ -50,13 +50,27 @@ _WEIGHT_LAYER_INDEX_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
 
 def _require_accuracy_safe_kv_cache_dtype(kv_cache_dtype: str) -> None:
     """Reject HY V4 KV-cache formats without verified output parity."""
-    if kv_cache_dtype not in ("auto", "bfloat16"):
+    if kv_cache_dtype not in (
+        "auto",
+        "bfloat16",
+        "fp8_e4m3",
+        "fp8_ds_mla",
+    ):
         raise RuntimeError(
-            "HY V4 accuracy-first inference currently supports only auto or "
-            f"bfloat16 KV cache; got {kv_cache_dtype!r}. "
-            "use --kv-cache-dtype auto until quantized KV-cache parity is "
-            "restored."
+            "HY V4 accuracy-first inference supports auto, bfloat16, "
+            "fp8_e4m3, or fp8_ds_mla KV cache; "
+            f"got {kv_cache_dtype!r}. "
+            "use --kv-cache-dtype fp8_e4m3 or fp8_ds_mla for quantized "
+            "KV cache."
         )
+
+
+def _normalize_hy_v4_kv_cache_dtype(kv_cache_dtype: str) -> str:
+    """Normalize HY V4's E4M3 alias to the sparse FlashMLA cache layout."""
+    _require_accuracy_safe_kv_cache_dtype(kv_cache_dtype)
+    if kv_cache_dtype == "fp8_e4m3":
+        return "fp8_ds_mla"
+    return kv_cache_dtype
 
 
 def require_hyv4_sink_backend(
@@ -397,7 +411,9 @@ class HYV4MLAAttention(nn.Module):
         # Do not silently degrade sparse layers into dense attention. Probe the
         # sparse MLA backend directly and fail fast with the real error.
         kv_cache_dtype = cache_config.cache_dtype if cache_config else "auto"
-        _require_accuracy_safe_kv_cache_dtype(kv_cache_dtype)
+        kv_cache_dtype = _normalize_hy_v4_kv_cache_dtype(kv_cache_dtype)
+        if cache_config is not None:
+            cache_config.cache_dtype = cast(CacheDType, kv_cache_dtype)
         if self.is_sparse:
             try:
                 get_attn_backend(

--- a/vllm_hcu/models/hy_v4/attention.py
+++ b/vllm_hcu/models/hy_v4/attention.py
@@ -65,10 +65,14 @@ def _require_accuracy_safe_kv_cache_dtype(kv_cache_dtype: str) -> None:
         )
 
 
-def _normalize_hy_v4_kv_cache_dtype(kv_cache_dtype: str) -> str:
+def _normalize_hy_v4_kv_cache_dtype(
+    kv_cache_dtype: str,
+    *,
+    use_sparse: bool,
+) -> str:
     """Normalize HY V4's E4M3 alias to the sparse FlashMLA cache layout."""
     _require_accuracy_safe_kv_cache_dtype(kv_cache_dtype)
-    if kv_cache_dtype == "fp8_e4m3":
+    if use_sparse and kv_cache_dtype == "fp8_e4m3":
         return "fp8_ds_mla"
     return kv_cache_dtype
 
@@ -410,9 +414,17 @@ class HYV4MLAAttention(nn.Module):
 
         # Do not silently degrade sparse layers into dense attention. Probe the
         # sparse MLA backend directly and fail fast with the real error.
-        kv_cache_dtype = cache_config.cache_dtype if cache_config else "auto"
-        kv_cache_dtype = _normalize_hy_v4_kv_cache_dtype(kv_cache_dtype)
-        if cache_config is not None:
+        requested_kv_cache_dtype = (
+            cache_config.cache_dtype if cache_config else "auto"
+        )
+        kv_cache_dtype = _normalize_hy_v4_kv_cache_dtype(
+            requested_kv_cache_dtype,
+            use_sparse=self.is_sparse,
+        )
+        if (
+            cache_config is not None
+            and kv_cache_dtype != requested_kv_cache_dtype
+        ):
             cache_config.cache_dtype = cast(CacheDType, kv_cache_dtype)
         if self.is_sparse:
             try:

--- a/vllm_hcu/models/hy_v4/attention.py
+++ b/vllm_hcu/models/hy_v4/attention.py
@@ -7,6 +7,7 @@ sparse backend forwards the per-head learnable sink through both prefill and
 decode without changing backend behavior for other models.
 """
 
+from dataclasses import replace
 from typing import cast
 
 import regex as re
@@ -41,6 +42,7 @@ from vllm.v1.attention.backend import (
     SparseMLAAttentionImpl,
 )
 from vllm.v1.attention.selector import get_attn_backend
+from vllm.v1.kv_cache_interface import KVCacheSpec, get_kv_quant_mode
 
 logger = init_logger(__name__)
 
@@ -344,6 +346,17 @@ class Indexer(nn.Module):
         return hidden_states, q_fp8, k, weights
 
 
+class HYV4MLAAttentionLayer(MLAAttention):
+    """Attach the quantization mode omitted by vLLM 0.25.1 MLA specs."""
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        spec = super().get_kv_cache_spec(vllm_config)
+        return replace(
+            spec,
+            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
+        )
+
+
 class HYV4MLAAttention(nn.Module):
     """Multi-head latent attention with optional sparse lightning indexer.
 
@@ -590,7 +603,7 @@ class HYV4MLAAttention(nn.Module):
                 _require_sparse_mqa_backend(sink_backend)
 
         extra_impl_args = {} if sinks is None else {"sinks": sinks}
-        self.mla_attn = MLAAttention(
+        self.mla_attn = HYV4MLAAttentionLayer(
             num_heads=self.num_local_heads,
             scale=self.scaling,
             qk_nope_head_dim=self.qk_nope_head_dim,

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -351,6 +351,10 @@ _FRAMEWORK_CALLBACKS: tuple[_CallbackSpec, ...] = (
     _CallbackSpec(_adapter("framework_opt", "patch_gpu_ubatch_wrapper")),
     _CallbackSpec(_adapter("framework_opt", "patch_ubatch_utils")),
     _CallbackSpec(
+        _adapter("framework_opt", "patch_base_communicator_pcp"),
+        feature="deepep",
+    ),
+    _CallbackSpec(
         _adapter("framework_opt", "patch_all2all"), feature="deepep"
     ),
     _CallbackSpec(

--- a/vllm_hcu/patch/worker/framework_opt/patch_base_communicator_pcp.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_base_communicator_pcp.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Enable DeepEP all2all under PCP + EP even when DP=TP=1.
+
+Upstream vLLM (base_device_communicator.DeviceCommunicatorBase.__init__)
+computes ``use_all2all = is_ep_communicator and (dp_size > 1 or
+use_sequence_parallel_moe)``. In the HCU PCP + EP scenario with DP=TP=1,
+this evaluates to False, so cuda_communicator never constructs a
+DeepEP all2all manager. This adapter widens the gate to also cover
+PCP > 1 + EP + explicit DeepEP backend.
+"""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+from ._common import (
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_exact_signature,
+)
+
+TARGET_MODULE = "vllm.distributed.device_communicators.base_device_communicator"
+PATCH_ID = "worker.framework_opt.communicator.base_pcp_ep"
+TARGETS = (f"{TARGET_MODULE}.DeviceCommunicatorBase.__init__",)
+_MARKER = "_vllm_hcu_base_pcp_ep_applied"
+_WRAPPER = "_vllm_hcu_base_pcp_ep_wrapper"
+
+_DEEPEP_BACKENDS = frozenset(
+    {"deepep_high_throughput", "deepep_low_latency"}
+)
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    base_mod = load_exact_module(TARGET_MODULE, module)
+    cls = require_class(
+        base_mod,
+        "DeviceCommunicatorBase",
+        f"{TARGET_MODULE}.DeviceCommunicatorBase",
+    )
+    wrapped = ((cls, "__init__", TARGETS[0], _WRAPPER),)
+    if already_applied(base_mod, _MARKER, wrapped):
+        return False
+
+    original_init = require_callable(cls, "__init__", TARGETS[0])
+    require_exact_signature(
+        original_init,
+        TARGETS[0],
+        positional=(
+            "self",
+            "cpu_group",
+            "device",
+            "device_group",
+            "unique_name",
+            "global_ranks",
+            "global_world_size",
+        ),
+        defaults={
+            "device": None,
+            "device_group": None,
+            "unique_name": "",
+            "global_ranks": None,
+            "global_world_size": None,
+        },
+    )
+
+    @functools.wraps(original_init)
+    def hcu_init(
+        self,
+        cpu_group,
+        device=None,
+        device_group=None,
+        unique_name="",
+        global_ranks=None,
+        global_world_size=None,
+    ):
+        original_init(
+            self,
+            cpu_group,
+            device=device,
+            device_group=device_group,
+            unique_name=unique_name,
+            global_ranks=global_ranks,
+            global_world_size=global_world_size,
+        )
+        # Upstream already enabled all2all via DP>1 / use_sequence_parallel_moe.
+        if getattr(self, "use_all2all", False):
+            return
+        # Only EP communicators care about all2all managers.
+        if not getattr(self, "is_ep_communicator", False):
+            return
+
+        from vllm.config import get_current_vllm_config_or_none
+
+        cfg = get_current_vllm_config_or_none()
+        if cfg is None:
+            return
+        pc = getattr(cfg, "parallel_config", None)
+        if pc is None:
+            return
+        pcp_size = int(getattr(pc, "prefill_context_parallel_size", 1) or 1)
+        ep_enabled = bool(getattr(pc, "enable_expert_parallel", False))
+        backend = getattr(pc, "all2all_backend", None)
+        if (
+            pcp_size > 1
+            and ep_enabled
+            and backend in _DEEPEP_BACKENDS
+        ):
+            self.use_all2all = True
+            print(
+                "[HCU PATCH base_pcp_ep] force use_all2all=True "
+                f"pcp={pcp_size} backend={backend} unique_name={unique_name!r}",
+                flush=True,
+            )
+
+    setattr(hcu_init, _WRAPPER, True)
+    setattr(cls, "_vllm_hcu_original_init", original_init)
+    setattr(cls, "__init__", hcu_init)
+    setattr(base_mod, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/worker/op_opt/moe/patch_all2all_utils.py
+++ b/vllm_hcu/patch/worker/op_opt/moe/patch_all2all_utils.py
@@ -131,6 +131,7 @@ def apply_to_module(module: ModuleType) -> bool:
                 physical_to_global=physical_to_global,
                 local_expert_global_ids=local_expert_global_ids,
             )
+            ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer = True
             from vllm_hcu.model_executor.layers.fused_moe.prepare_finalize import (
                 deepep_auto,
             )

--- a/vllm_hcu/patch/worker/op_opt/patch_compressed_tensors_w8a8_fp8.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_compressed_tensors_w8a8_fp8.py
@@ -28,6 +28,8 @@ TARGETS = (
 )
 _CLASS_MARKER = "_vllm_hcu_w8a8_fp8_applied"
 _WRAPPER_MARKER = "_vllm_hcu_w8a8_fp8_wrapper"
+_SUPPORTED_FP8_BACKENDS = frozenset(("lightop", "target-triton"))
+
 
 def apply_to_module(module: ModuleType) -> bool:
     fp8_module = load_exact_module(TARGET_MODULE, module)
@@ -71,11 +73,11 @@ def apply_to_module(module: ModuleType) -> bool:
             if (
                 not getattr(kernel_class, "_hcu_fp8_patch_applied", False)
                 or getattr(kernel_class, "_hcu_fp8_backend", None)
-                != "target-triton"
+                not in _SUPPORTED_FP8_BACKENDS
             ):
                 raise RuntimeError(
-                    "channelwise FP8 requires the reviewed target Triton "
-                    "scaled-mm adapter before weight processing"
+                    "channelwise FP8 requires a reviewed HCU scaled-mm "
+                    "adapter before weight processing"
                 )
 
         original_process(self, layer)
@@ -107,7 +109,7 @@ def apply_to_module(module: ModuleType) -> bool:
         if not supports_quanted_inputs(self):
             raise RuntimeError(
                 "prequantized FP8 inputs are only supported by the reviewed "
-                "Channel-FP8 target Triton route"
+                "HCU Channel-FP8 route"
             )
         return self.fp8_linear.apply_weights(
             layer,
@@ -122,7 +124,7 @@ def apply_to_module(module: ModuleType) -> bool:
             self.strategy == fp8_module.QuantizationStrategy.CHANNEL
             and getattr(kernel_class, "_hcu_fp8_patch_applied", False)
             and getattr(kernel_class, "_hcu_fp8_backend", None)
-            == "target-triton"
+            in _SUPPORTED_FP8_BACKENDS
         )
 
     for function in (hcu_process_weights_after_loading, hcu_apply_weights):

--- a/vllm_hcu/patch/worker/op_opt/patch_scaled_mm_linear_kernel.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_scaled_mm_linear_kernel.py
@@ -27,6 +27,7 @@ TARGETS = (
 )
 _CLASS_MARKER = "_vllm_hcu_prequantized_input_applied"
 _WRAPPER_MARKER = "_vllm_hcu_prequantized_input_wrapper"
+_SUPPORTED_FP8_BACKENDS = frozenset(("lightop", "target-triton"))
 
 
 def apply_to_module(module: ModuleType) -> bool:
@@ -67,8 +68,8 @@ def apply_to_module(module: ModuleType) -> bool:
             return original(self, layer, x, bias)
         if not supports_quanted_inputs(self):
             raise RuntimeError(
-                "prequantized FP8 inputs require the reviewed Channel-FP8 "
-                "target Triton route"
+                "prequantized FP8 inputs require a reviewed HCU Channel-FP8 "
+                "route"
             )
         if not isinstance(x_and_scale_quanted, tuple) or len(x_and_scale_quanted) != 2:
             raise ValueError("x_and_scale_quanted must be a (tensor, scale) tuple")
@@ -104,8 +105,8 @@ def apply_to_module(module: ModuleType) -> bool:
         # SymBool.  vLLM's piecewise splitter can then thread the relation into
         # a standalone subgraph as a ``sympy.Equality`` input, which this Torch
         # Inductor does not support.  Preserve the friendly eager error here;
-        # the target-Triton custom-op implementation repeats this contract with
-        # concrete runtime dimensions before launching the backend.
+        # the HCU custom-op implementation repeats this contract with concrete
+        # runtime dimensions before launching the selected backend.
         if not torch.compiler.is_compiling():
             if tuple(x_scale.shape) not in (
                 (),
@@ -144,7 +145,7 @@ def apply_to_module(module: ModuleType) -> bool:
         return bool(
             getattr(kernel_class, "_hcu_fp8_patch_applied", False)
             and getattr(kernel_class, "_hcu_fp8_backend", None)
-            == "target-triton"
+            in _SUPPORTED_FP8_BACKENDS
         )
 
     setattr(hcu_apply_weights, _WRAPPER_MARKER, True)

--- a/vllm_hcu/platforms/envs.py
+++ b/vllm_hcu/platforms/envs.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     VLLM_HCU_USE_CAT_MLA: bool = False
     VLLM_HCU_DISABLE_DSA: bool = False
     VLLM_HCU_USE_FP8_MIXED_BATCH: bool = False
-    VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM : bool = False
+    VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM: bool = True
     VLLM_HCU_USE_CUSTOM_OPS : bool = False
     VLLM_HCU_USE_CUSTOM_SILU_AND_MUL : bool = False
     VLLM_HCU_USE_CUSTOM_GEMMA_RMS_NORM : bool = False
@@ -166,7 +166,8 @@ hcu_vllm_environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_HCU_USE_FP8_MIXED_BATCH":
         lambda: (os.getenv('VLLM_HCU_USE_FP8_MIXED_BATCH', 'True').lower() in
                  ("true", "1")),  
-    # If set, control hcu custom gemm including w8a8 int8/fp8 etc
+    # Enable HCU custom quantization GEMMs by default. Channel-wise FP8 uses
+    # LightOp when enabled and retains the vLLM Triton path when disabled.
     "VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM":
     lambda: (os.environ.get("VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM", "True").lower() in
              ("true", "1")),

--- a/vllm_hcu/runtime_compat/scaled_mm.py
+++ b/vllm_hcu/runtime_compat/scaled_mm.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
-"""Target-native Triton compatibility for channel-wise FP8 scaled MM."""
+"""HCU backend selection for channel-wise FP8 scaled MM."""
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
+from functools import cache
 from inspect import signature
 from math import prod
 from threading import RLock
@@ -18,11 +20,140 @@ _TRITON_MODULE = (
     "vllm.model_executor.layers.quantization.compressed_tensors."
     "triton_scaled_mm"
 )
+# Keep the established dispatcher name so persisted vLLM compile artifacts do
+# not lose their registered operator when the selected backend is LightOp.
 _CUSTOM_OP_NAME = "hcu_channel_fp8_target_triton_scaled_mm"
 _CUSTOM_OP_LOCK = RLock()
 _CUSTOM_OP: Callable[..., torch.Tensor] | None = None
 _CUSTOM_OP_BACKEND: Callable[..., torch.Tensor] | None = None
 _CUSTOM_OP_REGISTRATION_ERROR: str | None = None
+_LOGGER = logging.getLogger(__name__)
+
+
+def _custom_quantization_gemm_enabled() -> bool:
+    try:
+        from vllm_hcu.platforms import envs as henvs
+
+        return bool(henvs.VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM)
+    except (AttributeError, ImportError) as exc:
+        raise RuntimeError(
+            "required HCU flag VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM "
+            "is unavailable"
+        ) from exc
+
+
+@cache
+def _make_lightop_scaled_mm(
+    lightop_gemm: Callable[..., tuple[bool, torch.Tensor]],
+) -> Callable[..., torch.Tensor]:
+    if not callable(lightop_gemm):
+        raise TypeError("LightOp channel-wise GEMM backend must be callable")
+
+    def lightop_scaled_mm(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+        out_dtype: torch.dtype,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if (
+            input.dtype != torch.float8_e4m3fn
+            or weight.dtype != torch.float8_e4m3fn
+        ):
+            raise ValueError(
+                "LightOp channel-wise GEMM requires float8_e4m3fn operands"
+            )
+        if scale_a.dtype != torch.float32 or scale_b.dtype != torch.float32:
+            raise ValueError(
+                "LightOp channel-wise GEMM requires float32 scales"
+            )
+        if out_dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError(
+                "LightOp channel-wise GEMM output must be float16 or bfloat16"
+            )
+        if bias is not None and bias.dtype != out_dtype:
+            raise ValueError(
+                "LightOp channel-wise GEMM bias dtype must match its output"
+            )
+        m, k = input.shape
+        n = weight.shape[1]
+        status, output = lightop_gemm(
+            input,
+            weight.t(),
+            scale_a,
+            scale_b,
+            m,
+            n,
+            k,
+            "NT",
+            out_dtype,
+            bias,
+        )
+        if status is not True:
+            raise RuntimeError("LightOp channel-wise GEMM reported failure")
+        if not isinstance(output, torch.Tensor):
+            raise RuntimeError("LightOp channel-wise GEMM did not return a tensor")
+        if tuple(output.shape) not in ((m, n), (1, m, n)):
+            raise RuntimeError(
+                "LightOp channel-wise GEMM returned an incompatible output"
+            )
+        return output.view(m, n)
+
+    return lightop_scaled_mm
+
+
+def _resolve_scaled_mm_backend() -> tuple[str, Callable[..., torch.Tensor]]:
+    if _custom_quantization_gemm_enabled():
+        try:
+            from lightop.gemm_ops import hipblaslt_w8a8_channelwise_gemm
+        except (AttributeError, ImportError) as exc:
+            raise RuntimeError(
+                "VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM requires LightOp "
+                "hipblaslt_w8a8_channelwise_gemm"
+            ) from exc
+
+        lightop_parameters = tuple(
+            signature(hipblaslt_w8a8_channelwise_gemm).parameters
+        )
+        if lightop_parameters[:10] != (
+            "a",
+            "b",
+            "scale_a",
+            "scale_b",
+            "m",
+            "n",
+            "k",
+            "transpose_flag",
+            "out_dtype",
+            "bias",
+        ):
+            raise RuntimeError(
+                "LightOp channel-wise GEMM signature drifted from the "
+                "reviewed 0.6.0 contract"
+            )
+        return "lightop", _make_lightop_scaled_mm(
+            hipblaslt_w8a8_channelwise_gemm
+        )
+
+    from vllm.model_executor.layers.quantization.compressed_tensors.triton_scaled_mm import (  # noqa: E501
+        triton_scaled_mm,
+    )
+
+    triton_parameters = tuple(signature(triton_scaled_mm).parameters)
+    if triton_parameters[:6] != (
+        "input",
+        "weight",
+        "scale_a",
+        "scale_b",
+        "out_dtype",
+        "bias",
+    ):
+        raise RuntimeError(
+            "vLLM target triton_scaled_mm signature drifted from the reviewed "
+            "v0.25.1 contract"
+        )
+    return "target-triton", triton_scaled_mm
 
 
 def _eager_shape_check(condition, message: str) -> None:
@@ -82,14 +213,18 @@ def _validate_target_output(
     out_dtype: torch.dtype,
 ) -> torch.Tensor:
     if not isinstance(output, torch.Tensor):
-        raise RuntimeError("target triton_scaled_mm did not return a tensor")
+        raise RuntimeError(
+            "selected Channel-FP8 backend did not return a tensor"
+        )
     if (
         output.ndim != 2
         or tuple(output.shape) != (A.shape[0], B.shape[1])
         or output.device != A.device
         or output.dtype != out_dtype
     ):
-        raise RuntimeError("target triton_scaled_mm returned an incompatible output")
+        raise RuntimeError(
+            "selected Channel-FP8 backend returned an incompatible output"
+        )
     return output
 
 
@@ -103,7 +238,7 @@ def _channel_fp8_target_triton_impl(
 ) -> torch.Tensor:
     backend = _CUSTOM_OP_BACKEND
     if backend is None:
-        raise RuntimeError("Channel-FP8 target Triton backend is not initialized")
+        raise RuntimeError("selected Channel-FP8 backend is not initialized")
     # The dispatcher calls this real implementation outside Dynamo capture, so
     # these relations use concrete runtime dimensions and cannot become
     # piecewise graph inputs.  Repeat them here because the fake implementation
@@ -158,35 +293,34 @@ def _register_channel_fp8_custom_op() -> Callable[..., torch.Tensor]:
 
 
 def _ensure_channel_fp8_custom_op(
-    triton_scaled_mm: Callable[..., torch.Tensor],
+    backend: Callable[..., torch.Tensor],
 ) -> Callable[..., torch.Tensor]:
     global _CUSTOM_OP, _CUSTOM_OP_BACKEND, _CUSTOM_OP_REGISTRATION_ERROR
 
-    if not callable(triton_scaled_mm):
-        raise TypeError("target triton_scaled_mm backend must be callable")
+    if not callable(backend):
+        raise TypeError("Channel-FP8 backend must be callable")
     with _CUSTOM_OP_LOCK:
         if _CUSTOM_OP_REGISTRATION_ERROR is not None:
             raise RuntimeError(
-                "Channel-FP8 target Triton custom-op registration previously "
+                "Channel-FP8 custom-op registration previously "
                 f"failed: {_CUSTOM_OP_REGISTRATION_ERROR}"
             )
         if _CUSTOM_OP is not None:
-            if _CUSTOM_OP_BACKEND is not triton_scaled_mm:
+            if _CUSTOM_OP_BACKEND is not backend:
                 raise RuntimeError(
-                    "Channel-FP8 target Triton custom op is already bound to a "
+                    "Channel-FP8 custom op is already bound to a "
                     "different backend"
                 )
             return _CUSTOM_OP
 
-        _CUSTOM_OP_BACKEND = triton_scaled_mm
+        _CUSTOM_OP_BACKEND = backend
         try:
             custom_op = _register_channel_fp8_custom_op()
         except Exception as exc:
             _CUSTOM_OP_BACKEND = None
             _CUSTOM_OP_REGISTRATION_ERROR = f"{type(exc).__name__}: {exc}"
             raise RuntimeError(
-                "failed to register the HCU-owned Channel-FP8 target Triton "
-                "custom op"
+                "failed to register the HCU-owned Channel-FP8 custom op"
             ) from exc
         _CUSTOM_OP = custom_op
         return custom_op
@@ -233,7 +367,7 @@ def install_fp8_scaled_mm_compat(module: ModuleType | None = None) -> None:
                 "_hcu_fp8_backend",
                 None,
             )
-            == "target-triton"
+            in {"lightop", "target-triton"}
             and getattr(
                 ChannelWiseTorchFP8ScaledMMLinearKernel.get_output_padding,
                 "_hcu_fp8_target_triton_wrapper",
@@ -248,28 +382,11 @@ def install_fp8_scaled_mm_compat(module: ModuleType | None = None) -> None:
             return
         raise RuntimeError(
             "channelwise FP8 scaled-mm adapter marker exists without the "
-            "reviewed target Triton wrapper ownership"
+            "reviewed HCU wrapper ownership"
         )
 
-    from vllm.model_executor.layers.quantization.compressed_tensors.triton_scaled_mm import (  # noqa: E501
-        triton_scaled_mm,
-    )
-
-    triton_parameters = tuple(signature(triton_scaled_mm).parameters)
-    if triton_parameters[:6] != (
-        "input",
-        "weight",
-        "scale_a",
-        "scale_b",
-        "out_dtype",
-        "bias",
-    ):
-        raise RuntimeError(
-            "vLLM target triton_scaled_mm signature drifted from the reviewed "
-            "v0.25.1 contract"
-        )
-
-    channel_fp8_custom_op = _ensure_channel_fp8_custom_op(triton_scaled_mm)
+    backend_name, scaled_mm_backend = _resolve_scaled_mm_backend()
+    channel_fp8_custom_op = _ensure_channel_fp8_custom_op(scaled_mm_backend)
 
     original_get_output_padding = (
         ChannelWiseTorchFP8ScaledMMLinearKernel.get_output_padding
@@ -330,8 +447,8 @@ def install_fp8_scaled_mm_compat(module: ModuleType | None = None) -> None:
         # across subgraphs.  The target Torch Inductor does not accept a
         # ``sympy.Equality`` graph input.  Keep the friendly validation for
         # concrete eager calls; the custom-op implementation delegates to the
-        # target v0.25.1 Triton backend and repeats the HCU/target scale contract
-        # with concrete runtime dimensions.
+        # selected backend and repeats the HCU scale contract with concrete
+        # runtime dimensions.
         if not torch.compiler.is_compiling():
             _validate_scale_shapes(As, Bs, m, n)
         if (
@@ -377,20 +494,23 @@ def install_fp8_scaled_mm_compat(module: ModuleType | None = None) -> None:
             bias,
         )
         if not isinstance(output, torch.Tensor):
-            raise RuntimeError("target triton_scaled_mm did not return a tensor")
+            raise RuntimeError(
+                "selected Channel-FP8 backend did not return a tensor"
+            )
         if (
             output.ndim != 2
             or output.device != A.device
             or output.dtype != out_dtype
         ):
             raise RuntimeError(
-                "target triton_scaled_mm returned an incompatible output"
+                "selected Channel-FP8 backend returned an incompatible output"
             )
         if not torch.compiler.is_compiling():
             try:
                 _eager_shape_check(
                     (output.shape[0] == m) & (output.shape[1] == n),
-                    "target triton_scaled_mm returned an incompatible output",
+                    "selected Channel-FP8 backend returned an incompatible "
+                    "output",
                 )
             except ValueError as exc:
                 raise RuntimeError(str(exc)) from exc
@@ -400,10 +520,11 @@ def install_fp8_scaled_mm_compat(module: ModuleType | None = None) -> None:
 
     ChannelWiseTorchFP8ScaledMMLinearKernel.apply_scaled_mm = new_apply_scaled_mm
     ChannelWiseTorchFP8ScaledMMLinearKernel._hcu_fp8_patch_applied = True
-    ChannelWiseTorchFP8ScaledMMLinearKernel._hcu_fp8_backend = "target-triton"
+    ChannelWiseTorchFP8ScaledMMLinearKernel._hcu_fp8_backend = backend_name
     ChannelWiseTorchFP8ScaledMMLinearKernel._hcu_original_get_output_padding = (
         original_get_output_padding
     )
     ChannelWiseTorchFP8ScaledMMLinearKernel._hcu_original_apply_scaled_mm = (
         original_apply_scaled_mm
     )
+    _LOGGER.info("Channel-wise FP8 scaled MM backend: %s", backend_name)


### PR DESCRIPTION
## Summary

- merge the `feat/hy4-pcp-ep` implementation into `feat/hy-v4-mtp-blockwise-v0251`
- port the two FP8 E4M3 KV-cache commits from #61
- add unit, CLI, and real-model parity coverage for prefill, decode, and MTP

## Commits

- `feat:support pcp+ep`
- `fix(hy-v4): support fp8 e4m3 kv cache`
- `test(hy-v4): validate fp8 kv cache parity`

## Verification

- `python -m pytest -q tests/models/hy_v4/test_attention.py tests/integration/test_model_runtime_cli.py` — 47 passed
- full suite with `VLLM_V0251_SOURCE_ROOT=/models/vllm_0251`: 1453 passed, 60 skipped, 2 failed, 3 errors
- the same 2 failures and 3 errors reproduce on the unmodified branch baseline: GLM-5.2 PCP services exit before ready, and the checkout lacks a locally built `hcu_ops` extension
