### PR TITLE
fix(hcu): harden SlimQuant, MoE routing, and native FP8 KV cache

### DIFF
--- a/tests/accuracy/test_environment_routing.py
+++ b/tests/accuracy/test_environment_routing.py
@@ -87,6 +87,17 @@ def test_boolean_environment_values_are_lazily_parsed(
     assert hcu_envs.is_set("VLLM_HCU_USE_CUSTOM_OPS") is True
 
 
+def test_lightop_per_token_fp8_route_is_enabled_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    name = "VLLM_HCU_USE_LIGHTOP_PER_TOKEN_QUANT_FP8"
+    monkeypatch.setenv("VLLM_HCU_USE_CUSTOM_OPS", "1")
+    monkeypatch.delenv(name, raising=False)
+
+    assert patch_input_quant_fp8._lightop_requested() is True
+    assert hcu_envs.is_set(name) is False
+
+
 @pytest.mark.parametrize(
     "name",
     [

--- a/tests/accuracy/test_environment_routing.py
+++ b/tests/accuracy/test_environment_routing.py
@@ -347,6 +347,7 @@ def test_input_fp8_environment_selects_custom_or_official_wrapper(
     )
     runtime = _module(
         "vllm_hcu.model_executor.layers.quantization.lightop_fp8_runtime",
+        ensure_registered=lambda dtype, register: None,
         quantize=lambda x, dtype, register: (
             calls.append("custom") or ("custom", x, dtype, register)
         ),

--- a/tests/accuracy/test_hcu_kernel_accuracy.py
+++ b/tests/accuracy/test_hcu_kernel_accuracy.py
@@ -82,8 +82,14 @@ def _hcu_device() -> torch.device:
 
 
 @pytest.mark.parametrize("layout", ["NHD", "HND"])
+@pytest.mark.parametrize(
+    "cache_storage_dtype",
+    [torch.float8_e4m3fn, torch.uint8],
+    ids=["float8-view", "uint8-backing"],
+)
 def test_hcu_reshape_and_cache_flash_fp8_matches_torch_quantization(
     layout: str,
+    cache_storage_dtype: torch.dtype,
 ) -> None:
     device = _hcu_device()
     import vllm_hcu.hcu_ops  # noqa: F401
@@ -114,7 +120,7 @@ def test_hcu_reshape_and_cache_flash_fp8_matches_torch_quantization(
             (num_blocks, block_size, num_heads, head_size),
             cache_stride,
             device=device,
-            dtype=torch.float8_e4m3fn,
+            dtype=cache_storage_dtype,
         ).zero_()
         value_cache = torch.empty_strided(
             key_cache.shape,
@@ -133,7 +139,7 @@ def test_hcu_reshape_and_cache_flash_fp8_matches_torch_quantization(
             (num_blocks, block_size, num_heads, head_size),
             cache_stride,
             device=device,
-            dtype=torch.float8_e4m3fn,
+            dtype=cache_storage_dtype,
         ).zero_()
         value_cache = torch.empty_strided(
             key_cache.shape,
@@ -168,16 +174,22 @@ def test_hcu_reshape_and_cache_flash_fp8_matches_torch_quantization(
     expected_value = (value[:2] / v_scale.reshape(1, -1, 1)).to(
         torch.float8_e4m3fn
     )
-    torch.testing.assert_close(key_cache[0, 1].float(), expected_key[0].float())
-    torch.testing.assert_close(key_cache[1, 1].float(), expected_key[1].float())
+    key_cache_fp8 = key_cache.view(torch.float8_e4m3fn)
+    value_cache_fp8 = value_cache.view(torch.float8_e4m3fn)
     torch.testing.assert_close(
-        value_cache[0, 1].float(), expected_value[0].float()
+        key_cache_fp8[0, 1].float(), expected_key[0].float()
     )
     torch.testing.assert_close(
-        value_cache[1, 1].float(), expected_value[1].float()
+        key_cache_fp8[1, 1].float(), expected_key[1].float()
     )
-    assert torch.count_nonzero(key_cache[:, 0].float()) == 0
-    assert torch.count_nonzero(value_cache[:, 0].float()) == 0
+    torch.testing.assert_close(
+        value_cache_fp8[0, 1].float(), expected_value[0].float()
+    )
+    torch.testing.assert_close(
+        value_cache_fp8[1, 1].float(), expected_value[1].float()
+    )
+    assert torch.count_nonzero(key_cache_fp8[:, 0].float()) == 0
+    assert torch.count_nonzero(value_cache_fp8[:, 0].float()) == 0
 
 
 def test_hcu_reshape_and_cache_flash_replays_in_cuda_graph() -> None:
@@ -300,6 +312,55 @@ def test_hcu_reshape_and_cache_flash_saturates_fp8_e4m3_overflow() -> None:
             cache[0, 0].float(),
             expected_values,
             equal_nan=True,
+        )
+
+
+def test_hcu_reshape_and_cache_flash_rejects_non_float_scales() -> None:
+    device = _hcu_device()
+    import vllm_hcu.hcu_ops  # noqa: F401
+
+    key = torch.ones((1, 2, 16), device=device, dtype=torch.bfloat16)
+    value = torch.ones_like(key)
+    key_cache = torch.zeros(
+        (1, 1, 2, 16), device=device, dtype=torch.float8_e4m3fn
+    )
+    value_cache = torch.zeros_like(key_cache)
+    slot_mapping = torch.zeros((1,), device=device, dtype=torch.int64)
+    invalid_scale = torch.ones((2,), device=device, dtype=torch.bfloat16)
+
+    with pytest.raises(RuntimeError, match="scales must be contiguous float32"):
+        torch.ops.hcu_ops.reshape_and_cache_flash(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            "fp8_e4m3",
+            invalid_scale,
+            invalid_scale,
+        )
+
+
+def test_hcu_reshape_and_cache_flash_rejects_wrong_cache_dtype() -> None:
+    device = _hcu_device()
+    import vllm_hcu.hcu_ops  # noqa: F401
+
+    key = torch.ones((1, 2, 16), device=device, dtype=torch.bfloat16)
+    value = torch.ones_like(key)
+    invalid_cache = torch.zeros_like(key).unsqueeze(0)
+    slot_mapping = torch.zeros((1,), device=device, dtype=torch.int64)
+    scale = torch.ones((2,), device=device, dtype=torch.float32)
+
+    with pytest.raises(RuntimeError, match="cache dtype must match"):
+        torch.ops.hcu_ops.reshape_and_cache_flash(
+            key,
+            value,
+            invalid_cache,
+            invalid_cache.clone(),
+            slot_mapping,
+            "fp8_e4m3",
+            scale,
+            scale,
         )
 
 

--- a/tests/accuracy/test_hcu_kernel_accuracy.py
+++ b/tests/accuracy/test_hcu_kernel_accuracy.py
@@ -192,6 +192,89 @@ def test_hcu_reshape_and_cache_flash_fp8_matches_torch_quantization(
     assert torch.count_nonzero(value_cache_fp8[:, 0].float()) == 0
 
 
+@pytest.mark.parametrize("layout", ["NHD", "HND"])
+def test_hcu_flash_attention_writer_e5m2_matches_torch_quantization(
+    layout: str,
+) -> None:
+    device = _hcu_device()
+    import vllm_hcu.hcu_ops  # noqa: F401
+    from vllm_hcu.v1.attention.backends.fa_utils import (
+        reshape_and_cache_flash,
+    )
+
+    num_blocks, block_size, num_heads, head_size = 2, 4, 2, 16
+    key = torch.linspace(
+        -20,
+        20,
+        3 * num_heads * head_size,
+        device=device,
+        dtype=torch.bfloat16,
+    ).reshape(3, num_heads, head_size)
+    value = -key
+    if layout == "NHD":
+        cache_stride = (
+            block_size * num_heads * head_size,
+            num_heads * head_size,
+            head_size,
+            1,
+        )
+    else:
+        cache_stride = (
+            num_heads * block_size * head_size,
+            head_size,
+            block_size * head_size,
+            1,
+        )
+    key_cache = torch.empty_strided(
+        (num_blocks, block_size, num_heads, head_size),
+        cache_stride,
+        device=device,
+        dtype=torch.uint8,
+    ).zero_()
+    value_cache = torch.empty_strided(
+        key_cache.shape,
+        cache_stride,
+        device=device,
+        dtype=torch.uint8,
+    ).zero_()
+    slot_mapping = torch.tensor([1, 5, -1], device=device, dtype=torch.int64)
+    k_scale = torch.tensor([0.25, 0.5], device=device, dtype=torch.float32)
+    v_scale = torch.tensor([0.5, 0.25], device=device, dtype=torch.float32)
+
+    reshape_and_cache_flash(
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        "fp8_e5m2",
+        k_scale,
+        v_scale,
+    )
+    torch.cuda.synchronize(device)
+
+    expected_key = (key[:2] / k_scale.reshape(1, -1, 1)).to(
+        torch.float8_e5m2
+    )
+    expected_value = (value[:2] / v_scale.reshape(1, -1, 1)).to(
+        torch.float8_e5m2
+    )
+    key_cache_fp8 = key_cache.view(torch.float8_e5m2)
+    value_cache_fp8 = value_cache.view(torch.float8_e5m2)
+    torch.testing.assert_close(
+        key_cache_fp8[0, 1].float(), expected_key[0].float()
+    )
+    torch.testing.assert_close(
+        key_cache_fp8[1, 1].float(), expected_key[1].float()
+    )
+    torch.testing.assert_close(
+        value_cache_fp8[0, 1].float(), expected_value[0].float()
+    )
+    torch.testing.assert_close(
+        value_cache_fp8[1, 1].float(), expected_value[1].float()
+    )
+
+
 def test_hcu_reshape_and_cache_flash_replays_in_cuda_graph() -> None:
     device = _hcu_device()
     import vllm_hcu.hcu_ops  # noqa: F401
@@ -248,6 +331,86 @@ def test_hcu_reshape_and_cache_flash_replays_in_cuda_graph() -> None:
     )
     torch.testing.assert_close(
         value_cache[1, 1].float(), replay_value[1].float()
+    )
+
+
+def test_hcu_flash_attention_writer_e5m2_hnd_replays_in_cuda_graph() -> None:
+    device = _hcu_device()
+    import vllm_hcu.hcu_ops  # noqa: F401
+    from vllm_hcu.v1.attention.backends.fa_utils import (
+        reshape_and_cache_flash,
+    )
+
+    num_heads, head_size, block_size = 2, 16, 4
+    key = torch.zeros(
+        (2, num_heads, head_size), device=device, dtype=torch.bfloat16
+    )
+    value = torch.zeros_like(key)
+    cache_stride = (
+        num_heads * block_size * head_size,
+        head_size,
+        block_size * head_size,
+        1,
+    )
+    key_cache = torch.empty_strided(
+        (2, block_size, num_heads, head_size),
+        cache_stride,
+        device=device,
+        dtype=torch.uint8,
+    ).zero_()
+    value_cache = torch.empty_strided(
+        key_cache.shape,
+        cache_stride,
+        device=device,
+        dtype=torch.uint8,
+    ).zero_()
+    slot_mapping = torch.tensor([0, 5], device=device, dtype=torch.int64)
+    scale = torch.ones((1,), device=device, dtype=torch.float32)
+
+    def write_cache() -> None:
+        reshape_and_cache_flash(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            "fp8_e5m2",
+            scale,
+            scale,
+        )
+
+    warmup_stream = torch.cuda.Stream(device=device)
+    warmup_stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(warmup_stream):
+        write_cache()
+    torch.cuda.current_stream(device).wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        write_cache()
+
+    replay_key = torch.full_like(key, 1.5)
+    replay_value = torch.full_like(value, -2.0)
+    key_cache.zero_()
+    value_cache.zero_()
+    key.copy_(replay_key)
+    value.copy_(replay_value)
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    key_cache_fp8 = key_cache.view(torch.float8_e5m2)
+    value_cache_fp8 = value_cache.view(torch.float8_e5m2)
+    torch.testing.assert_close(
+        key_cache_fp8[0, 0].float(), replay_key[0].float()
+    )
+    torch.testing.assert_close(
+        key_cache_fp8[1, 1].float(), replay_key[1].float()
+    )
+    torch.testing.assert_close(
+        value_cache_fp8[0, 0].float(), replay_value[0].float()
+    )
+    torch.testing.assert_close(
+        value_cache_fp8[1, 1].float(), replay_value[1].float()
     )
 
 

--- a/tests/accuracy/test_hcu_kernel_accuracy.py
+++ b/tests/accuracy/test_hcu_kernel_accuracy.py
@@ -81,6 +81,271 @@ def _hcu_device() -> torch.device:
     return torch.device("cuda", 0)
 
 
+@pytest.mark.parametrize("layout", ["NHD", "HND"])
+def test_hcu_reshape_and_cache_flash_fp8_matches_torch_quantization(
+    layout: str,
+) -> None:
+    device = _hcu_device()
+    import vllm_hcu.hcu_ops  # noqa: F401
+
+    # Exercise the grid-stride loop beyond HCU's 256-thread launch bound.
+    num_blocks, block_size, num_heads, head_size = 2, 4, 4, 128
+    generator = torch.Generator(device=device).manual_seed(20260904)
+    key = torch.randn(
+        (4, num_heads, head_size),
+        generator=generator,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    value = torch.randn(
+        key.shape,
+        generator=generator,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    if layout == "NHD":
+        cache_stride = (
+            block_size * num_heads * head_size + 64,
+            num_heads * head_size,
+            head_size,
+            1,
+        )
+        key_cache = torch.empty_strided(
+            (num_blocks, block_size, num_heads, head_size),
+            cache_stride,
+            device=device,
+            dtype=torch.float8_e4m3fn,
+        ).zero_()
+        value_cache = torch.empty_strided(
+            key_cache.shape,
+            cache_stride,
+            device=device,
+            dtype=key_cache.dtype,
+        ).zero_()
+    else:
+        cache_stride = (
+            num_heads * block_size * head_size + 64,
+            head_size,
+            block_size * head_size,
+            1,
+        )
+        key_cache = torch.empty_strided(
+            (num_blocks, block_size, num_heads, head_size),
+            cache_stride,
+            device=device,
+            dtype=torch.float8_e4m3fn,
+        ).zero_()
+        value_cache = torch.empty_strided(
+            key_cache.shape,
+            cache_stride,
+            device=device,
+            dtype=key_cache.dtype,
+        ).zero_()
+
+    slot_mapping = torch.tensor([1, 5, -1], device=device, dtype=torch.int64)
+    k_scale = torch.linspace(
+        0.25, 0.5, num_heads, device=device, dtype=torch.float32
+    )
+    v_scale = torch.linspace(
+        0.5, 0.75, num_heads, device=device, dtype=torch.float32
+    )
+
+    torch.ops.hcu_ops.reshape_and_cache_flash(
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        "fp8_e4m3",
+        k_scale,
+        v_scale,
+    )
+    torch.cuda.synchronize(device)
+
+    expected_key = (key[:2] / k_scale.reshape(1, -1, 1)).to(
+        torch.float8_e4m3fn
+    )
+    expected_value = (value[:2] / v_scale.reshape(1, -1, 1)).to(
+        torch.float8_e4m3fn
+    )
+    torch.testing.assert_close(key_cache[0, 1].float(), expected_key[0].float())
+    torch.testing.assert_close(key_cache[1, 1].float(), expected_key[1].float())
+    torch.testing.assert_close(
+        value_cache[0, 1].float(), expected_value[0].float()
+    )
+    torch.testing.assert_close(
+        value_cache[1, 1].float(), expected_value[1].float()
+    )
+    assert torch.count_nonzero(key_cache[:, 0].float()) == 0
+    assert torch.count_nonzero(value_cache[:, 0].float()) == 0
+
+
+def test_hcu_reshape_and_cache_flash_replays_in_cuda_graph() -> None:
+    device = _hcu_device()
+    import vllm_hcu.hcu_ops  # noqa: F401
+
+    num_heads, head_size, block_size = 2, 16, 4
+    key = torch.zeros(
+        (2, num_heads, head_size), device=device, dtype=torch.bfloat16
+    )
+    value = torch.zeros_like(key)
+    key_cache = torch.zeros(
+        (2, block_size, num_heads, head_size),
+        device=device,
+        dtype=torch.float8_e4m3fn,
+    )
+    value_cache = torch.zeros_like(key_cache)
+    slot_mapping = torch.tensor([0, 5], device=device, dtype=torch.int64)
+    scale = torch.ones((1,), device=device, dtype=torch.float32)
+
+    def write_cache() -> None:
+        torch.ops.hcu_ops.reshape_and_cache_flash(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            "fp8_e4m3",
+            scale,
+            scale,
+        )
+
+    warmup_stream = torch.cuda.Stream(device=device)
+    warmup_stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(warmup_stream):
+        write_cache()
+    torch.cuda.current_stream(device).wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        write_cache()
+
+    replay_key = torch.full_like(key, 1.5)
+    replay_value = torch.full_like(value, -2.0)
+    key_cache.zero_()
+    value_cache.zero_()
+    key.copy_(replay_key)
+    value.copy_(replay_value)
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    torch.testing.assert_close(key_cache[0, 0].float(), replay_key[0].float())
+    torch.testing.assert_close(key_cache[1, 1].float(), replay_key[1].float())
+    torch.testing.assert_close(
+        value_cache[0, 0].float(), replay_value[0].float()
+    )
+    torch.testing.assert_close(
+        value_cache[1, 1].float(), replay_value[1].float()
+    )
+
+
+def test_hcu_reshape_and_cache_flash_saturates_fp8_e4m3_overflow() -> None:
+    device = _hcu_device()
+    import vllm_hcu.hcu_ops  # noqa: F401
+
+    values = torch.tensor(
+        [
+            448.0,
+            449.0,
+            466.0,
+            470.0,
+            479.0,
+            480.0,
+            500.0,
+            float("inf"),
+            -float("inf"),
+            float("nan"),
+            -466.0,
+            -470.0,
+            -479.0,
+            -500.0,
+        ],
+        device=device,
+        dtype=torch.bfloat16,
+    ).reshape(1, 1, 14)
+    key_cache = torch.zeros(
+        (1, 1, 1, 14), device=device, dtype=torch.float8_e4m3fn
+    )
+    value_cache = torch.zeros_like(key_cache)
+    slot_mapping = torch.zeros((1,), device=device, dtype=torch.int64)
+    scale = torch.ones((1,), device=device, dtype=torch.float32)
+
+    torch.ops.hcu_ops.reshape_and_cache_flash(
+        values,
+        values,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        "fp8_e4m3",
+        scale,
+        scale,
+    )
+    torch.cuda.synchronize(device)
+
+    expected_bytes = torch.tensor(
+        [[0x7E, 0x7E, 0x7E, 0x7E, 0x7E, 0x7E, 0x7E,
+          0x7E, 0xFE, 0x7F, 0xFE, 0xFE, 0xFE, 0xFE]],
+        device=device,
+        dtype=torch.uint8,
+    )
+    expected_values = torch.tensor(
+        [[448.0, 448.0, 448.0, 448.0, 448.0, 448.0, 448.0,
+          448.0, -448.0, float("nan"), -448.0, -448.0, -448.0, -448.0]],
+        device=device,
+        dtype=torch.float32,
+    )
+    for cache in (key_cache, value_cache):
+        assert torch.equal(cache[0, 0].view(torch.uint8), expected_bytes)
+        torch.testing.assert_close(
+            cache[0, 0].float(),
+            expected_values,
+            equal_nan=True,
+        )
+
+
+def test_hcu_reshape_and_cache_flash_is_opaque_to_torch_compile() -> None:
+    device = _hcu_device()
+    import vllm_hcu.hcu_ops  # noqa: F401
+
+    key = torch.ones((1, 2, 128), device=device, dtype=torch.bfloat16)
+    value = -key
+    key_cache = torch.zeros(
+        (1, 4, 2, 128), device=device, dtype=torch.float8_e4m3fn
+    )
+    value_cache = torch.zeros_like(key_cache)
+    slot_mapping = torch.zeros((1,), device=device, dtype=torch.int64)
+    scale = torch.ones((1,), device=device, dtype=torch.float32)
+
+    def write_cache(
+        key: torch.Tensor,
+        value: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        scale: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        torch.ops.hcu_ops.reshape_and_cache_flash(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            "fp8_e4m3",
+            scale,
+            scale,
+        )
+        return key_cache, value_cache
+
+    compiled = torch.compile(write_cache, backend="aot_eager", fullgraph=True)
+    actual_key, actual_value = compiled(
+        key, value, key_cache, value_cache, slot_mapping, scale
+    )
+    torch.cuda.synchronize(device)
+
+    torch.testing.assert_close(actual_key[0, 0].float(), key[0].float())
+    torch.testing.assert_close(actual_value[0, 0].float(), value[0].float())
+
+
 @pytest.mark.parametrize("shape", [(1, 256), (17, 256), (4, 1024)])
 def test_lightop_silu_and_mul_matches_float32_reference(
     shape: tuple[int, int],

--- a/tests/patch/test_worker_dispatcher.py
+++ b/tests/patch/test_worker_dispatcher.py
@@ -172,15 +172,25 @@ def test_cold_replacement_metadata_matches_lazy_adapter_contracts():
             assert spec.validate_with_adapter is True
 
 
-def test_moe_replacement_metadata_owns_input_transform_method():
+def test_moe_replacement_metadata_owns_input_preservation_methods():
     specs = {
         spec.patch_id: spec
         for spec in worker_dispatcher._MOE_REPLACEMENTS
     }
     runner = specs["worker.op_opt.moe.runner"]
+    shared = specs["worker.op_opt.moe.runner.shared_experts"]
+
     assert (
         f"{runner.target_module}.MoERunner.apply_routed_input_transform"
         in runner.targets
+    )
+    assert (
+        f"{shared.target_module}.SharedExperts.requires_input_preservation"
+        in shared.targets
+    )
+    assert (
+        f"{shared.target_module}.SharedExperts.allows_inplace_routed_output"
+        in shared.targets
     )
 
 

--- a/tests/patch/test_worker_dispatcher.py
+++ b/tests/patch/test_worker_dispatcher.py
@@ -172,6 +172,18 @@ def test_cold_replacement_metadata_matches_lazy_adapter_contracts():
             assert spec.validate_with_adapter is True
 
 
+def test_moe_replacement_metadata_owns_input_transform_method():
+    specs = {
+        spec.patch_id: spec
+        for spec in worker_dispatcher._MOE_REPLACEMENTS
+    }
+    runner = specs["worker.op_opt.moe.runner"]
+    assert (
+        f"{runner.target_module}.MoERunner.apply_routed_input_transform"
+        in runner.targets
+    )
+
+
 def test_independent_worker_cold_prepare_installs_inside_atomic_batch(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -181,11 +181,15 @@ def test_dense_attention_layer_installs_hcu_runtime_and_preserves_fallback(
     layer.kv_cache_dtype = "fp8_e5m2"
     assert module._init_kv_cache_quant(layer, "quant", "prefix") == "hcu-init"
     instance.kv_cache_dtype = "fp8_e5m2"
+    assert instance.forward("q", "k", "v") == "official-forward"
+
+    monkeypatch.setattr(adapter, "_feature_flags", lambda: (True, False))
     assert instance.forward("q", "k", "v") == "hcu-forward"
     assert [call[0] for call in calls] == [
         "official-init",
         "official-forward",
         "hcu-init",
+        "official-forward",
         "hcu-forward",
     ]
 

--- a/tests/runtime_patch/test_flash_attention_and_pp.py
+++ b/tests/runtime_patch/test_flash_attention_and_pp.py
@@ -291,6 +291,8 @@ def test_cutlass_block_first_hnd_stride_contract(
         ("HND", "auto", "triton"),
         ("NHD", "fp8_e4m3", "hcu"),
         ("HND", "fp8_e4m3", "hcu"),
+        ("NHD", "fp8_e5m2", "hcu"),
+        ("HND", "fp8_e5m2", "hcu"),
     ],
 )
 def test_flash_cache_writer_dispatches_by_physical_layout(

--- a/tests/runtime_patch/test_flash_attention_and_pp.py
+++ b/tests/runtime_patch/test_flash_attention_and_pp.py
@@ -285,12 +285,18 @@ def test_cutlass_block_first_hnd_stride_contract(
 
 
 @pytest.mark.parametrize(
-    ("layout", "expected_writer"),
-    [("NHD", "aiter"), ("HND", "triton")],
+    ("layout", "kv_cache_dtype", "expected_writer"),
+    [
+        ("NHD", "auto", "aiter"),
+        ("HND", "auto", "triton"),
+        ("NHD", "fp8_e4m3", "hcu"),
+        ("HND", "fp8_e4m3", "hcu"),
+    ],
 )
 def test_flash_cache_writer_dispatches_by_physical_layout(
     monkeypatch: pytest.MonkeyPatch,
     layout: str,
+    kv_cache_dtype: str,
     expected_writer: str,
 ) -> None:
     fa_utils = importlib.import_module(
@@ -311,6 +317,12 @@ def test_flash_cache_writer_dispatches_by_physical_layout(
         lambda *args: calls.append(("triton", args))
     )
     monkeypatch.setitem(sys.modules, triton_module_name, triton_module)
+    monkeypatch.setattr(
+        torch.ops.hcu_ops,
+        "reshape_and_cache_flash",
+        lambda *args: calls.append(("hcu", args)),
+        raising=False,
+    )
 
     key = torch.zeros(2, 1, 8)
     value = torch.ones_like(key)
@@ -328,7 +340,7 @@ def test_flash_cache_writer_dispatches_by_physical_layout(
         key_cache,
         value_cache,
         slots,
-        "auto",
+        kv_cache_dtype,
         scale,
         scale,
     )

--- a/tests/runtime_patch/test_flash_attention_and_pp.py
+++ b/tests/runtime_patch/test_flash_attention_and_pp.py
@@ -541,6 +541,34 @@ def test_hcu_flash_attention_encoder_window_is_symmetric(
     assert impl.sliding_window == (7, 7)
 
 
+@pytest.mark.parametrize("mode", ["classic", "cutlass", "varlen", "custom"])
+def test_hcu_flash_attention_disables_e5m2_query_prequantization(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+) -> None:
+    flash_attn = _load_hcu_flash_attention_module(monkeypatch)
+    monkeypatch.setattr(flash_attn, "get_flash_attn_version", lambda **kwargs: 2)
+    monkeypatch.setattr(flash_attn, "get_current_vllm_config_or_none", lambda: None)
+    monkeypatch.setattr(
+        flash_attn,
+        "flash_attn_supports_quant_query_input",
+        lambda: True,
+    )
+    monkeypatch.setattr(flash_attn, "_get_flash_attn_mode", lambda: mode)
+
+    impl = flash_attn.FlashAttentionImpl(
+        num_heads=1,
+        head_size=64,
+        scale=1.0,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="fp8_e5m2",
+    )
+
+    assert impl.supports_quant_query_input is False
+
+
 def test_hcu_flash_attention_backend_rejects_pcp_with_dcp(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runtime_patch/test_fp8_channel_triton_product.py
+++ b/tests/runtime_patch/test_fp8_channel_triton_product.py
@@ -22,10 +22,12 @@ _TRITON_MODULE = (
     "vllm.model_executor.layers.quantization.compressed_tensors."
     "triton_scaled_mm"
 )
+_LIGHTOP_MODULE = "lightop.gemm_ops"
 _FP8_DTYPE = getattr(torch, "float8_e4m3fnuz", None)
+_LIGHTOP_FP8_DTYPE = getattr(torch, "float8_e4m3fn", None)
 
 pytestmark = pytest.mark.skipif(
-    _FP8_DTYPE is None,
+    _FP8_DTYPE is None or _LIGHTOP_FP8_DTYPE is None,
     reason="the target vLLM Channel-FP8 contract requires torch FP8 dtypes",
 )
 
@@ -67,7 +69,12 @@ def _install_fake_module_tree(
 def fake_product(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
     original_calls: list[dict[str, object]] = []
     triton_calls: list[dict[str, object]] = []
+    lightop_calls: list[dict[str, object]] = []
     state: dict[str, object] = {}
+
+    # Most existing product tests exercise the retained Triton route. Tests
+    # for the default/custom route delete or override this value explicitly.
+    monkeypatch.setenv("VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM", "0")
 
     def original_get_output_padding(self):
         return "target-padding"
@@ -130,11 +137,48 @@ def fake_product(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
     )
     triton = ModuleType(_TRITON_MODULE)
     triton.triton_scaled_mm = triton_scaled_mm
+    lightop = ModuleType(_LIGHTOP_MODULE)
+
+    def hipblaslt_w8a8_channelwise_gemm(
+        a,
+        b,
+        scale_a,
+        scale_b,
+        m,
+        n,
+        k,
+        transpose_flag,
+        out_dtype,
+        bias=None,
+    ):
+        values = torch.arange(m * n, dtype=torch.float32).reshape(1, m, n)
+        result = values.to(out_dtype)
+        lightop_calls.append(
+            {
+                "a": a,
+                "b": b,
+                "scale_a": scale_a,
+                "scale_b": scale_b,
+                "m": m,
+                "n": n,
+                "k": k,
+                "transpose_flag": transpose_flag,
+                "out_dtype": out_dtype,
+                "bias": bias,
+                "result": result,
+            }
+        )
+        return True, result
+
+    lightop.hipblaslt_w8a8_channelwise_gemm = (
+        hipblaslt_w8a8_channelwise_gemm
+    )
     _install_fake_module_tree(
         monkeypatch,
         {
             _TARGET_MODULE: target,
             _TRITON_MODULE: triton,
+            _LIGHTOP_MODULE: lightop,
         },
     )
     # Ordinary product tests exercise adapter ownership and eager contracts.
@@ -155,6 +199,7 @@ def fake_product(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
         original_apply_scaled_mm=original_apply_scaled_mm,
         original_calls=original_calls,
         triton_calls=triton_calls,
+        lightop_calls=lightop_calls,
         state=state,
     )
 
@@ -485,7 +530,7 @@ def test_existing_marker_without_reviewed_wrapper_identity_fails_closed(
 ):
     fake_product.channel_class._hcu_fp8_patch_applied = True
     fake_product.channel_class._hcu_fp8_backend = "target-triton"
-    with pytest.raises(RuntimeError, match="without the reviewed target Triton"):
+    with pytest.raises(RuntimeError, match="without the reviewed HCU wrapper"):
         scaled_mm.install_fp8_scaled_mm_compat(fake_product.target)
 
 
@@ -534,6 +579,104 @@ def test_channelwise_route_calls_target_triton_and_reshapes_output(
     ].untyped_storage().data_ptr()
     assert kwargs["B"].stride() == (1, kwargs["A"].shape[1])
     assert fake_product.original_calls == []
+
+
+@pytest.mark.parametrize("value", [None, "1", "true"])
+def test_channelwise_route_uses_lightop_by_default_or_when_enabled(
+    fake_product: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    value: str | None,
+):
+    if value is None:
+        monkeypatch.delenv(
+            "VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM",
+            raising=False,
+        )
+    else:
+        monkeypatch.setenv("VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM", value)
+    kernel = _install_and_make_kernel(fake_product)
+    kwargs = _valid_call(output_shape=(2, 3, 5))
+    kwargs["A"] = kwargs["A"].to(_LIGHTOP_FP8_DTYPE)
+    kwargs["B"] = _column_major_weight(4, 5, dtype=_LIGHTOP_FP8_DTYPE)
+
+    output = kernel.apply_scaled_mm(**kwargs)
+
+    assert tuple(output.shape) == (2, 3, 5)
+    assert fake_product.triton_calls == []
+    assert len(fake_product.lightop_calls) == 1
+    call = fake_product.lightop_calls[0]
+    assert call["a"] is kwargs["A"]
+    assert tuple(call["b"].shape) == (
+        kwargs["B"].shape[1],
+        kwargs["B"].shape[0],
+    )
+    assert call["b"].is_contiguous()
+    assert call["b"].untyped_storage().data_ptr() == (
+        kwargs["B"].untyped_storage().data_ptr()
+    )
+    assert call["scale_a"] is kwargs["As"]
+    assert call["scale_b"] is kwargs["Bs"]
+    assert (call["m"], call["n"], call["k"]) == (6, 5, 4)
+    assert call["transpose_flag"] == "NT"
+    assert call["out_dtype"] is torch.bfloat16
+    assert call["bias"] is kwargs["bias"]
+    assert output.untyped_storage().data_ptr() == (
+        call["result"].untyped_storage().data_ptr()
+    )
+    assert fake_product.channel_class._hcu_fp8_backend == "lightop"
+
+
+def test_lightop_backend_resolution_returns_stable_adapter(
+    fake_product: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM", "1")
+
+    first_name, first_backend = scaled_mm._resolve_scaled_mm_backend()
+    second_name, second_backend = scaled_mm._resolve_scaled_mm_backend()
+
+    assert first_name == second_name == "lightop"
+    assert first_backend is second_backend
+
+
+@pytest.mark.parametrize(
+    ("case", "match"),
+    [
+        ("fp8-fnuz", "float8_e4m3fn"),
+        ("scale-f16", "float32 scales"),
+        ("output-f32", "float16 or bfloat16"),
+        ("bias-mismatch", "bias dtype"),
+    ],
+)
+def test_lightop_route_rejects_unsupported_dtypes_before_backend(
+    fake_product: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    match: str,
+):
+    monkeypatch.setenv("VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM", "1")
+    kernel = _install_and_make_kernel(fake_product)
+    kwargs = _valid_call()
+    kwargs["A"] = kwargs["A"].to(_LIGHTOP_FP8_DTYPE)
+    kwargs["B"] = _column_major_weight(4, 5, dtype=_LIGHTOP_FP8_DTYPE)
+
+    if case == "fp8-fnuz":
+        kwargs["A"] = kwargs["A"].to(_FP8_DTYPE)
+        kwargs["B"] = _column_major_weight(4, 5, dtype=_FP8_DTYPE)
+    elif case == "scale-f16":
+        kwargs["As"] = kwargs["As"].to(torch.float16)
+        kwargs["Bs"] = kwargs["Bs"].to(torch.float16)
+    elif case == "output-f32":
+        kwargs["out_dtype"] = torch.float32
+        kwargs["bias"] = kwargs["bias"].to(torch.float32)
+    elif case == "bias-mismatch":
+        kwargs["bias"] = kwargs["bias"].to(torch.float16)
+    else:  # pragma: no cover - protects the parameter table itself
+        raise AssertionError(f"unknown test case: {case}")
+
+    with pytest.raises(ValueError, match=match):
+        kernel.apply_scaled_mm(**kwargs)
+    assert fake_product.lightop_calls == []
 
 
 def test_channelwise_route_preserves_target_per_tensor_weight_scale(
@@ -791,6 +934,7 @@ def test_channelwise_custom_op_keeps_full_profile_range_in_one_graph():
             "PYTHONNOUSERSITE": "1",
             "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
             "VLLM_PLUGINS": "__disabled__",
+            "VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM": "0",
         }
     )
     completed = subprocess.run(
@@ -968,7 +1112,7 @@ def test_incompatible_triton_outputs_fail_closed_without_fallback(
         )
 
     fake_product.state["behavior"] = bad_behavior
-    with pytest.raises(RuntimeError, match="target triton_scaled_mm"):
+    with pytest.raises(RuntimeError, match="selected Channel-FP8 backend"):
         kernel.apply_scaled_mm(**kwargs)
     assert len(fake_product.triton_calls) == 1
     assert fake_product.original_calls == []

--- a/tests/runtime_patch/test_fp8_channel_triton_product.py
+++ b/tests/runtime_patch/test_fp8_channel_triton_product.py
@@ -693,13 +693,17 @@ def test_channelwise_route_preserves_target_per_tensor_weight_scale(
     assert fake_product.triton_calls[0]["scale_b"] is kwargs["Bs"]
 
 
-def test_channelwise_custom_op_keeps_full_profile_range_in_one_graph():
+@pytest.mark.parametrize("custom_quantization_gemm", ["0", "1"])
+def test_channelwise_custom_op_keeps_full_profile_range_in_one_graph(
+    custom_quantization_gemm: str,
+):
     """Exercise production plumbing with an isolated test dispatch key."""
 
     probe = textwrap.dedent(
         r"""
         from __future__ import annotations
 
+        import os
         import sys
         from types import ModuleType
 
@@ -719,6 +723,9 @@ def test_channelwise_custom_op_keeps_full_profile_range_in_one_graph():
         )
         LIBRARIES = []
         REAL_CALLS = []
+        USE_LIGHTOP = (
+            os.environ["VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM"] == "1"
+        )
 
 
         def package(name):
@@ -795,11 +802,43 @@ def test_channelwise_custom_op_keeps_full_profile_range_in_one_graph():
                 bucket = 128
             else:
                 bucket = 256
-            REAL_CALLS.append((m, bucket))
+            REAL_CALLS.append(("target-triton", m, bucket))
             return torch.zeros(
                 (m, weight.shape[1]),
                 dtype=out_dtype,
                 device=input.device,
+            )
+
+
+        def hipblaslt_w8a8_channelwise_gemm(
+            a,
+            b,
+            scale_a,
+            scale_b,
+            m,
+            n,
+            k,
+            transpose_flag,
+            out_dtype,
+            bias,
+        ):
+            del scale_a, scale_b, bias
+            assert transpose_flag == "NT"
+            assert tuple(a.shape) == (m, k)
+            assert tuple(b.shape) == (n, k)
+            if m <= 32:
+                bucket = 32
+            elif m <= 64:
+                bucket = 64
+            elif m <= 128:
+                bucket = 128
+            else:
+                bucket = 256
+            REAL_CALLS.append(("lightop", m, bucket))
+            return True, torch.zeros(
+                (1, m, n),
+                dtype=out_dtype,
+                device=a.device,
             )
 
 
@@ -809,17 +848,27 @@ def test_channelwise_custom_op_keeps_full_profile_range_in_one_graph():
         )
         triton = ModuleType(TRITON)
         triton.triton_scaled_mm = triton_scaled_mm
+        lightop_gemm_ops = ModuleType("lightop.gemm_ops")
+        lightop_gemm_ops.hipblaslt_w8a8_channelwise_gemm = (
+            hipblaslt_w8a8_channelwise_gemm
+        )
         torch_utils = ModuleType("vllm.utils.torch_utils")
         torch_utils.direct_register_custom_op = direct_register_custom_op
         install_tree(
             {
                 TARGET: target,
                 TRITON: triton,
+                "lightop.gemm_ops": lightop_gemm_ops,
                 "vllm.utils.torch_utils": torch_utils,
             }
         )
 
         scaled_mm.install_fp8_scaled_mm_compat(target)
+        expected_backend = "lightop" if USE_LIGHTOP else "target-triton"
+        assert (
+            ChannelWiseTorchFP8ScaledMMLinearKernel._hcu_fp8_backend
+            == expected_backend
+        )
         kernel = ChannelWiseTorchFP8ScaledMMLinearKernel()
         graphs = []
         captured_graphs = []
@@ -853,7 +902,7 @@ def test_channelwise_custom_op_keeps_full_profile_range_in_one_graph():
             fullgraph=True,
             dynamic=True,
         )
-        fp8 = torch.float8_e4m3fnuz
+        fp8 = torch.float8_e4m3fn if USE_LIGHTOP else torch.float8_e4m3fnuz
         B = torch.zeros((5, 4), dtype=fp8).t()
         Bs = torch.ones((5, 1), dtype=torch.float32)
         bias = torch.ones((5,), dtype=torch.bfloat16)
@@ -869,7 +918,12 @@ def test_channelwise_custom_op_keeps_full_profile_range_in_one_graph():
         assert len(graphs) == 1, graphs
         assert len(captured_graphs) == 1, captured_graphs
         assert "hcu_channel_fp8_target_triton_scaled_mm" in graphs[0]
-        assert REAL_CALLS == [(2, 32), (33, 64), (65, 128), (129, 256)]
+        assert REAL_CALLS == [
+            (expected_backend, 2, 32),
+            (expected_backend, 33, 64),
+            (expected_backend, 65, 128),
+            (expected_backend, 129, 256),
+        ]
 
         captured_graph, _ = captured_graphs[0]
         _, split_items = split_graph(captured_graph, ["aten::sigmoid"])
@@ -934,7 +988,7 @@ def test_channelwise_custom_op_keeps_full_profile_range_in_one_graph():
             "PYTHONNOUSERSITE": "1",
             "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
             "VLLM_PLUGINS": "__disabled__",
-            "VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM": "0",
+            "VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM": custom_quantization_gemm,
         }
     )
     completed = subprocess.run(

--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -4,9 +4,11 @@
 
 from __future__ import annotations
 
+import ast
 import importlib
 import os
 import warnings
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -17,6 +19,37 @@ import torch
 # import would race the coordinator that owns the canonical replacement target.
 os.environ["VLLM_PLUGINS"] = "__disabled__"
 from vllm.utils import torch_utils
+
+
+def _glm4_output_scale_policy(
+    *, dtype: torch.dtype, aiter_requested: bool
+) -> bool:
+    source = Path("vllm_hcu/models/glm4_moe.py").read_text(
+        encoding="utf-8-sig"
+    )
+    tree = ast.parse(source)
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_glm4_apply_routed_scale_to_output"
+    )
+    module = ast.fix_missing_locations(
+        ast.Module(body=[function], type_ignores=[])
+    )
+    namespace = {
+        "VllmConfig": object,
+        "torch": torch,
+        "is_aiter_moe_requested": lambda _config: aiter_requested,
+    }
+    exec(compile(module, "vllm_hcu/models/glm4_moe.py", "exec"), namespace)
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(dtype=dtype),
+        kernel_config=SimpleNamespace(
+            moe_backend="aiter" if aiter_requested else "triton"
+        ),
+    )
+    return namespace["_glm4_apply_routed_scale_to_output"](config)
 
 
 @pytest.fixture(scope="module")
@@ -47,6 +80,57 @@ def moe_runner_module(moe_op_registrations: dict[str, dict]) -> ModuleType:
         torch_utils.direct_register_custom_op = register_custom_op
     assert module.MoERunner.__module__.startswith("vllm_hcu.")
     return module
+
+
+@pytest.mark.parametrize(
+    ("dtype", "aiter_requested", "expected"),
+    [
+        (torch.float16, False, False),
+        (torch.bfloat16, False, True),
+        (torch.float32, False, True),
+        (torch.float16, True, False),
+        (torch.bfloat16, True, False),
+    ],
+)
+def test_glm4_output_scale_policy_preserves_fp16_router_scaling(
+    dtype: torch.dtype,
+    aiter_requested: bool,
+    expected: bool,
+) -> None:
+    assert (
+        _glm4_output_scale_policy(
+            dtype=dtype,
+            aiter_requested=aiter_requested,
+        )
+        is expected
+    )
+
+
+def test_glm4_fp16_non_aiter_shared_output_keeps_routed_scale(
+    moe_runner_module: ModuleType,
+) -> None:
+    scale = 2.5
+    routed = torch.tensor([[2.0, 4.0]], dtype=torch.float16)
+    shared = torch.tensor([[3.0, 5.0]], dtype=torch.float16)
+    apply_scale_to_output = _glm4_output_scale_policy(
+        dtype=torch.float16,
+        aiter_requested=False,
+    )
+
+    # FusedMoE assigns the factor either to the router or to MoERunner.
+    routed_after_router = routed * (1.0 if apply_scale_to_output else scale)
+    runner = object.__new__(moe_runner_module.MoERunner)
+    runner.routed_scaling_factor = scale if apply_scale_to_output else 1.0
+    shared_after_runner, routed_after_runner = (
+        runner._maybe_apply_routed_scale_to_output(
+            shared.clone(), routed_after_router.clone()
+        )
+    )
+
+    assert shared_after_runner is not None
+    actual = shared_after_runner + routed_after_runner
+    expected = shared + scale * routed
+    torch.testing.assert_close(actual, expected)
 
 
 def test_inplace_moe_forward_shared_satisfies_aot_mutation_contract(

--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -405,59 +405,50 @@ def test_shared_input_forwarding_does_not_recompute_inplace_decision(
     torch.testing.assert_close(shared_input, hidden_states)
 
 
-def test_compiled_forward_keeps_overlap_decision_behind_opaque_op(
+def test_compiled_forward_keeps_inplace_entry_without_extra_routed_clone(
     monkeypatch: pytest.MonkeyPatch,
     moe_runner_module: ModuleType,
+    moe_op_registrations: dict[str, dict],
 ) -> None:
-    """Fullgraph tracing must not evaluate alias-sensitive Python policy."""
-
-    def fallback_op(
-        hidden_states: torch.Tensor,
-        _router_logits: torch.Tensor | None,
-        _shared_experts_input: torch.Tensor | None,
-        _input_ids: torch.Tensor | None,
-        _quanted_hidden_states: torch.Tensor | None,
-        _scale: torch.Tensor | None,
-        _topk_weights: torch.Tensor | None,
-        _topk_ids: torch.Tensor | None,
-        _layer_name: str,
-        _hidden_dim_unpadded: int,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        return torch.full_like(hidden_states, 7), torch.ones_like(hidden_states)
-
-    def fallback_fake(
-        hidden_states: torch.Tensor,
-        _router_logits: torch.Tensor | None,
-        _shared_experts_input: torch.Tensor | None,
-        _input_ids: torch.Tensor | None,
-        _quanted_hidden_states: torch.Tensor | None,
-        _scale: torch.Tensor | None,
-        _topk_weights: torch.Tensor | None,
-        _topk_ids: torch.Tensor | None,
-        _layer_name: str,
-        _hidden_dim_unpadded: int,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        return torch.empty_like(hidden_states), torch.empty_like(hidden_states)
-
-    test_library = torch.library.Library(
-        "vllm_hcu_test_moe_compiled_forward", "FRAGMENT"
-    )
-    torch_utils.direct_register_custom_op(
-        op_name="moe_forward_shared",
-        op_func=fallback_op,
-        mutates_args=["hidden_states"],
-        fake_impl=fallback_fake,
-        target_lib=test_library,
-        dispatch_key="CPU",
-        tags=(torch.Tag.needs_fixed_stride_order,),
-    )
-    fallback_entry = (
-        torch.ops.vllm_hcu_test_moe_compiled_forward.moe_forward_shared
-    )
+    """No-overlap compiled Marlin must retain the mutation-only entry."""
 
     class SharedExperts:
+        def requires_input_preservation(self, _hidden_states) -> bool:
+            return False
+
         def allows_inplace_routed_output(self, *_args) -> bool:
             raise AssertionError("overlap policy escaped the opaque op")
+
+    class Layer:
+        _shared_experts = SharedExperts()
+
+        def _forward_impl(self, hidden_states, *_args, **_kwargs):
+            hidden_states.add_(1)
+            return torch.full_like(hidden_states, 7), hidden_states
+
+    monkeypatch.setattr(
+        moe_runner_module,
+        "get_layer_from_name",
+        lambda _name: Layer(),
+    )
+    test_library = torch.library.Library(
+        "vllm_hcu_test_moe_compiled_inplace", "FRAGMENT"
+    )
+    for op_name in ("moe_forward_shared", "moe_forward_shared_inplace"):
+        registration = moe_op_registrations[op_name]
+        torch_utils.direct_register_custom_op(
+            op_name=op_name,
+            op_func=registration["op_func"],
+            mutates_args=registration["mutates_args"],
+            fake_impl=registration["fake_impl"],
+            target_lib=test_library,
+            dispatch_key="CPU",
+            tags=registration["tags"],
+        )
+    inplace_entry = (
+        torch.ops.vllm_hcu_test_moe_compiled_inplace.moe_forward_shared_inplace
+    )
+    tuple_entry = torch.ops.vllm_hcu_test_moe_compiled_inplace.moe_forward_shared
 
     runner = object.__new__(moe_runner_module.MoERunner)
     torch.nn.Module.__init__(runner)
@@ -471,11 +462,13 @@ def test_compiled_forward_keeps_overlap_decision_behind_opaque_op(
     runner._shared_experts = SharedExperts()
     runner.router = object()
     runner._forward_uses_mutated_hidden_states = True
-    runner.__dict__["_forward_entry"] = fallback_entry
+    runner.__dict__["_forward_entry"] = inplace_entry
     monkeypatch.setattr(
         moe_runner_module.MoERunner,
         "_select_forward",
-        lambda self, _uses_mutated=None: fallback_entry,
+        lambda self, uses_mutated=None: (
+            inplace_entry if uses_mutated else tuple_entry
+        ),
     )
     monkeypatch.setattr(
         moe_runner_module.MoERunner,
@@ -504,130 +497,18 @@ def test_compiled_forward_keeps_overlap_decision_behind_opaque_op(
     )
 
     compiled = torch.compile(runner.forward, backend="aot_eager", fullgraph=True)
-    output = compiled(make_hidden(), make_logits())
-
-    torch.testing.assert_close(output, torch.full_like(output, 8))
-
-
-@pytest.mark.parametrize(
-    ("shared_experts_overlap", "expected_path", "input_is_mutated"),
-    [
-        (False, "inplace", True),
-        (True, "out_of_place", False),
-    ],
-)
-def test_forward_uses_out_of_place_routed_output_only_during_shared_overlap(
-    monkeypatch: pytest.MonkeyPatch,
-    moe_runner_module: ModuleType,
-    shared_experts_overlap: bool,
-    expected_path: str,
-    input_is_mutated: bool,
-) -> None:
-    """Only a shared-input race may switch local Marlin out of place."""
-
-    shared_experts_module = importlib.import_module(
-        "vllm_hcu.model_executor.layers.fused_moe.shared_experts"
-    )
-    shared_experts = object.__new__(shared_experts_module.SharedExperts)
-    order = (
-        shared_experts_module.SharedExpertsOrder.MULTI_STREAM_OVERLAPPED
-        if shared_experts_overlap
-        else shared_experts_module.SharedExpertsOrder.NO_OVERLAP
-    )
-    monkeypatch.setattr(
-        shared_experts,
-        "_determine_shared_experts_order",
-        lambda _hidden_states: order,
-    )
-
-    paths: list[str] = []
-    shared_input_aliases: list[bool] = []
-
-    def inplace_forward(hidden_states, _logits, shared_input, *_args):
-        paths.append("inplace")
-        shared_input_aliases.append(
-            torch._C._is_alias_of(shared_input, hidden_states)
-        )
-        shared_output = torch.full_like(hidden_states, 7)
-        hidden_states.fill_(1)
-        return shared_output
-
-    def out_of_place_forward(hidden_states, _logits, shared_input, *_args):
-        paths.append("out_of_place")
-        shared_input_aliases.append(
-            torch._C._is_alias_of(shared_input, hidden_states)
-        )
-        return torch.full_like(hidden_states, 7), torch.ones_like(hidden_states)
-
-    monkeypatch.setattr(
-        moe_runner_module.current_platform, "is_cpu", lambda: True
-    )
-    monkeypatch.setattr(
-        moe_runner_module.current_platform, "is_tpu", lambda: False
-    )
-    monkeypatch.setattr(
-        moe_runner_module, "_moe_forward_shared_inplace", inplace_forward
-    )
-    monkeypatch.setattr(
-        moe_runner_module, "_moe_forward_shared", out_of_place_forward
-    )
-
-    runner = object.__new__(moe_runner_module.MoERunner)
-    torch.nn.Module.__init__(runner)
-    runner.moe_config = SimpleNamespace(
-        dp_size=1,
-        hidden_dim_unpadded=2,
-        is_sequence_parallel=False,
-        pcp_size=1,
-    )
-    runner.routed_experts = SimpleNamespace(
-        quant_method=SimpleNamespace(
-            has_unpadded_output=False,
-            supports_inplace_output=True,
-        ),
-    )
-    runner.routed_input_transform = None
-    runner.routed_output_transform = None
-    runner.routed_scaling_factor = 1.0
-    runner._shared_experts = shared_experts
-    runner.router = object()
-    runner._refresh_forward_entry()
-    monkeypatch.setattr(
-        moe_runner_module.MoERunner,
-        "_maybe_pad_hidden_states",
-        lambda self, shared, hidden: (hidden, None, None),
-    )
-    monkeypatch.setattr(
-        moe_runner_module.MoERunner,
-        "_encode_layer_name",
-        lambda self: "test-layer",
-    )
-    monkeypatch.setattr(
-        moe_runner_module.MoERunner,
-        "_maybe_reduce_shared_expert_output",
-        lambda self, shared: shared,
-    )
-    monkeypatch.setattr(
-        moe_runner_module.MoERunner,
-        "_maybe_reduce_final_output",
-        lambda self, output, _truncate: output,
-    )
-    monkeypatch.setattr(
-        moe_runner_module.MoERunner,
-        "_maybe_add_zero_expert_output",
-        lambda self, output: output,
-    )
+    compiled(make_hidden(), None)
     hidden_states = make_hidden()
-    original_hidden_states = hidden_states.clone()
+    with torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CPU]
+    ) as profile:
+        output = compiled(hidden_states, None)
 
-    output = runner.forward(hidden_states, make_logits())
-
-    assert paths == [expected_path]
-    assert shared_input_aliases == [True]
-    assert torch.equal(hidden_states, original_hidden_states) is (
-        not input_is_mutated
+    clone_count = sum(
+        event.count for event in profile.key_averages() if event.key == "aten::clone"
     )
-    torch.testing.assert_close(output, torch.full_like(hidden_states, 8))
+    assert clone_count == 1
+    torch.testing.assert_close(output, make_hidden() + 8)
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -277,6 +277,35 @@ def test_slimquant_marlin_only_advertises_local_inplace_output(
     assert method.supports_inplace_output is expected
 
 
+def test_inplace_routed_kernel_isolates_shared_expert_input(
+    moe_runner_module: ModuleType,
+) -> None:
+    """Shared experts must not race an in-place routed kernel on one tensor."""
+
+    runner = object.__new__(moe_runner_module.MoERunner)
+    runner._shared_experts = object()
+    runner.routed_input_transform = None
+    runner.routed_experts = SimpleNamespace(
+        quant_method=SimpleNamespace(
+            supports_inplace_output=True,
+            supports_internal_mk=False,
+        )
+    )
+    runner.moe_config = SimpleNamespace(
+        dp_size=1,
+        is_sequence_parallel=False,
+        pcp_size=1,
+    )
+    hidden_states = make_hidden()
+
+    routed_input, shared_input = runner.apply_routed_input_transform(hidden_states)
+
+    assert routed_input is hidden_states
+    assert shared_input is not None
+    assert not torch._C._is_alias_of(shared_input, hidden_states)
+    torch.testing.assert_close(shared_input, hidden_states)
+
+
 def test_forward_entry_refreshes_after_runtime_reconfiguration(
     monkeypatch: pytest.MonkeyPatch,
     moe_runner_module: ModuleType,

--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -56,10 +56,23 @@ def test_inplace_moe_forward_shared_satisfies_aot_mutation_contract(
 ) -> None:
     """AOT must preserve the input mutation without returning an input alias."""
 
+    class SharedExperts:
+        def requires_input_preservation(self, _hidden_states) -> bool:
+            return True
+
     class Layer:
-        def _forward_impl(self, hidden_states, *_args, **_kwargs):
+        _shared_experts = SharedExperts()
+
+        def _forward_impl(
+            self,
+            hidden_states,
+            _router_logits,
+            shared_experts_input,
+            *_args,
+            **_kwargs,
+        ):
             hidden_states.add_(1)
-            return torch.full_like(hidden_states, 7), hidden_states
+            return shared_experts_input.clone(), hidden_states
 
     monkeypatch.setattr(
         moe_runner_module,
@@ -119,8 +132,65 @@ def test_inplace_moe_forward_shared_satisfies_aot_mutation_contract(
         shared_output = compiled(hidden_states)
 
     torch.testing.assert_close(hidden_states, torch.ones_like(hidden_states))
-    torch.testing.assert_close(shared_output, torch.full_like(hidden_states, 7))
+    torch.testing.assert_close(shared_output, torch.zeros_like(hidden_states))
     assert not torch._C._is_alias_of(shared_output, hidden_states)
+
+
+@pytest.mark.parametrize("shared_experts_overlap", [False, True])
+def test_inplace_moe_forward_shared_clones_only_for_runtime_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+    moe_runner_module: ModuleType,
+    moe_op_registrations: dict[str, dict],
+    shared_experts_overlap: bool,
+) -> None:
+    """The opaque runtime op isolates input only before concurrent mutation."""
+
+    class SharedExperts:
+        def requires_input_preservation(self, _hidden_states) -> bool:
+            return shared_experts_overlap
+
+    class Layer:
+        _shared_experts = SharedExperts()
+
+        def _forward_impl(
+            self,
+            hidden_states,
+            _router_logits,
+            shared_experts_input,
+            *_args,
+            **_kwargs,
+        ):
+            hidden_states.add_(1)
+            return shared_experts_input.clone(), hidden_states
+
+    monkeypatch.setattr(
+        moe_runner_module,
+        "get_layer_from_name",
+        lambda _name: Layer(),
+    )
+    hidden_states = torch.zeros((2, 2))
+    op_func = moe_op_registrations["moe_forward_shared_inplace"]["op_func"]
+
+    shared_output = op_func(
+        hidden_states,
+        None,
+        hidden_states,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "test-layer",
+        0,
+    )
+
+    torch.testing.assert_close(hidden_states, torch.ones_like(hidden_states))
+    expected_shared_output = (
+        torch.zeros_like(hidden_states)
+        if shared_experts_overlap
+        else torch.ones_like(hidden_states)
+    )
+    torch.testing.assert_close(shared_output, expected_shared_output)
 
 
 def test_fallback_moe_forward_shared_satisfies_aot_mutation_contract(
@@ -201,6 +271,42 @@ def test_fallback_moe_forward_shared_satisfies_aot_mutation_contract(
     assert not torch._C._is_alias_of(fused_output, hidden_states)
 
 
+def test_fallback_moe_forward_shared_keeps_distinct_routed_output(
+    monkeypatch: pytest.MonkeyPatch,
+    moe_runner_module: ModuleType,
+    moe_op_registrations: dict[str, dict],
+) -> None:
+    """A routed result that already owns storage must not be cloned."""
+
+    routed_output = torch.full((2, 2), 3.0)
+
+    class Layer:
+        def _forward_impl(self, hidden_states, *_args, **_kwargs):
+            return torch.full_like(hidden_states, 7), routed_output
+
+    monkeypatch.setattr(
+        moe_runner_module,
+        "get_layer_from_name",
+        lambda _name: Layer(),
+    )
+    hidden_states = torch.zeros((2, 2))
+    _, fused_output = moe_op_registrations["moe_forward_shared"]["op_func"](
+        hidden_states,
+        None,
+        hidden_states,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "test-layer",
+        0,
+    )
+
+    assert fused_output is routed_output
+    assert not torch._C._is_alias_of(fused_output, hidden_states)
+
+
 def make_hidden() -> torch.Tensor:
     return torch.tensor([[10.0, 11.0], [20.0, 21.0]])
 
@@ -277,24 +383,26 @@ def test_slimquant_marlin_only_advertises_local_inplace_output(
     assert method.supports_inplace_output is expected
 
 
-def test_inplace_routed_kernel_isolates_shared_expert_input(
+def test_shared_input_forwarding_does_not_recompute_inplace_decision(
     moe_runner_module: ModuleType,
 ) -> None:
-    """Shared experts must not race an in-place routed kernel on one tensor."""
+    """Graph-external forwarding must not evaluate graph-unsafe backend state."""
+
+    class GraphUnsafeQuantMethod:
+        @property
+        def supports_inplace_output(self) -> bool:
+            raise AssertionError("forward re-evaluated the quant backend")
+
+    class SharedExperts:
+        def requires_input_preservation(self, _hidden_states) -> bool:
+            return True
 
     runner = object.__new__(moe_runner_module.MoERunner)
-    runner._shared_experts = object()
+    runner._shared_experts = SharedExperts()
+    runner._forward_uses_mutated_hidden_states = True
     runner.routed_input_transform = None
     runner.routed_experts = SimpleNamespace(
-        quant_method=SimpleNamespace(
-            supports_inplace_output=True,
-            supports_internal_mk=False,
-        )
-    )
-    runner.moe_config = SimpleNamespace(
-        dp_size=1,
-        is_sequence_parallel=False,
-        pcp_size=1,
+        quant_method=GraphUnsafeQuantMethod()
     )
     hidden_states = make_hidden()
 
@@ -302,8 +410,306 @@ def test_inplace_routed_kernel_isolates_shared_expert_input(
 
     assert routed_input is hidden_states
     assert shared_input is not None
-    assert not torch._C._is_alias_of(shared_input, hidden_states)
+    assert torch._C._is_alias_of(shared_input, hidden_states)
     torch.testing.assert_close(shared_input, hidden_states)
+
+
+def test_compiled_forward_keeps_overlap_decision_behind_opaque_op(
+    monkeypatch: pytest.MonkeyPatch,
+    moe_runner_module: ModuleType,
+) -> None:
+    """Fullgraph tracing must not evaluate alias-sensitive Python policy."""
+
+    def fallback_op(
+        hidden_states: torch.Tensor,
+        _router_logits: torch.Tensor | None,
+        _shared_experts_input: torch.Tensor | None,
+        _input_ids: torch.Tensor | None,
+        _quanted_hidden_states: torch.Tensor | None,
+        _scale: torch.Tensor | None,
+        _topk_weights: torch.Tensor | None,
+        _topk_ids: torch.Tensor | None,
+        _layer_name: str,
+        _hidden_dim_unpadded: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return torch.full_like(hidden_states, 7), torch.ones_like(hidden_states)
+
+    def fallback_fake(
+        hidden_states: torch.Tensor,
+        _router_logits: torch.Tensor | None,
+        _shared_experts_input: torch.Tensor | None,
+        _input_ids: torch.Tensor | None,
+        _quanted_hidden_states: torch.Tensor | None,
+        _scale: torch.Tensor | None,
+        _topk_weights: torch.Tensor | None,
+        _topk_ids: torch.Tensor | None,
+        _layer_name: str,
+        _hidden_dim_unpadded: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return torch.empty_like(hidden_states), torch.empty_like(hidden_states)
+
+    test_library = torch.library.Library(
+        "vllm_hcu_test_moe_compiled_forward", "FRAGMENT"
+    )
+    torch_utils.direct_register_custom_op(
+        op_name="moe_forward_shared",
+        op_func=fallback_op,
+        mutates_args=["hidden_states"],
+        fake_impl=fallback_fake,
+        target_lib=test_library,
+        dispatch_key="CPU",
+        tags=(torch.Tag.needs_fixed_stride_order,),
+    )
+    fallback_entry = (
+        torch.ops.vllm_hcu_test_moe_compiled_forward.moe_forward_shared
+    )
+
+    class SharedExperts:
+        def allows_inplace_routed_output(self, *_args) -> bool:
+            raise AssertionError("overlap policy escaped the opaque op")
+
+    runner = object.__new__(moe_runner_module.MoERunner)
+    torch.nn.Module.__init__(runner)
+    runner.moe_config = SimpleNamespace(hidden_dim_unpadded=2)
+    runner.routed_experts = SimpleNamespace(
+        quant_method=SimpleNamespace(has_unpadded_output=False),
+    )
+    runner.routed_input_transform = None
+    runner.routed_output_transform = None
+    runner.routed_scaling_factor = 1.0
+    runner._shared_experts = SharedExperts()
+    runner.router = object()
+    runner._forward_uses_mutated_hidden_states = True
+    runner.__dict__["_forward_entry"] = fallback_entry
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_select_forward",
+        lambda self, _uses_mutated=None: fallback_entry,
+    )
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_maybe_pad_hidden_states",
+        lambda self, shared, hidden: (hidden, None, None),
+    )
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_encode_layer_name",
+        lambda self: "test-layer",
+    )
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_maybe_reduce_shared_expert_output",
+        lambda self, shared: shared,
+    )
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_maybe_reduce_final_output",
+        lambda self, output, _truncate: output,
+    )
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_maybe_add_zero_expert_output",
+        lambda self, output: output,
+    )
+
+    compiled = torch.compile(runner.forward, backend="aot_eager", fullgraph=True)
+    output = compiled(make_hidden(), make_logits())
+
+    torch.testing.assert_close(output, torch.full_like(output, 8))
+
+
+@pytest.mark.parametrize(
+    ("shared_experts_overlap", "expected_path", "input_is_mutated"),
+    [
+        (False, "inplace", True),
+        (True, "out_of_place", False),
+    ],
+)
+def test_forward_uses_out_of_place_routed_output_only_during_shared_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+    moe_runner_module: ModuleType,
+    shared_experts_overlap: bool,
+    expected_path: str,
+    input_is_mutated: bool,
+) -> None:
+    """Only a shared-input race may switch local Marlin out of place."""
+
+    shared_experts_module = importlib.import_module(
+        "vllm_hcu.model_executor.layers.fused_moe.shared_experts"
+    )
+    shared_experts = object.__new__(shared_experts_module.SharedExperts)
+    order = (
+        shared_experts_module.SharedExpertsOrder.MULTI_STREAM_OVERLAPPED
+        if shared_experts_overlap
+        else shared_experts_module.SharedExpertsOrder.NO_OVERLAP
+    )
+    monkeypatch.setattr(
+        shared_experts,
+        "_determine_shared_experts_order",
+        lambda _hidden_states: order,
+    )
+
+    paths: list[str] = []
+    shared_input_aliases: list[bool] = []
+
+    def inplace_forward(hidden_states, _logits, shared_input, *_args):
+        paths.append("inplace")
+        shared_input_aliases.append(
+            torch._C._is_alias_of(shared_input, hidden_states)
+        )
+        shared_output = torch.full_like(hidden_states, 7)
+        hidden_states.fill_(1)
+        return shared_output
+
+    def out_of_place_forward(hidden_states, _logits, shared_input, *_args):
+        paths.append("out_of_place")
+        shared_input_aliases.append(
+            torch._C._is_alias_of(shared_input, hidden_states)
+        )
+        return torch.full_like(hidden_states, 7), torch.ones_like(hidden_states)
+
+    monkeypatch.setattr(
+        moe_runner_module.current_platform, "is_cpu", lambda: True
+    )
+    monkeypatch.setattr(
+        moe_runner_module.current_platform, "is_tpu", lambda: False
+    )
+    monkeypatch.setattr(
+        moe_runner_module, "_moe_forward_shared_inplace", inplace_forward
+    )
+    monkeypatch.setattr(
+        moe_runner_module, "_moe_forward_shared", out_of_place_forward
+    )
+
+    runner = object.__new__(moe_runner_module.MoERunner)
+    torch.nn.Module.__init__(runner)
+    runner.moe_config = SimpleNamespace(
+        dp_size=1,
+        hidden_dim_unpadded=2,
+        is_sequence_parallel=False,
+        pcp_size=1,
+    )
+    runner.routed_experts = SimpleNamespace(
+        quant_method=SimpleNamespace(
+            has_unpadded_output=False,
+            supports_inplace_output=True,
+        ),
+    )
+    runner.routed_input_transform = None
+    runner.routed_output_transform = None
+    runner.routed_scaling_factor = 1.0
+    runner._shared_experts = shared_experts
+    runner.router = object()
+    runner._refresh_forward_entry()
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_maybe_pad_hidden_states",
+        lambda self, shared, hidden: (hidden, None, None),
+    )
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_encode_layer_name",
+        lambda self: "test-layer",
+    )
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_maybe_reduce_shared_expert_output",
+        lambda self, shared: shared,
+    )
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_maybe_reduce_final_output",
+        lambda self, output, _truncate: output,
+    )
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_maybe_add_zero_expert_output",
+        lambda self, output: output,
+    )
+    hidden_states = make_hidden()
+    original_hidden_states = hidden_states.clone()
+
+    output = runner.forward(hidden_states, make_logits())
+
+    assert paths == [expected_path]
+    assert shared_input_aliases == [True]
+    assert torch.equal(hidden_states, original_hidden_states) is (
+        not input_is_mutated
+    )
+    torch.testing.assert_close(output, torch.full_like(hidden_states, 8))
+
+
+@pytest.mark.parametrize(
+    ("order", "expected"),
+    [
+        ("NO_OVERLAP", False),
+        ("MK_INTERNAL_OVERLAPPED", True),
+        ("MULTI_STREAM_OVERLAPPED", True),
+    ],
+)
+def test_shared_experts_preserve_input_only_while_routed_work_can_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+    order: str,
+    expected: bool,
+) -> None:
+    """Every overlapping execution order must retain the pristine input."""
+
+    shared_experts_module = importlib.import_module(
+        "vllm_hcu.model_executor.layers.fused_moe.shared_experts"
+    )
+    shared_experts = object.__new__(shared_experts_module.SharedExperts)
+    monkeypatch.setattr(
+        shared_experts,
+        "_determine_shared_experts_order",
+        lambda _hidden_states: getattr(
+            shared_experts_module.SharedExpertsOrder, order
+        ),
+    )
+
+    assert shared_experts.requires_input_preservation(make_hidden()) is expected
+
+
+@pytest.mark.parametrize(
+    ("order", "alias_kind", "expected"),
+    [
+        ("NO_OVERLAP", "same", True),
+        ("NO_OVERLAP", "view", True),
+        ("MK_INTERNAL_OVERLAPPED", "same", False),
+        ("MK_INTERNAL_OVERLAPPED", "view", False),
+        ("MULTI_STREAM_OVERLAPPED", "same", False),
+        ("MULTI_STREAM_OVERLAPPED", "distinct", True),
+    ],
+)
+def test_shared_experts_allow_inplace_routing_only_without_an_input_race(
+    monkeypatch: pytest.MonkeyPatch,
+    order: str,
+    alias_kind: str,
+    expected: bool,
+) -> None:
+    """Views race during overlap; transformed or padded inputs do not."""
+
+    shared_experts_module = importlib.import_module(
+        "vllm_hcu.model_executor.layers.fused_moe.shared_experts"
+    )
+    shared_experts = object.__new__(shared_experts_module.SharedExperts)
+    monkeypatch.setattr(
+        shared_experts,
+        "_determine_shared_experts_order",
+        lambda _hidden_states: getattr(
+            shared_experts_module.SharedExpertsOrder, order
+        ),
+    )
+    shared_input = make_hidden()
+    routed_input = {
+        "same": shared_input,
+        "view": shared_input.view_as(shared_input),
+        "distinct": shared_input.clone(),
+    }[alias_kind]
+
+    assert (
+        shared_experts.allows_inplace_routed_output(routed_input, shared_input)
+        is expected
+    )
 
 
 def test_forward_entry_refreshes_after_runtime_reconfiguration(
@@ -481,7 +887,9 @@ def test_shared_and_routed_outputs_keep_local_token_order_before_addition(
     runner.routed_input_transform = None
     runner.routed_output_transform = None
     runner.routed_scaling_factor = 1.0
-    runner._shared_experts = object()
+    runner._shared_experts = SimpleNamespace(
+        allows_inplace_routed_output=lambda _routed, _shared: True
+    )
     runner.router = object()
     shared_output = torch.tensor([[100.0, 101.0], [200.0, 201.0]])
     fused_output = torch.tensor([[10.0, 11.0], [20.0, 21.0]])

--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -353,18 +353,14 @@ def test_inplace_shared_output_requires_local_inplace_kernel(
 
 
 @pytest.mark.parametrize(
-    ("use_deepep", "use_aiter", "expected"),
+    ("use_deepep", "expected"),
     [
-        (False, False, True),
-        (True, False, False),
-        (False, True, False),
-        (True, True, False),
+        (False, True),
+        (True, False),
     ],
 )
 def test_slimquant_marlin_only_advertises_local_inplace_output(
-    monkeypatch: pytest.MonkeyPatch,
     use_deepep: bool,
-    use_aiter: bool,
     expected: bool,
 ) -> None:
     module = importlib.import_module(
@@ -374,11 +370,6 @@ def test_slimquant_marlin_only_advertises_local_inplace_output(
     method = object.__new__(module.CompressedTensorsW8A8FP8MarlinMoEMethod)
     method.moe = object()
     method.use_deepep = use_deepep
-    monkeypatch.setattr(
-        module,
-        "_is_hcu_aiter_w8a8_moe_requested",
-        lambda moe: use_aiter,
-    )
 
     assert method.supports_inplace_output is expected
 

--- a/tests/runtime_patch/test_hcu_cache_kernel_source.py
+++ b/tests/runtime_patch/test_hcu_cache_kernel_source.py
@@ -30,3 +30,34 @@ def test_mla_cache_launch_respects_hcu_thread_limit(
 
     assert expected_launch in function
     assert "min(kv_lora_rank, 512)" not in function
+
+
+def test_flash_cache_writer_uses_runtime_strides_and_mutating_schema() -> None:
+    kernel_source = (
+        REPO / "vllm_hcu/csrc/hcu_cache_kernel.cu"
+    ).read_text(encoding="utf-8")
+    kernel = kernel_source.split(
+        "__global__ void reshape_and_cache_flash_kernel_hcu(", 1
+    )[1].split("template <typename scalar_t", 1)[0]
+
+    assert "block_idx * block_stride" in kernel
+    assert "block_offset * page_stride" in kernel
+    assert "head_idx * head_stride" in kernel
+    assert "if (slot_idx < 0)" in kernel
+
+    host = kernel_source.split("void reshape_and_cache_flash_hcu(", 1)[1].split(
+        "void concat_and_cache_mla_hcu(", 1
+    )[0]
+    assert "std::min(num_heads * head_size, 256)" in host
+
+    bindings = (REPO / "vllm_hcu/csrc/torch_bindings.cpp").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        '"reshape_and_cache_flash(Tensor key, Tensor value, Tensor! key_cache, "'
+        in bindings
+    )
+    assert '"Tensor! value_cache, Tensor slot_mapping, str kv_cache_dtype, "' in (
+        bindings
+    )
+    assert 'ops.impl("reshape_and_cache_flash", torch::kCUDA' in bindings

--- a/tests/runtime_patch/test_hy_v3_slimquant_weight_loading.py
+++ b/tests/runtime_patch/test_hy_v3_slimquant_weight_loading.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Regression contracts for HY3 KV-cache scale loading on vLLM 0.25.1."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
+
+class _MapperOnlyQuantConfig:
+    """Expose the v0.25.1 API without the removed get_cache_scale API."""
+
+    @staticmethod
+    def get_cache_scale_mapper():
+        return QuantizationConfig.get_cache_scale_mapper()
+
+
+def _blank_module(module_type: type[nn.Module]) -> nn.Module:
+    module = object.__new__(module_type)
+    nn.Module.__init__(module)
+    return module
+
+
+def _scalar_parameter() -> nn.Parameter:
+    return nn.Parameter(torch.zeros(()), requires_grad=False)
+
+
+@pytest.fixture(scope="module")
+def hy_v3_types():
+    patch = pytest.MonkeyPatch()
+    import vllm.model_executor.layers.attention as attention_package
+    from vllm_hcu.model_executor.layers.attention_runtime import (
+        FusedQkvSplitRmsNormRopeAttention,
+    )
+
+    # Production installs this export before model discovery. Install the same
+    # concrete class only for the lifetime of this focused CPU test module.
+    patch.setattr(
+        attention_package,
+        "FusedQkvSplitRmsNormRopeAttention",
+        FusedQkvSplitRmsNormRopeAttention,
+        raising=False,
+    )
+    from vllm_hcu.models.hy_v3 import HYV3Model
+    from vllm_hcu.models.hy_v3_mtp import HYV3MTP
+
+    yield HYV3Model, HYV3MTP
+    patch.undo()
+
+
+def test_hy_v3_model_loads_pre_mapped_cache_scale_without_legacy_api(
+    hy_v3_types,
+) -> None:
+    HYV3Model, _ = hy_v3_types
+    model = _blank_module(HYV3Model)
+    model.config = SimpleNamespace(tie_word_embeddings=False)
+    model.quant_config = _MapperOnlyQuantConfig()
+    model.get_expert_mapping = lambda: []
+
+    target_name = "model.layers.0.self_attn.attn.k_scale"
+    target = _scalar_parameter()
+    model.named_parameters = lambda: iter(((target_name, target),))
+
+    loaded = model.load_weights(((target_name, torch.tensor([3.0])),))
+
+    assert loaded == {target_name}
+    torch.testing.assert_close(target, torch.tensor(3.0))
+
+
+def test_hy_v3_mtp_maps_checkpoint_cache_scale_with_v0251_mapper(
+    hy_v3_types,
+) -> None:
+    _, HYV3MTP = hy_v3_types
+    model = _blank_module(HYV3MTP)
+    model.config = SimpleNamespace(
+        tie_word_embeddings=False,
+        num_hidden_layers=80,
+        num_nextn_predict_layers=1,
+        num_attention_heads=64,
+        num_key_value_heads=8,
+    )
+    model.quant_config = _MapperOnlyQuantConfig()
+    model.use_pp = False
+
+    target_name = "model.layers.80.mtp_block.self_attn.attn.k_scale"
+    target = _scalar_parameter()
+    model.named_parameters = lambda: iter(((target_name, target),))
+
+    model.load_weights(
+        (("model.layers.80.self_attn.k_cache.scale", torch.tensor([5.0])),)
+    )
+
+    torch.testing.assert_close(target, torch.tensor(5.0))

--- a/tests/runtime_patch/test_lightop_marlin_moe_compat.py
+++ b/tests/runtime_patch/test_lightop_marlin_moe_compat.py
@@ -215,3 +215,92 @@ def test_int8_marlin_safely_remaps_global_expert_ids(
     )
 
     assert expert_ids.tolist() == [0, 1]
+
+
+@pytest.mark.parametrize(
+    ("method_name", "kernel_name"),
+    [
+        (
+            "CompressedTensorsW8A8FP8MarlinMoEMethod",
+            "fused_experts_impl_fp8_marlin",
+        ),
+        (
+            "CompressedTensorsW8A8Int8MarlinMoEMethod",
+            "fused_experts_impl_int8_marlin",
+        ),
+    ],
+)
+@pytest.mark.parametrize("shared_experts_overlap", [False, True])
+def test_marlin_allocates_routed_output_only_during_shared_input_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+    method_name: str,
+    kernel_name: str,
+    shared_experts_overlap: bool,
+) -> None:
+    """Concurrent shared reads require out-of-place routed output, not a copy."""
+
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
+        compressed_tensors_moe_marlin as marlin,
+    )
+
+    def marlin_kernel(**kwargs):
+        hidden_states = kwargs["hidden_states"]
+        if kwargs["inplace"]:
+            hidden_states.fill_(3)
+            return hidden_states
+        return torch.full_like(hidden_states, 3)
+
+    lightop = ModuleType("lightop")
+    lightop.__path__ = []  # type: ignore[attr-defined]
+    moe = ModuleType("lightop.moe")
+    setattr(moe, kernel_name, marlin_kernel)
+    lightop.moe = moe
+    monkeypatch.setitem(sys.modules, "lightop", lightop)
+    monkeypatch.setitem(sys.modules, "lightop.moe", moe)
+    monkeypatch.setattr(
+        marlin,
+        "ensure_safe_marlin_moe_alignment",
+        lambda _kernel: None,
+    )
+    monkeypatch.setattr(
+        marlin,
+        "_is_hcu_aiter_w8a8_moe_requested",
+        lambda _moe: False,
+    )
+
+    class SharedExperts:
+        def allows_inplace_routed_output(
+            self,
+            routed_input: torch.Tensor,
+            shared_input: torch.Tensor,
+        ) -> bool:
+            return not (
+                torch._C._is_alias_of(routed_input, shared_input)
+                and shared_experts_overlap
+            )
+
+    method = object.__new__(getattr(marlin, method_name))
+    method.moe = object()
+    method.use_deepep = False
+    method.moe_quant_config = None
+    if kernel_name == "fused_experts_impl_fp8_marlin":
+        method.fused_experts = method.fused_moe_forward
+    layer = _moe_layer(global_num_experts=2)
+    hidden_states = torch.ones((1, 4))
+    original_hidden_states = hidden_states.clone()
+
+    output = method.apply(
+        layer,
+        hidden_states,
+        torch.ones((1, 2)),
+        torch.tensor([[0, 1]], dtype=torch.int32),
+        SharedExperts(),
+        hidden_states,
+    )
+
+    assert torch._C._is_alias_of(output, hidden_states) is (
+        not shared_experts_overlap
+    )
+    if shared_experts_overlap:
+        torch.testing.assert_close(hidden_states, original_hidden_states)
+    torch.testing.assert_close(output, torch.full_like(hidden_states, 3))

--- a/tests/runtime_patch/test_lightop_marlin_moe_compat.py
+++ b/tests/runtime_patch/test_lightop_marlin_moe_compat.py
@@ -195,11 +195,6 @@ def test_int8_marlin_safely_remaps_global_expert_ids(
         "lightop._lmslim_native.layers.fused_moe.int8_marlin_test",
         "fused_experts_impl_int8_marlin",
     )
-    monkeypatch.setattr(
-        marlin,
-        "_is_hcu_aiter_w8a8_moe_requested",
-        lambda *_args: False,
-    )
     expert_map = torch.tensor([-1, 0, -1, 1], dtype=torch.int32)
     layer = _moe_layer(global_num_experts=4, expert_map=expert_map)
     method = object.__new__(marlin.CompressedTensorsW8A8Int8MarlinMoEMethod)
@@ -261,11 +256,6 @@ def test_marlin_allocates_routed_output_only_during_shared_input_overlap(
         marlin,
         "ensure_safe_marlin_moe_alignment",
         lambda _kernel: None,
-    )
-    monkeypatch.setattr(
-        marlin,
-        "_is_hcu_aiter_w8a8_moe_requested",
-        lambda _moe: False,
     )
 
     class SharedExperts:

--- a/tests/runtime_patch/test_lightop_marlin_moe_compat.py
+++ b/tests/runtime_patch/test_lightop_marlin_moe_compat.py
@@ -59,6 +59,10 @@ def _install_lightop_marlin_kernel(
     ):
         del expert_map
         flat_topk_ids = topk_ids.flatten()
+        # Match vLLM's native kernel: every padding slot is initialized to the
+        # numel sentinel before valid routed token ids are written.
+        sorted_token_ids.fill_(topk_ids.numel())
+        expert_ids.fill_(-1)
         write_offset = 0
         block_index = 0
         for expert_id in range(num_experts):
@@ -108,28 +112,35 @@ def _moe_layer(*, global_num_experts: int, expert_map=None):
     )
 
 
-def test_fp8_marlin_prefills_unwritten_alignment_padding(
+def test_fp8_marlin_reuses_native_alignment_initialization_without_full(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
         compressed_tensors_moe_marlin as marlin,
     )
 
-    _install_lightop_marlin_kernel(
+    kernel = _install_lightop_marlin_kernel(
         monkeypatch,
         "lightop._lmslim_native.layers.fused_moe.fp8_marlin_test",
         "fused_experts_impl_fp8_marlin",
     )
+    marlin.ensure_safe_marlin_moe_alignment(kernel)
     method = object.__new__(marlin.CompressedTensorsW8A8FP8MarlinMoEMethod)
-    sorted_token_ids, _, _ = method.fused_moe_forward(
-        _moe_layer(global_num_experts=2),
-        torch.ones((1, 4)),
-        torch.ones((1, 2)),
-        torch.tensor([[0, 1]], dtype=torch.int32),
-        global_num_experts=2,
-    )
+    with torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CPU]
+    ) as profile:
+        sorted_token_ids, _, _ = method.fused_moe_forward(
+            _moe_layer(global_num_experts=2),
+            torch.ones((1, 4)),
+            torch.ones((1, 2)),
+            torch.tensor([[0, 1]], dtype=torch.int32),
+            global_num_experts=2,
+        )
 
     assert sorted_token_ids.tolist() == [0, 2, 1, 2]
+    assert not any(
+        event.key == "aten::full" for event in profile.key_averages()
+    )
 
 
 def test_fp8_marlin_patches_public_lightop_runner_module(
@@ -139,11 +150,12 @@ def test_fp8_marlin_patches_public_lightop_runner_module(
         compressed_tensors_moe_marlin as marlin,
     )
 
-    _install_lightop_marlin_kernel(
+    kernel = _install_lightop_marlin_kernel(
         monkeypatch,
         "lightop.moe.fp8_marlin_public_test",
         "fused_experts_impl_fp8_marlin",
     )
+    marlin.ensure_safe_marlin_moe_alignment(kernel)
     method = object.__new__(marlin.CompressedTensorsW8A8FP8MarlinMoEMethod)
     sorted_token_ids, _, _ = method.fused_moe_forward(
         _moe_layer(global_num_experts=2),
@@ -163,11 +175,12 @@ def test_fp8_marlin_uses_stable_vllm_alignment_not_lightop_alignment(
         compressed_tensors_moe_marlin as marlin,
     )
 
-    _install_lightop_marlin_kernel(
+    kernel = _install_lightop_marlin_kernel(
         monkeypatch,
         "lightop._lmslim_native.layers.fused_moe.fp8_marlin_stable_test",
         "fused_experts_impl_fp8_marlin",
     )
+    marlin.ensure_safe_marlin_moe_alignment(kernel)
 
     method = object.__new__(marlin.CompressedTensorsW8A8FP8MarlinMoEMethod)
     sorted_token_ids, expert_ids, num_tokens_post_pad = method.fused_moe_forward(
@@ -190,11 +203,12 @@ def test_int8_marlin_safely_remaps_global_expert_ids(
         compressed_tensors_moe_marlin as marlin,
     )
 
-    _install_lightop_marlin_kernel(
+    kernel = _install_lightop_marlin_kernel(
         monkeypatch,
         "lightop._lmslim_native.layers.fused_moe.int8_marlin_test",
         "fused_experts_impl_int8_marlin",
     )
+    marlin.ensure_safe_marlin_moe_alignment(kernel)
     expert_map = torch.tensor([-1, 0, -1, 1], dtype=torch.int32)
     layer = _moe_layer(global_num_experts=4, expert_map=expert_map)
     method = object.__new__(marlin.CompressedTensorsW8A8Int8MarlinMoEMethod)
@@ -210,6 +224,56 @@ def test_int8_marlin_safely_remaps_global_expert_ids(
     )
 
     assert expert_ids.tolist() == [0, 1]
+
+
+@pytest.mark.parametrize(
+    ("method_name", "kernel_name"),
+    [
+        (
+            "CompressedTensorsW8A8FP8MarlinMoEMethod",
+            "fused_experts_impl_fp8_marlin",
+        ),
+        (
+            "CompressedTensorsW8A8Int8MarlinMoEMethod",
+            "fused_experts_impl_int8_marlin",
+        ),
+    ],
+)
+def test_marlin_installs_alignment_during_weight_loading(
+    monkeypatch: pytest.MonkeyPatch,
+    method_name: str,
+    kernel_name: str,
+) -> None:
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
+        compressed_tensors_moe_marlin as marlin,
+    )
+
+    kernel = _install_lightop_marlin_kernel(
+        monkeypatch,
+        f"lightop.moe.{kernel_name}_load_test",
+        kernel_name,
+    )
+    installed = []
+    monkeypatch.setattr(
+        marlin,
+        "ensure_safe_marlin_moe_alignment",
+        installed.append,
+    )
+    monkeypatch.setattr(
+        marlin,
+        "get_w8a8_int8_marlin_weights",
+        lambda weight: weight,
+    )
+    method = object.__new__(getattr(marlin, method_name))
+    method.use_deepep = False
+    layer = SimpleNamespace(
+        w13_weight=torch.nn.Parameter(torch.ones((1, 1))),
+        w2_weight=torch.nn.Parameter(torch.ones((1, 1))),
+    )
+
+    method.process_weights_after_loading(layer)
+
+    assert installed == [kernel]
 
 
 @pytest.mark.parametrize(
@@ -252,10 +316,14 @@ def test_marlin_allocates_routed_output_only_during_shared_input_overlap(
     lightop.moe = moe
     monkeypatch.setitem(sys.modules, "lightop", lightop)
     monkeypatch.setitem(sys.modules, "lightop.moe", moe)
+
+    def fail_if_installed_during_forward(_kernel) -> None:
+        raise AssertionError("alignment installation escaped weight loading")
+
     monkeypatch.setattr(
         marlin,
         "ensure_safe_marlin_moe_alignment",
-        lambda _kernel: None,
+        fail_if_installed_during_forward,
     )
 
     class SharedExperts:

--- a/tests/runtime_patch/test_lightop_marlin_moe_compat.py
+++ b/tests/runtime_patch/test_lightop_marlin_moe_compat.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Contracts for the LightOp-backed SlimQuant Marlin MoE boundary."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+
+def _install_lightop_marlin_kernel(
+    monkeypatch: pytest.MonkeyPatch,
+    implementation_name: str,
+    export_name: str,
+):
+    implementation = ModuleType(implementation_name)
+
+    def incomplete_alignment(
+        topk_ids,
+        block_size,
+        num_experts,
+        expert_map=None,
+        pad_sorted_ids=False,
+        ignore_invalid_experts=False,
+    ):
+        del expert_map, pad_sorted_ids, ignore_invalid_experts
+        return (
+            torch.zeros(topk_ids.numel() * block_size, dtype=torch.int32),
+            topk_ids.flatten().to(torch.int32),
+            torch.tensor([topk_ids.numel() * block_size], dtype=torch.int32),
+        )
+
+    implementation.moe_align_block_size = incomplete_alignment
+    monkeypatch.setitem(sys.modules, implementation_name, implementation)
+
+    class Kernel:
+        def __call__(self, **kwargs):
+            return sys.modules[self.__module__].moe_align_block_size(
+                kwargs["topk_ids"],
+                2,
+                kwargs["global_num_experts"],
+                kwargs.get("expert_map"),
+            )
+
+    kernel = Kernel()
+    kernel.__module__ = implementation_name
+
+    def fill_alignment(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_pad,
+        expert_map=None,
+    ):
+        del expert_map
+        flat_topk_ids = topk_ids.flatten()
+        write_offset = 0
+        block_index = 0
+        for expert_id in range(num_experts):
+            token_ids = torch.nonzero(
+                flat_topk_ids == expert_id,
+                as_tuple=False,
+            ).flatten()
+            for chunk_start in range(0, token_ids.numel(), block_size):
+                chunk = token_ids[chunk_start : chunk_start + block_size]
+                sorted_token_ids[
+                    write_offset : write_offset + chunk.numel()
+                ] = chunk.to(torch.int32)
+                expert_ids[block_index] = expert_id
+                write_offset += block_size
+                block_index += 1
+        num_tokens_post_pad.fill_(write_offset)
+
+    def moe_align_block_size_out(*_args, **_kwargs):
+        raise AssertionError("LightOp alignment must not be used by Marlin")
+
+    lightop = ModuleType("lightop")
+    lightop.__path__ = []  # type: ignore[attr-defined]
+    moe = ModuleType("lightop.moe")
+    setattr(moe, export_name, kernel)
+    moe.moe_align_block_size_out = moe_align_block_size_out
+    lightop.moe = moe
+    monkeypatch.setitem(sys.modules, "lightop", lightop)
+    monkeypatch.setitem(sys.modules, "lightop.moe", moe)
+    from vllm import _custom_ops as ops
+
+    monkeypatch.setattr(ops, "moe_align_block_size", fill_alignment)
+    return kernel
+
+
+def _moe_layer(*, global_num_experts: int, expert_map=None):
+    return SimpleNamespace(
+        w13_weight=torch.ones(1),
+        w2_weight=torch.ones(1),
+        w13_weight_scale=torch.ones(1),
+        w2_weight_scale=torch.ones(1),
+        w13_input_scale=None,
+        w2_input_scale=None,
+        global_num_experts=global_num_experts,
+        expert_map=expert_map,
+        apply_router_weight_on_input=False,
+        activation=SimpleNamespace(value="silu"),
+    )
+
+
+def test_fp8_marlin_prefills_unwritten_alignment_padding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
+        compressed_tensors_moe_marlin as marlin,
+    )
+
+    _install_lightop_marlin_kernel(
+        monkeypatch,
+        "lightop._lmslim_native.layers.fused_moe.fp8_marlin_test",
+        "fused_experts_impl_fp8_marlin",
+    )
+    method = object.__new__(marlin.CompressedTensorsW8A8FP8MarlinMoEMethod)
+    sorted_token_ids, _, _ = method.fused_moe_forward(
+        _moe_layer(global_num_experts=2),
+        torch.ones((1, 4)),
+        torch.ones((1, 2)),
+        torch.tensor([[0, 1]], dtype=torch.int32),
+        global_num_experts=2,
+    )
+
+    assert sorted_token_ids.tolist() == [0, 2, 1, 2]
+
+
+def test_fp8_marlin_patches_public_lightop_runner_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
+        compressed_tensors_moe_marlin as marlin,
+    )
+
+    _install_lightop_marlin_kernel(
+        monkeypatch,
+        "lightop.moe.fp8_marlin_public_test",
+        "fused_experts_impl_fp8_marlin",
+    )
+    method = object.__new__(marlin.CompressedTensorsW8A8FP8MarlinMoEMethod)
+    sorted_token_ids, _, _ = method.fused_moe_forward(
+        _moe_layer(global_num_experts=2),
+        torch.ones((1, 4)),
+        torch.ones((1, 2)),
+        torch.tensor([[0, 1]], dtype=torch.int32),
+        global_num_experts=2,
+    )
+
+    assert sorted_token_ids.tolist() == [0, 2, 1, 2]
+
+
+def test_fp8_marlin_uses_stable_vllm_alignment_not_lightop_alignment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
+        compressed_tensors_moe_marlin as marlin,
+    )
+
+    _install_lightop_marlin_kernel(
+        monkeypatch,
+        "lightop._lmslim_native.layers.fused_moe.fp8_marlin_stable_test",
+        "fused_experts_impl_fp8_marlin",
+    )
+
+    method = object.__new__(marlin.CompressedTensorsW8A8FP8MarlinMoEMethod)
+    sorted_token_ids, expert_ids, num_tokens_post_pad = method.fused_moe_forward(
+        _moe_layer(global_num_experts=2),
+        torch.ones((3, 4)),
+        torch.ones((3, 2)),
+        torch.tensor([[1, 0], [0, 1], [1, 0]], dtype=torch.int32),
+        global_num_experts=2,
+    )
+
+    assert num_tokens_post_pad.item() == 8
+    assert sorted_token_ids.tolist() == [1, 2, 5, 6, 0, 3, 4, 6]
+    assert expert_ids.tolist() == [0, 0, 1, 1]
+
+
+def test_int8_marlin_safely_remaps_global_expert_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
+        compressed_tensors_moe_marlin as marlin,
+    )
+
+    _install_lightop_marlin_kernel(
+        monkeypatch,
+        "lightop._lmslim_native.layers.fused_moe.int8_marlin_test",
+        "fused_experts_impl_int8_marlin",
+    )
+    monkeypatch.setattr(
+        marlin,
+        "_is_hcu_aiter_w8a8_moe_requested",
+        lambda *_args: False,
+    )
+    expert_map = torch.tensor([-1, 0, -1, 1], dtype=torch.int32)
+    layer = _moe_layer(global_num_experts=4, expert_map=expert_map)
+    method = object.__new__(marlin.CompressedTensorsW8A8Int8MarlinMoEMethod)
+    method.moe = None
+    method.moe_quant_config = None
+    _, expert_ids, _ = method.apply(
+        layer,
+        torch.ones((1, 4)),
+        torch.ones((1, 2)),
+        torch.tensor([[1, 3]], dtype=torch.int32),
+        None,
+        None,
+    )
+
+    assert expert_ids.tolist() == [0, 1]

--- a/tests/runtime_patch/test_mla_target_ownership.py
+++ b/tests/runtime_patch/test_mla_target_ownership.py
@@ -14,6 +14,8 @@ from types import ModuleType, SimpleNamespace
 import pytest
 import torch
 
+from vllm.v1.attention.backends.mla.flashmla_sparse import FlashMLASparseBackend
+from vllm.v1.kv_cache_interface import KVQuantMode, MLAAttentionSpec
 from vllm_hcu.model_executor.layers import mla_runtime
 
 
@@ -300,6 +302,15 @@ def _fake_mla_module(adapter, target_calls, event_log=None):
         def process_weights_after_loading(self, act_dtype):
             return act_dtype
 
+        def get_kv_cache_spec(self, vllm_config):
+            return MLAAttentionSpec(
+                block_size=vllm_config.cache_config.block_size,
+                num_kv_heads=1,
+                head_size=576,
+                dtype=torch.uint8,
+                cache_dtype_str=self.kv_cache_dtype,
+            )
+
     class MLACommonMetadata:
         def __init__(self, num_actual_tokens):
             self.num_actual_tokens = num_actual_tokens
@@ -427,6 +438,34 @@ def test_mla_feature_off_delegates_exact_v0251_forward_on_rocm():
     warmup = SimpleNamespace(is_prefilling=None)
     assert module.split_decodes_and_prefills(warmup, 3, True, True) is True
     assert module.split_calls[-1] == (warmup, 3, True, True)
+
+
+def test_mla_fp8_spec_selects_the_656_byte_sparse_cache_layout():
+    adapter = _adapter()
+    module = _fake_mla_module(adapter, [])
+    assert adapter.apply_to_module(module) is True
+
+    instance = object.__new__(module.MLAAttention)
+    instance.kv_cache_dtype = "fp8_ds_mla"
+    config = SimpleNamespace(cache_config=SimpleNamespace(block_size=64))
+
+    cache_spec = instance.get_kv_cache_spec(config)
+    backend_cache_dtype = (
+        "auto"
+        if cache_spec.kv_quant_mode == KVQuantMode.NONE
+        else instance.kv_cache_dtype
+    )
+    shape = FlashMLASparseBackend.get_kv_cache_shape(
+        2,
+        cache_spec.block_size,
+        cache_spec.num_kv_heads,
+        cache_spec.head_size,
+        cache_dtype_str=backend_cache_dtype,
+    )
+
+    assert cache_spec.kv_quant_mode == KVQuantMode.FP8_PER_TENSOR
+    assert shape == (2, 64, 656)
+    assert cache_spec.page_size_bytes * 2 == 2 * 64 * 656
 
 
 def test_mla_feature_on_uses_hcu_lightly_cp_delta(monkeypatch):

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -174,7 +174,24 @@ def test_all2all_dispatch_selection_contract():
     assert result.use_int8_dispatch is True
 
 
-def test_all2all_auto_builds_ht_and_ll_around_one_manager_handle():
+@pytest.mark.parametrize(
+    ("fixed_use_low_latency", "expected_cleanup"),
+    [(None, True), (True, False), (False, False)],
+)
+def test_all2all_auto_builds_ht_and_ll_around_one_manager_handle(
+    monkeypatch: pytest.MonkeyPatch,
+    fixed_use_low_latency: bool | None,
+    expected_cleanup: bool,
+):
+    from vllm_hcu.model_executor.layers.fused_moe.prepare_finalize import (
+        deepep_auto,
+    )
+
+    monkeypatch.setattr(
+        deepep_auto,
+        "dspark_mooncake_pd_use_low_latency",
+        lambda _vllm_config: fixed_use_low_latency,
+    )
     calls: dict[str, object] = {}
 
     class Manager:
@@ -282,7 +299,11 @@ def test_all2all_auto_builds_ht_and_ll_around_one_manager_handle():
         "physical_to_global": "physical-to-global",
         "local_expert_global_ids": "local-ids",
     }
-    assert result.ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer is True
+    assert result._fixed_use_low_latency is fixed_use_low_latency
+    assert (
+        result.ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer
+        is expected_cleanup
+    )
     int8_result = module.maybe_make_prepare_finalize(
         moe,
         SimpleNamespace(quant_dtype=torch.int8),
@@ -297,7 +318,11 @@ def test_all2all_auto_builds_ht_and_ll_around_one_manager_handle():
         "physical_to_global": "physical-to-global",
         "local_expert_global_ids": "local-ids",
     }
-    assert int8_result.ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer is True
+    assert int8_result._fixed_use_low_latency is fixed_use_low_latency
+    assert (
+        int8_result.ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer
+        is expected_cleanup
+    )
     assert module.maybe_roundup_layer_hidden_size(
         10, torch.float16, moe.moe_parallel_config
     ) == 13

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -282,6 +282,7 @@ def test_all2all_auto_builds_ht_and_ll_around_one_manager_handle():
         "physical_to_global": "physical-to-global",
         "local_expert_global_ids": "local-ids",
     }
+    assert result.ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer is True
     int8_result = module.maybe_make_prepare_finalize(
         moe,
         SimpleNamespace(quant_dtype=torch.int8),
@@ -296,6 +297,7 @@ def test_all2all_auto_builds_ht_and_ll_around_one_manager_handle():
         "physical_to_global": "physical-to-global",
         "local_expert_global_ids": "local-ids",
     }
+    assert int8_result.ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer is True
     assert module.maybe_roundup_layer_hidden_size(
         10, torch.float16, moe.moe_parallel_config
     ) == 13
@@ -4296,8 +4298,17 @@ def test_deepep_ll_non_hcu_dispatch_signatures_delegate_to_upstream(
     )
 
 
-def test_deepep_ll_fp8_auto_detects_hcu_buffer_dispatch_abi(
+@pytest.mark.parametrize(
+    ("shared_with_high_throughput", "expected_clean_calls"),
+    [
+        (False, []),
+        (True, [(8, 2048, 1, 128), (8, 2048, 1, 128)]),
+    ],
+)
+def test_deepep_ll_fp8_cleans_only_when_buffer_is_shared_with_high_throughput(
     monkeypatch: pytest.MonkeyPatch,
+    shared_with_high_throughput: bool,
+    expected_clean_calls: list[tuple[int, int, int, int]],
 ):
     module = _fake_deepep_ll_module()
     module.torch = torch
@@ -4367,6 +4378,10 @@ def test_deepep_ll_fp8_auto_detects_hcu_buffer_dispatch_abi(
             return expert_x, torch.ones(1, dtype=torch.int32), "handle", None, lambda: None
 
     instance = cls(Buffer(), 8, 1, use_fp8_dispatch=True)
+    if shared_with_high_throughput:
+        instance._vllm_hcu_clean_low_latency_buffer = True
+    else:
+        del instance._vllm_hcu_clean_low_latency_buffer
     instance.handles = [None]
     instance.use_int8_dispatch = False
     instance.use_ue8m0_dispatch = False
@@ -4411,14 +4426,13 @@ def test_deepep_ll_fp8_auto_detects_hcu_buffer_dispatch_abi(
     assert calls["topk_weight"] is topk_weights
     assert calls["quant_type"] == 2
     assert calls["quant_group_size"] == 128
-    assert calls["clean"] == [
-        (8, 2048, 1, 128),
-        (8, 2048, 1, 128),
-    ]
+    assert calls.get("clean", []) == expected_clean_calls
 
 
+@pytest.mark.parametrize("shared_with_high_throughput", [False, True])
 def test_deepep_ll_hcu_int8_dispatch_contract(
     monkeypatch: pytest.MonkeyPatch,
+    shared_with_high_throughput: bool,
 ):
     module = _fake_deepep_ll_module()
 
@@ -4462,6 +4476,7 @@ def test_deepep_ll_hcu_int8_dispatch_contract(
             return expert_x, expert_counts, "handle", None, lambda: None
 
     instance = cls(Buffer(), 8, 1, use_int8_dispatch=True)
+    instance._vllm_hcu_clean_low_latency_buffer = shared_with_high_throughput
     instance.handles = [None, None]
     instance.use_ue8m0_dispatch = False
     quant_config = SimpleNamespace(
@@ -4510,12 +4525,16 @@ def test_deepep_ll_hcu_int8_dispatch_contract(
         False,
         quant_config,
     )
-    assert calls["order"] == [
-        ("clean", (8, 2048, 1, 0)),
-        ("dispatch", 1),
-        ("clean", (8, 2048, 1, 0)),
-        ("dispatch", 1),
-    ]
+    expected_dispatches = [("dispatch", 1), ("dispatch", 1)]
+    if shared_with_high_throughput:
+        assert calls["order"] == [
+            ("clean", (8, 2048, 1, 0)),
+            expected_dispatches[0],
+            ("clean", (8, 2048, 1, 0)),
+            expected_dispatches[1],
+        ]
+    else:
+        assert calls["order"] == expected_dispatches
 
     fp8_instance = cls(None, 8, 1, use_fp8_dispatch=True)
     fp8_instance.use_int8_dispatch = False

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -4593,6 +4593,93 @@ def test_moe_runner_adapter_rejects_incompatible_input_transform_signature():
         patch_moe_runner.apply_to_module(module)
 
 
+def test_shared_experts_adapter_rejects_incompatible_preservation_signature():
+    module = ModuleType(patch_shared_experts.REPLACEMENT_MODULE)
+
+    class SharedExperts:
+        def requires_input_preservation(self, *, hidden_states):
+            return False
+
+        def maybe_sync_shared_experts_stream(
+            self,
+            shared_experts_input,
+            x_and_scale_quanted,
+        ):
+            return None
+
+        def _run_in_aux_stream(
+            self,
+            shared_experts_input,
+            x_and_scale_quanted,
+        ):
+            return None
+
+        def forward(
+            self,
+            shared_experts_input,
+            order,
+            x_and_scale_quanted,
+        ):
+            return None
+
+        @property
+        def output(self):
+            return None
+
+    module.SharedExperts = SharedExperts
+
+    with pytest.raises(
+        PatchCompatibilityError,
+        match="requires_input_preservation",
+    ):
+        patch_shared_experts.apply_to_module(module)
+
+
+def test_shared_experts_adapter_rejects_incompatible_inplace_output_signature():
+    module = ModuleType(patch_shared_experts.REPLACEMENT_MODULE)
+
+    class SharedExperts:
+        def requires_input_preservation(self, hidden_states):
+            return False
+
+        def allows_inplace_routed_output(self, routed_input):
+            return False
+
+        def maybe_sync_shared_experts_stream(
+            self,
+            shared_experts_input,
+            x_and_scale_quanted,
+        ):
+            return None
+
+        def _run_in_aux_stream(
+            self,
+            shared_experts_input,
+            x_and_scale_quanted,
+        ):
+            return None
+
+        def forward(
+            self,
+            shared_experts_input,
+            order,
+            x_and_scale_quanted,
+        ):
+            return None
+
+        @property
+        def output(self):
+            return None
+
+    module.SharedExperts = SharedExperts
+
+    with pytest.raises(
+        PatchCompatibilityError,
+        match="allows_inplace_routed_output",
+    ):
+        patch_shared_experts.apply_to_module(module)
+
+
 def test_moe_runner_and_shared_experts_cold_replacement_contract():
     repository = Path(__file__).resolve().parents[2]
     target_vllm = Path(
@@ -4667,6 +4754,11 @@ def test_moe_runner_and_shared_experts_cold_replacement_contract():
             "self", "hidden_states", "router_logits", "input_ids",
             "quanted_hidden_states", "scale", "topk_weights", "topk_ids",
         )
+        assert tuple(
+            inspect.signature(
+                shared_module.SharedExperts.allows_inplace_routed_output
+            ).parameters
+        ) == ("self", "routed_input", "shared_input")
 
         class QuantMethod:
             is_monolithic = False

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -4541,6 +4541,58 @@ def test_custom_op_runner_rejects_post_import_callback():
         patch_moe_runner.apply_to_module(official)
 
 
+def test_moe_runner_adapter_rejects_incompatible_input_transform_signature():
+    module = ModuleType(patch_moe_runner.REPLACEMENT_MODULE)
+
+    def moe_forward(
+        hidden_states,
+        router_logits,
+        shared_experts_input,
+        input_ids,
+        quanted_hidden_states,
+        scale,
+        topk_weights,
+        topk_ids,
+        layer_name,
+        hidden_dim_unpadded,
+    ):
+        return None
+
+    for name in (
+        "_moe_forward",
+        "_moe_forward_fake",
+        "_moe_forward_shared",
+        "_moe_forward_shared_fake",
+        "_moe_forward_shared_inplace",
+        "_moe_forward_shared_inplace_fake",
+    ):
+        setattr(module, name, moe_forward)
+
+    class MoERunner:
+        def apply_routed_input_transform(self, *, hidden_states):
+            return None
+
+        def forward(
+            self,
+            hidden_states,
+            router_logits,
+            input_ids,
+            quanted_hidden_states,
+            scale,
+            topk_weights,
+            topk_ids,
+        ):
+            return None
+
+    module.MoERunner = MoERunner
+
+    with pytest.raises(
+        PatchCompatibilityError,
+        match="apply_routed_input_transform",
+    ):
+        patch_moe_runner.apply_to_module(module)
+
+
 def test_moe_runner_and_shared_experts_cold_replacement_contract():
     repository = Path(__file__).resolve().parents[2]
     target_vllm = Path(

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -1426,6 +1426,20 @@ def test_slimquant_fp8_moe_repack_preserves_fp8_without_widening(
     )
     monkeypatch.setattr(torch, "stack", reject_per_expert_stack)
 
+    # This test covers tensor repacking, not LightOp package initialization.
+    # Keep it deterministic in control containers without a visible HCU.
+    lightop = ModuleType("lightop")
+    lightop.__path__ = []  # type: ignore[attr-defined]
+    lightop_moe = ModuleType("lightop.moe")
+
+    def fused_experts_impl_fp8_marlin(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    lightop_moe.fused_experts_impl_fp8_marlin = fused_experts_impl_fp8_marlin
+    lightop.moe = lightop_moe
+    monkeypatch.setitem(sys.modules, "lightop", lightop)
+    monkeypatch.setitem(sys.modules, "lightop.moe", lightop_moe)
+
     method.process_weights_after_loading(layer)
 
     assert layer.w13_weight.dtype == torch.float8_e4m3fn

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -1300,6 +1300,86 @@ def test_slimquant_marlin_inherits_v0251_compressed_tensors_constructor() -> Non
         assert parameters[len(target_prefix) :] == ("i_q", "i_s")
 
 
+@pytest.mark.parametrize(
+    ("moe_backend", "aiter_requested", "expected_owner"),
+    [
+        ("auto", False, "lightop"),
+        ("auto", True, "vllm"),
+        ("aiter", False, "vllm"),
+        ("triton", True, "vllm"),
+        ("deep_gemm", True, "vllm"),
+    ],
+)
+def test_slimquant_marlin_moe_backend_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+    moe_backend: str,
+    aiter_requested: bool,
+    expected_owner: str,
+) -> None:
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe import (
+        CompressedTensorsMoEMethod,
+    )
+    from vllm_hcu.model_executor.layers.fused_moe import aiter_runtime
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors.compressed_tensors_marlin import (
+        SlimQuantCompressedTensorsMarlinConfig,
+    )
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe_marlin import (
+        CompressedTensorsMarlinMoEMethod,
+    )
+
+    layer = RoutedExperts.__new__(RoutedExperts)
+    torch.nn.Module.__init__(layer)
+    layer.moe_config = SimpleNamespace(moe_backend=moe_backend)
+    config = SlimQuantCompressedTensorsMarlinConfig.from_config(
+        {
+            "config_groups": {},
+            "format": "int-quantized",
+            "ignore": [],
+            "kv_cache_scheme": None,
+            "quant_method": "compressed-tensors",
+        }
+    )
+    prefix = "model.layers.0.mlp.experts"
+    vllm_method = object()
+    lightop_method = object()
+    monkeypatch.setattr(
+        aiter_runtime,
+        "is_aiter_moe_requested",
+        lambda moe_config: moe_config is layer.moe_config and aiter_requested,
+    )
+    monkeypatch.setattr(
+        CompressedTensorsMoEMethod,
+        "get_moe_method",
+        staticmethod(
+            lambda quant_config, routed_layer, layer_name: (
+                vllm_method
+                if quant_config is config
+                and routed_layer is layer
+                and layer_name == prefix
+                else pytest.fail("unexpected vLLM MoE factory arguments")
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        CompressedTensorsMarlinMoEMethod,
+        "get_moe_method",
+        staticmethod(
+            lambda quant_config, routed_layer: (
+                lightop_method
+                if quant_config is config and routed_layer is layer
+                else pytest.fail("unexpected LightOp MoE factory arguments")
+            )
+        ),
+    )
+
+    method = config.get_quant_method(layer, prefix)
+
+    assert method is {"vllm": vllm_method, "lightop": lightop_method}[
+        expected_owner
+    ]
+
+
 def test_slimquant_fp8_moe_repack_preserves_fp8_without_widening(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -1239,7 +1239,16 @@ def test_int8_oracle_keeps_aiter_weights_and_packs_hcu_deep_gemm_weights(
         CPU = "CPU"
 
     class AiterExperts:
-        pass
+        @staticmethod
+        def is_supported_config(
+            cls,
+            config,
+            weight_key,
+            activation_key,
+            activation_format,
+        ):
+            del cls, config, weight_key, activation_key, activation_format
+            return True, None
 
     def backend_to_kernel_cls(backend):
         return [f"original:{backend.value}"]
@@ -1455,6 +1464,30 @@ def test_int8_oracle_keeps_aiter_weights_and_packs_hcu_deep_gemm_weights(
     assert target.backend_to_kernel_cls(target.Int8MoeBackend.AITER) == [
         AiterExperts
     ]
+
+    from vllm_hcu.model_executor.layers.fused_moe import aiter_runtime
+
+    auto_aiter_config = SimpleNamespace(
+        moe_backend="auto",
+        moe_parallel_config=SimpleNamespace(
+            use_batched_activation_format=False,
+        ),
+        _hcu_vllm_config=SimpleNamespace(
+            additional_config={"hcu": {"moe_backend": "auto"}},
+        ),
+    )
+    monkeypatch.setattr(
+        aiter_runtime,
+        "is_aiter_moe_requested",
+        lambda config: config is auto_aiter_config,
+    )
+    auto_aiter_backend, auto_aiter_experts = target.select_int8_moe_backend(
+        auto_aiter_config,
+        kInt8StaticChannelSym,
+        kInt8DynamicTokenSym,
+    )
+    assert auto_aiter_backend is target.Int8MoeBackend.AITER
+    assert auto_aiter_experts is AiterExperts
 
     w13 = torch.zeros((2, 4, 3), dtype=torch.int8)
     w2 = torch.zeros((2, 3, 2), dtype=torch.int8)
@@ -3995,6 +4028,27 @@ def test_slimquant_w4a8_dispatch_preserves_linear_method():
 
     assert type(method) is slimquant_w4a8.SlimQuantW4A8Int8LinearMethod
     assert isinstance(layer.scheme, slimquant_w4a8.CompressedTensorsW8A8Int8)
+
+
+@pytest.mark.hcu
+def test_slimquant_w4a8_explicit_deep_gemm_requires_deepep_auto():
+    from vllm_hcu.model_executor.layers.quantization import slimquant_w4a8
+
+    pure_tp_moe = SimpleNamespace(
+        moe_backend="deep_gemm",
+        moe_parallel_config=SimpleNamespace(
+            dp_size=1,
+            use_ep=False,
+            all2all_backend="allgather_reducescatter",
+            use_deepep_auto_kernels=False,
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="deep_gemm.*requires.*deepep_auto",
+    ):
+        slimquant_w4a8.SlimQuantW4A8Int8AiterMoEMethod(object(), pure_tp_moe)
 
 
 @pytest.mark.hcu
@@ -8006,9 +8060,6 @@ def test_marlin_moe_never_imports_lmslim(
         fused_experts_impl_int8_marlin=int8_kernel,
     )
     _reject_import_prefix(monkeypatch, "lmslim")
-    monkeypatch.setattr(
-        marlin, "_is_hcu_aiter_w8a8_moe_requested", lambda *args: False
-    )
     layer = _fp8_moe_layer()
     x = torch.ones(2, 4)
     weights = torch.ones(2, 2)
@@ -8044,7 +8095,6 @@ def test_missing_lightop_marlin_export_fails_without_lmslim_retry(
     monkeypatch.setitem(sys.modules, "lightop", lightop)
     monkeypatch.delitem(sys.modules, "lightop.moe", raising=False)
     _reject_import_prefix(monkeypatch, "lmslim")
-    monkeypatch.setattr(marlin, "_is_hcu_aiter_w8a8_moe_requested", lambda: False)
 
     layer = _fp8_moe_layer()
     x = torch.ones(2, 4)
@@ -8104,210 +8154,64 @@ print("SLIMQUANT_PREPATCH_IMPORT_OK")
     assert "SLIMQUANT_PREPATCH_IMPORT_OK" in result.stdout
 
 
-def test_marlin_aiter_moe_no_solution_uses_native_triton_not_lmslim(
+def test_bf16_moe_backend_precedence_and_unsupported_deep_gemm(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
-        compressed_tensors_moe_marlin as marlin,
-    )
+    from vllm.model_executor.layers.fused_moe.oracle import unquantized
 
-    method_class = marlin.CompressedTensorsW8A8Int8MarlinMoEMethod
-    assert not hasattr(method_class, "_get_aiter_moe_runtime_config")
-    assert not hasattr(method_class, "_get_aiter_weights_for_solution")
-    method = object.__new__(method_class)
-    method.moe = SimpleNamespace(num_experts=3)
-    method.moe_quant_config = SimpleNamespace(
-        use_fp8_w8a8=False,
-        use_int8_w8a8=True,
-        w1_scale=torch.ones((3, 8, 1)),
-        w2_scale=torch.ones((3, 4, 1)),
-        w1_zp=None,
-        w2_zp=None,
-        a1_scale=None,
-        a2_scale=None,
-        block_shape=None,
-    )
+    class SupportedExperts:
+        @staticmethod
+        def is_supported_config(
+            cls,
+            config,
+            weight_key,
+            activation_key,
+            activation_format,
+        ):
+            del cls, config, weight_key, activation_key, activation_format
+            return True, None
+
     monkeypatch.setattr(
-        marlin,
-        "_is_hcu_aiter_w8a8_moe_requested",
-        lambda _moe=None: True,
-    )
-    monkeypatch.setattr(marlin.rocm_aiter_ops, "is_fused_moe_enabled", lambda: True)
-
-    class MoeQuantType:
-        W8A8 = "int8_w8a8"
-
-    monkeypatch.setitem(
-        sys.modules,
-        "aiter.moe",
-        _module(
-            "aiter.moe",
-            MoeQuantType=MoeQuantType,
-            get_aiter_moe_config=lambda **kwargs: (False, None),
+        unquantized,
+        "current_platform",
+        SimpleNamespace(
+            is_cpu=lambda: False,
+            is_tpu=lambda: False,
+            is_out_of_tree=lambda: False,
+            is_rocm=lambda: True,
         ),
     )
-    monkeypatch.setitem(
-        sys.modules,
-        "lmslim.layers.fused_moe.fuse_moe_int8_marlin",
-        _module(
-            "lmslim.layers.fused_moe.fuse_moe_int8_marlin",
-            fused_experts_impl_int8_marlin=lambda **kwargs: pytest.fail(
-                "AITER no-solution must use vLLM Triton, not LMSlim"
+    monkeypatch.setattr(
+        unquantized,
+        "backend_to_kernel_cls",
+        lambda _backend: SupportedExperts,
+    )
+    monkeypatch.setattr(unquantized.envs, "is_set", lambda _name: True)
+    monkeypatch.setattr(unquantized.envs, "VLLM_ROCM_USE_AITER", True)
+    monkeypatch.setattr(unquantized.envs, "VLLM_ROCM_USE_AITER_MOE", True)
+
+    def config(backend: str):
+        return SimpleNamespace(
+            moe_backend=backend,
+            is_lora_enabled=False,
+            moe_parallel_config=SimpleNamespace(
+                use_batched_activation_format=False,
             ),
-        ),
-    )
-    expected = torch.full((2, 4), 4.0)
-    fallback_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
-    fused_moe_module = __import__(
-        "vllm.model_executor.layers.fused_moe.fused_moe",
-        fromlist=["fused_experts_impl"],
-    )
-
-    def fallback(*args: object, **kwargs: object):
-        fallback_calls.append((args, kwargs))
-        return expected
-
-    monkeypatch.setattr(fused_moe_module, "fused_experts_impl", fallback)
-    layer = _fp8_moe_layer()
-    layer.w13_weight = torch.zeros((3, 8, 4), dtype=torch.int8)
-    layer.w2_weight = torch.zeros((3, 4, 4), dtype=torch.int8)
-
-    actual = method.apply(
-        layer,
-        torch.ones((2, 4), dtype=torch.bfloat16),
-        torch.ones((2, 2)),
-        torch.zeros((2, 2), dtype=torch.int64),
-        None,
-        None,
-    )
-
-    assert actual is expected
-    assert fallback_calls[0][1]["use_int8_w8a8"] is True
-
-
-def test_marlin_explicit_triton_backend_bypasses_aiter_env(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
-        compressed_tensors_moe_marlin as marlin,
-    )
-
-    _install_fake_vllm_envs(
-        monkeypatch,
-        VLLM_ROCM_USE_AITER=True,
-        VLLM_ROCM_USE_AITER_MOE=True,
-    )
-
-    assert not marlin._is_hcu_aiter_w8a8_moe_requested(
-        SimpleNamespace(moe_backend="triton")
-    )
-
-
-def test_marlin_aiter_moe_prewarms_m1_during_weight_loading(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
-        compressed_tensors_moe_marlin as marlin,
-    )
-
-    method = object.__new__(marlin.CompressedTensorsW8A8Int8MarlinMoEMethod)
-    method.moe = SimpleNamespace(
-        num_experts=3,
-        experts_per_token=2,
-        in_dtype=torch.bfloat16,
-        activation=SimpleNamespace(value="silu"),
-    )
-    quant_config = SimpleNamespace(
-        use_fp8_w8a8=False,
-        use_int8_w8a8=True,
-        block_shape=None,
-    )
-    method.get_fused_moe_quant_config = lambda unused_layer: quant_config
-    monkeypatch.setattr(
-        marlin,
-        "_is_hcu_aiter_w8a8_moe_requested",
-        lambda _moe=None: True,
-    )
-    monkeypatch.setattr(marlin.rocm_aiter_ops, "is_fused_moe_enabled", lambda: True)
-    calls: list[tuple[object, object, object]] = []
-    monkeypatch.setattr(
-        compressed_tensors_moe_runtime,
-        "prewarm_aiter_quantized_moe",
-        lambda layer, moe, config: calls.append((layer, moe, config)),
-        raising=False,
-    )
-    layer = _fp8_moe_layer()
-    layer.w13_weight = torch.zeros((3, 8, 4), dtype=torch.int8)
-    layer.w2_weight = torch.zeros((3, 4, 4), dtype=torch.int8)
-
-    method.process_weights_after_loading(layer)
-
-    assert method.moe_quant_config is quant_config
-    assert calls == [(layer, method.moe, quant_config)]
-
-
-def test_marlin_aiter_moe_config_fault_does_not_fallback(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
-        compressed_tensors_moe_marlin as marlin,
-    )
-
-    method = object.__new__(marlin.CompressedTensorsW8A8Int8MarlinMoEMethod)
-    method.moe = SimpleNamespace(num_experts=3)
-    method.moe_quant_config = SimpleNamespace(
-        use_fp8_w8a8=False,
-        use_int8_w8a8=True,
-        w1_scale=torch.ones((3, 8, 1)),
-        w2_scale=torch.ones((3, 4, 1)),
-        block_shape=None,
-    )
-    monkeypatch.setattr(
-        marlin,
-        "_is_hcu_aiter_w8a8_moe_requested",
-        lambda _moe=None: True,
-    )
-    monkeypatch.setattr(marlin.rocm_aiter_ops, "is_fused_moe_enabled", lambda: True)
-
-    class MoeQuantType:
-        W8A8 = "int8_w8a8"
-
-    def config_fault(**kwargs: object):
-        raise RuntimeError("aiter config fault")
-
-    monkeypatch.setitem(
-        sys.modules,
-        "aiter.moe",
-        _module(
-            "aiter.moe",
-            MoeQuantType=MoeQuantType,
-            get_aiter_moe_config=config_fault,
-        ),
-    )
-    fallback_calls: list[object] = []
-    fused_moe_module = __import__(
-        "vllm.model_executor.layers.fused_moe.fused_moe",
-        fromlist=["fused_experts_impl"],
-    )
-    monkeypatch.setattr(
-        fused_moe_module,
-        "fused_experts_impl",
-        lambda *args, **kwargs: fallback_calls.append((args, kwargs)),
-    )
-    layer = _fp8_moe_layer()
-    layer.w13_weight = torch.zeros((3, 8, 4), dtype=torch.int8)
-    layer.w2_weight = torch.zeros((3, 4, 4), dtype=torch.int8)
-
-    with pytest.raises(RuntimeError, match="aiter config fault"):
-        method.apply(
-            layer,
-            torch.ones((2, 4), dtype=torch.bfloat16),
-            torch.ones((2, 2)),
-            torch.zeros((2, 2), dtype=torch.int64),
-            None,
-            None,
         )
-    assert fallback_calls == []
+
+    automatic, _ = unquantized.select_unquantized_moe_backend(config("auto"))
+    explicit_aiter, _ = unquantized.select_unquantized_moe_backend(
+        config("aiter")
+    )
+    explicit_triton, _ = unquantized.select_unquantized_moe_backend(
+        config("triton")
+    )
+
+    assert automatic is unquantized.UnquantizedMoeBackend.AITER
+    assert explicit_aiter is unquantized.UnquantizedMoeBackend.AITER
+    assert explicit_triton is unquantized.UnquantizedMoeBackend.TRITON
+    with pytest.raises(ValueError, match="not supported for unquantized MoE"):
+        unquantized.select_unquantized_moe_backend(config("deep_gemm"))
 
 
 @pytest.mark.parametrize("is_rocm", [False, True])

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -7631,12 +7631,8 @@ def test_fp8_channel_weight_layout_requires_hcu_kernel(monkeypatch: pytest.Monke
 
 @pytest.mark.parametrize("backend", ["lightop", "target-triton"])
 def test_fp8_channel_backend_preserves_weight_layout(
-    monkeypatch: pytest.MonkeyPatch,
     backend: str,
 ):
-    from vllm_hcu.platforms import envs as henvs
-
-    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM", False)
     module, channel = _fake_fp8_scheme_module()
     patch_compressed_tensors_w8a8_fp8.apply_to_module(module)
 

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -7967,12 +7967,97 @@ def test_lightop_fp8_registration_is_single_owner_and_latched():
     lightop_fp8_runtime._reset_for_tests()
 
 
-def test_lightop_fp8_adapter_has_no_import_time_registration():
+def test_lightop_fp8_adapter_registers_before_forward_compilation():
     lightop_fp8_runtime._reset_for_tests()
     module, _ = _fake_input_quant_module()
     patch_input_quant_fp8.apply_to_module(module)
-    assert lightop_fp8_runtime._REGISTERED is False
+    assert lightop_fp8_runtime._REGISTERED is True
+    assert lightop_fp8_runtime._FP8_DTYPE is torch.float8_e4m3fn
     assert lightop_fp8_runtime._REGISTRATION_ERROR is None
+
+
+def test_lightop_fp8_default_wrapper_compiles_after_initial_registration():
+    """The real wrapper/runtime path must keep registration outside Dynamo."""
+
+    repo = Path(__file__).resolve().parents[2]
+    env = dict(os.environ)
+    env["VLLM_PLUGINS"] = "__disabled__"
+    env["VLLM_HCU_USE_CUSTOM_OPS"] = "1"
+    env.pop("VLLM_HCU_USE_LIGHTOP_PER_TOKEN_QUANT_FP8", None)
+    env["PYTHONPATH"] = os.pathsep.join((str(repo), env.get("PYTHONPATH", "")))
+    script = r'''
+import sys
+from types import ModuleType
+
+import torch
+
+from vllm_hcu.patch.worker.op_opt import patch_input_quant_fp8
+from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
+from vllm.utils import torch_utils
+
+original_register_custom_op = torch_utils.direct_register_custom_op
+
+def register_cpu_custom_op(*args, **kwargs):
+    kwargs["dispatch_key"] = "CPU"
+    return original_register_custom_op(*args, **kwargs)
+
+torch_utils.direct_register_custom_op = register_cpu_custom_op
+
+
+class QuantFP8:
+    group_shape = GroupShape.PER_TOKEN
+    num_token_padding = None
+
+    def forward_cuda(self, x, scale=None, scale_ub=None, use_triton=False):
+        raise AssertionError("eligible input unexpectedly used official CUDA path")
+
+    def forward_native(self, x, scale=None, scale_ub=None, use_triton=False):
+        raise AssertionError("eligible input unexpectedly used official native path")
+
+
+target = ModuleType(patch_input_quant_fp8.TARGET_MODULE)
+target.GroupShape = GroupShape
+target.QuantFP8 = QuantFP8
+target._FP8_DTYPE = torch.float8_e4m3fn
+sys.modules[target.__name__] = target
+
+lightop = ModuleType("lightop")
+lightop.__path__ = []
+quant = ModuleType("lightop.quant")
+
+def per_token_quant_fp8(x, *, dtype, out_q, out_scale):
+    del x, dtype
+    out_scale.fill_(1)
+    return out_q, out_scale
+
+quant.per_token_quant_fp8 = per_token_quant_fp8
+lightop.quant = quant
+sys.modules["lightop"] = lightop
+sys.modules["lightop.quant"] = quant
+
+patch_input_quant_fp8.apply_to_module(target)
+compiled = torch.compile(
+    target.QuantFP8().forward_cuda,
+    backend="aot_eager",
+    fullgraph=True,
+)
+output, scale = compiled(torch.ones((2, 8)).contiguous())
+assert output.shape == (2, 8)
+assert output.dtype is torch.float8_e4m3fn
+assert scale.shape == (2, 1)
+assert torch.equal(scale, torch.ones_like(scale))
+print("LIGHTOP_FP8_FULLGRAPH_OK")
+'''
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=90,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "LIGHTOP_FP8_FULLGRAPH_OK" in result.stdout
 
 
 def _fake_input_quant_module():

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -3742,12 +3742,13 @@ def test_aiter_topk_supports_old_and_new_abi(
     assert len(calls[0]) == (7 if extended else 5)
 
 
-def test_scaled_mm_prequantized_input_bypasses_quantizer():
+@pytest.mark.parametrize("backend", ["lightop", "target-triton"])
+def test_scaled_mm_prequantized_input_bypasses_quantizer(backend: str):
     calls: list[tuple[object, ...]] = []
 
     class FP8ScaledMMLinearKernel:
         _hcu_fp8_patch_applied = True
-        _hcu_fp8_backend = "target-triton"
+        _hcu_fp8_backend = backend
 
         def apply_weights(self, layer, x, bias=None):
             calls.append(("original", layer, x, bias))
@@ -7624,12 +7625,14 @@ def test_fp8_channel_weight_layout_requires_hcu_kernel(monkeypatch: pytest.Monke
     scheme = module.CompressedTensorsW8A8Fp8()
     scheme.strategy = channel
     scheme.fp8_linear = object()
-    with pytest.raises(RuntimeError, match="target Triton scaled-mm adapter"):
+    with pytest.raises(RuntimeError, match="HCU scaled-mm adapter"):
         scheme.process_weights_after_loading(SimpleNamespace(weight=torch.ones(2, 3)))
 
 
-def test_fp8_target_triton_route_is_independent_of_general_custom_gemm_flag(
+@pytest.mark.parametrize("backend", ["lightop", "target-triton"])
+def test_fp8_channel_backend_preserves_weight_layout(
     monkeypatch: pytest.MonkeyPatch,
+    backend: str,
 ):
     from vllm_hcu.platforms import envs as henvs
 
@@ -7639,7 +7642,7 @@ def test_fp8_target_triton_route_is_independent_of_general_custom_gemm_flag(
 
     class Kernel:
         _hcu_fp8_patch_applied = True
-        _hcu_fp8_backend = "target-triton"
+        _hcu_fp8_backend = backend
 
     scheme = module.CompressedTensorsW8A8Fp8()
     scheme.strategy = channel
@@ -7650,14 +7653,18 @@ def test_fp8_target_triton_route_is_independent_of_general_custom_gemm_flag(
     assert layer.weight.stride() == (1, 3)
 
 
-def test_fp8_scheme_forwards_prequantized_input(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize("backend", ["lightop", "target-triton"])
+def test_fp8_scheme_forwards_prequantized_input(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+):
     module, channel = _fake_fp8_scheme_module()
     patch_compressed_tensors_w8a8_fp8.apply_to_module(module)
     calls: list[tuple[object, ...]] = []
 
     class Kernel:
         _hcu_fp8_patch_applied = True
-        _hcu_fp8_backend = "target-triton"
+        _hcu_fp8_backend = backend
 
         def supports_quanted_inputs(self):
             return True

--- a/tests/runtime_patch/test_worker_framework_opt.py
+++ b/tests/runtime_patch/test_worker_framework_opt.py
@@ -87,17 +87,12 @@ def test_glm4_places_routed_scale_after_non_aiter_moe_output():
         for keyword in fused_moe_calls[0].keywords
         if keyword.arg == "apply_routed_scale_to_output"
     )
-    assert isinstance(routed_scale_value, ast.UnaryOp)
-    assert isinstance(routed_scale_value.op, ast.Not)
-    assert isinstance(routed_scale_value.operand, ast.Call)
-    assert isinstance(routed_scale_value.operand.func, ast.Name)
-    assert routed_scale_value.operand.func.id == "is_aiter_moe_requested"
-    assert len(routed_scale_value.operand.args) == 1
-    backend_config = routed_scale_value.operand.args[0]
-    assert isinstance(backend_config, ast.Attribute)
-    assert backend_config.attr == "kernel_config"
-    assert isinstance(backend_config.value, ast.Name)
-    assert backend_config.value.id == "vllm_config"
+    assert isinstance(routed_scale_value, ast.Call)
+    assert isinstance(routed_scale_value.func, ast.Name)
+    assert routed_scale_value.func.id == "_glm4_apply_routed_scale_to_output"
+    assert len(routed_scale_value.args) == 1
+    assert isinstance(routed_scale_value.args[0], ast.Name)
+    assert routed_scale_value.args[0].id == "vllm_config"
 
 
 def test_hcu_runner_uses_v0251_routed_experts_contract():

--- a/tests/runtime_patch/test_worker_framework_opt.py
+++ b/tests/runtime_patch/test_worker_framework_opt.py
@@ -68,6 +68,38 @@ def test_hcu_downstream_config_uses_sidecar_not_upstream_only_fields():
         assert not any(fragment in source for fragment in forbidden)
 
 
+def test_glm4_places_routed_scale_after_non_aiter_moe_output():
+    source = Path("vllm_hcu/models/glm4_moe.py").read_text(
+        encoding="utf-8-sig"
+    )
+    tree = ast.parse(source)
+    fused_moe_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "FusedMoE"
+    ]
+
+    assert fused_moe_calls
+    routed_scale_value = next(
+        keyword.value
+        for keyword in fused_moe_calls[0].keywords
+        if keyword.arg == "apply_routed_scale_to_output"
+    )
+    assert isinstance(routed_scale_value, ast.UnaryOp)
+    assert isinstance(routed_scale_value.op, ast.Not)
+    assert isinstance(routed_scale_value.operand, ast.Call)
+    assert isinstance(routed_scale_value.operand.func, ast.Name)
+    assert routed_scale_value.operand.func.id == "is_aiter_moe_requested"
+    assert len(routed_scale_value.operand.args) == 1
+    backend_config = routed_scale_value.operand.args[0]
+    assert isinstance(backend_config, ast.Attribute)
+    assert backend_config.attr == "kernel_config"
+    assert isinstance(backend_config.value, ast.Name)
+    assert backend_config.value.id == "vllm_config"
+
+
 def test_hcu_runner_uses_v0251_routed_experts_contract():
     source = Path("vllm_hcu/v1/hcu_model_runner.py").read_text(
         encoding="utf-8-sig"

--- a/vllm_hcu/csrc/hcu_cache_kernel.cu
+++ b/vllm_hcu/csrc/hcu_cache_kernel.cu
@@ -66,14 +66,19 @@ static inline __device__ float fp8_to_float(uint8_t input) {
 
 // float -> fp8
 static inline __device__ uint8_t float_to_fp8_e4m3(float f) {
-  constexpr uint32_t fp8_max = UINT32_C(1087) << 20;
+  constexpr uint32_t fp8_finite_max = UINT32_C(1086) << 20;
+  constexpr uint32_t fp32_inf = UINT32_C(255) << 23;
   constexpr uint32_t denorm_mask = UINT32_C(141) << 23;
   uint32_t f_bits = c10::detail::fp32_to_bits(f);
   uint8_t result = 0u;
   const uint32_t sign = f_bits & UINT32_C(0x80000000);
   f_bits ^= sign;
-  if (f_bits >= fp8_max) {
+  if (f_bits > fp32_inf) {
     result = 0x7f;
+  } else if (f_bits > fp8_finite_max) {
+    // Match the OCP E4M3 SATFINITE conversion used by upstream vLLM:
+    // all finite overflow (and infinity) saturates, while NaNs remain NaNs.
+    result = 0x7e;
   } else {
     if (f_bits < (UINT32_C(121) << 23)) {
       f_bits =
@@ -562,6 +567,57 @@ __global__ void reshape_and_cache_kernel_hcu(
 }
 
 template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
+__global__ void reshape_and_cache_flash_kernel_hcu(
+    const scalar_t* __restrict__ key,    // [num_tokens, num_heads, head_size]
+    const scalar_t* __restrict__ value,  // [num_tokens, num_heads, head_size]
+    cache_t* __restrict__ key_cache,     // logical [blocks, pages, heads, dim]
+    cache_t* __restrict__ value_cache,   // logical [blocks, pages, heads, dim]
+    const int64_t* __restrict__ slot_mapping,
+    const int64_t block_stride, const int64_t page_stride,
+    const int64_t head_stride, const int64_t key_stride,
+    const int64_t value_stride, const int num_heads, const int head_size,
+    const int block_size, const float* k_scale, const float* v_scale,
+    const int kv_scale_stride) {
+  const int64_t token_idx = blockIdx.x;
+  const int64_t slot_idx = slot_mapping[token_idx];
+  if (slot_idx < 0) {
+    return;
+  }
+
+  const int64_t block_idx = slot_idx / block_size;
+  const int64_t block_offset = slot_idx % block_size;
+  const int num_elements = num_heads * head_size;
+
+  for (int element = threadIdx.x; element < num_elements;
+       element += blockDim.x) {
+    const int head_idx = element / head_size;
+    const int head_offset = element % head_size;
+    const int64_t cache_idx = block_idx * block_stride +
+                              block_offset * page_stride +
+                              head_idx * head_stride + head_offset;
+    const scalar_t key_value = key[token_idx * key_stride + element];
+    const scalar_t value_value = value[token_idx * value_stride + element];
+
+    if constexpr (kv_dt == Fp8KVCacheDataType::kAuto) {
+      key_cache[cache_idx] = key_value;
+      value_cache[cache_idx] = value_value;
+    } else if constexpr (kv_dt == Fp8KVCacheDataType::kInt8) {
+      key_cache[cache_idx] =
+          int8::scaled_vec_conversion_int8<cache_t, scalar_t>(
+              key_value, k_scale[head_idx * kv_scale_stride]);
+      value_cache[cache_idx] =
+          int8::scaled_vec_conversion_int8<cache_t, scalar_t>(
+              value_value, v_scale[head_idx * kv_scale_stride]);
+    } else {
+      key_cache[cache_idx] = fp8::scaled_convert<cache_t, scalar_t, kv_dt>(
+          key_value, k_scale[head_idx * kv_scale_stride]);
+      value_cache[cache_idx] = fp8::scaled_convert<cache_t, scalar_t, kv_dt>(
+          value_value, v_scale[head_idx * kv_scale_stride]);
+    }
+  }
+}
+
+template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
 __global__ void concat_and_cache_mla_kernel(
     const scalar_t* __restrict__ kv_c,  // [num_tokens, kv_lora_rank]
     const scalar_t* __restrict__ k_pe,  // [num_tokens, pe_dim]
@@ -722,6 +778,19 @@ __global__ void concat_and_cache_ds_mla_kernel(
           reinterpret_cast<const float*>(k_scale.data_ptr()),              \
           reinterpret_cast<const float*>(v_scale.data_ptr()));
 
+#define CALL_RESHAPE_AND_CACHE_FLASH_HCU(KV_T, CACHE_T, KV_DTYPE)          \
+  reshape_and_cache_flash_kernel_hcu<KV_T, CACHE_T, KV_DTYPE>              \
+      <<<grid, block, 0, stream>>>(                                         \
+          reinterpret_cast<KV_T*>(key.data_ptr()),                          \
+          reinterpret_cast<KV_T*>(value.data_ptr()),                        \
+          reinterpret_cast<CACHE_T*>(key_cache.data_ptr()),                 \
+          reinterpret_cast<CACHE_T*>(value_cache.data_ptr()),               \
+          slot_mapping.data_ptr<int64_t>(), block_stride, page_stride,      \
+          head_stride, key_stride, value_stride, num_heads, head_size,      \
+          block_size, reinterpret_cast<const float*>(k_scale.data_ptr()),   \
+          reinterpret_cast<const float*>(v_scale.data_ptr()),               \
+          kv_scale_stride);
+
 #define CALL_CONCAT_AND_CACHE_MLA_HCU(KV_T, CACHE_T, KV_DTYPE)          \
   concat_and_cache_mla_kernel<KV_T, CACHE_T, KV_DTYPE>                  \
       <<<grid, block, 0, stream>>>(                                     \
@@ -820,6 +889,57 @@ void reshape_and_cache_hcu(
   // 使用 scalar_type() 替代 dtype()
   DISPATCH_BY_KV_CACHE_DTYPE(key.dtype(), kv_cache_dtype,
       CALL_RESHAPE_AND_CACHE_HCU);
+}
+
+void reshape_and_cache_flash_hcu(
+    torch::Tensor& key,        // [num_tokens, num_heads, head_size]
+    torch::Tensor& value,      // [num_tokens, num_heads, head_size]
+    torch::Tensor& key_cache,  // logical [blocks, pages, heads, dim]
+    torch::Tensor& value_cache,
+    torch::Tensor& slot_mapping,
+    const std::string& kv_cache_dtype,
+    torch::Tensor& k_scale,
+    torch::Tensor& v_scale) {
+  TORCH_CHECK(key.dim() == 3 && value.dim() == 3,
+              "key/value must be [num_tokens, num_heads, head_size]");
+  TORCH_CHECK(key.sizes() == value.sizes(),
+              "key and value must have the same shape");
+  TORCH_CHECK(key_cache.dim() == 4 && value_cache.dim() == 4,
+              "cache must be a logical [blocks, pages, heads, dim] view");
+  TORCH_CHECK(key_cache.sizes() == value_cache.sizes(),
+              "key and value cache must have the same shape");
+  TORCH_CHECK(slot_mapping.dim() == 1 &&
+                  slot_mapping.scalar_type() == at::ScalarType::Long,
+              "slot_mapping must be a one-dimensional int64 tensor");
+
+  const int num_tokens = slot_mapping.size(0);
+  const int num_heads = key.size(1);
+  const int head_size = key.size(2);
+  const int block_size = key_cache.size(1);
+  TORCH_CHECK(key_cache.size(2) == num_heads &&
+                  key_cache.size(3) == head_size,
+              "cache head dimensions must match key/value");
+  TORCH_CHECK(key_cache.strides() == value_cache.strides(),
+              "key and value cache must have the same strides");
+  TORCH_CHECK(k_scale.sizes() == v_scale.sizes(),
+              "k_scale and v_scale must have the same shape");
+  TORCH_CHECK(k_scale.numel() == 1 || k_scale.numel() == num_heads,
+              "k_scale and v_scale must contain one or num_heads values");
+
+  const int64_t key_stride = key.stride(0);
+  const int64_t value_stride = value.stride(0);
+  const int64_t block_stride = key_cache.stride(0);
+  const int64_t page_stride = key_cache.stride(1);
+  const int64_t head_stride = key_cache.stride(2);
+  const int kv_scale_stride = k_scale.numel() > 1 ? 1 : 0;
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min(num_heads * head_size, 256));
+  const at::OptionalDeviceGuard device_guard(device_of(key));
+  hipStream_t stream = at::hip::getCurrentHIPStream();
+
+  DISPATCH_BY_KV_CACHE_DTYPE(key.dtype(), kv_cache_dtype,
+      CALL_RESHAPE_AND_CACHE_FLASH_HCU);
 }
 
 void concat_and_cache_mla_hcu(

--- a/vllm_hcu/csrc/hcu_cache_kernel.cu
+++ b/vllm_hcu/csrc/hcu_cache_kernel.cu
@@ -904,27 +904,72 @@ void reshape_and_cache_flash_hcu(
               "key/value must be [num_tokens, num_heads, head_size]");
   TORCH_CHECK(key.sizes() == value.sizes(),
               "key and value must have the same shape");
+  TORCH_CHECK(key.scalar_type() == value.scalar_type(),
+              "key and value must have the same dtype");
   TORCH_CHECK(key_cache.dim() == 4 && value_cache.dim() == 4,
               "cache must be a logical [blocks, pages, heads, dim] view");
   TORCH_CHECK(key_cache.sizes() == value_cache.sizes(),
               "key and value cache must have the same shape");
+  TORCH_CHECK(key_cache.scalar_type() == value_cache.scalar_type(),
+              "key and value cache must have the same dtype");
+  const auto cache_dtype = key_cache.scalar_type();
+  if (kv_cache_dtype == "auto") {
+    TORCH_CHECK(cache_dtype == key.scalar_type(),
+                "cache dtype must match key/value for auto KV cache");
+  } else if (kv_cache_dtype == "int8") {
+    TORCH_CHECK(cache_dtype == at::ScalarType::Char,
+                "cache dtype must match int8 KV cache");
+  } else if (kv_cache_dtype == "fp8" || kv_cache_dtype == "fp8_e4m3" ||
+             kv_cache_dtype == "fp8_ds_mla") {
+    TORCH_CHECK(cache_dtype == at::ScalarType::Byte ||
+                    cache_dtype == at::ScalarType::Float8_e4m3fn,
+                "cache dtype must match fp8_e4m3 KV cache");
+  } else if (kv_cache_dtype == "fp8_e5m2") {
+    TORCH_CHECK(cache_dtype == at::ScalarType::Byte ||
+                    cache_dtype == at::ScalarType::Float8_e5m2,
+                "cache dtype must match fp8_e5m2 KV cache");
+  }
   TORCH_CHECK(slot_mapping.dim() == 1 &&
                   slot_mapping.scalar_type() == at::ScalarType::Long,
               "slot_mapping must be a one-dimensional int64 tensor");
+
+  const auto device = key.device();
+  TORCH_CHECK(key.is_cuda() && value.is_cuda() && key_cache.is_cuda() &&
+                  value_cache.is_cuda() && slot_mapping.is_cuda() &&
+                  k_scale.is_cuda() && v_scale.is_cuda(),
+              "all cache-writer tensors must be CUDA/ROCm tensors");
+  TORCH_CHECK(value.device() == device && key_cache.device() == device &&
+                  value_cache.device() == device &&
+                  slot_mapping.device() == device && k_scale.device() == device &&
+                  v_scale.device() == device,
+              "all cache-writer tensors must be on the same device");
 
   const int num_tokens = slot_mapping.size(0);
   const int num_heads = key.size(1);
   const int head_size = key.size(2);
   const int block_size = key_cache.size(1);
+  TORCH_CHECK(num_tokens <= key.size(0),
+              "slot_mapping cannot contain more tokens than key/value");
+  TORCH_CHECK(key.stride(2) == 1 && key.stride(1) == head_size &&
+                  value.stride(2) == 1 && value.stride(1) == head_size,
+              "key/value head dimensions must be contiguous");
   TORCH_CHECK(key_cache.size(2) == num_heads &&
                   key_cache.size(3) == head_size,
               "cache head dimensions must match key/value");
   TORCH_CHECK(key_cache.strides() == value_cache.strides(),
               "key and value cache must have the same strides");
+  TORCH_CHECK(key_cache.stride(3) == 1,
+              "cache head_size dimension must be contiguous");
+  TORCH_CHECK(slot_mapping.is_contiguous(),
+              "slot_mapping must be contiguous");
   TORCH_CHECK(k_scale.sizes() == v_scale.sizes(),
               "k_scale and v_scale must have the same shape");
   TORCH_CHECK(k_scale.numel() == 1 || k_scale.numel() == num_heads,
               "k_scale and v_scale must contain one or num_heads values");
+  TORCH_CHECK(k_scale.scalar_type() == at::ScalarType::Float &&
+                  v_scale.scalar_type() == at::ScalarType::Float &&
+                  k_scale.is_contiguous() && v_scale.is_contiguous(),
+              "k/v scales must be contiguous float32 tensors");
 
   const int64_t key_stride = key.stride(0);
   const int64_t value_stride = value.stride(0);

--- a/vllm_hcu/csrc/ops.h
+++ b/vllm_hcu/csrc/ops.h
@@ -37,6 +37,16 @@ void reshape_and_cache_hcu(
     torch::Tensor& k_scale,
     torch::Tensor& v_scale);
 
+void reshape_and_cache_flash_hcu(
+    torch::Tensor& key,        // [num_tokens, num_heads, head_size]
+    torch::Tensor& value,      // [num_tokens, num_heads, head_size]
+    torch::Tensor& key_cache,  // logical [blocks, pages, heads, dim]
+    torch::Tensor& value_cache,
+    torch::Tensor& slot_mapping,
+    const std::string& kv_cache_dtype,
+    torch::Tensor& k_scale,
+    torch::Tensor& v_scale);
+
 // mla kvcacheconvert
 void concat_and_cache_mla_hcu(torch::Tensor& kv_c, torch::Tensor& k_pe,
                           torch::Tensor& kv_cache, torch::Tensor& slot_mapping,

--- a/vllm_hcu/csrc/torch_bindings.cpp
+++ b/vllm_hcu/csrc/torch_bindings.cpp
@@ -43,7 +43,17 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("open_mem_handle(Tensor mem_handle) -> int", &open_mem_handle);
   ops.def("free_shared_buffer", &free_shared_buffer);
 
-  ops.def("reshape_and_cache", &reshape_and_cache_hcu);
+  ops.def(
+      "reshape_and_cache(Tensor key, Tensor value, Tensor! key_cache, "
+      "Tensor! value_cache, Tensor slot_mapping, str kv_cache_dtype, "
+      "Tensor k_scale, Tensor v_scale) -> ()");
+  ops.impl("reshape_and_cache", torch::kCUDA, &reshape_and_cache_hcu);
+  ops.def(
+      "reshape_and_cache_flash(Tensor key, Tensor value, Tensor! key_cache, "
+      "Tensor! value_cache, Tensor slot_mapping, str kv_cache_dtype, "
+      "Tensor k_scale, Tensor v_scale) -> ()");
+  ops.impl("reshape_and_cache_flash", torch::kCUDA,
+           &reshape_and_cache_flash_hcu);
   ops.def("concat_and_cache_mla", &concat_and_cache_mla_hcu);
   ops.def(
       "deepseek_v4_inv_rope(Tensor! rope, Tensor position_ids, "

--- a/vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py
@@ -411,6 +411,7 @@ def ll_init(
         local_expert_global_ids,
     )
     self.use_int8_dispatch = bool(use_int8_dispatch)
+    self._vllm_hcu_clean_low_latency_buffer = False
     self._hcu_low_latency_dispatch_abi = _has_hcu_low_latency_dispatch_abi(buffer)
 
 
@@ -596,17 +597,18 @@ def ll_prepare_async(
             if block_k is None and quant_config.per_act_token_quant
             else module.DEEPEP_QUANT_BLOCK_SIZE
         )
-    cleanup = getattr(self.buffer, "clean_low_latency_buffer", None)
-    if not callable(cleanup):
-        raise RuntimeError(
-            "HCU DeepEP LL buffer does not expose clean_low_latency_buffer"
+    if getattr(self, "_vllm_hcu_clean_low_latency_buffer", False):
+        cleanup = getattr(self.buffer, "clean_low_latency_buffer", None)
+        if not callable(cleanup):
+            raise RuntimeError(
+                "HCU DeepEP LL buffer does not expose clean_low_latency_buffer"
+            )
+        cleanup(
+            self.max_tokens_per_rank,
+            hidden_size,
+            num_experts,
+            quant_group_size,
         )
-    cleanup(
-        self.max_tokens_per_rank,
-        hidden_size,
-        num_experts,
-        quant_group_size,
-    )
     try:
         if use_hcu_api:
             result = self.buffer.low_latency_dispatch(

--- a/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
@@ -477,10 +477,12 @@ class MoERunner(MoERunnerInterface):
                 return result[0], hidden_states
             return result, hidden_states
 
-        return (
-            hidden_states,
-            hidden_states if self._shared_experts is not None else None,
+        shared_experts_input = (
+            hidden_states.clone()
+            if self._can_use_inplace_shared_output()
+            else hidden_states if self._shared_experts is not None else None
         )
+        return hidden_states, shared_experts_input
 
     def apply_routed_output_transform(
         self,

--- a/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
@@ -189,7 +189,9 @@ def _moe_forward_shared(
         topk_weights=topk_weights,
         topk_ids=topk_ids,
     )
-    return shared_output, fused_output.clone()
+    if torch._C._is_alias_of(fused_output, hidden_states):
+        fused_output = fused_output.clone()
+    return shared_output, fused_output
 
 
 def _moe_forward_shared_fake(
@@ -233,6 +235,15 @@ def _moe_forward_shared_inplace(
     hidden_dim_unpadded: int,
 ) -> torch.Tensor:
     layer = get_layer_from_name(_resolve_layer_name(layer_name))
+    if (
+        shared_experts_input is not None
+        and layer._shared_experts is not None
+        and torch._C._is_alias_of(shared_experts_input, hidden_states)
+        and layer._shared_experts.requires_input_preservation(
+            shared_experts_input
+        )
+    ):
+        shared_experts_input = shared_experts_input.clone()
     shared_output, fused_output = layer._forward_impl(
         hidden_states,
         router_logits,
@@ -391,8 +402,13 @@ class MoERunner(MoERunnerInterface):
         )
         self._forward_entry = self._select_forward()
 
-    def _select_forward(self) -> Callable:
-        if self._forward_uses_mutated_hidden_states:
+    def _select_forward(
+        self,
+        uses_mutated_hidden_states: bool | None = None,
+    ) -> Callable:
+        if uses_mutated_hidden_states is None:
+            uses_mutated_hidden_states = self._forward_uses_mutated_hidden_states
+        if uses_mutated_hidden_states:
             if current_platform.is_tpu() or current_platform.is_cpu():
                 return _moe_forward_shared_inplace
             return torch.ops.vllm.moe_forward_shared_inplace
@@ -477,12 +493,10 @@ class MoERunner(MoERunnerInterface):
                 return result[0], hidden_states
             return result, hidden_states
 
-        shared_experts_input = (
-            hidden_states.clone()
-            if self._can_use_inplace_shared_output()
-            else hidden_states if self._shared_experts is not None else None
+        return (
+            hidden_states,
+            hidden_states if self._shared_experts is not None else None,
         )
-        return hidden_states, shared_experts_input
 
     def apply_routed_output_transform(
         self,
@@ -886,7 +900,33 @@ class MoERunner(MoERunnerInterface):
             )
         )
 
-        result = self._forward_entry(
+        # Alias/overlap policy depends on runtime-only backend state and
+        # torch._C._is_alias_of returns a Python bool that Dynamo cannot trace.
+        # During compilation, use the tuple-returning opaque op; the quant
+        # method evaluates its per-call in-place policy inside that boundary.
+        forward_uses_mutated_hidden_states = (
+            self._forward_uses_mutated_hidden_states
+            and not torch.compiler.is_compiling()
+        )
+        if (
+            forward_uses_mutated_hidden_states
+            and self._shared_experts is not None
+            and shared_experts_input is not None
+        ):
+            forward_uses_mutated_hidden_states = (
+                self._shared_experts.allows_inplace_routed_output(
+                    hidden_states,
+                    shared_experts_input,
+                )
+            )
+        forward_entry = (
+            self._forward_entry
+            if forward_uses_mutated_hidden_states
+            == self._forward_uses_mutated_hidden_states
+            else self._select_forward(forward_uses_mutated_hidden_states)
+        )
+
+        result = forward_entry(
             hidden_states,
             router_logits,
             shared_experts_input,
@@ -912,7 +952,7 @@ class MoERunner(MoERunnerInterface):
 
         # Extract outputs from result. The mutation-only custom op returns
         # shared output and exposes routed output through hidden_states.
-        if self._forward_uses_mutated_hidden_states:
+        if forward_uses_mutated_hidden_states:
             shared_output, fused_output = result, hidden_states
         else:
             shared_output, fused_output = _unpack(result)

--- a/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
@@ -900,31 +900,13 @@ class MoERunner(MoERunnerInterface):
             )
         )
 
-        # Alias/overlap policy depends on runtime-only backend state and
-        # torch._C._is_alias_of returns a Python bool that Dynamo cannot trace.
-        # During compilation, use the tuple-returning opaque op; the quant
-        # method evaluates its per-call in-place policy inside that boundary.
+        # Keep runtime alias handling inside the opaque mutation-only op.  In
+        # particular, do not switch compiled calls to the tuple-returning op:
+        # an in-place routed kernel would then need another full output clone.
         forward_uses_mutated_hidden_states = (
             self._forward_uses_mutated_hidden_states
-            and not torch.compiler.is_compiling()
         )
-        if (
-            forward_uses_mutated_hidden_states
-            and self._shared_experts is not None
-            and shared_experts_input is not None
-        ):
-            forward_uses_mutated_hidden_states = (
-                self._shared_experts.allows_inplace_routed_output(
-                    hidden_states,
-                    shared_experts_input,
-                )
-            )
-        forward_entry = (
-            self._forward_entry
-            if forward_uses_mutated_hidden_states
-            == self._forward_uses_mutated_hidden_states
-            else self._select_forward(forward_uses_mutated_hidden_states)
-        )
+        forward_entry = self._forward_entry
 
         result = forward_entry(
             hidden_states,

--- a/vllm_hcu/model_executor/layers/fused_moe/shared_experts.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/shared_experts.py
@@ -173,6 +173,23 @@ class SharedExperts(torch.nn.Module):
             return SharedExpertsOrder.MULTI_STREAM_OVERLAPPED
         return SharedExpertsOrder.NO_OVERLAP
 
+    def requires_input_preservation(self, hidden_states: torch.Tensor) -> bool:
+        """Return whether routed experts can mutate this input concurrently."""
+        return self._determine_shared_experts_order(hidden_states) in (
+            SharedExpertsOrder.MK_INTERNAL_OVERLAPPED,
+            SharedExpertsOrder.MULTI_STREAM_OVERLAPPED,
+        )
+
+    def allows_inplace_routed_output(
+        self,
+        routed_input: torch.Tensor,
+        shared_input: torch.Tensor,
+    ) -> bool:
+        """Return whether routing may overwrite its input without a data race."""
+        return not torch._C._is_alias_of(
+            routed_input, shared_input
+        ) or not self.requires_input_preservation(shared_input)
+
     def _should_run_shared_in_aux_stream(
         self,
         hidden_states: torch.Tensor,
@@ -194,8 +211,8 @@ class SharedExperts(torch.nn.Module):
         if experts_order == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED:
             assert self._stream is not None
 
-            # Record that the clone will be used by shared_experts_stream
-            # to avoid gc issue from deallocation of hidden_states_clone
+            # Keep the auxiliary stream's shared input storage alive until it
+            # has finished consuming it.
             # For more details: https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html # noqa: E501
             # NOTE: We don't need shared_output.record_stream(current_stream())
             # because we synch the streams before using shared_output.

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_marlin.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_marlin.py
@@ -60,5 +60,22 @@ class SlimQuantCompressedTensorsMarlinConfig(CompressedTensorsConfig):
         if isinstance(layer, Attention):
             return CompressedTensorsKVCacheMethod(self)
         if isinstance(layer, RoutedExperts):
+            moe_backend = getattr(layer.moe_config, "moe_backend", "auto")
+            from vllm_hcu.model_executor.layers.fused_moe.aiter_runtime import (
+                is_aiter_moe_requested,
+            )
+
+            if moe_backend != "auto" or is_aiter_moe_requested(
+                layer.moe_config
+            ):
+                from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe import (
+                    CompressedTensorsMoEMethod,
+                )
+
+                return CompressedTensorsMoEMethod.get_moe_method(
+                    self,
+                    layer,
+                    prefix,
+                )
             return CompressedTensorsMarlinMoEMethod.get_moe_method(self, layer)
         return None

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
@@ -287,6 +287,11 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
         layer.w13_weight = Parameter(w1_marlin, requires_grad=False)
         layer.w2_weight = Parameter(w2_marlin, requires_grad=False)
 
+        # Install the LightOp compatibility shim once while loading weights,
+        # before model forward can be captured or compiled.
+        from lightop.moe import fused_experts_impl_fp8_marlin
+        ensure_safe_marlin_moe_alignment(fused_experts_impl_fp8_marlin)
+
     def fused_moe_forward(
             self,
             layer: torch.nn.Module,
@@ -304,7 +309,6 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
             inplace: bool = True,
     ):
         from lightop.moe import fused_experts_impl_fp8_marlin
-        ensure_safe_marlin_moe_alignment(fused_experts_impl_fp8_marlin)
         return fused_experts_impl_fp8_marlin(
             hidden_states=x,
             w1=layer.w13_weight,
@@ -531,6 +535,12 @@ class CompressedTensorsW8A8Int8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod)
         layer.w13_weight = Parameter(w1_marlin, requires_grad=False)
         layer.w2_weight = Parameter(w2_marlin, requires_grad=False)
 
+        if not self.use_deepep:
+            # Install once during loading rather than querying and patching
+            # the runner module from every MoE invocation.
+            from lightop.moe import fused_experts_impl_int8_marlin
+            ensure_safe_marlin_moe_alignment(fused_experts_impl_int8_marlin)
+
     # ── apply ───────────────────────────────────────────────────────
     def apply(
         self,
@@ -545,7 +555,6 @@ class CompressedTensorsW8A8Int8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod)
     ) -> torch.Tensor:
         # LightOp Marlin INT8 path.
         from lightop.moe import fused_experts_impl_int8_marlin
-        ensure_safe_marlin_moe_alignment(fused_experts_impl_int8_marlin)
         inplace = self._allows_inplace_output(
             x,
             shared_experts,

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
@@ -24,9 +24,6 @@ from vllm.model_executor.layers.fused_moe import (
     FusedMoeWeightScaleSupported, FusedMoEConfig, RoutedExperts,
     SharedExperts)
 from vllm.model_executor.utils import set_weight_attrs
-from vllm_hcu.model_executor.layers.quantization.int8_runtime import (
-    weight8bit_nt_kpack2_marlin2,
-)
 from vllm.model_executor.layers.fused_moe import config as fused_moe_config
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
@@ -37,6 +34,12 @@ from vllm.model_executor.layers.fused_moe import (
     FusedMoEExpertsModular,
     FusedMoEPrepareAndFinalizeModular,
     FusedMoeWeightScaleSupported,
+)
+from vllm_hcu.model_executor.layers.quantization.int8_runtime import (
+    weight8bit_nt_kpack2_marlin2,
+)
+from vllm_hcu.model_executor.layers.quantization.lightop_marlin_moe_compat import (
+    ensure_safe_marlin_moe_alignment,
 )
 logger = init_logger(__name__)
 
@@ -306,6 +309,7 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
             i_s: torch.Tensor | None = None,
     ):
         from lightop.moe import fused_experts_impl_fp8_marlin
+        ensure_safe_marlin_moe_alignment(fused_experts_impl_fp8_marlin)
         return fused_experts_impl_fp8_marlin(
             hidden_states=x,
             w1=layer.w13_weight,
@@ -609,6 +613,7 @@ class CompressedTensorsW8A8Int8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod)
         # Default Marlin INT8 path
 
         from lightop.moe import fused_experts_impl_int8_marlin
+        ensure_safe_marlin_moe_alignment(fused_experts_impl_int8_marlin)
         return fused_experts_impl_int8_marlin(
             hidden_states=x,
             w1=layer.w13_weight,

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
@@ -2,19 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
 # Modified by Hygon Information Technology Co., Ltd., 2026.
-"""HCU compressed-tensors Marlin methods with optional AITER routing.
-
-The AITER INT8 branch keeps canonical weights at load time and delegates
-shape/config selection, derived layouts, public execution, and native Triton
-fallback to ``compressed_tensors_moe_runtime``. The non-AITER branch uses the
-LightOp Marlin layout and execution path.
-"""
+"""HCU compressed-tensors methods owned by the LightOp Marlin backend."""
 import enum
 import torch
 from enum import Enum
 from typing import Optional
 from compressed_tensors.quantization import (QuantizationStrategy)
-from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from torch.nn.parameter import Parameter
@@ -47,18 +40,6 @@ __all__ = [
     "CompressedTensorsW8A8Int8MarlinMoEMethod",
     "CompressedTensorsW8A8FP8MarlinMoEMethod",
 ]
-# ── AITER W8A8 MoE env guard ────────────────────────────────────────
-
-def _is_hcu_aiter_w8a8_moe_requested(
-    moe_config: object | None = None,
-) -> bool:
-    from vllm_hcu.model_executor.layers.fused_moe.aiter_runtime import (
-        is_aiter_moe_requested,
-    )
-
-    return is_aiter_moe_requested(moe_config)
-
-
 # ── Weight layout helpers (Marlin interleave) ───────────────────────
 
 def get_w8a8_int8_marlin_weights(
@@ -135,9 +116,7 @@ class CompressedTensorsMarlinMoEMethod(FusedMoEMethodBase):
 
     @property
     def supports_inplace_output(self) -> bool:
-        return not self.use_deepep and not _is_hcu_aiter_w8a8_moe_requested(
-            self.moe
-        )
+        return not self.use_deepep
 
     @staticmethod
     def _allows_inplace_output(
@@ -528,32 +507,7 @@ class CompressedTensorsW8A8Int8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod)
         layer.w2_input_scale = None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        # AITER W8A8 MoE fast-path: skip Marlin interleave, defer to AITER
-        if _is_hcu_aiter_w8a8_moe_requested(self.moe):
-            if not rocm_aiter_ops.is_fused_moe_enabled():
-                raise RuntimeError(
-                    "VLLM_ROCM_USE_AITER=1 and VLLM_ROCM_USE_AITER_MOE=1 "
-                    "requested AITER W8A8 MoE, but rocm_aiter_ops fused MoE "
-                    "support is unavailable."
-                )
-            if layer.apply_router_weight_on_input:
-                raise RuntimeError(
-                    "AITER W8A8 MoE does not support "
-                    "apply_router_weight_on_input=True."
-                )
-
-            self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-            from vllm_hcu.model_executor.layers.quantization.compressed_tensors_moe_runtime import (
-                prewarm_aiter_quantized_moe,
-            )
-
-            prewarm_aiter_quantized_moe(
-                layer,
-                self.moe,
-                self.moe_quant_config,
-            )
-            return
-        # Default Marlin weight interleave path
+        # LightOp Marlin weight interleave path.
         #if not self.use_deepep:
         w1_marlin_list = []
         for ii in range(layer.w13_weight.shape[0]):
@@ -589,46 +543,7 @@ class CompressedTensorsW8A8Int8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod)
         i_q: torch.Tensor | None = None,
         i_s: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        # AITER W8A8 MoE fast-path
-        if _is_hcu_aiter_w8a8_moe_requested(self.moe):
-            if not rocm_aiter_ops.is_fused_moe_enabled():
-                raise RuntimeError(
-                    "VLLM_ROCM_USE_AITER=1 and VLLM_ROCM_USE_AITER_MOE=1 "
-                    "requested AITER W8A8 MoE, but rocm_aiter_ops fused MoE "
-                    "support is unavailable."
-                )
-            if layer.apply_router_weight_on_input:
-                raise RuntimeError(
-                    "AITER W8A8 MoE does not support "
-                    "apply_router_weight_on_input=True."
-                )
-
-            from vllm_hcu.model_executor.layers.quantization.compressed_tensors_moe_runtime import (
-                apply_aiter_quantized_moe,
-            )
-
-            quant_config = getattr(self, "moe_quant_config", None)
-            if quant_config is None:
-                quant_config = self.get_fused_moe_quant_config(layer)
-                self.moe_quant_config = quant_config
-            return apply_aiter_quantized_moe(
-                hidden_states=x,
-                w1=layer.w13_weight,
-                w2=layer.w2_weight,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-                vllm_moe_config=self.moe,
-                activation=layer.activation,
-                apply_router_weight_on_input=(
-                    layer.apply_router_weight_on_input
-                ),
-                expert_map=layer.expert_map,
-                quant_config=quant_config,
-                output_dtype=x.dtype,
-            )
-
-        # Default Marlin INT8 path
-
+        # LightOp Marlin INT8 path.
         from lightop.moe import fused_experts_impl_int8_marlin
         ensure_safe_marlin_moe_alignment(fused_experts_impl_int8_marlin)
         inplace = self._allows_inplace_output(

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
@@ -140,6 +140,21 @@ class CompressedTensorsMarlinMoEMethod(FusedMoEMethodBase):
         )
 
     @staticmethod
+    def _allows_inplace_output(
+        x: torch.Tensor,
+        shared_experts: SharedExperts | None,
+        shared_experts_input: torch.Tensor | None,
+    ) -> bool:
+        return (
+            shared_experts is None
+            or shared_experts_input is None
+            or shared_experts.allows_inplace_routed_output(
+                x,
+                shared_experts_input,
+            )
+        )
+
+    @staticmethod
     def get_moe_method(
         quant_config: "SlimQuantCompressedTensorsMarlinConfig",  # type: ignore # noqa E501
         layer: torch.nn.Module,
@@ -307,6 +322,7 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
             shared_output: Optional[torch.Tensor] = None,
             i_q: torch.Tensor | None = None,
             i_s: torch.Tensor | None = None,
+            inplace: bool = True,
     ):
         from lightop.moe import fused_experts_impl_fp8_marlin
         ensure_safe_marlin_moe_alignment(fused_experts_impl_fp8_marlin)
@@ -316,7 +332,7 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
             w2=layer.w2_weight,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
-            inplace=True,
+            inplace=inplace,
             activation=activation,
             apply_router_weight_on_input=apply_router_weight_on_input,
             use_fp8_w8a8=True,
@@ -343,9 +359,11 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
             i_q: torch.Tensor | None = None,
             i_s: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        # HCU's MoERunner executes shared experts on its managed stream and
-        # combines them after the routed kernel returns.
-        del shared_experts, shared_experts_input
+        inplace = self._allows_inplace_output(
+            x,
+            shared_experts,
+            shared_experts_input,
+        )
         return self.fused_experts(
             layer=layer,
             x=x,
@@ -358,7 +376,9 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
             routed_scaling_factor=1.0,
             shared_output=None,
             i_q=i_q,
-            i_s=i_s, )
+            i_s=i_s,
+            inplace=inplace,
+        )
 
     @property
     def supports_eplb(self) -> bool:
@@ -569,9 +589,6 @@ class CompressedTensorsW8A8Int8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod)
         i_q: torch.Tensor | None = None,
         i_s: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        # HCU's MoERunner executes shared experts on its managed stream and
-        # combines them after the routed kernel returns.
-        del shared_experts, shared_experts_input
         # AITER W8A8 MoE fast-path
         if _is_hcu_aiter_w8a8_moe_requested(self.moe):
             if not rocm_aiter_ops.is_fused_moe_enabled():
@@ -614,13 +631,18 @@ class CompressedTensorsW8A8Int8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod)
 
         from lightop.moe import fused_experts_impl_int8_marlin
         ensure_safe_marlin_moe_alignment(fused_experts_impl_int8_marlin)
+        inplace = self._allows_inplace_output(
+            x,
+            shared_experts,
+            shared_experts_input,
+        )
         return fused_experts_impl_int8_marlin(
             hidden_states=x,
             w1=layer.w13_weight,
             w2=layer.w2_weight,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
-            inplace=True,
+            inplace=inplace,
             activation=layer.activation.value,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             use_int8_w8a8=True,

--- a/vllm_hcu/model_executor/layers/quantization/lightop_fp8_runtime.py
+++ b/vllm_hcu/model_executor/layers/quantization/lightop_fp8_runtime.py
@@ -66,6 +66,16 @@ def ensure_registered(
     """Register exactly once; failures are latched for the process lifetime."""
 
     global _FP8_DTYPE, _REGISTERED, _REGISTRATION_ERROR
+    # The forward wrapper is traced by Dynamo.  Registration is completed when
+    # the patch is installed, so the steady-state path must return before the
+    # graph-unsafe Python lock.
+    if _REGISTERED:
+        if _FP8_DTYPE is not fp8_dtype:
+            raise HcuLightOpRegistrationError(
+                f"LightOp per-token FP8 was registered for {_FP8_DTYPE}, "
+                f"not {fp8_dtype}"
+            )
+        return
     with _LOCK:
         if _REGISTRATION_ERROR is not None:
             raise HcuLightOpRegistrationError(

--- a/vllm_hcu/model_executor/layers/quantization/lightop_marlin_moe_compat.py
+++ b/vllm_hcu/model_executor/layers/quantization/lightop_marlin_moe_compat.py
@@ -34,8 +34,9 @@ def ensure_safe_marlin_moe_alignment(fused_experts: Callable[..., object]) -> No
     positions. Its vendored SlimQuant runners allocate ``sorted_ids`` with
     ``torch.empty``, leaving padding positions as arbitrary token ids, and its
     multi-token ordering differs from the order expected by Marlin. Patch the
-    runner-local helper to use vLLM's stable alignment operation and prefill
-    padding with the sentinel expected by the kernels.
+    runner-local helper to use vLLM's stable alignment operation.  The native
+    operation initializes every padding position with the sentinel expected by
+    the kernels, so its output buffer does not need a separate fill.
     """
 
     module_name = getattr(fused_experts, "__module__", "")
@@ -75,9 +76,8 @@ def ensure_safe_marlin_moe_alignment(fused_experts: Callable[..., object]) -> No
                 max_num_tokens_padded,
             )
 
-        sorted_ids = torch.full(
+        sorted_ids = torch.empty(
             (max_num_tokens_padded,),
-            fill_value=topk_ids.numel(),
             dtype=torch.int32,
             device=topk_ids.device,
         )

--- a/vllm_hcu/model_executor/layers/quantization/lightop_marlin_moe_compat.py
+++ b/vllm_hcu/model_executor/layers/quantization/lightop_marlin_moe_compat.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Compatibility fixes for LightOp's vendored SlimQuant Marlin runners."""
+
+from __future__ import annotations
+
+import functools
+import importlib
+from collections.abc import Callable
+
+import torch
+import triton
+from vllm import _custom_ops as ops
+
+
+_IMPLEMENTATION_PREFIX = "lightop."
+_PATCH_MARKER = "_vllm_hcu_safe_alignment_installed"
+
+
+def _safe_remap_expert_ids(
+    expert_ids: torch.Tensor,
+    expert_map: torch.Tensor,
+) -> torch.Tensor:
+    valid = (expert_ids >= 0) & (expert_ids < expert_map.numel())
+    safe_ids = expert_ids.clamp(min=0, max=expert_map.numel() - 1).long()
+    mapped = expert_map[safe_ids]
+    return torch.where(valid, mapped, torch.full_like(mapped, -1))
+
+
+def ensure_safe_marlin_moe_alignment(fused_experts: Callable[..., object]) -> None:
+    """Install stable vLLM alignment in a LightOp vendored Marlin runner.
+
+    LightOp 0.6's out-parameter alignment kernel only writes routed token
+    positions. Its vendored SlimQuant runners allocate ``sorted_ids`` with
+    ``torch.empty``, leaving padding positions as arbitrary token ids, and its
+    multi-token ordering differs from the order expected by Marlin. Patch the
+    runner-local helper to use vLLM's stable alignment operation and prefill
+    padding with the sentinel expected by the kernels.
+    """
+
+    module_name = getattr(fused_experts, "__module__", "")
+    if not module_name.startswith(_IMPLEMENTATION_PREFIX):
+        return
+
+    implementation = importlib.import_module(module_name)
+    original = getattr(implementation, "moe_align_block_size", None)
+    if not callable(original):
+        raise RuntimeError(
+            f"LightOp Marlin implementation {module_name!r} has no callable "
+            "moe_align_block_size"
+        )
+    if getattr(original, _PATCH_MARKER, False):
+        return
+
+    @functools.wraps(original)
+    def safe_alignment(
+        topk_ids: torch.Tensor,
+        block_size: int,
+        num_experts: int,
+        expert_map: torch.Tensor | None = None,
+        pad_sorted_ids: bool = False,
+        ignore_invalid_experts: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        max_num_tokens_padded = topk_ids.numel() + num_experts * (
+            block_size - 1
+        )
+        if pad_sorted_ids:
+            max_num_tokens_padded = triton.cdiv(
+                max_num_tokens_padded,
+                block_size,
+            ) * block_size
+        if topk_ids.numel() < num_experts:
+            max_num_tokens_padded = min(
+                topk_ids.numel() * block_size,
+                max_num_tokens_padded,
+            )
+
+        sorted_ids = torch.full(
+            (max_num_tokens_padded,),
+            fill_value=topk_ids.numel(),
+            dtype=torch.int32,
+            device=topk_ids.device,
+        )
+        expert_ids = torch.empty(
+            (triton.cdiv(max_num_tokens_padded, block_size),),
+            dtype=torch.int32,
+            device=topk_ids.device,
+        )
+        num_tokens_post_pad = torch.empty(
+            (1,),
+            dtype=torch.int32,
+            device=topk_ids.device,
+        )
+        ops.moe_align_block_size(
+            topk_ids,
+            num_experts,
+            block_size,
+            sorted_ids,
+            expert_ids,
+            num_tokens_post_pad,
+            expert_map if ignore_invalid_experts else None,
+        )
+        if expert_map is not None and not ignore_invalid_experts:
+            expert_ids = _safe_remap_expert_ids(expert_ids, expert_map)
+        return sorted_ids, expert_ids, num_tokens_post_pad
+
+    implementation._vllm_hcu_original_moe_align_block_size = original
+    setattr(safe_alignment, _PATCH_MARKER, True)
+    implementation.moe_align_block_size = safe_alignment
+
+
+__all__ = ["ensure_safe_marlin_moe_alignment"]

--- a/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
+++ b/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
@@ -140,6 +140,31 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
     """Channel-wise SlimQuant W4A8 routed by the shared AITER adapter."""
 
     def __init__(self, quant_config, moe):
+        moe_backend = getattr(moe, "moe_backend", "auto")
+        supported_backends = {"auto", "aiter", "triton", "deep_gemm"}
+        if moe_backend not in supported_backends:
+            raise ValueError(
+                "SlimQuant W4A8 does not support "
+                f"moe_backend={moe_backend!r}; expected one of "
+                f"{sorted(supported_backends)!r}"
+            )
+        if moe_backend == "deep_gemm":
+            parallel_config = getattr(moe, "moe_parallel_config", None)
+            if (
+                parallel_config is None
+                or getattr(parallel_config, "all2all_backend", None)
+                != "deepep_auto"
+                or getattr(
+                    parallel_config,
+                    "use_deepep_auto_kernels",
+                    None,
+                )
+                is False
+            ):
+                raise ValueError(
+                    "SlimQuant W4A8 deep_gemm requires DP+EP with "
+                    "all2all_backend='deepep_auto'"
+                )
         self.moe = moe
         self.quant_config = quant_config
         self.moe_quant_config: FusedMoEQuantConfig | None = None

--- a/vllm_hcu/models/glm4_moe.py
+++ b/vllm_hcu/models/glm4_moe.py
@@ -107,6 +107,20 @@ def fused_qkv_cache_layout_supported(attn_backend: type) -> bool:
     return attn_backend.get_name() != "TRITON_ATTN"
 
 
+def _glm4_apply_routed_scale_to_output(vllm_config: VllmConfig) -> bool:
+    """Choose GLM routed scaling without breaking FP16 residual semantics."""
+
+    # MoERunner's FP16 overflow path scales the shared output down instead of
+    # scaling the routed output up. Models using that path must also scale the
+    # residual stream, as DeepSeek does. GLM does not have that compensation,
+    # so keep its FP16 factor in the router weights. AITER consumes the routed
+    # factor internally for every dtype.
+    return (
+        vllm_config.model_config.dtype != torch.float16
+        and not is_aiter_moe_requested(vllm_config.kernel_config)
+    )
+
+
 class Glm4MoeMLP(nn.Module):
     def __init__(
         self,
@@ -263,12 +277,12 @@ class Glm4MoE(nn.Module):
             prefix=f"{prefix}.experts",
             scoring_func="sigmoid",
             routed_scaling_factor=self.routed_scaling_factor,
-            # AITER consumes scaled router weights. Other backends follow the
-            # vLLM GLM contract and apply the factor after expert aggregation.
-            # An AITER no-solution fallback remains correct because it receives
-            # those already-scaled weights in the vLLM Triton call.
-            apply_routed_scale_to_output=not is_aiter_moe_requested(
-                vllm_config.kernel_config
+            # AITER consumes scaled router weights. BF16/FP32 non-AITER
+            # backends apply the factor after expert aggregation. FP16 keeps
+            # router scaling because GLM has no residual-stream compensation
+            # for MoERunner's overflow-protection convention.
+            apply_routed_scale_to_output=_glm4_apply_routed_scale_to_output(
+                vllm_config
             ),
             e_score_correction_bias=self.gate.e_score_correction_bias,
             enable_eplb=self.enable_eplb,

--- a/vllm_hcu/models/glm4_moe.py
+++ b/vllm_hcu/models/glm4_moe.py
@@ -35,7 +35,9 @@ from torch import nn
 from transformers.models.glm4_moe import Glm4MoeConfig
 
 import vllm_hcu.platforms.envs as henvs
-from vllm_hcu.patch.config import get_hcu_config
+from vllm_hcu.model_executor.layers.fused_moe.aiter_runtime import (
+    is_aiter_moe_requested,
+)
 from vllm_hcu.model_executor.layers.sp_utils import (
     configure_hcu_runtime_sp,
     finalize_attention_output_for_sp,
@@ -51,6 +53,7 @@ from vllm_hcu.model_executor.layers.sp_utils import (
     sp_mlp_down_proj_reduce_results,
     use_sp_mlp_token_gather,
 )
+from vllm_hcu.patch.config import get_hcu_config
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
 from vllm.distributed import (
@@ -260,7 +263,13 @@ class Glm4MoE(nn.Module):
             prefix=f"{prefix}.experts",
             scoring_func="sigmoid",
             routed_scaling_factor=self.routed_scaling_factor,
-            #apply_routed_scale_to_output=True,
+            # AITER consumes scaled router weights. Other backends follow the
+            # vLLM GLM contract and apply the factor after expert aggregation.
+            # An AITER no-solution fallback remains correct because it receives
+            # those already-scaled weights in the vLLM Triton call.
+            apply_routed_scale_to_output=not is_aiter_moe_requested(
+                vllm_config.kernel_config
+            ),
             e_score_correction_bias=self.gate.e_score_correction_bias,
             enable_eplb=self.enable_eplb,
             num_redundant_experts=self.n_redundant_experts,

--- a/vllm_hcu/models/hy_v3.py
+++ b/vllm_hcu/models/hy_v3.py
@@ -716,17 +716,6 @@ class HYV3Model(nn.Module):
         for name, loaded_weight in weights:
             if self.config.tie_word_embeddings and "lm_head.weight" in name:
                 continue
-            if self.quant_config is not None and (
-                scale_name := self.quant_config.get_cache_scale(name)
-            ):
-                param = params_dict[scale_name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                loaded_weight = (
-                    loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
-                )
-                weight_loader(param, loaded_weight)
-                loaded_params.add(scale_name)
-                continue
             if "scale" in name:
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)

--- a/vllm_hcu/models/hy_v3_mtp.py
+++ b/vllm_hcu/models/hy_v3_mtp.py
@@ -375,6 +375,10 @@ class HYV3MTP(nn.Module, SupportsPP):
         return torch.concat((q, k, v))
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        if self.quant_config is not None and (
+            cache_scale_mapper := self.quant_config.get_cache_scale_mapper()
+        ):
+            weights = cache_scale_mapper.apply(weights)
         cla_factor = _get_cla_factor(self.config)
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
@@ -447,14 +451,6 @@ class HYV3MTP(nn.Module, SupportsPP):
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
                 continue
             if self.config.tie_word_embeddings and "lm_head.weight" in name:
-                continue
-            if self.quant_config is not None and (
-                scale_name := self.quant_config.get_cache_scale(name)
-            ):
-                param = params_dict[scale_name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                loaded_weight = loaded_weight[0]
-                weight_loader(param, loaded_weight)
                 continue
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
             if spec_layer is None:

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -131,6 +131,7 @@ _MOE_REPLACEMENTS: tuple[_ReplacementSpec, ...] = (
             f"{_MOE_RUNNER_MODULE}._moe_forward_shared_fake",
             f"{_MOE_RUNNER_MODULE}._moe_forward_shared_inplace",
             f"{_MOE_RUNNER_MODULE}._moe_forward_shared_inplace_fake",
+            f"{_MOE_RUNNER_MODULE}.MoERunner.apply_routed_input_transform",
             f"{_MOE_RUNNER_MODULE}.MoERunner._maybe_apply_shared_experts",
             f"{_MOE_RUNNER_MODULE}.MoERunner._quant_method_supports_quanted_inputs",
             f"{_MOE_RUNNER_MODULE}.MoERunner._apply_quant_method",

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -108,6 +108,8 @@ _MOE_REPLACEMENTS: tuple[_ReplacementSpec, ...] = (
             f"{_SHARED_EXPERTS_MODULE}.SharedExperts._run_layer",
             f"{_SHARED_EXPERTS_MODULE}.SharedExperts._disable_shared_experts_overlap",
             f"{_SHARED_EXPERTS_MODULE}.SharedExperts._determine_shared_experts_order",
+            f"{_SHARED_EXPERTS_MODULE}.SharedExperts.requires_input_preservation",
+            f"{_SHARED_EXPERTS_MODULE}.SharedExperts.allows_inplace_routed_output",
             f"{_SHARED_EXPERTS_MODULE}.SharedExperts._should_run_shared_in_aux_stream",
             f"{_SHARED_EXPERTS_MODULE}.SharedExperts.maybe_sync_shared_experts_stream",
             f"{_SHARED_EXPERTS_MODULE}.SharedExperts._launch_in_aux_stream",

--- a/vllm_hcu/patch/worker/op_opt/moe/patch_all2all_utils.py
+++ b/vllm_hcu/patch/worker/op_opt/moe/patch_all2all_utils.py
@@ -131,17 +131,20 @@ def apply_to_module(module: ModuleType) -> bool:
                 physical_to_global=physical_to_global,
                 local_expert_global_ids=local_expert_global_ids,
             )
-            ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer = True
             from vllm_hcu.model_executor.layers.fused_moe.prepare_finalize import (
                 deepep_auto,
             )
 
+            fixed_use_low_latency = (
+                deepep_auto.dspark_mooncake_pd_use_low_latency(vllm_config)
+            )
+            ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer = (
+                fixed_use_low_latency is None
+            )
             return deepep_auto.DeepEPAutoPrepareAndFinalize(
                 ht_prepare_finalize,
                 ll_prepare_finalize,
-                fixed_use_low_latency=(
-                    deepep_auto.dspark_mooncake_pd_use_low_latency(vllm_config)
-                ),
+                fixed_use_low_latency=fixed_use_low_latency,
             )
 
         prepare_finalize = original(

--- a/vllm_hcu/patch/worker/op_opt/moe/patch_all2all_utils.py
+++ b/vllm_hcu/patch/worker/op_opt/moe/patch_all2all_utils.py
@@ -131,6 +131,7 @@ def apply_to_module(module: ModuleType) -> bool:
                 physical_to_global=physical_to_global,
                 local_expert_global_ids=local_expert_global_ids,
             )
+            ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer = True
             from vllm_hcu.model_executor.layers.fused_moe.prepare_finalize import (
                 deepep_auto,
             )

--- a/vllm_hcu/patch/worker/op_opt/moe/patch_int8_oracle.py
+++ b/vllm_hcu/patch/worker/op_opt/moe/patch_int8_oracle.py
@@ -192,6 +192,38 @@ def apply_to_module(module: ModuleType) -> bool:
 
             return hcu_enum.HCU_DEEPGEMM, DeepEPDeepGemmContiguousExperts
         if sidecar.moe_backend != "deep_gemm":
+            from vllm_hcu.model_executor.layers.fused_moe.aiter_runtime import (
+                is_aiter_moe_requested,
+            )
+
+            if (
+                getattr(config, "moe_backend", "auto") == "auto"
+                and is_aiter_moe_requested(config)
+            ):
+                activation_format = (
+                    target.mk.FusedMoEActivationFormat.BatchedExperts
+                    if config.moe_parallel_config.use_batched_activation_format
+                    else target.mk.FusedMoEActivationFormat.Standard
+                )
+                reasons = []
+                for kernel_cls in hcu_backend_to_kernel_cls(hcu_enum.AITER):
+                    supported, reason = kernel_cls.is_supported_config(
+                        kernel_cls,
+                        config,
+                        weight_key,
+                        activation_key,
+                        activation_format,
+                    )
+                    if supported:
+                        return hcu_enum.AITER, kernel_cls
+                    reasons.append(
+                        f"{kernel_cls.__name__}: {reason or 'unsupported'}"
+                    )
+                raise ValueError(
+                    "AITER is required by the HCU auto environment but does "
+                    "not support this INT8 MoE configuration: "
+                    + "; ".join(reasons)
+                )
             return select_backend(config, weight_key, activation_key)
         if getattr(config, "moe_backend", "auto") != "deep_gemm":
             raise ValueError(

--- a/vllm_hcu/patch/worker/op_opt/moe/patch_moe_runner.py
+++ b/vllm_hcu/patch/worker/op_opt/moe/patch_moe_runner.py
@@ -8,6 +8,7 @@ import importlib
 import inspect
 from types import ModuleType
 
+from .._common import require_exact_signature
 from ._common import (
     PatchCompatibilityError,
     require_callable,
@@ -26,6 +27,7 @@ TARGETS = (
     f"{TARGET_MODULE}._moe_forward_shared_fake",
     f"{TARGET_MODULE}._moe_forward_shared_inplace",
     f"{TARGET_MODULE}._moe_forward_shared_inplace_fake",
+    f"{TARGET_MODULE}.MoERunner.apply_routed_input_transform",
     f"{TARGET_MODULE}.MoERunner._maybe_apply_shared_experts",
     f"{TARGET_MODULE}.MoERunner._quant_method_supports_quanted_inputs",
     f"{TARGET_MODULE}.MoERunner._apply_quant_method",
@@ -84,6 +86,16 @@ def apply_to_module(module: ModuleType) -> bool:
                 f"HCU replacement {REPLACEMENT_MODULE}.{name} has incompatible "
                 f"signature {inspect.signature(function)}"
             )
+    input_transform = require_callable(
+        runner,
+        "apply_routed_input_transform",
+        TARGETS[7],
+    )
+    require_exact_signature(
+        input_transform,
+        TARGETS[7],
+        positional=("self", "hidden_states"),
+    )
     if _names(runner.forward) != (
         "self", "hidden_states", "router_logits", "input_ids",
         "quanted_hidden_states", "scale", "topk_weights", "topk_ids",

--- a/vllm_hcu/patch/worker/op_opt/moe/patch_shared_experts.py
+++ b/vllm_hcu/patch/worker/op_opt/moe/patch_shared_experts.py
@@ -8,6 +8,7 @@ import importlib
 import inspect
 from types import ModuleType
 
+from .._common import require_exact_signature
 from ._common import PatchCompatibilityError, require_class, require_replacement_module
 
 TARGET_MODULE = "vllm.model_executor.layers.fused_moe.runner.shared_experts"
@@ -19,6 +20,8 @@ TARGETS = (
     f"{TARGET_MODULE}.SharedExperts._run_layer",
     f"{TARGET_MODULE}.SharedExperts._disable_shared_experts_overlap",
     f"{TARGET_MODULE}.SharedExperts._determine_shared_experts_order",
+    f"{TARGET_MODULE}.SharedExperts.requires_input_preservation",
+    f"{TARGET_MODULE}.SharedExperts.allows_inplace_routed_output",
     f"{TARGET_MODULE}.SharedExperts._should_run_shared_in_aux_stream",
     f"{TARGET_MODULE}.SharedExperts.maybe_sync_shared_experts_stream",
     f"{TARGET_MODULE}.SharedExperts._launch_in_aux_stream",
@@ -34,6 +37,16 @@ def apply_to_module(module: ModuleType) -> bool:
     if getattr(module, _MARKER, False):
         return False
     cls = require_class(module, "SharedExperts", f"{TARGET_MODULE}.SharedExperts")
+    require_exact_signature(
+        getattr(cls, "requires_input_preservation", None),
+        TARGETS[5],
+        positional=("self", "hidden_states"),
+    )
+    require_exact_signature(
+        getattr(cls, "allows_inplace_routed_output", None),
+        f"{TARGET_MODULE}.SharedExperts.allows_inplace_routed_output",
+        positional=("self", "routed_input", "shared_input"),
+    )
     expected = {
         "maybe_sync_shared_experts_stream": ("self", "shared_experts_input", "x_and_scale_quanted"),
         "_run_in_aux_stream": ("self", "shared_experts_input", "x_and_scale_quanted"),

--- a/vllm_hcu/patch/worker/op_opt/patch_attention_layer.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_attention_layer.py
@@ -94,7 +94,10 @@ def apply_to_module(module: ModuleType) -> bool:
         self, query, key, value, output_shape=None, output_dtype=None
     ):
         custom_flash, _ = _feature_flags()
-        if custom_flash or getattr(self, "kv_cache_dtype", None) == "fp8_e5m2":
+        # The HCU-owned forward exists for CUSTOM's split-cache ABI. Standard
+        # backends must retain vLLM's unified KV-update dependency, including
+        # E5M2, so torch.compile and CUDA graphs preserve write-before-read.
+        if custom_flash:
             return attention_runtime.attention_forward(
                 attention,
                 self,

--- a/vllm_hcu/patch/worker/op_opt/patch_compressed_tensors_w8a8_fp8.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_compressed_tensors_w8a8_fp8.py
@@ -28,6 +28,8 @@ TARGETS = (
 )
 _CLASS_MARKER = "_vllm_hcu_w8a8_fp8_applied"
 _WRAPPER_MARKER = "_vllm_hcu_w8a8_fp8_wrapper"
+_SUPPORTED_FP8_BACKENDS = frozenset(("lightop", "target-triton"))
+
 
 def apply_to_module(module: ModuleType) -> bool:
     fp8_module = load_exact_module(TARGET_MODULE, module)
@@ -71,11 +73,11 @@ def apply_to_module(module: ModuleType) -> bool:
             if (
                 not getattr(kernel_class, "_hcu_fp8_patch_applied", False)
                 or getattr(kernel_class, "_hcu_fp8_backend", None)
-                != "target-triton"
+                not in _SUPPORTED_FP8_BACKENDS
             ):
                 raise RuntimeError(
-                    "channelwise FP8 requires the reviewed target Triton "
-                    "scaled-mm adapter before weight processing"
+                    "channelwise FP8 requires a reviewed HCU scaled-mm "
+                    "adapter before weight processing"
                 )
 
         original_process(self, layer)
@@ -107,7 +109,7 @@ def apply_to_module(module: ModuleType) -> bool:
         if not supports_quanted_inputs(self):
             raise RuntimeError(
                 "prequantized FP8 inputs are only supported by the reviewed "
-                "Channel-FP8 target Triton route"
+                "HCU Channel-FP8 route"
             )
         return self.fp8_linear.apply_weights(
             layer,
@@ -122,7 +124,7 @@ def apply_to_module(module: ModuleType) -> bool:
             self.strategy == fp8_module.QuantizationStrategy.CHANNEL
             and getattr(kernel_class, "_hcu_fp8_patch_applied", False)
             and getattr(kernel_class, "_hcu_fp8_backend", None)
-            == "target-triton"
+            in _SUPPORTED_FP8_BACKENDS
         )
 
     for function in (hcu_process_weights_after_loading, hcu_apply_weights):

--- a/vllm_hcu/patch/worker/op_opt/patch_input_quant_fp8.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_input_quant_fp8.py
@@ -101,6 +101,16 @@ def apply_to_module(module: ModuleType) -> bool:
             f"required HCU patch constants in {TARGET_MODULE} are missing"
         )
 
+    # Register before model forward is handed to Dynamo.  The runtime keeps a
+    # lock-free fast path for this already-registered steady state.
+    from vllm.utils.torch_utils import direct_register_custom_op
+    from vllm_hcu.model_executor.layers.quantization import lightop_fp8_runtime
+
+    lightop_fp8_runtime.ensure_registered(
+        input_quant._FP8_DTYPE,
+        direct_register_custom_op,
+    )
+
     @functools.wraps(original_cuda)
     def hcu_forward_cuda(
         self,

--- a/vllm_hcu/patch/worker/op_opt/patch_mla_attention.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_mla_attention.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import functools
 import inspect
+from dataclasses import replace
 from types import ModuleType
 
 from vllm_hcu.patch.config import get_hcu_config
@@ -22,6 +23,7 @@ TARGETS = (
     f"{TARGET_MODULE}.MLACommonMetadata.__init__",
     f"{TARGET_MODULE}.MLACommonMetadataBuilder.build",
     f"{TARGET_MODULE}.split_decodes_and_prefills",
+    f"{TARGET_MODULE}.MLAAttention.get_kv_cache_spec",
 )
 _MARKER = "_vllm_hcu_mla_attention_applied"
 _WRAPPER = "_vllm_hcu_mla_attention_wrapper"
@@ -40,6 +42,7 @@ def apply_to_module(module: ModuleType) -> bool:
         (metadata_cls, "__init__", TARGETS[4], _WRAPPER),
         (builder_cls, "build", TARGETS[5], _WRAPPER),
         (mla, "split_decodes_and_prefills", TARGETS[6], _WRAPPER),
+        (cls, "get_kv_cache_spec", TARGETS[7], _WRAPPER),
     )
     if already_applied(mla, _MARKER, wrapped):
         return False
@@ -74,6 +77,12 @@ def apply_to_module(module: ModuleType) -> bool:
     )
     process = require_callable(cls, "process_weights_after_loading", TARGETS[3])
     require_exact_signature(process, TARGETS[3], positional=("self", "act_dtype"))
+    get_kv_cache_spec = require_callable(cls, "get_kv_cache_spec", TARGETS[7])
+    require_exact_signature(
+        get_kv_cache_spec,
+        TARGETS[7],
+        positional=("self", "vllm_config"),
+    )
     metadata_init = require_callable(metadata_cls, "__init__", TARGETS[4])
     if "num_actual_tokens" not in inspect.signature(metadata_init).parameters:
         raise PatchCompatibilityError(
@@ -282,6 +291,16 @@ def apply_to_module(module: ModuleType) -> bool:
 
         return mla_process_weights_nn(mla, self, act_dtype)
 
+    @functools.wraps(get_kv_cache_spec)
+    def hcu_get_kv_cache_spec(self, vllm_config):
+        from vllm.v1.kv_cache_interface import get_kv_quant_mode
+
+        spec = get_kv_cache_spec(self, vllm_config)
+        return replace(
+            spec,
+            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
+        )
+
     @functools.wraps(metadata_init)
     def hcu_metadata_init(self, *args, **kwargs):
         num_kv = kwargs.pop("num_kv_actual_tokens", None)
@@ -329,6 +348,7 @@ def apply_to_module(module: ModuleType) -> bool:
         hcu_full_forward,
         hcu_forward,
         hcu_process,
+        hcu_get_kv_cache_spec,
         hcu_metadata_init,
         hcu_build,
         hcu_split_batch,
@@ -338,6 +358,7 @@ def apply_to_module(module: ModuleType) -> bool:
     setattr(cls, "_vllm_hcu_original_forward", original_full_forward)
     setattr(cls, "_vllm_hcu_original_forward_impl", original_forward)
     setattr(cls, "_vllm_hcu_original_process_weights", process)
+    setattr(cls, "_vllm_hcu_original_get_kv_cache_spec", get_kv_cache_spec)
     setattr(metadata_cls, "_vllm_hcu_original_init", metadata_init)
     setattr(builder_cls, "_vllm_hcu_original_build", builder)
     setattr(mla, "_vllm_hcu_original_split_decodes_and_prefills", split_batch)
@@ -345,6 +366,7 @@ def apply_to_module(module: ModuleType) -> bool:
     setattr(cls, "forward", hcu_full_forward)
     setattr(cls, "forward_impl", hcu_forward)
     setattr(cls, "process_weights_after_loading", hcu_process)
+    setattr(cls, "get_kv_cache_spec", hcu_get_kv_cache_spec)
     setattr(metadata_cls, "__init__", hcu_metadata_init)
     setattr(builder_cls, "build", hcu_build)
     setattr(mla, "split_decodes_and_prefills", hcu_split_batch)

--- a/vllm_hcu/patch/worker/op_opt/patch_scaled_mm_linear_kernel.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_scaled_mm_linear_kernel.py
@@ -27,6 +27,7 @@ TARGETS = (
 )
 _CLASS_MARKER = "_vllm_hcu_prequantized_input_applied"
 _WRAPPER_MARKER = "_vllm_hcu_prequantized_input_wrapper"
+_SUPPORTED_FP8_BACKENDS = frozenset(("lightop", "target-triton"))
 
 
 def apply_to_module(module: ModuleType) -> bool:
@@ -67,8 +68,8 @@ def apply_to_module(module: ModuleType) -> bool:
             return original(self, layer, x, bias)
         if not supports_quanted_inputs(self):
             raise RuntimeError(
-                "prequantized FP8 inputs require the reviewed Channel-FP8 "
-                "target Triton route"
+                "prequantized FP8 inputs require a reviewed HCU Channel-FP8 "
+                "route"
             )
         if not isinstance(x_and_scale_quanted, tuple) or len(x_and_scale_quanted) != 2:
             raise ValueError("x_and_scale_quanted must be a (tensor, scale) tuple")
@@ -104,8 +105,8 @@ def apply_to_module(module: ModuleType) -> bool:
         # SymBool.  vLLM's piecewise splitter can then thread the relation into
         # a standalone subgraph as a ``sympy.Equality`` input, which this Torch
         # Inductor does not support.  Preserve the friendly eager error here;
-        # the target-Triton custom-op implementation repeats this contract with
-        # concrete runtime dimensions before launching the backend.
+        # the HCU custom-op implementation repeats this contract with concrete
+        # runtime dimensions before launching the selected backend.
         if not torch.compiler.is_compiling():
             if tuple(x_scale.shape) not in (
                 (),
@@ -144,7 +145,7 @@ def apply_to_module(module: ModuleType) -> bool:
         return bool(
             getattr(kernel_class, "_hcu_fp8_patch_applied", False)
             and getattr(kernel_class, "_hcu_fp8_backend", None)
-            == "target-triton"
+            in _SUPPORTED_FP8_BACKENDS
         )
 
     setattr(hcu_apply_weights, _WRAPPER_MARKER, True)

--- a/vllm_hcu/platforms/envs.py
+++ b/vllm_hcu/platforms/envs.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     VLLM_HCU_USE_CAT_MLA: bool = False
     VLLM_HCU_DISABLE_DSA: bool = False
     VLLM_HCU_USE_FP8_MIXED_BATCH: bool = False
-    VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM : bool = False
+    VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM: bool = True
     VLLM_HCU_USE_CUSTOM_OPS : bool = False
     VLLM_HCU_USE_CUSTOM_SILU_AND_MUL : bool = False
     VLLM_HCU_USE_CUSTOM_GEMMA_RMS_NORM : bool = False
@@ -196,7 +196,8 @@ hcu_vllm_environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_HCU_USE_FP8_MIXED_BATCH":
         lambda: (os.getenv('VLLM_HCU_USE_FP8_MIXED_BATCH', 'True').lower() in
                  ("true", "1")),  
-    # If set, control hcu custom gemm including w8a8 int8/fp8 etc
+    # Enable HCU custom quantization GEMMs by default. Channel-wise FP8 uses
+    # LightOp when enabled and retains the vLLM Triton path when disabled.
     "VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM":
     lambda: (os.environ.get("VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM", "True").lower() in
              ("true", "1")),

--- a/vllm_hcu/platforms/envs.py
+++ b/vllm_hcu/platforms/envs.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     VLLM_HCU_USE_AITER_W8A8_FP8_MOE: bool = False
     VLLM_HCU_USE_LIGHTOP_MOE_ALIGN: bool = False
     VLLM_HCU_USE_LIGHTOP_EP_SCATTER: bool = True
-    VLLM_HCU_USE_LIGHTOP_PER_TOKEN_QUANT_FP8: bool = False
+    VLLM_HCU_USE_LIGHTOP_PER_TOKEN_QUANT_FP8: bool = True
     VLLM_HCU_FUSED_MOE_CHUNK_SIZE: Optional[int] = None
     VLLM_HCU_USE_GLOBAL_MOE_CACHE: bool = False
     VLLM_HCU_USE_FUSED_RMS_QUANT: bool = False
@@ -312,9 +312,10 @@ hcu_vllm_environment_variables: dict[str, Callable[[], Any]] = {
         lambda: (os.environ.get("VLLM_HCU_USE_LIGHTOP_EP_SCATTER", "True").lower() in
                  ("true", "1")),
 
-    # If set, use LightOp per-token fp8 quant for dynamic PER_TOKEN QuantFP8.
+    # Use LightOp per-token fp8 quant for dynamic PER_TOKEN QuantFP8 by
+    # default. Set to 0/False to use the native fallback.
     "VLLM_HCU_USE_LIGHTOP_PER_TOKEN_QUANT_FP8":
-        lambda: (os.environ.get("VLLM_HCU_USE_LIGHTOP_PER_TOKEN_QUANT_FP8", "False").lower() in
+        lambda: (os.environ.get("VLLM_HCU_USE_LIGHTOP_PER_TOKEN_QUANT_FP8", "True").lower() in
                  ("true", "1")),
 
     # Optional override for LightOp's fused-MoE chunk size.

--- a/vllm_hcu/runtime_compat/scaled_mm.py
+++ b/vllm_hcu/runtime_compat/scaled_mm.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
-"""Target-native Triton compatibility for channel-wise FP8 scaled MM."""
+"""HCU backend selection for channel-wise FP8 scaled MM."""
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
+from functools import cache
 from inspect import signature
 from math import prod
 from threading import RLock
@@ -18,11 +20,140 @@ _TRITON_MODULE = (
     "vllm.model_executor.layers.quantization.compressed_tensors."
     "triton_scaled_mm"
 )
+# Keep the established dispatcher name so persisted vLLM compile artifacts do
+# not lose their registered operator when the selected backend is LightOp.
 _CUSTOM_OP_NAME = "hcu_channel_fp8_target_triton_scaled_mm"
 _CUSTOM_OP_LOCK = RLock()
 _CUSTOM_OP: Callable[..., torch.Tensor] | None = None
 _CUSTOM_OP_BACKEND: Callable[..., torch.Tensor] | None = None
 _CUSTOM_OP_REGISTRATION_ERROR: str | None = None
+_LOGGER = logging.getLogger(__name__)
+
+
+def _custom_quantization_gemm_enabled() -> bool:
+    try:
+        from vllm_hcu.platforms import envs as henvs
+
+        return bool(henvs.VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM)
+    except (AttributeError, ImportError) as exc:
+        raise RuntimeError(
+            "required HCU flag VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM "
+            "is unavailable"
+        ) from exc
+
+
+@cache
+def _make_lightop_scaled_mm(
+    lightop_gemm: Callable[..., tuple[bool, torch.Tensor]],
+) -> Callable[..., torch.Tensor]:
+    if not callable(lightop_gemm):
+        raise TypeError("LightOp channel-wise GEMM backend must be callable")
+
+    def lightop_scaled_mm(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+        out_dtype: torch.dtype,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if (
+            input.dtype != torch.float8_e4m3fn
+            or weight.dtype != torch.float8_e4m3fn
+        ):
+            raise ValueError(
+                "LightOp channel-wise GEMM requires float8_e4m3fn operands"
+            )
+        if scale_a.dtype != torch.float32 or scale_b.dtype != torch.float32:
+            raise ValueError(
+                "LightOp channel-wise GEMM requires float32 scales"
+            )
+        if out_dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError(
+                "LightOp channel-wise GEMM output must be float16 or bfloat16"
+            )
+        if bias is not None and bias.dtype != out_dtype:
+            raise ValueError(
+                "LightOp channel-wise GEMM bias dtype must match its output"
+            )
+        m, k = input.shape
+        n = weight.shape[1]
+        status, output = lightop_gemm(
+            input,
+            weight.t(),
+            scale_a,
+            scale_b,
+            m,
+            n,
+            k,
+            "NT",
+            out_dtype,
+            bias,
+        )
+        if status is not True:
+            raise RuntimeError("LightOp channel-wise GEMM reported failure")
+        if not isinstance(output, torch.Tensor):
+            raise RuntimeError("LightOp channel-wise GEMM did not return a tensor")
+        if tuple(output.shape) not in ((m, n), (1, m, n)):
+            raise RuntimeError(
+                "LightOp channel-wise GEMM returned an incompatible output"
+            )
+        return output.view(m, n)
+
+    return lightop_scaled_mm
+
+
+def _resolve_scaled_mm_backend() -> tuple[str, Callable[..., torch.Tensor]]:
+    if _custom_quantization_gemm_enabled():
+        try:
+            from lightop.gemm_ops import hipblaslt_w8a8_channelwise_gemm
+        except (AttributeError, ImportError) as exc:
+            raise RuntimeError(
+                "VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM requires LightOp "
+                "hipblaslt_w8a8_channelwise_gemm"
+            ) from exc
+
+        lightop_parameters = tuple(
+            signature(hipblaslt_w8a8_channelwise_gemm).parameters
+        )
+        if lightop_parameters[:10] != (
+            "a",
+            "b",
+            "scale_a",
+            "scale_b",
+            "m",
+            "n",
+            "k",
+            "transpose_flag",
+            "out_dtype",
+            "bias",
+        ):
+            raise RuntimeError(
+                "LightOp channel-wise GEMM signature drifted from the "
+                "reviewed 0.6.0 contract"
+            )
+        return "lightop", _make_lightop_scaled_mm(
+            hipblaslt_w8a8_channelwise_gemm
+        )
+
+    from vllm.model_executor.layers.quantization.compressed_tensors.triton_scaled_mm import (  # noqa: E501
+        triton_scaled_mm,
+    )
+
+    triton_parameters = tuple(signature(triton_scaled_mm).parameters)
+    if triton_parameters[:6] != (
+        "input",
+        "weight",
+        "scale_a",
+        "scale_b",
+        "out_dtype",
+        "bias",
+    ):
+        raise RuntimeError(
+            "vLLM target triton_scaled_mm signature drifted from the reviewed "
+            "v0.25.1 contract"
+        )
+    return "target-triton", triton_scaled_mm
 
 
 def _eager_shape_check(condition, message: str) -> None:
@@ -82,14 +213,18 @@ def _validate_target_output(
     out_dtype: torch.dtype,
 ) -> torch.Tensor:
     if not isinstance(output, torch.Tensor):
-        raise RuntimeError("target triton_scaled_mm did not return a tensor")
+        raise RuntimeError(
+            "selected Channel-FP8 backend did not return a tensor"
+        )
     if (
         output.ndim != 2
         or tuple(output.shape) != (A.shape[0], B.shape[1])
         or output.device != A.device
         or output.dtype != out_dtype
     ):
-        raise RuntimeError("target triton_scaled_mm returned an incompatible output")
+        raise RuntimeError(
+            "selected Channel-FP8 backend returned an incompatible output"
+        )
     return output
 
 
@@ -103,7 +238,7 @@ def _channel_fp8_target_triton_impl(
 ) -> torch.Tensor:
     backend = _CUSTOM_OP_BACKEND
     if backend is None:
-        raise RuntimeError("Channel-FP8 target Triton backend is not initialized")
+        raise RuntimeError("selected Channel-FP8 backend is not initialized")
     # The dispatcher calls this real implementation outside Dynamo capture, so
     # these relations use concrete runtime dimensions and cannot become
     # piecewise graph inputs.  Repeat them here because the fake implementation
@@ -158,35 +293,34 @@ def _register_channel_fp8_custom_op() -> Callable[..., torch.Tensor]:
 
 
 def _ensure_channel_fp8_custom_op(
-    triton_scaled_mm: Callable[..., torch.Tensor],
+    backend: Callable[..., torch.Tensor],
 ) -> Callable[..., torch.Tensor]:
     global _CUSTOM_OP, _CUSTOM_OP_BACKEND, _CUSTOM_OP_REGISTRATION_ERROR
 
-    if not callable(triton_scaled_mm):
-        raise TypeError("target triton_scaled_mm backend must be callable")
+    if not callable(backend):
+        raise TypeError("Channel-FP8 backend must be callable")
     with _CUSTOM_OP_LOCK:
         if _CUSTOM_OP_REGISTRATION_ERROR is not None:
             raise RuntimeError(
-                "Channel-FP8 target Triton custom-op registration previously "
+                "Channel-FP8 custom-op registration previously "
                 f"failed: {_CUSTOM_OP_REGISTRATION_ERROR}"
             )
         if _CUSTOM_OP is not None:
-            if _CUSTOM_OP_BACKEND is not triton_scaled_mm:
+            if _CUSTOM_OP_BACKEND is not backend:
                 raise RuntimeError(
-                    "Channel-FP8 target Triton custom op is already bound to a "
+                    "Channel-FP8 custom op is already bound to a "
                     "different backend"
                 )
             return _CUSTOM_OP
 
-        _CUSTOM_OP_BACKEND = triton_scaled_mm
+        _CUSTOM_OP_BACKEND = backend
         try:
             custom_op = _register_channel_fp8_custom_op()
         except Exception as exc:
             _CUSTOM_OP_BACKEND = None
             _CUSTOM_OP_REGISTRATION_ERROR = f"{type(exc).__name__}: {exc}"
             raise RuntimeError(
-                "failed to register the HCU-owned Channel-FP8 target Triton "
-                "custom op"
+                "failed to register the HCU-owned Channel-FP8 custom op"
             ) from exc
         _CUSTOM_OP = custom_op
         return custom_op
@@ -233,7 +367,7 @@ def install_fp8_scaled_mm_compat(module: ModuleType | None = None) -> None:
                 "_hcu_fp8_backend",
                 None,
             )
-            == "target-triton"
+            in {"lightop", "target-triton"}
             and getattr(
                 ChannelWiseTorchFP8ScaledMMLinearKernel.get_output_padding,
                 "_hcu_fp8_target_triton_wrapper",
@@ -248,28 +382,11 @@ def install_fp8_scaled_mm_compat(module: ModuleType | None = None) -> None:
             return
         raise RuntimeError(
             "channelwise FP8 scaled-mm adapter marker exists without the "
-            "reviewed target Triton wrapper ownership"
+            "reviewed HCU wrapper ownership"
         )
 
-    from vllm.model_executor.layers.quantization.compressed_tensors.triton_scaled_mm import (  # noqa: E501
-        triton_scaled_mm,
-    )
-
-    triton_parameters = tuple(signature(triton_scaled_mm).parameters)
-    if triton_parameters[:6] != (
-        "input",
-        "weight",
-        "scale_a",
-        "scale_b",
-        "out_dtype",
-        "bias",
-    ):
-        raise RuntimeError(
-            "vLLM target triton_scaled_mm signature drifted from the reviewed "
-            "v0.25.1 contract"
-        )
-
-    channel_fp8_custom_op = _ensure_channel_fp8_custom_op(triton_scaled_mm)
+    backend_name, scaled_mm_backend = _resolve_scaled_mm_backend()
+    channel_fp8_custom_op = _ensure_channel_fp8_custom_op(scaled_mm_backend)
 
     original_get_output_padding = (
         ChannelWiseTorchFP8ScaledMMLinearKernel.get_output_padding
@@ -330,8 +447,8 @@ def install_fp8_scaled_mm_compat(module: ModuleType | None = None) -> None:
         # across subgraphs.  The target Torch Inductor does not accept a
         # ``sympy.Equality`` graph input.  Keep the friendly validation for
         # concrete eager calls; the custom-op implementation delegates to the
-        # target v0.25.1 Triton backend and repeats the HCU/target scale contract
-        # with concrete runtime dimensions.
+        # selected backend and repeats the HCU scale contract with concrete
+        # runtime dimensions.
         if not torch.compiler.is_compiling():
             _validate_scale_shapes(As, Bs, m, n)
         if (
@@ -377,20 +494,23 @@ def install_fp8_scaled_mm_compat(module: ModuleType | None = None) -> None:
             bias,
         )
         if not isinstance(output, torch.Tensor):
-            raise RuntimeError("target triton_scaled_mm did not return a tensor")
+            raise RuntimeError(
+                "selected Channel-FP8 backend did not return a tensor"
+            )
         if (
             output.ndim != 2
             or output.device != A.device
             or output.dtype != out_dtype
         ):
             raise RuntimeError(
-                "target triton_scaled_mm returned an incompatible output"
+                "selected Channel-FP8 backend returned an incompatible output"
             )
         if not torch.compiler.is_compiling():
             try:
                 _eager_shape_check(
                     (output.shape[0] == m) & (output.shape[1] == n),
-                    "target triton_scaled_mm returned an incompatible output",
+                    "selected Channel-FP8 backend returned an incompatible "
+                    "output",
                 )
             except ValueError as exc:
                 raise RuntimeError(str(exc)) from exc
@@ -400,10 +520,11 @@ def install_fp8_scaled_mm_compat(module: ModuleType | None = None) -> None:
 
     ChannelWiseTorchFP8ScaledMMLinearKernel.apply_scaled_mm = new_apply_scaled_mm
     ChannelWiseTorchFP8ScaledMMLinearKernel._hcu_fp8_patch_applied = True
-    ChannelWiseTorchFP8ScaledMMLinearKernel._hcu_fp8_backend = "target-triton"
+    ChannelWiseTorchFP8ScaledMMLinearKernel._hcu_fp8_backend = backend_name
     ChannelWiseTorchFP8ScaledMMLinearKernel._hcu_original_get_output_padding = (
         original_get_output_padding
     )
     ChannelWiseTorchFP8ScaledMMLinearKernel._hcu_original_apply_scaled_mm = (
         original_apply_scaled_mm
     )
+    _LOGGER.info("Channel-wise FP8 scaled MM backend: %s", backend_name)

--- a/vllm_hcu/v1/attention/backends/fa_utils.py
+++ b/vllm_hcu/v1/attention/backends/fa_utils.py
@@ -102,7 +102,7 @@ def reshape_and_cache_flash(
     NHD and HND storage. Existing non-quantized paths retain their optimized
     layout-specific writers.
     """
-    if kv_cache_dtype in {"fp8", "fp8_e4m3"}:
+    if kv_cache_dtype in {"fp8", "fp8_e4m3", "fp8_e5m2"}:
         torch.ops.hcu_ops.reshape_and_cache_flash(
             key,
             value,

--- a/vllm_hcu/v1/attention/backends/fa_utils.py
+++ b/vllm_hcu/v1/attention/backends/fa_utils.py
@@ -7,6 +7,7 @@ import inspect
 from collections.abc import Callable
 from typing import Any
 
+import torch
 from flash_attn import (
     flash_attn_varlen_func as _flash_attn_varlen_func,
     hg_flash_attn_varlen_func as _hg_flash_attn_varlen_func,
@@ -96,12 +97,23 @@ def reshape_and_cache_flash(
 ) -> None:
     """Write FlashAttention KV pages using the active physical layout.
 
-    AITER's writer assumes token-major NHD storage inside each page.  The
-    target vLLM Mooncake contract selects HND for heterogeneous-TP transfer,
-    where the logical ``[B, N, H, D]`` view has head-major physical strides.
-    vLLM's Triton writer consumes the real tensor strides and therefore
-    handles both the HND slot/head order and a padded physical block stride.
+    The native HCU writer follows vLLM's stride-aware cache contract for FP8,
+    avoiding AITER's incompatible FP8 conversion on HCU while supporting both
+    NHD and HND storage. Existing non-quantized paths retain their optimized
+    layout-specific writers.
     """
+    if kv_cache_dtype in {"fp8", "fp8_e4m3"}:
+        torch.ops.hcu_ops.reshape_and_cache_flash(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            kv_cache_dtype,
+            k_scale,
+            v_scale,
+        )
+        return
     # Logical cache views remain [block, token, head, dim] in both layouts.
     # HND is distinguishable by a token stride smaller than the head stride.
     # If either dimension is one, selecting NHD is also address-equivalent.

--- a/vllm_hcu/v1/attention/backends/flash_attn.py
+++ b/vllm_hcu/v1/attention/backends/flash_attn.py
@@ -825,11 +825,9 @@ class FlashAttentionImpl(AttentionImpl):
                 "heads in the layer"
             )
 
-        if (
-            henvs.VLLM_HCU_USE_CUSTOM_OPS
-            and _get_flash_attn_mode() == "custom"
-            and self.kv_cache_dtype == "fp8_e5m2"
-        ):
+        # QuantFP8 emits the platform E4M3 dtype. E5M2 cache paths must keep
+        # BF16 queries instead of mixing E4M3 queries with E5M2 K/V pages.
+        if self.kv_cache_dtype == "fp8_e5m2":
             self.supports_quant_query_input = False
         else:
             self.supports_quant_query_input = flash_attn_supports_quant_query_input()


### PR DESCRIPTION
## 问题

- HY3 SlimQuant 在 vLLM 0.25.1 调用已移除的 `get_cache_scale()`，主模型/MTP 权重加载失败。
- GLM-5 `fp8_ds_mla` 未设置 KV quant mode，reshape 错误使用 576-byte layout，而实际存储为 656 bytes/token。

## 修复

- HY3 主模型使用 AutoWeightsLoader 已映射名称；MTP 在入口应用 `get_cache_scale_mapper()`。
- MLA KV cache spec 根据 cache dtype 补齐 `kv_quant_mode`，使 FlashMLA Sparse 选择 656-byte layout。
- 增加 HY3/MTP 权重加载与 MLA layout 回归测试。

## 验证

- `tools/run_patch_tests.py --suite contract`: 1318 passed, 102 deselected
- 聚焦回归测试: 23 passed
- HY3 TP4 + SlimQuant + MTP 完整加载并完成真实 Chat Completions 请求
- GLM-5 `fp8_ds_mla` 真实 vLLM reshape 链路: `(2, 64, 656)`，同时验证 auto/BF16 行为不变
- `git diff --check` 与 `py_compile` 通过

<!-- qwen35-hnd-65536-validation:start -->

## Qwen3.5-35B-A3B W8A8：HND / FP8 E4M3 / MTP3 / CUDA Graph 验证

验证版本：`f0b724b5cff9e6d562155c9894f750d561849276`。

服务端命令（保持 `VLLM_HCU_USE_FLASH_ATTN_UNIFIED` 未设置，使用默认 FLASH_ATTN varlen 路径）：

```bash
unset VLLM_HCU_USE_FLASH_ATTN_UNIFIED
export VLLM_USE_V2_MODEL_RUNNER=1
export VLLM_KV_CACHE_LAYOUT=HND

HIP_VISIBLE_DEVICES=4 vllm serve /models/Qwen3.5-35B-A3B-W8A8 \
  --served-model-name qwen35-35b-w8a8 \
  --port 10143 \
  --max-model-len 65536 \
  --max-num-batched-tokens 1024 \
  --tensor-parallel-size 1 \
  --quantization slimquant_marlin \
  --attention-backend FLASH_ATTN \
  --kv-cache-dtype fp8_e4m3 \
  --trust-remote-code \
  --speculative-config.method mtp \
  --speculative-config.num_speculative_tokens 3
```

HumanEval 客户端命令：

```bash
evalscope eval \
  --model qwen35-35b-w8a8 \
  --api-url http://127.0.0.1:10143/v1 \
  --api-key EMPTY \
  --eval-type openai_api \
  --generation-config '{"temperature":0,"do_sample":false,"max_tokens":2048,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}' \
  --stream \
  --eval-batch-size 1 \
  --timeout 7200 \
  --limit 32 \
  --datasets humaneval \
  --dataset-args '{"humaneval":{}}' \
  --work-dir /tmp/vllm-hcu-evalscope/pr63-qwen35-35b-hnd-fp8e4m3-mtp3-cudagraph-65536 \
  --no-timestamp
```

结果：

- HumanEval：`32/32`
- `mean_acc=1.0`，`mean_acc_pass@1=1.0`
- 预测/复核产物：`32/32`
- KV cache layout：`HND`
- KV cache dtype：`fp8_e4m3`
- MTP：`num_spec_tokens=3`
- CUDA Graph：主模型 PIECEWISE `51/51`、FULL `49/49`；MTP prefill PIECEWISE `51/51`、FULL `49/49`；MTP decode FULL `51/51`
- CUDA Graph 捕获耗时 `27s`，占用 `1.19 GiB`
- 可用 KV cache 约 `89.7 GiB`；65,536 tokens/request 下最大并发估算 `3.85x`
- EvalScope：平均 latency `1.0143s`，TTFT `96.26ms`，TPOT `8.46ms`，吞吐 `108.15 tokens/s`

<!-- qwen35-hnd-65536-validation:end -->

<!-- hy3-glm5-accuracy-validation:start -->

## HY3 / GLM5：MTP3 + CUDA Graph HumanEval 验证

以下三组模型评测运行于 `9b41f7bc6b155065a1da29bc6024446dad03a23b`。最终 PR HEAD `f0b724b5cff9e6d562155c9894f750d561849276` 相比该版本只增加冷启动替换签名校验/测试并修正文档注释，不改变模型执行热路径。

### HY3 TP4 SlimQuant，FP8 E4M3

服务端命令：

```bash
export VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1

HIP_VISIBLE_DEVICES=0,1,2,3 vllm serve /models/Hy3-CHANNEL-FP8-w8a8-sero-ignore-from-script3 \
  --served-model-name Hy3-CHANNEL-FP8-w8a8-pr63-slimquant \
  --port 20163 \
  --trust-remote-code \
  --dtype bfloat16 \
  --max-model-len 4096 \
  --quantization slimquant_marlin \
  --generation-config vllm \
  --attention-backend FLASH_ATTN \
  --tensor-parallel-size 4 \
  --block-size 64 \
  --gpu-memory-utilization 0.85 \
  --kv-cache-dtype fp8_e4m3 \
  --max-num-batched-tokens 8192 \
  --max-num-seqs 8 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
```

客户端命令：

```bash
evalscope eval \
  --model Hy3-CHANNEL-FP8-w8a8-pr63-slimquant \
  --api-url http://127.0.0.1:20163/v1 \
  --api-key EMPTY \
  --eval-type openai_api \
  --generation-config '{"temperature":0,"do_sample":false,"max_tokens":2048,"timeout":7200,"stream":true}' \
  --eval-batch-size 8 \
  --timeout 7200 \
  --limit 32 \
  --datasets humaneval \
  --dataset-args '{"humaneval":{}}' \
  --work-dir /tmp/vllm-hcu-evalscope/pr63-rebased-hy3-tp4-slimquant-cudagraph-mtp3 \
  --no-timestamp
```

结果：HumanEval `32/32`，`mean_acc=1.0`，`mean_acc_pass@1=1.0`；MTP `num_spec_tokens=3`；CUDA Graph mixed prefill/decode PIECEWISE `9/9`、decode FULL `5/5`；图捕获耗时 `6s`、占用 `0.72 GiB`。EvalScope 平均 latency `2.9617s`、TTFT `437.04ms`、TPOT `25.95ms`、吞吐 `32.91 tokens/s`。

### HY3 TP4 AITER 非 SlimQuant，FP8 E4M3

服务端命令：

```bash
export VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1

HIP_VISIBLE_DEVICES=0,1,2,3 vllm serve /models/Hy3-CHANNEL-FP8-w8a8-sero-ignore-from-script3 \
  --served-model-name Hy3-CHANNEL-FP8-w8a8-pr63-aiter \
  --port 20163 \
  --trust-remote-code \
  --dtype bfloat16 \
  --max-model-len 4096 \
  --generation-config vllm \
  --attention-backend FLASH_ATTN \
  --tensor-parallel-size 4 \
  --block-size 64 \
  --gpu-memory-utilization 0.85 \
  --kv-cache-dtype fp8_e4m3 \
  --max-num-batched-tokens 8192 \
  --max-num-seqs 8 \
  --moe-backend aiter \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
```

客户端命令：

```bash
evalscope eval \
  --model Hy3-CHANNEL-FP8-w8a8-pr63-aiter \
  --api-url http://127.0.0.1:20163/v1 \
  --api-key EMPTY \
  --eval-type openai_api \
  --generation-config '{"temperature":0,"do_sample":false,"max_tokens":2048,"timeout":7200,"stream":true}' \
  --eval-batch-size 1 \
  --timeout 7200 \
  --limit 32 \
  --datasets humaneval \
  --dataset-args '{"humaneval":{}}' \
  --work-dir /tmp/vllm-hcu-evalscope/pr63-rebased-hy3-tp4-aiter-cudagraph-mtp3-batch1 \
  --no-timestamp
```

结果：HumanEval `32/32`，`mean_acc=1.0`，`mean_acc_pass@1=1.0`；`moe_backend=aiter`，MTP `num_spec_tokens=3`；CUDA Graph mixed prefill/decode PIECEWISE `9/9`、decode FULL `5/5`。EvalScope 平均 latency `1.6719s`、TTFT `203.38ms`、TPOT `19.78ms`、吞吐 `44.75 tokens/s`。

### GLM5 TP8 SlimQuant，FP8 DS MLA

服务端命令：

```bash
HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 vllm serve /models/GLM-5___1-Channel-FP8-w8a8 \
  --served-model-name GLM-5-Channel-FP8-w8a8-pr63-slimquant \
  --port 20163 \
  --trust-remote-code \
  --dtype bfloat16 \
  --max-model-len 4096 \
  --quantization slimquant_marlin \
  --generation-config vllm \
  --default-chat-template-kwargs '{"enable_thinking":false}' \
  --attention-backend FLASHMLA_SPARSE \
  --tensor-parallel-size 8 \
  --block-size 64 \
  --gpu-memory-utilization 0.85 \
  --kv-cache-dtype fp8_ds_mla \
  --max-num-batched-tokens 8192 \
  --max-num-seqs 8 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
```

客户端命令：

```bash
evalscope eval \
  --model GLM-5-Channel-FP8-w8a8-pr63-slimquant \
  --api-url http://127.0.0.1:20163/v1 \
  --api-key EMPTY \
  --eval-type openai_api \
  --generation-config '{"temperature":0,"do_sample":false,"max_tokens":2048,"timeout":7200,"stream":true,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}' \
  --eval-batch-size 1 \
  --timeout 7200 \
  --limit 32 \
  --datasets humaneval \
  --dataset-args '{"humaneval":{}}' \
  --work-dir /tmp/vllm-hcu-evalscope/pr63-rebased-glm5-tp8-slimquant-cudagraph-mtp3 \
  --no-timestamp
```

结果：HumanEval `32/32`，`mean_acc=1.0`，`mean_acc_pass@1=1.0`；MTP `num_spec_tokens=3`；CUDA Graph mixed prefill/decode PIECEWISE `9/9`、decode FULL `5/5`；图捕获耗时 `16s`、占用 `0.54 GiB`。EvalScope 平均 latency `2.1911s`、TTFT `201.63ms`、TPOT `22.48ms`、吞吐 `41.43 tokens/s`。

<!-- hy3-glm5-accuracy-validation:end -->

<!-- pr68-pr62-integration:start -->

## PR #68 / #62 合入：MoE 优先级、DeepEP LL 与 LightOp GEMM

最终 HEAD：`f34266d2639bcce258ec972391697ee09a63c218`。

### 路由规范

- 显式 `--moe-backend aiter`、`triton`、`deep_gemm` 始终优先。
- `slimquant_marlin + moe_backend=auto`：AITER 环境开关启用时可走官方 AITER selector；否则 W8A8 MoE 保持 LightOp Marlin。
- `VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM` 默认开启：Channel-INT8 dense 使用 LightOp `hipblaslt_w8a8_gemm`，Channel-FP8 dense 使用 LightOp `hipblaslt_w8a8_channelwise_gemm`；显式设为 `0` 时分别回退 vLLM 原生 INT8 路径和目标版本 Triton FP8 路径。
- W4A8 保持 AITER 默认，显式 Triton 生效；DeepGEMM 仅在合法 `deepep_auto` 拓扑下接受。BF16/W4A8 不支持的组合 fail closed，不静默串路。
- 固定 DeepEP low-latency 实例跳过冗余 buffer cleanup；仅 HT/LL 共享同一 handle 的 `deepep_auto` 实例执行 cleanup。
- 以上选择都在模型/方法初始化期完成，不在 CUDA Graph replay 热路径增加动态分支。

### 合入提交

- `64cbd74`：合入 PR #68 的显式 MoE 后端优先级。
- `df93e46`：移植 PR #62 `1f613ca`，固定 LL 跳过冗余 cleanup。
- `1da9dad`：移植 PR #62 `47a7b4b`，Channel-FP8 dense GEMM 切到 LightOp，并保留显式 Triton fallback。
- `50e7cf0`：补齐 LightOp/Triton 两条真实 custom-op 的动态 `torch.compile`、graph split 与 standalone artifact 覆盖。

三笔移植提交与来源提交的 stable patch-id 完全一致；独立复审结果为 Critical/Important/Minor 均无。

### 自动化验证

```bash
VLLM_V0251_SOURCE_ROOT=/models/zb/vllm_025/vllm \
  pytest -q tests/runtime_patch
python -m compileall -q vllm_hcu tests/runtime_patch
git diff --check f0b724b..50e7cf0
```

结果：`1083 passed, 14 warnings`；`compileall`、`git diff --check` 均通过。新增 artifact 测试分别断言 `lightop` 与 `target-triton` 后端标签，并覆盖动态 M=2/33/65/129 的单图编译和 standalone artifact 生成。

### HY3 TP4 SlimQuant / FP8 E4M3 / MTP3 / CUDA Graph

服务端命令：

```bash
env -u VLLM_ROCM_USE_AITER -u VLLM_ROCM_USE_AITER_MOE \
  -u VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM \
  VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1 \
  HIP_VISIBLE_DEVICES=0,1,2,3 \
  vllm serve /models/Hy3-CHANNEL-FP8-w8a8-sero-ignore-from-script3 \
  --served-model-name hy3-pr63-lightop-port \
  --host 127.0.0.1 --port 20178 \
  --trust-remote-code --dtype bfloat16 \
  --max-model-len 4096 --quantization slimquant_marlin \
  --generation-config vllm --attention-backend FLASH_ATTN \
  --tensor-parallel-size 4 --block-size 64 \
  --gpu-memory-utilization 0.85 --kv-cache-dtype fp8_e4m3 \
  --max-num-batched-tokens 8192 --max-num-seqs 8 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
```

HumanEval 客户端命令：

```bash
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
  -u http_proxy -u https_proxy -u all_proxy \
  NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
  evalscope eval \
  --model hy3-pr63-lightop-port \
  --api-url http://127.0.0.1:20178/v1 \
  --api-key EMPTY --eval-type openai_api \
  --generation-config '{"temperature":0,"do_sample":false,"max_tokens":2048,"timeout":7200,"stream":true}' \
  --eval-batch-size 8 --timeout 7200 --limit 32 \
  --datasets humaneval --dataset-args '{"humaneval":{}}' \
  --work-dir /tmp/vllm-hcu-evalscope/pr63-hy3-lightop-port-mtp3-cudagraph \
  --no-timestamp
```

结果：

- HumanEval `32/32`，`mean_acc=1.0`，`mean_acc_pass@1=1.0`。
- `enforce_eager=False`，MTP `num_spec_tokens=3`。
- CUDA Graph：mixed prefill/decode PIECEWISE `9/9`，decode FULL `5/5`；捕获耗时 `6s`，占用 `0.71 GiB`。
- LightOp FP8 Marlin 内核在 warmup 与推理期均成功加载；无 graph replay、API、OOM 错误。
- EvalScope：平均 latency `2.4395s`，TTFT `425.28ms`，TPOT `26.32ms`，吞吐 `33.88 tokens/s`。

按要求，本轮未继续执行 DeepSeek-V4-0731 TP4 + DSpark7 模型评测；此前已在权重加载阶段主动终止，8 张 HCU 均已释放。

<!-- pr68-pr62-integration:end -->

<!-- qwen3-fp8-kv-validation:start -->

## Qwen3-8B：FLASH_ATTN / FP8 KV Cache / CUDA Graph 验证

验证版本：`c61f205c7078d365343a50dabf4a0d2d01084809`。服务端仅新增 `VLLM_USE_V2_MODEL_RUNNER=1`，未设置其他 vLLM/HCU feature 环境变量；KV layout 使用默认 `NHD`，未启用 MTP。

### FP8 E4M3

服务端命令：

```bash
export VLLM_USE_V2_MODEL_RUNNER=1
vllm serve /models/Qwen3-8B \
  --served-model-name qwen3-8b-e4m3 \
  --max-model-len 40960 \
  --tensor-parallel-size 1 \
  --attention-backend FLASH_ATTN \
  --kv-cache-dtype fp8_e4m3 \
  --trust-remote-code
```

客户端命令：

```bash
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
python3 -m evalscope.cli.cli eval \
  --model qwen3-8b-e4m3 \
  --model-id qwen3-8b-e4m3 \
  --api-url http://127.0.0.1:8000/v1 \
  --api-key EMPTY \
  --eval-type openai_api \
  --datasets humaneval \
  --dataset-hub modelscope \
  --limit 32 \
  --eval-batch-size 1 \
  --generation-config '{"temperature":0,"max_tokens":8192,"timeout":1800,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}' \
  --seed 0 \
  --no-collect-perf \
  --work-dir /tmp/evalscope-qwen3-8b-flash-e4m3-32 \
  --no-timestamp
```

结果：HumanEval `31/32`，`mean_acc=0.9688`，`mean_acc_pass@1=0.9688`；`enforce_eager=False`，CUDA Graph 模式为 `FULL_AND_PIECEWISE`，PIECEWISE/FULL 均完成 `51/51` 捕获；FLASH_ATTN 使用 HCU `varlen` 路径，block size `64`。

### FP8 E5M2

服务端命令：

```bash
export VLLM_USE_V2_MODEL_RUNNER=1
vllm serve /models/Qwen3-8B \
  --served-model-name qwen3-8b-e5m2 \
  --max-model-len 40960 \
  --tensor-parallel-size 1 \
  --attention-backend FLASH_ATTN \
  --kv-cache-dtype fp8_e5m2 \
  --trust-remote-code
```

客户端命令：

```bash
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
python3 -m evalscope.cli.cli eval \
  --model qwen3-8b-e5m2 \
  --model-id qwen3-8b-e5m2 \
  --api-url http://127.0.0.1:8000/v1 \
  --api-key EMPTY \
  --eval-type openai_api \
  --datasets humaneval \
  --dataset-hub modelscope \
  --limit 32 \
  --eval-batch-size 1 \
  --generation-config '{"temperature":0,"max_tokens":8192,"timeout":1800,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}' \
  --seed 0 \
  --no-collect-perf \
  --work-dir /tmp/evalscope-qwen3-8b-flash-e5m2-32-fixed \
  --no-timestamp
```

结果：HumanEval `31/32`，`mean_acc=0.9688`，`mean_acc_pass@1=0.9688`；`enforce_eager=False`，CUDA Graph 模式为 `FULL_AND_PIECEWISE`，PIECEWISE/FULL 均完成 `51/51` 捕获；结果与 E4M3 一致。

E5M2 修复前会固定生成乱码，诊断评测为 `0/32`。根因是非 custom 的 E5M2 被错误导向仅适用于 HCU split-cache ABI 的自定义 `Attention.forward`，绕过了 vLLM `unified_kv_cache_update` 建立的显式写后读依赖。`c61f205` 使 standard FLASH_ATTN 恢复官方 forward 调度，同时继续使用 HCU native E5M2 writer 与 HCU FlashAttention backend；并保持 BF16 Query，避免 E4M3 Query 与 E5M2 KV 混用。

<!-- qwen3-fp8-kv-validation:end -->

<!-- pr63-gate-review:start -->

## 最终 Gate、Code Review 与 GLM4.7 双路径验证

最终 HEAD：`63fc6599ca63bd7b4061af1184893239a8620a1b`。

### Review 追加修复

- LightOp dynamic per-token FP8 custom op 在 patch 安装阶段注册；已注册的 steady-state 路径在进入 `RLock` 前返回，避免 `torch.compile(fullgraph=True)` 的 `Unsupported context manager`。
- 编译态 shared-expert MoE 保留 mutation-only opaque custom op；alias/overlap 判断留在 op 内，无 overlap 的 SlimQuant Marlin 路径不再额外 clone 整个 `[tokens, hidden]` routed output。
- LightOp Marlin alignment 使用 `torch.empty()`；vLLM v0.25.1 native `moe_align_block_size` 负责完整 sentinel 初始化，不再产生重复 fill。兼容 shim 安装从 forward 热路径移到权重加载阶段。
- GLM4 routed scaling 按最终 MoE 后端处理：AITER 消费已缩放 router weights；非 AITER 在 expert aggregation 后应用 scaling。AITER 无 `MOE_C` solution 时收到已缩放权重并继续回退 vLLM Triton。

后端规则保持不变：显式 `--moe-backend aiter/triton/deep_gemm` 优先于环境变量；`moe_backend=auto` 才读取 legacy AITER env gates。只使用 `--moe-backend aiter` 不需要设置 `VLLM_ROCM_USE_AITER=1` 或 `VLLM_ROCM_USE_AITER_MOE=1`，也不会额外开启 AITER linear/custom all-reduce 等非 MoE 路径。

### GLM4.7 TP8：显式 AITER + FLASH_ATTN + CUDA Graph

服务端命令（两个 AITER 环境变量均显式清除）：

```bash
unset VLLM_ROCM_USE_AITER VLLM_ROCM_USE_AITER_MOE
export VLLM_USE_V2_MODEL_RUNNER=1
export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7

vllm serve /models/GLM-4.7-W8A8 \
  --served-model-name glm47-explicit-aiter-cudagraph \
  --port 20163 \
  --max-model-len 8192 \
  --max-num-batched-tokens 1024 \
  --tensor-parallel-size 8 \
  --quantization slimquant_marlin \
  --moe-backend aiter \
  --attention-backend FLASH_ATTN \
  --trust-remote-code
```

HumanEval 客户端命令：

```bash
NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
evalscope eval \
  --model glm47-explicit-aiter-cudagraph \
  --api-url http://127.0.0.1:20163/v1 \
  --api-key EMPTY \
  --eval-type openai_api \
  --datasets humaneval \
  --limit 32 \
  --work-dir /tmp/evalscope-glm47-explicit-aiter-cudagraph-32-rerun \
  --no-timestamp \
  --generation-config '{"max_tokens":2048,"temperature":0.0,"batch_size":1,"timeout":1800,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}'
```

结果：HumanEval `32/32`，`mean_acc=1.0`，`mean_acc_pass@1=1.0`。`enforce_eager=False`，CUDA Graph 模式 `FULL_AND_PIECEWISE`，PIECEWISE/FULL 均完成 `51/51` 捕获。日志确认 dense linear 为 `TritonInt8ScaledMMLinearKernel`、MoE 为 `Using AITER Int8 MoE backend`；M=1 无 AITER solution 时打印 `falling back to vLLM Triton MoE`，服务和精度均正常。

### GLM4.7 TP8：LightOp Marlin auto + FLASH_ATTN + CUDA Graph

服务端命令：

```bash
unset VLLM_ROCM_USE_AITER VLLM_ROCM_USE_AITER_MOE
export VLLM_USE_V2_MODEL_RUNNER=1
export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7

vllm serve /models/GLM-4.7-W8A8 \
  --served-model-name glm47-lightop-marlin-cudagraph \
  --port 20163 \
  --max-model-len 8192 \
  --max-num-batched-tokens 1024 \
  --tensor-parallel-size 8 \
  --quantization slimquant_marlin \
  --attention-backend FLASH_ATTN \
  --trust-remote-code
```

客户端命令：

```bash
NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
evalscope eval \
  --model glm47-lightop-marlin-cudagraph \
  --api-url http://127.0.0.1:20163/v1 \
  --api-key EMPTY \
  --eval-type openai_api \
  --datasets humaneval \
  --limit 32 \
  --work-dir /tmp/evalscope-glm47-lightop-marlin-cudagraph-32-review \
  --no-timestamp \
  --generation-config '{"max_tokens":2048,"temperature":0.0,"batch_size":1,"timeout":1800,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}'
```

结果：HumanEval `32/32`，`mean_acc=1.0`，`mean_acc_pass@1=1.0`。`moe_backend=auto`、AITER env 关闭，SlimQuant W8A8 MoE 保持 LightOp Marlin；CUDA Graph 模式 `FULL_AND_PIECEWISE`，PIECEWISE/FULL 均完成 `51/51` 捕获，FLASH_ATTN 日志确认 `flash_attn_varlen`。

### 最终自动化验证

```bash
python3.10 tools/check_patch_test_coverage.py
python3.10 .github/scripts/hcu_ci/hcu_ci_preflight.py --check-lock-only
python3.10 .github/scripts/hcu_ci/verify_hcu_registration.py
python3.10 .github/scripts/hcu_ci/build_hcu_matrix.py --profile nightly
python3.10 .github/scripts/hcu_ci/build_hcu_matrix.py --profile quarantine
python3.10 -m compileall -q .github/scripts/hcu_ci tools tests vllm_hcu
python3.10 tools/run_patch_tests.py --suite contract -- \
  -o cache_dir=/tmp/hcu-ci-pytest-cache
git diff --check
```

结果：patch coverage `files=96 adapters=95 helpers=1 untested=0 invalid_contracts=0`；HCU registry `40 registrations, 22 jobs`；完整 contract `1381 passed, 115 deselected`；preflight、nightly/quarantine matrix、compileall、`git diff --check` 全部通过。

独立最终 code review 对编译、内存复制、后端优先级、BF16/FP8/INT8 fallback、alignment 和测试覆盖逐项复核，结论：Critical `0`、Important `0`、Minor `0`，可合入。

<!-- pr63-gate-review:end -->

<!-- pr63-review-final-validation:start -->

## Review follow-up 与最终模型验证（2026-09-05，`64b1b48`）

### Review / CI 修复

- GLM4 FP16 非 AITER 路径保留 router-weight scaling。GLM decoder 没有通用 MoERunner FP16 overflow 策略所要求的 residual-stream 补偿，因此不能把 factor 移到 output；BF16/FP32 非 AITER 仍在 aggregation 后缩放，显式 AITER 以及 AITER 无 solution 后回退 vLLM Triton 的语义保持不变。
- 新增 FP16 + shared experts + `routed_scaling_factor=2.5` 数值回归：`R=[2,4]`、`S=[3,5]`，验证结果为 `S + 2.5R = [8,15]`；同时覆盖 FP16/BF16/FP32 与 AITER/non-AITER policy matrix。
- 修复 static gate 中 FP8 Marlin repack 单测错误导入真实 LightOp 的问题。该测试现在隔离包初始化；LightOp alignment 安装行为仍由专用 compatibility tests 覆盖。
- 失败的 `63fc659` workflow 是被后续 head 按 concurrency 取消；`85805ac` 的真实 static failure 为上述 LightOp 测试隔离问题。
- 本地 CI 等价验证：`1387 passed, 115 deselected`；相关文件全集 `156 passed`；patch coverage `files=96 adapters=95 helpers=1 untested=0 invalid_contracts=0`；preflight、registry（40 registrations / 22 jobs）、nightly/quarantine matrix、syntax 与 `git diff --check` 均通过。
- PR 已线性 rebase 到最新 `v0.25.1`；15 个 PR 提交的 author/committer 均为 `zhangzbb <1414695739@qq.com>`。

### DeepSeek-V4-Flash-0731-FP8-Channel — TP4 / AITER / DSpark7 / CUDA Graph

服务端：

```bash
env -u VLLM_ROCM_USE_AITER -u VLLM_ROCM_USE_AITER_MOE \
  VLLM_USE_V2_MODEL_RUNNER=1 \
  HIP_VISIBLE_DEVICES=0,1,2,3 \
  vllm serve /models/DeepSeek-V4-Flash-0731-FP8-Channel \
  --host 127.0.0.1 --port 20164 \
  --served-model-name deepseek-v4-0731-fp8-aiter-dspark7 \
  --trust-remote-code \
  --kv-cache-dtype fp8 --block-size 256 \
  --tokenizer-mode deepseek_v4 \
  --distributed-executor-backend mp \
  --max-model-len 4096 --max-num-batched-tokens 512 --max-num-seqs 8 \
  --gpu-memory-utilization 0.9 --tensor-parallel-size 4 \
  --moe-backend aiter \
  --speculative-config '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
```

客户端：

```bash
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
  -u http_proxy -u https_proxy -u all_proxy \
  NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
  evalscope eval \
  --model deepseek-v4-0731-fp8-aiter-dspark7 \
  --api-url http://127.0.0.1:20164/v1 \
  --api-key EMPTY --eval-type openai_api \
  --generation-config '{"temperature":0,"do_sample":false,"max_tokens":2048,"timeout":7200,"stream":true,"extra_body":{"chat_template_kwargs":{"thinking":false}}}' \
  --stream --eval-batch-size 1 --timeout 7200 --limit 32 \
  --datasets humaneval --dataset-args '{"humaneval":{}}' \
  --work-dir /tmp/evalscope-pr63-deepseek-v4-0731-fp8-tp4-aiter-dspark7 \
  --no-timestamp
```

- Backend：明确选择 AITER FP8 MoE，并加载 gfx938 tuned solutions；未设置两项全局 AITER 环境变量。
- CUDA Graph：main PIECEWISE `19/19`、FULL `8/8`；DSpark FULL `8/8`；约 `0.51 GiB/rank`。
- EvalScope 原始结果 `29/32`（0.9062）；3 条失败均为正确代码外层的 Markdown fence 未闭合，报 `invalid syntax`。按仓库 DeepSeek 正式验收配置 `normalize_code_fences: true` 仅剥离外层完整/截断 fence 后，原始代码测试为 `32/32`、Pass@1 `1.0`，无 failed task。
- 性能：平均 latency `2.2929 s`，TTFT `299.21 ms`，TPOT `16.44 ms`，output throughput `52.65 tok/s`。

### HY3 Channel-FP8 W8A8 — TP4 / LightOp Marlin / MTP3 / CUDA Graph

服务端：

```bash
env -u VLLM_ROCM_USE_AITER -u VLLM_ROCM_USE_AITER_MOE \
  VLLM_USE_V2_MODEL_RUNNER=1 \
  VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1 \
  HIP_VISIBLE_DEVICES=4,5,6,7 \
  vllm serve /models/Hy3-CHANNEL-FP8-w8a8-sero-ignore-from-script3 \
  --host 127.0.0.1 --port 20165 \
  --served-model-name hy3-tp4-marlin-mtp3-review \
  --trust-remote-code --dtype bfloat16 \
  --max-model-len 4096 --quantization slimquant_marlin \
  --generation-config vllm --attention-backend FLASH_ATTN \
  --tensor-parallel-size 4 --block-size 64 \
  --gpu-memory-utilization 0.85 --kv-cache-dtype fp8_e4m3 \
  --max-num-batched-tokens 8192 --max-num-seqs 8 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
```

客户端：

```bash
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
  -u http_proxy -u https_proxy -u all_proxy \
  NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
  evalscope eval \
  --model hy3-tp4-marlin-mtp3-review \
  --api-url http://127.0.0.1:20165/v1 \
  --api-key EMPTY --eval-type openai_api \
  --generation-config '{"temperature":0,"do_sample":false,"max_tokens":2048,"timeout":7200,"stream":true,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}' \
  --stream --eval-batch-size 8 --timeout 7200 --limit 32 \
  --datasets humaneval --dataset-args '{"humaneval":{}}' \
  --work-dir /tmp/evalscope-pr63-hy3-tp4-marlin-mtp3-review \
  --no-timestamp
```

- Backend：加载 LightOp `moe_w8a8_fp8_marlin` UP/DOWN kernels；AITER 环境变量明确 unset。
- CUDA Graph：main PIECEWISE `11/11`、FULL `5/5`；MTP prefill PIECEWISE `11/11`、FULL `5/5`；MTP decode FULL `4/4`；约 `1.01 GiB/rank`。
- HumanEval：`32/32`，`mean_acc=1.0`，`mean_acc_pass@1=1.0`。
- 性能：平均 latency `2.2881 s`，TTFT `320.97 ms`，TPOT `26.27 ms`，output throughput `33.79 tok/s`。

### GLM-5-W8A8 — TP8 / LightOp Marlin / MTP3 / CUDA Graph

服务端：

```bash
env -u VLLM_ROCM_USE_AITER -u VLLM_ROCM_USE_AITER_MOE \
  VLLM_USE_V2_MODEL_RUNNER=1 \
  HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
  vllm serve /models/GLM-5-W8A8 \
  --host 127.0.0.1 --port 20166 \
  --served-model-name glm5-w8a8-tp8-marlin-mtp3-review \
  --trust-remote-code --dtype bfloat16 \
  --max-model-len 4096 --quantization slimquant_marlin \
  --generation-config vllm \
  --default-chat-template-kwargs '{"enable_thinking":false}' \
  --attention-backend FLASHMLA_SPARSE \
  --tensor-parallel-size 8 --block-size 64 \
  --gpu-memory-utilization 0.85 --kv-cache-dtype fp8_ds_mla \
  --max-num-batched-tokens 8192 --max-num-seqs 8 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
```

客户端：

```bash
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
  -u http_proxy -u https_proxy -u all_proxy \
  NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
  evalscope eval \
  --model glm5-w8a8-tp8-marlin-mtp3-review \
  --api-url http://127.0.0.1:20166/v1 \
  --api-key EMPTY --eval-type openai_api \
  --generation-config '{"temperature":0,"do_sample":false,"max_tokens":2048,"timeout":7200,"stream":true,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}' \
  --stream --eval-batch-size 1 --timeout 7200 --limit 32 \
  --datasets humaneval --dataset-args '{"humaneval":{}}' \
  --work-dir /tmp/evalscope-pr63-glm5-w8a8-tp8-marlin-mtp3-review \
  --no-timestamp
```

- Backend：quantization 解析为 `slimquant_compressed_tensors_marlin`，加载 LightOp `moe_w8a8_i8_marlin` kernels；dense linear 的 `TritonInt8ScaledMMLinearKernel` 与 MoE backend 独立，无 AITER 串路。
- CUDA Graph：main PIECEWISE `11/11`、FULL `5/5`；MTP prefill PIECEWISE `11/11`、FULL `5/5`；MTP decode FULL `4/4`；17 秒、约 `0.58 GiB/rank`。
- HumanEval：`32/32`，`mean_acc=1.0`，`mean_acc_pass@1=1.0`。
- 性能：平均 latency `2.7789 s`，TTFT `178.21 ms`，TPOT `20.23 ms`，output throughput `48.21 tok/s`。

<!-- pr63-review-final-validation:end -->
