### PR TITLE
ci: set Qwen3.5/Qwen3.6 max-model-len to 65536

### DIFF
--- a/docker/image-citest-conf-hcu.yaml
+++ b/docker/image-citest-conf-hcu.yaml
@@ -22,7 +22,7 @@ Qwen3.5-35B-A3B-W8A8:
   server_args:
     attention-backend: FLASH_ATTN
     kv-cache-dtype: fp8_e4m3
-    max-model-len: 40960
+    max-model-len: 65536
     max-num-batched-tokens: 16384
     max-num-seqs: 128
     quantization: slimquant_marlin
@@ -58,7 +58,7 @@ Qwen3.6-35B-A3B:
   server_args:
     attention-backend: FLASH_ATTN
     kv-cache-dtype: fp8_e4m3
-    max-model-len: 40960
+    max-model-len: 65536
     max-num-batched-tokens: 10240
     moe-backend: aiter
     speculative-config.method: mtp

--- a/docker/image-citest-conf-hcu.yaml
+++ b/docker/image-citest-conf-hcu.yaml
@@ -22,7 +22,7 @@ Qwen3.5-35B-A3B-W8A8:
   server_args:
     attention-backend: FLASH_ATTN
     kv-cache-dtype: fp8_e4m3
-    max-model-len: 32768
+    max-model-len: 40960
     max-num-batched-tokens: 16384
     max-num-seqs: 128
     quantization: slimquant_marlin
@@ -58,7 +58,7 @@ Qwen3.6-35B-A3B:
   server_args:
     attention-backend: FLASH_ATTN
     kv-cache-dtype: fp8_e4m3
-    max-model-len: 32768
+    max-model-len: 40960
     max-num-batched-tokens: 10240
     moe-backend: aiter
     speculative-config.method: mtp


### PR DESCRIPTION
Set `max-model-len` to `65536` for both `Qwen3.5-35B-A3B-W8A8` and `Qwen3.6-35B-A3B` in `docker/image-citest-conf-hcu.yaml`.