### PR TITLE
perf(hcu): avoid shared expert input clones

### DIFF
--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -201,6 +201,42 @@ def test_fallback_moe_forward_shared_satisfies_aot_mutation_contract(
     assert not torch._C._is_alias_of(fused_output, hidden_states)
 
 
+def test_fallback_moe_forward_shared_keeps_distinct_routed_output(
+    monkeypatch: pytest.MonkeyPatch,
+    moe_runner_module: ModuleType,
+    moe_op_registrations: dict[str, dict],
+) -> None:
+    """An already out-of-place routed output must not be copied again."""
+
+    routed_output = torch.full((2, 2), 3.0)
+
+    class Layer:
+        def _forward_impl(self, hidden_states, *_args, **_kwargs):
+            return torch.full_like(hidden_states, 7), routed_output
+
+    monkeypatch.setattr(
+        moe_runner_module,
+        "get_layer_from_name",
+        lambda _name: Layer(),
+    )
+    hidden_states = torch.zeros((2, 2))
+    _, fused_output = moe_op_registrations["moe_forward_shared"]["op_func"](
+        hidden_states,
+        None,
+        hidden_states,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "test-layer",
+        0,
+    )
+
+    assert fused_output is routed_output
+    assert not torch._C._is_alias_of(fused_output, hidden_states)
+
+
 def make_hidden() -> torch.Tensor:
     return torch.tensor([[10.0, 11.0], [20.0, 21.0]])
 
@@ -278,11 +314,11 @@ def test_slimquant_marlin_only_advertises_local_inplace_output(
 
 
 @pytest.mark.parametrize("shared_experts_overlap", [False, True])
-def test_inplace_routed_kernel_clones_only_for_overlapped_shared_experts(
+def test_routed_and_shared_experts_receive_the_same_untransformed_input(
     moe_runner_module: ModuleType,
     shared_experts_overlap: bool,
 ) -> None:
-    """Only concurrent shared experts need protection from in-place routing."""
+    """Overlap protection must not copy the common MoE input."""
 
     class SharedExperts:
         def requires_input_preservation(self, _hidden_states) -> bool:
@@ -308,10 +344,129 @@ def test_inplace_routed_kernel_clones_only_for_overlapped_shared_experts(
 
     assert routed_input is hidden_states
     assert shared_input is not None
-    assert torch._C._is_alias_of(shared_input, hidden_states) is (
-        not shared_experts_overlap
-    )
+    assert torch._C._is_alias_of(shared_input, hidden_states)
     torch.testing.assert_close(shared_input, hidden_states)
+
+
+@pytest.mark.parametrize(
+    ("shared_experts_overlap", "expected_path", "input_is_mutated"),
+    [
+        (False, "inplace", True),
+        (True, "out_of_place", False),
+    ],
+)
+def test_forward_uses_out_of_place_routed_output_only_during_shared_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+    moe_runner_module: ModuleType,
+    shared_experts_overlap: bool,
+    expected_path: str,
+    input_is_mutated: bool,
+) -> None:
+    """Only a shared-input race may switch local Marlin out of place."""
+
+    shared_experts_module = importlib.import_module(
+        "vllm_hcu.model_executor.layers.fused_moe.shared_experts"
+    )
+    shared_experts = object.__new__(shared_experts_module.SharedExperts)
+    order = (
+        shared_experts_module.SharedExpertsOrder.MULTI_STREAM_OVERLAPPED
+        if shared_experts_overlap
+        else shared_experts_module.SharedExpertsOrder.NO_OVERLAP
+    )
+    monkeypatch.setattr(
+        shared_experts,
+        "_determine_shared_experts_order",
+        lambda _hidden_states: order,
+    )
+
+    paths: list[str] = []
+    shared_input_aliases: list[bool] = []
+
+    def inplace_forward(hidden_states, _logits, shared_input, *_args):
+        paths.append("inplace")
+        shared_input_aliases.append(
+            torch._C._is_alias_of(shared_input, hidden_states)
+        )
+        shared_output = torch.full_like(hidden_states, 7)
+        hidden_states.fill_(1)
+        return shared_output
+
+    def out_of_place_forward(hidden_states, _logits, shared_input, *_args):
+        paths.append("out_of_place")
+        shared_input_aliases.append(
+            torch._C._is_alias_of(shared_input, hidden_states)
+        )
+        return torch.full_like(hidden_states, 7), torch.ones_like(hidden_states)
+
+    monkeypatch.setattr(
+        moe_runner_module.current_platform, "is_cpu", lambda: True
+    )
+    monkeypatch.setattr(
+        moe_runner_module.current_platform, "is_tpu", lambda: False
+    )
+    monkeypatch.setattr(
+        moe_runner_module, "_moe_forward_shared_inplace", inplace_forward
+    )
+    monkeypatch.setattr(
+        moe_runner_module, "_moe_forward_shared", out_of_place_forward
+    )
+
+    runner = object.__new__(moe_runner_module.MoERunner)
+    torch.nn.Module.__init__(runner)
+    runner.moe_config = SimpleNamespace(
+        dp_size=1,
+        hidden_dim_unpadded=2,
+        is_sequence_parallel=False,
+        pcp_size=1,
+    )
+    runner.routed_experts = SimpleNamespace(
+        quant_method=SimpleNamespace(
+            has_unpadded_output=False,
+            supports_inplace_output=True,
+        ),
+    )
+    runner.routed_input_transform = None
+    runner.routed_output_transform = None
+    runner.routed_scaling_factor = 1.0
+    runner._shared_experts = shared_experts
+    runner.router = object()
+    runner._refresh_forward_entry()
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_maybe_pad_hidden_states",
+        lambda self, shared, hidden: (hidden, None, None),
+    )
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_encode_layer_name",
+        lambda self: "test-layer",
+    )
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_maybe_reduce_shared_expert_output",
+        lambda self, shared: shared,
+    )
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_maybe_reduce_final_output",
+        lambda self, output, _truncate: output,
+    )
+    monkeypatch.setattr(
+        moe_runner_module.MoERunner,
+        "_maybe_add_zero_expert_output",
+        lambda self, output: output,
+    )
+    hidden_states = make_hidden()
+    original_hidden_states = hidden_states.clone()
+
+    output = runner.forward(hidden_states, make_logits())
+
+    assert paths == [expected_path]
+    assert shared_input_aliases == [True]
+    assert torch.equal(hidden_states, original_hidden_states) is (
+        not input_is_mutated
+    )
+    torch.testing.assert_close(output, torch.full_like(hidden_states, 8))
 
 
 @pytest.mark.parametrize(
@@ -342,6 +497,49 @@ def test_shared_experts_preserve_input_only_while_routed_work_can_overlap(
     )
 
     assert shared_experts.requires_input_preservation(make_hidden()) is expected
+
+
+@pytest.mark.parametrize(
+    ("order", "alias_kind", "expected"),
+    [
+        ("NO_OVERLAP", "same", True),
+        ("NO_OVERLAP", "view", True),
+        ("MK_INTERNAL_OVERLAPPED", "same", False),
+        ("MK_INTERNAL_OVERLAPPED", "view", False),
+        ("MULTI_STREAM_OVERLAPPED", "same", False),
+        ("MULTI_STREAM_OVERLAPPED", "distinct", True),
+    ],
+)
+def test_shared_experts_allow_inplace_routing_only_without_an_input_race(
+    monkeypatch: pytest.MonkeyPatch,
+    order: str,
+    alias_kind: str,
+    expected: bool,
+) -> None:
+    """Views race during overlap; transformed or padded inputs do not."""
+
+    shared_experts_module = importlib.import_module(
+        "vllm_hcu.model_executor.layers.fused_moe.shared_experts"
+    )
+    shared_experts = object.__new__(shared_experts_module.SharedExperts)
+    monkeypatch.setattr(
+        shared_experts,
+        "_determine_shared_experts_order",
+        lambda _hidden_states: getattr(
+            shared_experts_module.SharedExpertsOrder, order
+        ),
+    )
+    shared_input = make_hidden()
+    routed_input = {
+        "same": shared_input,
+        "view": shared_input.view_as(shared_input),
+        "distinct": shared_input.clone(),
+    }[alias_kind]
+
+    assert (
+        shared_experts.allows_inplace_routed_output(routed_input, shared_input)
+        is expected
+    )
 
 
 def test_forward_entry_refreshes_after_runtime_reconfiguration(
@@ -519,7 +717,9 @@ def test_shared_and_routed_outputs_keep_local_token_order_before_addition(
     runner.routed_input_transform = None
     runner.routed_output_transform = None
     runner.routed_scaling_factor = 1.0
-    runner._shared_experts = object()
+    runner._shared_experts = SimpleNamespace(
+        allows_inplace_routed_output=lambda _routed, _shared: True
+    )
     runner.router = object()
     shared_output = torch.tensor([[100.0, 101.0], [200.0, 201.0]])
     fused_output = torch.tensor([[10.0, 11.0], [20.0, 21.0]])

--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -277,13 +277,19 @@ def test_slimquant_marlin_only_advertises_local_inplace_output(
     assert method.supports_inplace_output is expected
 
 
-def test_inplace_routed_kernel_isolates_shared_expert_input(
+@pytest.mark.parametrize("shared_experts_overlap", [False, True])
+def test_inplace_routed_kernel_clones_only_for_overlapped_shared_experts(
     moe_runner_module: ModuleType,
+    shared_experts_overlap: bool,
 ) -> None:
-    """Shared experts must not race an in-place routed kernel on one tensor."""
+    """Only concurrent shared experts need protection from in-place routing."""
+
+    class SharedExperts:
+        def requires_input_preservation(self, _hidden_states) -> bool:
+            return shared_experts_overlap
 
     runner = object.__new__(moe_runner_module.MoERunner)
-    runner._shared_experts = object()
+    runner._shared_experts = SharedExperts()
     runner.routed_input_transform = None
     runner.routed_experts = SimpleNamespace(
         quant_method=SimpleNamespace(
@@ -302,8 +308,40 @@ def test_inplace_routed_kernel_isolates_shared_expert_input(
 
     assert routed_input is hidden_states
     assert shared_input is not None
-    assert not torch._C._is_alias_of(shared_input, hidden_states)
+    assert torch._C._is_alias_of(shared_input, hidden_states) is (
+        not shared_experts_overlap
+    )
     torch.testing.assert_close(shared_input, hidden_states)
+
+
+@pytest.mark.parametrize(
+    ("order", "expected"),
+    [
+        ("NO_OVERLAP", False),
+        ("MK_INTERNAL_OVERLAPPED", True),
+        ("MULTI_STREAM_OVERLAPPED", True),
+    ],
+)
+def test_shared_experts_preserve_input_only_while_routed_work_can_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+    order: str,
+    expected: bool,
+) -> None:
+    """Every overlapping execution order must retain the pristine input."""
+
+    shared_experts_module = importlib.import_module(
+        "vllm_hcu.model_executor.layers.fused_moe.shared_experts"
+    )
+    shared_experts = object.__new__(shared_experts_module.SharedExperts)
+    monkeypatch.setattr(
+        shared_experts,
+        "_determine_shared_experts_order",
+        lambda _hidden_states: getattr(
+            shared_experts_module.SharedExpertsOrder, order
+        ),
+    )
+
+    assert shared_experts.requires_input_preservation(make_hidden()) is expected
 
 
 def test_forward_entry_refreshes_after_runtime_reconfiguration(

--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -277,6 +277,35 @@ def test_slimquant_marlin_only_advertises_local_inplace_output(
     assert method.supports_inplace_output is expected
 
 
+def test_inplace_routed_kernel_isolates_shared_expert_input(
+    moe_runner_module: ModuleType,
+) -> None:
+    """Shared experts must not race an in-place routed kernel on one tensor."""
+
+    runner = object.__new__(moe_runner_module.MoERunner)
+    runner._shared_experts = object()
+    runner.routed_input_transform = None
+    runner.routed_experts = SimpleNamespace(
+        quant_method=SimpleNamespace(
+            supports_inplace_output=True,
+            supports_internal_mk=False,
+        )
+    )
+    runner.moe_config = SimpleNamespace(
+        dp_size=1,
+        is_sequence_parallel=False,
+        pcp_size=1,
+    )
+    hidden_states = make_hidden()
+
+    routed_input, shared_input = runner.apply_routed_input_transform(hidden_states)
+
+    assert routed_input is hidden_states
+    assert shared_input is not None
+    assert not torch._C._is_alias_of(shared_input, hidden_states)
+    torch.testing.assert_close(shared_input, hidden_states)
+
+
 def test_forward_entry_refreshes_after_runtime_reconfiguration(
     monkeypatch: pytest.MonkeyPatch,
     moe_runner_module: ModuleType,

--- a/tests/runtime_patch/test_hy_v3_slimquant_weight_loading.py
+++ b/tests/runtime_patch/test_hy_v3_slimquant_weight_loading.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Regression contracts for HY3 KV-cache scale loading on vLLM 0.25.1."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
+
+class _MapperOnlyQuantConfig:
+    """Expose the v0.25.1 API without the removed get_cache_scale API."""
+
+    @staticmethod
+    def get_cache_scale_mapper():
+        return QuantizationConfig.get_cache_scale_mapper()
+
+
+def _blank_module(module_type: type[nn.Module]) -> nn.Module:
+    module = object.__new__(module_type)
+    nn.Module.__init__(module)
+    return module
+
+
+def _scalar_parameter() -> nn.Parameter:
+    return nn.Parameter(torch.zeros(()), requires_grad=False)
+
+
+@pytest.fixture(scope="module")
+def hy_v3_types():
+    patch = pytest.MonkeyPatch()
+    import vllm.model_executor.layers.attention as attention_package
+    from vllm_hcu.model_executor.layers.attention_runtime import (
+        FusedQkvSplitRmsNormRopeAttention,
+    )
+
+    # Production installs this export before model discovery. Install the same
+    # concrete class only for the lifetime of this focused CPU test module.
+    patch.setattr(
+        attention_package,
+        "FusedQkvSplitRmsNormRopeAttention",
+        FusedQkvSplitRmsNormRopeAttention,
+        raising=False,
+    )
+    from vllm_hcu.models.hy_v3 import HYV3Model
+    from vllm_hcu.models.hy_v3_mtp import HYV3MTP
+
+    yield HYV3Model, HYV3MTP
+    patch.undo()
+
+
+def test_hy_v3_model_loads_pre_mapped_cache_scale_without_legacy_api(
+    hy_v3_types,
+) -> None:
+    HYV3Model, _ = hy_v3_types
+    model = _blank_module(HYV3Model)
+    model.config = SimpleNamespace(tie_word_embeddings=False)
+    model.quant_config = _MapperOnlyQuantConfig()
+    model.get_expert_mapping = lambda: []
+
+    target_name = "model.layers.0.self_attn.attn.k_scale"
+    target = _scalar_parameter()
+    model.named_parameters = lambda: iter(((target_name, target),))
+
+    loaded = model.load_weights(((target_name, torch.tensor([3.0])),))
+
+    assert loaded == {target_name}
+    torch.testing.assert_close(target, torch.tensor(3.0))
+
+
+def test_hy_v3_mtp_maps_checkpoint_cache_scale_with_v0251_mapper(
+    hy_v3_types,
+) -> None:
+    _, HYV3MTP = hy_v3_types
+    model = _blank_module(HYV3MTP)
+    model.config = SimpleNamespace(
+        tie_word_embeddings=False,
+        num_hidden_layers=80,
+        num_nextn_predict_layers=1,
+        num_attention_heads=64,
+        num_key_value_heads=8,
+    )
+    model.quant_config = _MapperOnlyQuantConfig()
+    model.use_pp = False
+
+    target_name = "model.layers.80.mtp_block.self_attn.attn.k_scale"
+    target = _scalar_parameter()
+    model.named_parameters = lambda: iter(((target_name, target),))
+
+    model.load_weights(
+        (("model.layers.80.self_attn.k_cache.scale", torch.tensor([5.0])),)
+    )
+
+    torch.testing.assert_close(target, torch.tensor(5.0))

--- a/tests/runtime_patch/test_lightop_marlin_moe_compat.py
+++ b/tests/runtime_patch/test_lightop_marlin_moe_compat.py
@@ -200,3 +200,92 @@ def test_int8_marlin_safely_remaps_global_expert_ids(
     )
 
     assert expert_ids.tolist() == [0, 1]
+
+
+@pytest.mark.parametrize(
+    ("method_name", "kernel_name"),
+    [
+        (
+            "CompressedTensorsW8A8FP8MarlinMoEMethod",
+            "fused_experts_impl_fp8_marlin",
+        ),
+        (
+            "CompressedTensorsW8A8Int8MarlinMoEMethod",
+            "fused_experts_impl_int8_marlin",
+        ),
+    ],
+)
+@pytest.mark.parametrize("shared_experts_overlap", [False, True])
+def test_marlin_allocates_routed_output_only_during_shared_input_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+    method_name: str,
+    kernel_name: str,
+    shared_experts_overlap: bool,
+) -> None:
+    """Concurrent shared reads require out-of-place routed output, not a copy."""
+
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
+        compressed_tensors_moe_marlin as marlin,
+    )
+
+    def marlin_kernel(**kwargs):
+        hidden_states = kwargs["hidden_states"]
+        if kwargs["inplace"]:
+            hidden_states.fill_(3)
+            return hidden_states
+        return torch.full_like(hidden_states, 3)
+
+    lightop = ModuleType("lightop")
+    lightop.__path__ = []  # type: ignore[attr-defined]
+    moe = ModuleType("lightop.moe")
+    setattr(moe, kernel_name, marlin_kernel)
+    lightop.moe = moe
+    monkeypatch.setitem(sys.modules, "lightop", lightop)
+    monkeypatch.setitem(sys.modules, "lightop.moe", moe)
+    monkeypatch.setattr(
+        marlin,
+        "ensure_safe_marlin_moe_alignment",
+        lambda _kernel: None,
+    )
+    monkeypatch.setattr(
+        marlin,
+        "_is_hcu_aiter_w8a8_moe_requested",
+        lambda _moe: False,
+    )
+
+    class SharedExperts:
+        def allows_inplace_routed_output(
+            self,
+            routed_input: torch.Tensor,
+            shared_input: torch.Tensor,
+        ) -> bool:
+            return not (
+                torch._C._is_alias_of(routed_input, shared_input)
+                and shared_experts_overlap
+            )
+
+    method = object.__new__(getattr(marlin, method_name))
+    method.moe = object()
+    method.use_deepep = False
+    method.moe_quant_config = None
+    if kernel_name == "fused_experts_impl_fp8_marlin":
+        method.fused_experts = method.fused_moe_forward
+    layer = _moe_layer(global_num_experts=2)
+    hidden_states = torch.ones((1, 4))
+    original_hidden_states = hidden_states.clone()
+
+    output = method.apply(
+        layer,
+        hidden_states,
+        torch.ones((1, 2)),
+        torch.tensor([[0, 1]], dtype=torch.int32),
+        SharedExperts(),
+        hidden_states,
+    )
+
+    assert torch._C._is_alias_of(output, hidden_states) is (
+        not shared_experts_overlap
+    )
+    if shared_experts_overlap:
+        torch.testing.assert_close(hidden_states, original_hidden_states)
+    torch.testing.assert_close(output, torch.full_like(hidden_states, 3))

--- a/tests/runtime_patch/test_lightop_marlin_moe_compat.py
+++ b/tests/runtime_patch/test_lightop_marlin_moe_compat.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Contracts for the LightOp-backed SlimQuant Marlin MoE boundary."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+
+def _install_lightop_marlin_kernel(
+    monkeypatch: pytest.MonkeyPatch,
+    implementation_name: str,
+    export_name: str,
+):
+    implementation = ModuleType(implementation_name)
+
+    def incomplete_alignment(
+        topk_ids,
+        block_size,
+        num_experts,
+        expert_map=None,
+        pad_sorted_ids=False,
+        ignore_invalid_experts=False,
+    ):
+        del expert_map, pad_sorted_ids, ignore_invalid_experts
+        return (
+            torch.zeros(topk_ids.numel() * block_size, dtype=torch.int32),
+            topk_ids.flatten().to(torch.int32),
+            torch.tensor([topk_ids.numel() * block_size], dtype=torch.int32),
+        )
+
+    implementation.moe_align_block_size = incomplete_alignment
+    monkeypatch.setitem(sys.modules, implementation_name, implementation)
+
+    class Kernel:
+        def __call__(self, **kwargs):
+            return sys.modules[self.__module__].moe_align_block_size(
+                kwargs["topk_ids"],
+                2,
+                kwargs["global_num_experts"],
+                kwargs.get("expert_map"),
+            )
+
+    kernel = Kernel()
+    kernel.__module__ = implementation_name
+
+    def fill_alignment(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_pad,
+        expert_map=None,
+    ):
+        del num_experts, expert_map
+        for index, expert_id in enumerate(topk_ids.flatten().tolist()):
+            sorted_token_ids[index * block_size] = index
+            expert_ids[index] = expert_id
+        num_tokens_post_pad.fill_(topk_ids.numel() * block_size)
+
+    def moe_align_block_size_out(*_args, **_kwargs):
+        raise AssertionError("LightOp alignment must not be used by Marlin")
+
+    lightop = ModuleType("lightop")
+    lightop.__path__ = []  # type: ignore[attr-defined]
+    moe = ModuleType("lightop.moe")
+    setattr(moe, export_name, kernel)
+    moe.moe_align_block_size_out = moe_align_block_size_out
+    lightop.moe = moe
+    monkeypatch.setitem(sys.modules, "lightop", lightop)
+    monkeypatch.setitem(sys.modules, "lightop.moe", moe)
+    from vllm import _custom_ops as ops
+
+    monkeypatch.setattr(ops, "moe_align_block_size", fill_alignment)
+    return kernel
+
+
+def _moe_layer(*, global_num_experts: int, expert_map=None):
+    return SimpleNamespace(
+        w13_weight=torch.ones(1),
+        w2_weight=torch.ones(1),
+        w13_weight_scale=torch.ones(1),
+        w2_weight_scale=torch.ones(1),
+        w13_input_scale=None,
+        w2_input_scale=None,
+        global_num_experts=global_num_experts,
+        expert_map=expert_map,
+        apply_router_weight_on_input=False,
+        activation=SimpleNamespace(value="silu"),
+    )
+
+
+def test_fp8_marlin_prefills_unwritten_alignment_padding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
+        compressed_tensors_moe_marlin as marlin,
+    )
+
+    _install_lightop_marlin_kernel(
+        monkeypatch,
+        "lightop._lmslim_native.layers.fused_moe.fp8_marlin_test",
+        "fused_experts_impl_fp8_marlin",
+    )
+    method = object.__new__(marlin.CompressedTensorsW8A8FP8MarlinMoEMethod)
+    sorted_token_ids, _, _ = method.fused_moe_forward(
+        _moe_layer(global_num_experts=2),
+        torch.ones((1, 4)),
+        torch.ones((1, 2)),
+        torch.tensor([[0, 1]], dtype=torch.int32),
+        global_num_experts=2,
+    )
+
+    assert sorted_token_ids.tolist() == [0, 2, 1, 2]
+
+
+def test_fp8_marlin_patches_public_lightop_runner_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
+        compressed_tensors_moe_marlin as marlin,
+    )
+
+    _install_lightop_marlin_kernel(
+        monkeypatch,
+        "lightop.moe.fp8_marlin_public_test",
+        "fused_experts_impl_fp8_marlin",
+    )
+    method = object.__new__(marlin.CompressedTensorsW8A8FP8MarlinMoEMethod)
+    sorted_token_ids, _, _ = method.fused_moe_forward(
+        _moe_layer(global_num_experts=2),
+        torch.ones((1, 4)),
+        torch.ones((1, 2)),
+        torch.tensor([[0, 1]], dtype=torch.int32),
+        global_num_experts=2,
+    )
+
+    assert sorted_token_ids.tolist() == [0, 2, 1, 2]
+
+
+def test_fp8_marlin_uses_stable_vllm_alignment_not_lightop_alignment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
+        compressed_tensors_moe_marlin as marlin,
+    )
+
+    _install_lightop_marlin_kernel(
+        monkeypatch,
+        "lightop._lmslim_native.layers.fused_moe.fp8_marlin_stable_test",
+        "fused_experts_impl_fp8_marlin",
+    )
+
+    method = object.__new__(marlin.CompressedTensorsW8A8FP8MarlinMoEMethod)
+    sorted_token_ids, _, _ = method.fused_moe_forward(
+        _moe_layer(global_num_experts=2),
+        torch.ones((1, 4)),
+        torch.ones((1, 2)),
+        torch.tensor([[0, 1]], dtype=torch.int32),
+        global_num_experts=2,
+    )
+
+    assert sorted_token_ids.tolist() == [0, 2, 1, 2]
+
+
+def test_int8_marlin_safely_remaps_global_expert_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
+        compressed_tensors_moe_marlin as marlin,
+    )
+
+    _install_lightop_marlin_kernel(
+        monkeypatch,
+        "lightop._lmslim_native.layers.fused_moe.int8_marlin_test",
+        "fused_experts_impl_int8_marlin",
+    )
+    monkeypatch.setattr(
+        marlin,
+        "_is_hcu_aiter_w8a8_moe_requested",
+        lambda *_args: False,
+    )
+    expert_map = torch.tensor([-1, 0, -1, 1], dtype=torch.int32)
+    layer = _moe_layer(global_num_experts=4, expert_map=expert_map)
+    method = object.__new__(marlin.CompressedTensorsW8A8Int8MarlinMoEMethod)
+    method.moe = None
+    method.moe_quant_config = None
+    _, expert_ids, _ = method.apply(
+        layer,
+        torch.ones((1, 4)),
+        torch.ones((1, 2)),
+        torch.tensor([[1, 3]], dtype=torch.int32),
+        None,
+        None,
+    )
+
+    assert expert_ids.tolist() == [0, 1]

--- a/tests/runtime_patch/test_mla_target_ownership.py
+++ b/tests/runtime_patch/test_mla_target_ownership.py
@@ -14,6 +14,8 @@ from types import ModuleType, SimpleNamespace
 import pytest
 import torch
 
+from vllm.v1.attention.backends.mla.flashmla_sparse import FlashMLASparseBackend
+from vllm.v1.kv_cache_interface import KVQuantMode, MLAAttentionSpec
 from vllm_hcu.model_executor.layers import mla_runtime
 
 
@@ -300,6 +302,15 @@ def _fake_mla_module(adapter, target_calls, event_log=None):
         def process_weights_after_loading(self, act_dtype):
             return act_dtype
 
+        def get_kv_cache_spec(self, vllm_config):
+            return MLAAttentionSpec(
+                block_size=vllm_config.cache_config.block_size,
+                num_kv_heads=1,
+                head_size=576,
+                dtype=torch.uint8,
+                cache_dtype_str=self.kv_cache_dtype,
+            )
+
     class MLACommonMetadata:
         def __init__(self, num_actual_tokens):
             self.num_actual_tokens = num_actual_tokens
@@ -427,6 +438,34 @@ def test_mla_feature_off_delegates_exact_v0251_forward_on_rocm():
     warmup = SimpleNamespace(is_prefilling=None)
     assert module.split_decodes_and_prefills(warmup, 3, True, True) is True
     assert module.split_calls[-1] == (warmup, 3, True, True)
+
+
+def test_mla_fp8_spec_selects_the_656_byte_sparse_cache_layout():
+    adapter = _adapter()
+    module = _fake_mla_module(adapter, [])
+    assert adapter.apply_to_module(module) is True
+
+    instance = object.__new__(module.MLAAttention)
+    instance.kv_cache_dtype = "fp8_ds_mla"
+    config = SimpleNamespace(cache_config=SimpleNamespace(block_size=64))
+
+    cache_spec = instance.get_kv_cache_spec(config)
+    backend_cache_dtype = (
+        "auto"
+        if cache_spec.kv_quant_mode == KVQuantMode.NONE
+        else instance.kv_cache_dtype
+    )
+    shape = FlashMLASparseBackend.get_kv_cache_shape(
+        2,
+        cache_spec.block_size,
+        cache_spec.num_kv_heads,
+        cache_spec.head_size,
+        cache_dtype_str=backend_cache_dtype,
+    )
+
+    assert cache_spec.kv_quant_mode == KVQuantMode.FP8_PER_TENSOR
+    assert shape == (2, 64, 656)
+    assert cache_spec.page_size_bytes * 2 == 2 * 64 * 656
 
 
 def test_mla_feature_on_uses_hcu_lightly_cp_delta(monkeypatch):

--- a/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
@@ -477,10 +477,12 @@ class MoERunner(MoERunnerInterface):
                 return result[0], hidden_states
             return result, hidden_states
 
-        return (
-            hidden_states,
-            hidden_states if self._shared_experts is not None else None,
+        shared_experts_input = (
+            hidden_states.clone()
+            if self._can_use_inplace_shared_output()
+            else hidden_states if self._shared_experts is not None else None
         )
+        return hidden_states, shared_experts_input
 
     def apply_routed_output_transform(
         self,

--- a/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
@@ -477,11 +477,15 @@ class MoERunner(MoERunnerInterface):
                 return result[0], hidden_states
             return result, hidden_states
 
-        shared_experts_input = (
-            hidden_states.clone()
-            if self._can_use_inplace_shared_output()
-            else hidden_states if self._shared_experts is not None else None
-        )
+        shared_experts_input = None
+        if self._shared_experts is not None:
+            must_preserve_input = (
+                self._can_use_inplace_shared_output()
+                and self._shared_experts.requires_input_preservation(hidden_states)
+            )
+            shared_experts_input = (
+                hidden_states.clone() if must_preserve_input else hidden_states
+            )
         return hidden_states, shared_experts_input
 
     def apply_routed_output_transform(

--- a/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/moe_runner.py
@@ -189,7 +189,9 @@ def _moe_forward_shared(
         topk_weights=topk_weights,
         topk_ids=topk_ids,
     )
-    return shared_output, fused_output.clone()
+    if torch._C._is_alias_of(fused_output, hidden_states):
+        fused_output = fused_output.clone()
+    return shared_output, fused_output
 
 
 def _moe_forward_shared_fake(
@@ -391,8 +393,13 @@ class MoERunner(MoERunnerInterface):
         )
         self._forward_entry = self._select_forward()
 
-    def _select_forward(self) -> Callable:
-        if self._forward_uses_mutated_hidden_states:
+    def _select_forward(
+        self,
+        uses_mutated_hidden_states: bool | None = None,
+    ) -> Callable:
+        if uses_mutated_hidden_states is None:
+            uses_mutated_hidden_states = self._forward_uses_mutated_hidden_states
+        if uses_mutated_hidden_states:
             if current_platform.is_tpu() or current_platform.is_cpu():
                 return _moe_forward_shared_inplace
             return torch.ops.vllm.moe_forward_shared_inplace
@@ -479,13 +486,7 @@ class MoERunner(MoERunnerInterface):
 
         shared_experts_input = None
         if self._shared_experts is not None:
-            must_preserve_input = (
-                self._can_use_inplace_shared_output()
-                and self._shared_experts.requires_input_preservation(hidden_states)
-            )
-            shared_experts_input = (
-                hidden_states.clone() if must_preserve_input else hidden_states
-            )
+            shared_experts_input = hidden_states
         return hidden_states, shared_experts_input
 
     def apply_routed_output_transform(
@@ -890,7 +891,28 @@ class MoERunner(MoERunnerInterface):
             )
         )
 
-        result = self._forward_entry(
+        forward_uses_mutated_hidden_states = (
+            self._forward_uses_mutated_hidden_states
+        )
+        if (
+            forward_uses_mutated_hidden_states
+            and self._shared_experts is not None
+            and shared_experts_input is not None
+        ):
+            forward_uses_mutated_hidden_states = (
+                self._shared_experts.allows_inplace_routed_output(
+                    hidden_states,
+                    shared_experts_input,
+                )
+            )
+        forward_entry = (
+            self._forward_entry
+            if forward_uses_mutated_hidden_states
+            == self._forward_uses_mutated_hidden_states
+            else self._select_forward(forward_uses_mutated_hidden_states)
+        )
+
+        result = forward_entry(
             hidden_states,
             router_logits,
             shared_experts_input,
@@ -916,7 +938,7 @@ class MoERunner(MoERunnerInterface):
 
         # Extract outputs from result. The mutation-only custom op returns
         # shared output and exposes routed output through hidden_states.
-        if self._forward_uses_mutated_hidden_states:
+        if forward_uses_mutated_hidden_states:
             shared_output, fused_output = result, hidden_states
         else:
             shared_output, fused_output = _unpack(result)

--- a/vllm_hcu/model_executor/layers/fused_moe/shared_experts.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/shared_experts.py
@@ -180,6 +180,16 @@ class SharedExperts(torch.nn.Module):
             SharedExpertsOrder.MULTI_STREAM_OVERLAPPED,
         )
 
+    def allows_inplace_routed_output(
+        self,
+        routed_input: torch.Tensor,
+        shared_input: torch.Tensor,
+    ) -> bool:
+        """Return whether routing may overwrite its input without a data race."""
+        return not torch._C._is_alias_of(
+            routed_input, shared_input
+        ) or not self.requires_input_preservation(shared_input)
+
     def _should_run_shared_in_aux_stream(
         self,
         hidden_states: torch.Tensor,

--- a/vllm_hcu/model_executor/layers/fused_moe/shared_experts.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/shared_experts.py
@@ -173,6 +173,13 @@ class SharedExperts(torch.nn.Module):
             return SharedExpertsOrder.MULTI_STREAM_OVERLAPPED
         return SharedExpertsOrder.NO_OVERLAP
 
+    def requires_input_preservation(self, hidden_states: torch.Tensor) -> bool:
+        """Return whether routed experts can mutate this input concurrently."""
+        return self._determine_shared_experts_order(hidden_states) in (
+            SharedExpertsOrder.MK_INTERNAL_OVERLAPPED,
+            SharedExpertsOrder.MULTI_STREAM_OVERLAPPED,
+        )
+
     def _should_run_shared_in_aux_stream(
         self,
         hidden_states: torch.Tensor,

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
@@ -24,9 +24,6 @@ from vllm.model_executor.layers.fused_moe import (
     FusedMoeWeightScaleSupported, FusedMoEConfig, RoutedExperts,
     SharedExperts)
 from vllm.model_executor.utils import set_weight_attrs
-from vllm_hcu.model_executor.layers.quantization.int8_runtime import (
-    weight8bit_nt_kpack2_marlin2,
-)
 from vllm.model_executor.layers.fused_moe import config as fused_moe_config
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
@@ -37,6 +34,12 @@ from vllm.model_executor.layers.fused_moe import (
     FusedMoEExpertsModular,
     FusedMoEPrepareAndFinalizeModular,
     FusedMoeWeightScaleSupported,
+)
+from vllm_hcu.model_executor.layers.quantization.int8_runtime import (
+    weight8bit_nt_kpack2_marlin2,
+)
+from vllm_hcu.model_executor.layers.quantization.lightop_marlin_moe_compat import (
+    ensure_safe_marlin_moe_alignment,
 )
 logger = init_logger(__name__)
 
@@ -306,6 +309,7 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
             i_s: torch.Tensor | None = None,
     ):
         from lightop.moe import fused_experts_impl_fp8_marlin
+        ensure_safe_marlin_moe_alignment(fused_experts_impl_fp8_marlin)
         return fused_experts_impl_fp8_marlin(
             hidden_states=x,
             w1=layer.w13_weight,
@@ -609,6 +613,7 @@ class CompressedTensorsW8A8Int8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod)
         # Default Marlin INT8 path
 
         from lightop.moe import fused_experts_impl_int8_marlin
+        ensure_safe_marlin_moe_alignment(fused_experts_impl_int8_marlin)
         return fused_experts_impl_int8_marlin(
             hidden_states=x,
             w1=layer.w13_weight,

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
@@ -140,6 +140,21 @@ class CompressedTensorsMarlinMoEMethod(FusedMoEMethodBase):
         )
 
     @staticmethod
+    def _allows_inplace_output(
+        x: torch.Tensor,
+        shared_experts: SharedExperts | None,
+        shared_experts_input: torch.Tensor | None,
+    ) -> bool:
+        return (
+            shared_experts is None
+            or shared_experts_input is None
+            or shared_experts.allows_inplace_routed_output(
+                x,
+                shared_experts_input,
+            )
+        )
+
+    @staticmethod
     def get_moe_method(
         quant_config: "SlimQuantCompressedTensorsMarlinConfig",  # type: ignore # noqa E501
         layer: torch.nn.Module,
@@ -307,6 +322,7 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
             shared_output: Optional[torch.Tensor] = None,
             i_q: torch.Tensor | None = None,
             i_s: torch.Tensor | None = None,
+            inplace: bool = True,
     ):
         from lightop.moe import fused_experts_impl_fp8_marlin
         ensure_safe_marlin_moe_alignment(fused_experts_impl_fp8_marlin)
@@ -316,7 +332,7 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
             w2=layer.w2_weight,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
-            inplace=True,
+            inplace=inplace,
             activation=activation,
             apply_router_weight_on_input=apply_router_weight_on_input,
             use_fp8_w8a8=True,
@@ -343,9 +359,11 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
             i_q: torch.Tensor | None = None,
             i_s: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        # HCU's MoERunner executes shared experts on its managed stream and
-        # combines them after the routed kernel returns.
-        del shared_experts, shared_experts_input
+        inplace = self._allows_inplace_output(
+            x,
+            shared_experts,
+            shared_experts_input,
+        )
         return self.fused_experts(
             layer=layer,
             x=x,
@@ -358,7 +376,9 @@ class CompressedTensorsW8A8FP8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod):
             routed_scaling_factor=1.0,
             shared_output=None,
             i_q=i_q,
-            i_s=i_s, )
+            i_s=i_s,
+            inplace=inplace,
+        )
 
     @property
     def supports_eplb(self) -> bool:
@@ -569,9 +589,6 @@ class CompressedTensorsW8A8Int8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod)
         i_q: torch.Tensor | None = None,
         i_s: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        # HCU's MoERunner executes shared experts on its managed stream and
-        # combines them after the routed kernel returns.
-        del shared_experts, shared_experts_input
         # AITER W8A8 MoE fast-path
         if _is_hcu_aiter_w8a8_moe_requested(self.moe):
             if not rocm_aiter_ops.is_fused_moe_enabled():
@@ -614,13 +631,18 @@ class CompressedTensorsW8A8Int8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod)
 
         from lightop.moe import fused_experts_impl_int8_marlin
         ensure_safe_marlin_moe_alignment(fused_experts_impl_int8_marlin)
+        inplace = self._allows_inplace_output(
+            x,
+            shared_experts,
+            shared_experts_input,
+        )
         return fused_experts_impl_int8_marlin(
             hidden_states=x,
             w1=layer.w13_weight,
             w2=layer.w2_weight,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
-            inplace=True,
+            inplace=inplace,
             activation=layer.activation.value,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             use_int8_w8a8=True,

--- a/vllm_hcu/model_executor/layers/quantization/lightop_marlin_moe_compat.py
+++ b/vllm_hcu/model_executor/layers/quantization/lightop_marlin_moe_compat.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Compatibility fixes for LightOp's vendored SlimQuant Marlin runners."""
+
+from __future__ import annotations
+
+import functools
+import importlib
+from collections.abc import Callable
+
+import torch
+import triton
+from vllm import _custom_ops as ops
+
+
+_IMPLEMENTATION_PREFIX = "lightop."
+_PATCH_MARKER = "_vllm_hcu_safe_alignment_installed"
+
+
+def _safe_remap_expert_ids(
+    expert_ids: torch.Tensor,
+    expert_map: torch.Tensor,
+) -> torch.Tensor:
+    valid = (expert_ids >= 0) & (expert_ids < expert_map.numel())
+    safe_ids = expert_ids.clamp(min=0, max=expert_map.numel() - 1).long()
+    mapped = expert_map[safe_ids]
+    return torch.where(valid, mapped, torch.full_like(mapped, -1))
+
+
+def ensure_safe_marlin_moe_alignment(fused_experts: Callable[..., object]) -> None:
+    """Install stable vLLM alignment in a LightOp vendored Marlin runner.
+
+    LightOp 0.6's out-parameter alignment kernel only writes routed token
+    positions. Its vendored SlimQuant runners allocate ``sorted_ids`` with
+    ``torch.empty``, leaving padding positions as arbitrary token ids, and its
+    multi-token ordering differs from the order expected by Marlin. Patch the
+    runner-local helper to use vLLM's stable alignment operation and prefill
+    padding with the sentinel expected by the kernels.
+    """
+
+    module_name = getattr(fused_experts, "__module__", "")
+    if not module_name.startswith(_IMPLEMENTATION_PREFIX):
+        return
+
+    implementation = importlib.import_module(module_name)
+    original = getattr(implementation, "moe_align_block_size", None)
+    if not callable(original):
+        raise RuntimeError(
+            f"LightOp Marlin implementation {module_name!r} has no callable "
+            "moe_align_block_size"
+        )
+    if getattr(original, _PATCH_MARKER, False):
+        return
+
+    @functools.wraps(original)
+    def safe_alignment(
+        topk_ids: torch.Tensor,
+        block_size: int,
+        num_experts: int,
+        expert_map: torch.Tensor | None = None,
+        pad_sorted_ids: bool = False,
+        ignore_invalid_experts: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        max_num_tokens_padded = topk_ids.numel() + num_experts * (
+            block_size - 1
+        )
+        if pad_sorted_ids:
+            max_num_tokens_padded = triton.cdiv(
+                max_num_tokens_padded,
+                block_size,
+            ) * block_size
+        if topk_ids.numel() < num_experts:
+            max_num_tokens_padded = min(
+                topk_ids.numel() * block_size,
+                max_num_tokens_padded,
+            )
+
+        sorted_ids = torch.full(
+            (max_num_tokens_padded,),
+            fill_value=topk_ids.numel(),
+            dtype=torch.int32,
+            device=topk_ids.device,
+        )
+        expert_ids = torch.empty(
+            (triton.cdiv(max_num_tokens_padded, block_size),),
+            dtype=torch.int32,
+            device=topk_ids.device,
+        )
+        num_tokens_post_pad = torch.empty(
+            (1,),
+            dtype=torch.int32,
+            device=topk_ids.device,
+        )
+        ops.moe_align_block_size(
+            topk_ids,
+            num_experts,
+            block_size,
+            sorted_ids,
+            expert_ids,
+            num_tokens_post_pad,
+            expert_map if ignore_invalid_experts else None,
+        )
+        if expert_map is not None and not ignore_invalid_experts:
+            expert_ids = _safe_remap_expert_ids(expert_ids, expert_map)
+        return sorted_ids, expert_ids, num_tokens_post_pad
+
+    implementation._vllm_hcu_original_moe_align_block_size = original
+    setattr(safe_alignment, _PATCH_MARKER, True)
+    implementation.moe_align_block_size = safe_alignment
+
+
+__all__ = ["ensure_safe_marlin_moe_alignment"]

--- a/vllm_hcu/models/hy_v3.py
+++ b/vllm_hcu/models/hy_v3.py
@@ -716,17 +716,6 @@ class HYV3Model(nn.Module):
         for name, loaded_weight in weights:
             if self.config.tie_word_embeddings and "lm_head.weight" in name:
                 continue
-            if self.quant_config is not None and (
-                scale_name := self.quant_config.get_cache_scale(name)
-            ):
-                param = params_dict[scale_name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                loaded_weight = (
-                    loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
-                )
-                weight_loader(param, loaded_weight)
-                loaded_params.add(scale_name)
-                continue
             if "scale" in name:
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)

--- a/vllm_hcu/models/hy_v3_mtp.py
+++ b/vllm_hcu/models/hy_v3_mtp.py
@@ -375,6 +375,10 @@ class HYV3MTP(nn.Module, SupportsPP):
         return torch.concat((q, k, v))
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        if self.quant_config is not None and (
+            cache_scale_mapper := self.quant_config.get_cache_scale_mapper()
+        ):
+            weights = cache_scale_mapper.apply(weights)
         cla_factor = _get_cla_factor(self.config)
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
@@ -447,14 +451,6 @@ class HYV3MTP(nn.Module, SupportsPP):
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
                 continue
             if self.config.tie_word_embeddings and "lm_head.weight" in name:
-                continue
-            if self.quant_config is not None and (
-                scale_name := self.quant_config.get_cache_scale(name)
-            ):
-                param = params_dict[scale_name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                loaded_weight = loaded_weight[0]
-                weight_loader(param, loaded_weight)
                 continue
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
             if spec_layer is None:

--- a/vllm_hcu/patch/worker/op_opt/patch_mla_attention.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_mla_attention.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import functools
 import inspect
+from dataclasses import replace
 from types import ModuleType
 
 from vllm_hcu.patch.config import get_hcu_config
@@ -22,6 +23,7 @@ TARGETS = (
     f"{TARGET_MODULE}.MLACommonMetadata.__init__",
     f"{TARGET_MODULE}.MLACommonMetadataBuilder.build",
     f"{TARGET_MODULE}.split_decodes_and_prefills",
+    f"{TARGET_MODULE}.MLAAttention.get_kv_cache_spec",
 )
 _MARKER = "_vllm_hcu_mla_attention_applied"
 _WRAPPER = "_vllm_hcu_mla_attention_wrapper"
@@ -40,6 +42,7 @@ def apply_to_module(module: ModuleType) -> bool:
         (metadata_cls, "__init__", TARGETS[4], _WRAPPER),
         (builder_cls, "build", TARGETS[5], _WRAPPER),
         (mla, "split_decodes_and_prefills", TARGETS[6], _WRAPPER),
+        (cls, "get_kv_cache_spec", TARGETS[7], _WRAPPER),
     )
     if already_applied(mla, _MARKER, wrapped):
         return False
@@ -74,6 +77,12 @@ def apply_to_module(module: ModuleType) -> bool:
     )
     process = require_callable(cls, "process_weights_after_loading", TARGETS[3])
     require_exact_signature(process, TARGETS[3], positional=("self", "act_dtype"))
+    get_kv_cache_spec = require_callable(cls, "get_kv_cache_spec", TARGETS[7])
+    require_exact_signature(
+        get_kv_cache_spec,
+        TARGETS[7],
+        positional=("self", "vllm_config"),
+    )
     metadata_init = require_callable(metadata_cls, "__init__", TARGETS[4])
     if "num_actual_tokens" not in inspect.signature(metadata_init).parameters:
         raise PatchCompatibilityError(
@@ -282,6 +291,16 @@ def apply_to_module(module: ModuleType) -> bool:
 
         return mla_process_weights_nn(mla, self, act_dtype)
 
+    @functools.wraps(get_kv_cache_spec)
+    def hcu_get_kv_cache_spec(self, vllm_config):
+        from vllm.v1.kv_cache_interface import get_kv_quant_mode
+
+        spec = get_kv_cache_spec(self, vllm_config)
+        return replace(
+            spec,
+            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
+        )
+
     @functools.wraps(metadata_init)
     def hcu_metadata_init(self, *args, **kwargs):
         num_kv = kwargs.pop("num_kv_actual_tokens", None)
@@ -329,6 +348,7 @@ def apply_to_module(module: ModuleType) -> bool:
         hcu_full_forward,
         hcu_forward,
         hcu_process,
+        hcu_get_kv_cache_spec,
         hcu_metadata_init,
         hcu_build,
         hcu_split_batch,
@@ -338,6 +358,7 @@ def apply_to_module(module: ModuleType) -> bool:
     setattr(cls, "_vllm_hcu_original_forward", original_full_forward)
     setattr(cls, "_vllm_hcu_original_forward_impl", original_forward)
     setattr(cls, "_vllm_hcu_original_process_weights", process)
+    setattr(cls, "_vllm_hcu_original_get_kv_cache_spec", get_kv_cache_spec)
     setattr(metadata_cls, "_vllm_hcu_original_init", metadata_init)
     setattr(builder_cls, "_vllm_hcu_original_build", builder)
     setattr(mla, "_vllm_hcu_original_split_decodes_and_prefills", split_batch)
@@ -345,6 +366,7 @@ def apply_to_module(module: ModuleType) -> bool:
     setattr(cls, "forward", hcu_full_forward)
     setattr(cls, "forward_impl", hcu_forward)
     setattr(cls, "process_weights_after_loading", hcu_process)
+    setattr(cls, "get_kv_cache_spec", hcu_get_kv_cache_spec)
     setattr(metadata_cls, "__init__", hcu_metadata_init)
     setattr(builder_cls, "build", hcu_build)
     setattr(mla, "split_decodes_and_prefills", hcu_split_batch)


### PR DESCRIPTION
## Summary

- remove the eager `hidden_states.clone()` from shared-expert overlap paths
- select SlimQuant Marlin in-place/out-of-place execution from the real input alias and overlap order
- avoid a redundant fallback clone when the routed result is already out-of-place
- cover FP8/INT8 LightOp Marlin while preserving the AITER route

## Validation

- `VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 pytest -q tests/runtime_patch`: 1053 passed
- HY3 TP4 + SlimQuant Marlin + model runner v2 + MTP1 + FLASH_ATTN: HumanEval 32/32, pass@1 1.0
- GLM5 TP8 + SlimQuant Marlin + model runner v2 + MTP1 + FLASHMLA_SPARSE: HumanEval 32/32, pass@1 1.0
- HY3 TP4 + AITER (without SlimQuant) + model runner v2 + MTP1 + FLASH_ATTN: HumanEval 32/32, pass@1 1.0

## Notes

This is a stacked PR based on #63. Merge after #63, or retarget it after #63 lands.