### PR TITLE
fix(hcu): normalize MoE backend precedence

### DIFF
--- a/tests/runtime_patch/test_glm52_pcp_moe.py
+++ b/tests/runtime_patch/test_glm52_pcp_moe.py
@@ -353,18 +353,14 @@ def test_inplace_shared_output_requires_local_inplace_kernel(
 
 
 @pytest.mark.parametrize(
-    ("use_deepep", "use_aiter", "expected"),
+    ("use_deepep", "expected"),
     [
-        (False, False, True),
-        (True, False, False),
-        (False, True, False),
-        (True, True, False),
+        (False, True),
+        (True, False),
     ],
 )
 def test_slimquant_marlin_only_advertises_local_inplace_output(
-    monkeypatch: pytest.MonkeyPatch,
     use_deepep: bool,
-    use_aiter: bool,
     expected: bool,
 ) -> None:
     module = importlib.import_module(
@@ -374,11 +370,6 @@ def test_slimquant_marlin_only_advertises_local_inplace_output(
     method = object.__new__(module.CompressedTensorsW8A8FP8MarlinMoEMethod)
     method.moe = object()
     method.use_deepep = use_deepep
-    monkeypatch.setattr(
-        module,
-        "_is_hcu_aiter_w8a8_moe_requested",
-        lambda moe: use_aiter,
-    )
 
     assert method.supports_inplace_output is expected
 

--- a/tests/runtime_patch/test_lightop_marlin_moe_compat.py
+++ b/tests/runtime_patch/test_lightop_marlin_moe_compat.py
@@ -195,11 +195,6 @@ def test_int8_marlin_safely_remaps_global_expert_ids(
         "lightop._lmslim_native.layers.fused_moe.int8_marlin_test",
         "fused_experts_impl_int8_marlin",
     )
-    monkeypatch.setattr(
-        marlin,
-        "_is_hcu_aiter_w8a8_moe_requested",
-        lambda *_args: False,
-    )
     expert_map = torch.tensor([-1, 0, -1, 1], dtype=torch.int32)
     layer = _moe_layer(global_num_experts=4, expert_map=expert_map)
     method = object.__new__(marlin.CompressedTensorsW8A8Int8MarlinMoEMethod)
@@ -261,11 +256,6 @@ def test_marlin_allocates_routed_output_only_during_shared_input_overlap(
         marlin,
         "ensure_safe_marlin_moe_alignment",
         lambda _kernel: None,
-    )
-    monkeypatch.setattr(
-        marlin,
-        "_is_hcu_aiter_w8a8_moe_requested",
-        lambda _moe: False,
     )
 
     class SharedExperts:

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -1300,6 +1300,86 @@ def test_slimquant_marlin_inherits_v0251_compressed_tensors_constructor() -> Non
         assert parameters[len(target_prefix) :] == ("i_q", "i_s")
 
 
+@pytest.mark.parametrize(
+    ("moe_backend", "aiter_requested", "expected_owner"),
+    [
+        ("auto", False, "lightop"),
+        ("auto", True, "vllm"),
+        ("aiter", False, "vllm"),
+        ("triton", True, "vllm"),
+        ("deep_gemm", True, "vllm"),
+    ],
+)
+def test_slimquant_marlin_moe_backend_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+    moe_backend: str,
+    aiter_requested: bool,
+    expected_owner: str,
+) -> None:
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe import (
+        CompressedTensorsMoEMethod,
+    )
+    from vllm_hcu.model_executor.layers.fused_moe import aiter_runtime
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors.compressed_tensors_marlin import (
+        SlimQuantCompressedTensorsMarlinConfig,
+    )
+    from vllm_hcu.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe_marlin import (
+        CompressedTensorsMarlinMoEMethod,
+    )
+
+    layer = RoutedExperts.__new__(RoutedExperts)
+    torch.nn.Module.__init__(layer)
+    layer.moe_config = SimpleNamespace(moe_backend=moe_backend)
+    config = SlimQuantCompressedTensorsMarlinConfig.from_config(
+        {
+            "config_groups": {},
+            "format": "int-quantized",
+            "ignore": [],
+            "kv_cache_scheme": None,
+            "quant_method": "compressed-tensors",
+        }
+    )
+    prefix = "model.layers.0.mlp.experts"
+    vllm_method = object()
+    lightop_method = object()
+    monkeypatch.setattr(
+        aiter_runtime,
+        "is_aiter_moe_requested",
+        lambda moe_config: moe_config is layer.moe_config and aiter_requested,
+    )
+    monkeypatch.setattr(
+        CompressedTensorsMoEMethod,
+        "get_moe_method",
+        staticmethod(
+            lambda quant_config, routed_layer, layer_name: (
+                vllm_method
+                if quant_config is config
+                and routed_layer is layer
+                and layer_name == prefix
+                else pytest.fail("unexpected vLLM MoE factory arguments")
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        CompressedTensorsMarlinMoEMethod,
+        "get_moe_method",
+        staticmethod(
+            lambda quant_config, routed_layer: (
+                lightop_method
+                if quant_config is config and routed_layer is layer
+                else pytest.fail("unexpected LightOp MoE factory arguments")
+            )
+        ),
+    )
+
+    method = config.get_quant_method(layer, prefix)
+
+    assert method is {"vllm": vllm_method, "lightop": lightop_method}[
+        expected_owner
+    ]
+
+
 def test_slimquant_fp8_moe_repack_preserves_fp8_without_widening(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runtime_patch/test_quant_gemm_aiter.py
+++ b/tests/runtime_patch/test_quant_gemm_aiter.py
@@ -1239,7 +1239,16 @@ def test_int8_oracle_keeps_aiter_weights_and_packs_hcu_deep_gemm_weights(
         CPU = "CPU"
 
     class AiterExperts:
-        pass
+        @staticmethod
+        def is_supported_config(
+            cls,
+            config,
+            weight_key,
+            activation_key,
+            activation_format,
+        ):
+            del cls, config, weight_key, activation_key, activation_format
+            return True, None
 
     def backend_to_kernel_cls(backend):
         return [f"original:{backend.value}"]
@@ -1455,6 +1464,30 @@ def test_int8_oracle_keeps_aiter_weights_and_packs_hcu_deep_gemm_weights(
     assert target.backend_to_kernel_cls(target.Int8MoeBackend.AITER) == [
         AiterExperts
     ]
+
+    from vllm_hcu.model_executor.layers.fused_moe import aiter_runtime
+
+    auto_aiter_config = SimpleNamespace(
+        moe_backend="auto",
+        moe_parallel_config=SimpleNamespace(
+            use_batched_activation_format=False,
+        ),
+        _hcu_vllm_config=SimpleNamespace(
+            additional_config={"hcu": {"moe_backend": "auto"}},
+        ),
+    )
+    monkeypatch.setattr(
+        aiter_runtime,
+        "is_aiter_moe_requested",
+        lambda config: config is auto_aiter_config,
+    )
+    auto_aiter_backend, auto_aiter_experts = target.select_int8_moe_backend(
+        auto_aiter_config,
+        kInt8StaticChannelSym,
+        kInt8DynamicTokenSym,
+    )
+    assert auto_aiter_backend is target.Int8MoeBackend.AITER
+    assert auto_aiter_experts is AiterExperts
 
     w13 = torch.zeros((2, 4, 3), dtype=torch.int8)
     w2 = torch.zeros((2, 3, 2), dtype=torch.int8)
@@ -3995,6 +4028,27 @@ def test_slimquant_w4a8_dispatch_preserves_linear_method():
 
     assert type(method) is slimquant_w4a8.SlimQuantW4A8Int8LinearMethod
     assert isinstance(layer.scheme, slimquant_w4a8.CompressedTensorsW8A8Int8)
+
+
+@pytest.mark.hcu
+def test_slimquant_w4a8_explicit_deep_gemm_requires_deepep_auto():
+    from vllm_hcu.model_executor.layers.quantization import slimquant_w4a8
+
+    pure_tp_moe = SimpleNamespace(
+        moe_backend="deep_gemm",
+        moe_parallel_config=SimpleNamespace(
+            dp_size=1,
+            use_ep=False,
+            all2all_backend="allgather_reducescatter",
+            use_deepep_auto_kernels=False,
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="deep_gemm.*requires.*deepep_auto",
+    ):
+        slimquant_w4a8.SlimQuantW4A8Int8AiterMoEMethod(object(), pure_tp_moe)
 
 
 @pytest.mark.hcu
@@ -8006,9 +8060,6 @@ def test_marlin_moe_never_imports_lmslim(
         fused_experts_impl_int8_marlin=int8_kernel,
     )
     _reject_import_prefix(monkeypatch, "lmslim")
-    monkeypatch.setattr(
-        marlin, "_is_hcu_aiter_w8a8_moe_requested", lambda *args: False
-    )
     layer = _fp8_moe_layer()
     x = torch.ones(2, 4)
     weights = torch.ones(2, 2)
@@ -8044,7 +8095,6 @@ def test_missing_lightop_marlin_export_fails_without_lmslim_retry(
     monkeypatch.setitem(sys.modules, "lightop", lightop)
     monkeypatch.delitem(sys.modules, "lightop.moe", raising=False)
     _reject_import_prefix(monkeypatch, "lmslim")
-    monkeypatch.setattr(marlin, "_is_hcu_aiter_w8a8_moe_requested", lambda: False)
 
     layer = _fp8_moe_layer()
     x = torch.ones(2, 4)
@@ -8104,210 +8154,64 @@ print("SLIMQUANT_PREPATCH_IMPORT_OK")
     assert "SLIMQUANT_PREPATCH_IMPORT_OK" in result.stdout
 
 
-def test_marlin_aiter_moe_no_solution_uses_native_triton_not_lmslim(
+def test_bf16_moe_backend_precedence_and_unsupported_deep_gemm(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
-        compressed_tensors_moe_marlin as marlin,
-    )
+    from vllm.model_executor.layers.fused_moe.oracle import unquantized
 
-    method_class = marlin.CompressedTensorsW8A8Int8MarlinMoEMethod
-    assert not hasattr(method_class, "_get_aiter_moe_runtime_config")
-    assert not hasattr(method_class, "_get_aiter_weights_for_solution")
-    method = object.__new__(method_class)
-    method.moe = SimpleNamespace(num_experts=3)
-    method.moe_quant_config = SimpleNamespace(
-        use_fp8_w8a8=False,
-        use_int8_w8a8=True,
-        w1_scale=torch.ones((3, 8, 1)),
-        w2_scale=torch.ones((3, 4, 1)),
-        w1_zp=None,
-        w2_zp=None,
-        a1_scale=None,
-        a2_scale=None,
-        block_shape=None,
-    )
+    class SupportedExperts:
+        @staticmethod
+        def is_supported_config(
+            cls,
+            config,
+            weight_key,
+            activation_key,
+            activation_format,
+        ):
+            del cls, config, weight_key, activation_key, activation_format
+            return True, None
+
     monkeypatch.setattr(
-        marlin,
-        "_is_hcu_aiter_w8a8_moe_requested",
-        lambda _moe=None: True,
-    )
-    monkeypatch.setattr(marlin.rocm_aiter_ops, "is_fused_moe_enabled", lambda: True)
-
-    class MoeQuantType:
-        W8A8 = "int8_w8a8"
-
-    monkeypatch.setitem(
-        sys.modules,
-        "aiter.moe",
-        _module(
-            "aiter.moe",
-            MoeQuantType=MoeQuantType,
-            get_aiter_moe_config=lambda **kwargs: (False, None),
+        unquantized,
+        "current_platform",
+        SimpleNamespace(
+            is_cpu=lambda: False,
+            is_tpu=lambda: False,
+            is_out_of_tree=lambda: False,
+            is_rocm=lambda: True,
         ),
     )
-    monkeypatch.setitem(
-        sys.modules,
-        "lmslim.layers.fused_moe.fuse_moe_int8_marlin",
-        _module(
-            "lmslim.layers.fused_moe.fuse_moe_int8_marlin",
-            fused_experts_impl_int8_marlin=lambda **kwargs: pytest.fail(
-                "AITER no-solution must use vLLM Triton, not LMSlim"
+    monkeypatch.setattr(
+        unquantized,
+        "backend_to_kernel_cls",
+        lambda _backend: SupportedExperts,
+    )
+    monkeypatch.setattr(unquantized.envs, "is_set", lambda _name: True)
+    monkeypatch.setattr(unquantized.envs, "VLLM_ROCM_USE_AITER", True)
+    monkeypatch.setattr(unquantized.envs, "VLLM_ROCM_USE_AITER_MOE", True)
+
+    def config(backend: str):
+        return SimpleNamespace(
+            moe_backend=backend,
+            is_lora_enabled=False,
+            moe_parallel_config=SimpleNamespace(
+                use_batched_activation_format=False,
             ),
-        ),
-    )
-    expected = torch.full((2, 4), 4.0)
-    fallback_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
-    fused_moe_module = __import__(
-        "vllm.model_executor.layers.fused_moe.fused_moe",
-        fromlist=["fused_experts_impl"],
-    )
-
-    def fallback(*args: object, **kwargs: object):
-        fallback_calls.append((args, kwargs))
-        return expected
-
-    monkeypatch.setattr(fused_moe_module, "fused_experts_impl", fallback)
-    layer = _fp8_moe_layer()
-    layer.w13_weight = torch.zeros((3, 8, 4), dtype=torch.int8)
-    layer.w2_weight = torch.zeros((3, 4, 4), dtype=torch.int8)
-
-    actual = method.apply(
-        layer,
-        torch.ones((2, 4), dtype=torch.bfloat16),
-        torch.ones((2, 2)),
-        torch.zeros((2, 2), dtype=torch.int64),
-        None,
-        None,
-    )
-
-    assert actual is expected
-    assert fallback_calls[0][1]["use_int8_w8a8"] is True
-
-
-def test_marlin_explicit_triton_backend_bypasses_aiter_env(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
-        compressed_tensors_moe_marlin as marlin,
-    )
-
-    _install_fake_vllm_envs(
-        monkeypatch,
-        VLLM_ROCM_USE_AITER=True,
-        VLLM_ROCM_USE_AITER_MOE=True,
-    )
-
-    assert not marlin._is_hcu_aiter_w8a8_moe_requested(
-        SimpleNamespace(moe_backend="triton")
-    )
-
-
-def test_marlin_aiter_moe_prewarms_m1_during_weight_loading(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
-        compressed_tensors_moe_marlin as marlin,
-    )
-
-    method = object.__new__(marlin.CompressedTensorsW8A8Int8MarlinMoEMethod)
-    method.moe = SimpleNamespace(
-        num_experts=3,
-        experts_per_token=2,
-        in_dtype=torch.bfloat16,
-        activation=SimpleNamespace(value="silu"),
-    )
-    quant_config = SimpleNamespace(
-        use_fp8_w8a8=False,
-        use_int8_w8a8=True,
-        block_shape=None,
-    )
-    method.get_fused_moe_quant_config = lambda unused_layer: quant_config
-    monkeypatch.setattr(
-        marlin,
-        "_is_hcu_aiter_w8a8_moe_requested",
-        lambda _moe=None: True,
-    )
-    monkeypatch.setattr(marlin.rocm_aiter_ops, "is_fused_moe_enabled", lambda: True)
-    calls: list[tuple[object, object, object]] = []
-    monkeypatch.setattr(
-        compressed_tensors_moe_runtime,
-        "prewarm_aiter_quantized_moe",
-        lambda layer, moe, config: calls.append((layer, moe, config)),
-        raising=False,
-    )
-    layer = _fp8_moe_layer()
-    layer.w13_weight = torch.zeros((3, 8, 4), dtype=torch.int8)
-    layer.w2_weight = torch.zeros((3, 4, 4), dtype=torch.int8)
-
-    method.process_weights_after_loading(layer)
-
-    assert method.moe_quant_config is quant_config
-    assert calls == [(layer, method.moe, quant_config)]
-
-
-def test_marlin_aiter_moe_config_fault_does_not_fallback(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    from vllm_hcu.model_executor.layers.quantization.compressed_tensors import (
-        compressed_tensors_moe_marlin as marlin,
-    )
-
-    method = object.__new__(marlin.CompressedTensorsW8A8Int8MarlinMoEMethod)
-    method.moe = SimpleNamespace(num_experts=3)
-    method.moe_quant_config = SimpleNamespace(
-        use_fp8_w8a8=False,
-        use_int8_w8a8=True,
-        w1_scale=torch.ones((3, 8, 1)),
-        w2_scale=torch.ones((3, 4, 1)),
-        block_shape=None,
-    )
-    monkeypatch.setattr(
-        marlin,
-        "_is_hcu_aiter_w8a8_moe_requested",
-        lambda _moe=None: True,
-    )
-    monkeypatch.setattr(marlin.rocm_aiter_ops, "is_fused_moe_enabled", lambda: True)
-
-    class MoeQuantType:
-        W8A8 = "int8_w8a8"
-
-    def config_fault(**kwargs: object):
-        raise RuntimeError("aiter config fault")
-
-    monkeypatch.setitem(
-        sys.modules,
-        "aiter.moe",
-        _module(
-            "aiter.moe",
-            MoeQuantType=MoeQuantType,
-            get_aiter_moe_config=config_fault,
-        ),
-    )
-    fallback_calls: list[object] = []
-    fused_moe_module = __import__(
-        "vllm.model_executor.layers.fused_moe.fused_moe",
-        fromlist=["fused_experts_impl"],
-    )
-    monkeypatch.setattr(
-        fused_moe_module,
-        "fused_experts_impl",
-        lambda *args, **kwargs: fallback_calls.append((args, kwargs)),
-    )
-    layer = _fp8_moe_layer()
-    layer.w13_weight = torch.zeros((3, 8, 4), dtype=torch.int8)
-    layer.w2_weight = torch.zeros((3, 4, 4), dtype=torch.int8)
-
-    with pytest.raises(RuntimeError, match="aiter config fault"):
-        method.apply(
-            layer,
-            torch.ones((2, 4), dtype=torch.bfloat16),
-            torch.ones((2, 2)),
-            torch.zeros((2, 2), dtype=torch.int64),
-            None,
-            None,
         )
-    assert fallback_calls == []
+
+    automatic, _ = unquantized.select_unquantized_moe_backend(config("auto"))
+    explicit_aiter, _ = unquantized.select_unquantized_moe_backend(
+        config("aiter")
+    )
+    explicit_triton, _ = unquantized.select_unquantized_moe_backend(
+        config("triton")
+    )
+
+    assert automatic is unquantized.UnquantizedMoeBackend.AITER
+    assert explicit_aiter is unquantized.UnquantizedMoeBackend.AITER
+    assert explicit_triton is unquantized.UnquantizedMoeBackend.TRITON
+    with pytest.raises(ValueError, match="not supported for unquantized MoE"):
+        unquantized.select_unquantized_moe_backend(config("deep_gemm"))
 
 
 @pytest.mark.parametrize("is_rocm", [False, True])

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_marlin.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_marlin.py
@@ -60,5 +60,22 @@ class SlimQuantCompressedTensorsMarlinConfig(CompressedTensorsConfig):
         if isinstance(layer, Attention):
             return CompressedTensorsKVCacheMethod(self)
         if isinstance(layer, RoutedExperts):
+            moe_backend = getattr(layer.moe_config, "moe_backend", "auto")
+            from vllm_hcu.model_executor.layers.fused_moe.aiter_runtime import (
+                is_aiter_moe_requested,
+            )
+
+            if moe_backend != "auto" or is_aiter_moe_requested(
+                layer.moe_config
+            ):
+                from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe import (
+                    CompressedTensorsMoEMethod,
+                )
+
+                return CompressedTensorsMoEMethod.get_moe_method(
+                    self,
+                    layer,
+                    prefix,
+                )
             return CompressedTensorsMarlinMoEMethod.get_moe_method(self, layer)
         return None

--- a/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
+++ b/vllm_hcu/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
@@ -2,19 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
 # Modified by Hygon Information Technology Co., Ltd., 2026.
-"""HCU compressed-tensors Marlin methods with optional AITER routing.
-
-The AITER INT8 branch keeps canonical weights at load time and delegates
-shape/config selection, derived layouts, public execution, and native Triton
-fallback to ``compressed_tensors_moe_runtime``. The non-AITER branch uses the
-LightOp Marlin layout and execution path.
-"""
+"""HCU compressed-tensors methods owned by the LightOp Marlin backend."""
 import enum
 import torch
 from enum import Enum
 from typing import Optional
 from compressed_tensors.quantization import (QuantizationStrategy)
-from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from torch.nn.parameter import Parameter
@@ -47,18 +40,6 @@ __all__ = [
     "CompressedTensorsW8A8Int8MarlinMoEMethod",
     "CompressedTensorsW8A8FP8MarlinMoEMethod",
 ]
-# ── AITER W8A8 MoE env guard ────────────────────────────────────────
-
-def _is_hcu_aiter_w8a8_moe_requested(
-    moe_config: object | None = None,
-) -> bool:
-    from vllm_hcu.model_executor.layers.fused_moe.aiter_runtime import (
-        is_aiter_moe_requested,
-    )
-
-    return is_aiter_moe_requested(moe_config)
-
-
 # ── Weight layout helpers (Marlin interleave) ───────────────────────
 
 def get_w8a8_int8_marlin_weights(
@@ -135,9 +116,7 @@ class CompressedTensorsMarlinMoEMethod(FusedMoEMethodBase):
 
     @property
     def supports_inplace_output(self) -> bool:
-        return not self.use_deepep and not _is_hcu_aiter_w8a8_moe_requested(
-            self.moe
-        )
+        return not self.use_deepep
 
     @staticmethod
     def _allows_inplace_output(
@@ -528,32 +507,7 @@ class CompressedTensorsW8A8Int8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod)
         layer.w2_input_scale = None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        # AITER W8A8 MoE fast-path: skip Marlin interleave, defer to AITER
-        if _is_hcu_aiter_w8a8_moe_requested(self.moe):
-            if not rocm_aiter_ops.is_fused_moe_enabled():
-                raise RuntimeError(
-                    "VLLM_ROCM_USE_AITER=1 and VLLM_ROCM_USE_AITER_MOE=1 "
-                    "requested AITER W8A8 MoE, but rocm_aiter_ops fused MoE "
-                    "support is unavailable."
-                )
-            if layer.apply_router_weight_on_input:
-                raise RuntimeError(
-                    "AITER W8A8 MoE does not support "
-                    "apply_router_weight_on_input=True."
-                )
-
-            self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-            from vllm_hcu.model_executor.layers.quantization.compressed_tensors_moe_runtime import (
-                prewarm_aiter_quantized_moe,
-            )
-
-            prewarm_aiter_quantized_moe(
-                layer,
-                self.moe,
-                self.moe_quant_config,
-            )
-            return
-        # Default Marlin weight interleave path
+        # LightOp Marlin weight interleave path.
         #if not self.use_deepep:
         w1_marlin_list = []
         for ii in range(layer.w13_weight.shape[0]):
@@ -589,46 +543,7 @@ class CompressedTensorsW8A8Int8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod)
         i_q: torch.Tensor | None = None,
         i_s: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        # AITER W8A8 MoE fast-path
-        if _is_hcu_aiter_w8a8_moe_requested(self.moe):
-            if not rocm_aiter_ops.is_fused_moe_enabled():
-                raise RuntimeError(
-                    "VLLM_ROCM_USE_AITER=1 and VLLM_ROCM_USE_AITER_MOE=1 "
-                    "requested AITER W8A8 MoE, but rocm_aiter_ops fused MoE "
-                    "support is unavailable."
-                )
-            if layer.apply_router_weight_on_input:
-                raise RuntimeError(
-                    "AITER W8A8 MoE does not support "
-                    "apply_router_weight_on_input=True."
-                )
-
-            from vllm_hcu.model_executor.layers.quantization.compressed_tensors_moe_runtime import (
-                apply_aiter_quantized_moe,
-            )
-
-            quant_config = getattr(self, "moe_quant_config", None)
-            if quant_config is None:
-                quant_config = self.get_fused_moe_quant_config(layer)
-                self.moe_quant_config = quant_config
-            return apply_aiter_quantized_moe(
-                hidden_states=x,
-                w1=layer.w13_weight,
-                w2=layer.w2_weight,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-                vllm_moe_config=self.moe,
-                activation=layer.activation,
-                apply_router_weight_on_input=(
-                    layer.apply_router_weight_on_input
-                ),
-                expert_map=layer.expert_map,
-                quant_config=quant_config,
-                output_dtype=x.dtype,
-            )
-
-        # Default Marlin INT8 path
-
+        # LightOp Marlin INT8 path.
         from lightop.moe import fused_experts_impl_int8_marlin
         ensure_safe_marlin_moe_alignment(fused_experts_impl_int8_marlin)
         inplace = self._allows_inplace_output(

--- a/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
+++ b/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
@@ -140,6 +140,31 @@ class SlimQuantW4A8Int8AiterMoEMethod(FusedMoEMethodBase):
     """Channel-wise SlimQuant W4A8 routed by the shared AITER adapter."""
 
     def __init__(self, quant_config, moe):
+        moe_backend = getattr(moe, "moe_backend", "auto")
+        supported_backends = {"auto", "aiter", "triton", "deep_gemm"}
+        if moe_backend not in supported_backends:
+            raise ValueError(
+                "SlimQuant W4A8 does not support "
+                f"moe_backend={moe_backend!r}; expected one of "
+                f"{sorted(supported_backends)!r}"
+            )
+        if moe_backend == "deep_gemm":
+            parallel_config = getattr(moe, "moe_parallel_config", None)
+            if (
+                parallel_config is None
+                or getattr(parallel_config, "all2all_backend", None)
+                != "deepep_auto"
+                or getattr(
+                    parallel_config,
+                    "use_deepep_auto_kernels",
+                    None,
+                )
+                is False
+            ):
+                raise ValueError(
+                    "SlimQuant W4A8 deep_gemm requires DP+EP with "
+                    "all2all_backend='deepep_auto'"
+                )
         self.moe = moe
         self.quant_config = quant_config
         self.moe_quant_config: FusedMoEQuantConfig | None = None

--- a/vllm_hcu/patch/worker/op_opt/moe/patch_int8_oracle.py
+++ b/vllm_hcu/patch/worker/op_opt/moe/patch_int8_oracle.py
@@ -192,6 +192,38 @@ def apply_to_module(module: ModuleType) -> bool:
 
             return hcu_enum.HCU_DEEPGEMM, DeepEPDeepGemmContiguousExperts
         if sidecar.moe_backend != "deep_gemm":
+            from vllm_hcu.model_executor.layers.fused_moe.aiter_runtime import (
+                is_aiter_moe_requested,
+            )
+
+            if (
+                getattr(config, "moe_backend", "auto") == "auto"
+                and is_aiter_moe_requested(config)
+            ):
+                activation_format = (
+                    target.mk.FusedMoEActivationFormat.BatchedExperts
+                    if config.moe_parallel_config.use_batched_activation_format
+                    else target.mk.FusedMoEActivationFormat.Standard
+                )
+                reasons = []
+                for kernel_cls in hcu_backend_to_kernel_cls(hcu_enum.AITER):
+                    supported, reason = kernel_cls.is_supported_config(
+                        kernel_cls,
+                        config,
+                        weight_key,
+                        activation_key,
+                        activation_format,
+                    )
+                    if supported:
+                        return hcu_enum.AITER, kernel_cls
+                    reasons.append(
+                        f"{kernel_cls.__name__}: {reason or 'unsupported'}"
+                    )
+                raise ValueError(
+                    "AITER is required by the HCU auto environment but does "
+                    "not support this INT8 MoE configuration: "
+                    + "; ".join(reasons)
+                )
             return select_backend(config, weight_key, activation_key)
         if getattr(config, "moe_backend", "auto") != "deep_gemm":
             raise ValueError(


### PR DESCRIPTION
## Summary

This is a stacked PR on #63. It separates MoE backend ownership and makes backend precedence explicit:

- explicit `--moe-backend aiter`, `triton`, or `deep_gemm` wins;
- `moe_backend=auto` plus both AITER environment switches routes to the official AITER selector;
- otherwise SlimQuant W8A8 stays on the LightOp INT8/FP8 Marlin path;
- W4A8 keeps AITER as the default, honors explicit Triton, and only accepts DeepGEMM with a valid `deepep_auto` topology;
- unsupported W4A8/BF16 backend combinations fail closed instead of silently falling back.

Backend selection remains at model/method initialization time and adds no branch to CUDA Graph replay.

## Verification

- `475 passed` across platform/factory, GLM5.2 PCP MoE, LightOp Marlin, AITER INT8, DeepEP, plugin lifecycle, and worker dispatcher tests.
- Production modules pass `python -m compileall -q`.
- `git diff --check` passes.

### Qwen3.5-35B-A3B-W8A8 — default LightOp path

```bash
env -u VLLM_ROCM_USE_AITER -u VLLM_ROCM_USE_AITER_MOE \
  VLLM_USE_V2_MODEL_RUNNER=1 VLLM_KV_CACHE_LAYOUT=HND \
  HIP_VISIBLE_DEVICES=4 \
  vllm serve /models/Qwen3.5-35B-A3B-W8A8 \
  --served-model-name qwen35-35b-w8a8-lightop \
  --host 127.0.0.1 --port 10163 \
  --max-model-len 40960 \
  --max-num-batched-tokens 1024 \
  --tensor-parallel-size 1 \
  --quantization slimquant_marlin \
  --attention-backend FLASH_ATTN \
  --kv-cache-dtype fp8_e4m3 \
  --trust-remote-code \
  --speculative-config.method mtp \
  --speculative-config.num_speculative_tokens 3
```

### Qwen3.5-35B-A3B-W8A8 — explicit AITER path

Use the same command with:

```bash
--served-model-name qwen35-35b-w8a8-aiter --moe-backend aiter
```

### HumanEval client

```bash
env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy \
  NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
  evalscope eval \
  --model <served-model-name> \
  --api-url http://127.0.0.1:10163/v1 \
  --api-key EMPTY --eval-type openai_api \
  --generation-config '{"temperature":0,"do_sample":false,"max_tokens":2048,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}' \
  --stream --eval-batch-size 1 --timeout 7200 --limit 32 \
  --datasets humaneval --dataset-args '{"humaneval":{}}' \
  --work-dir /tmp/vllm-hcu-evalscope/<run-name> \
  --no-timestamp
```

Both runs used CUDA Graphs (`enforce_eager=False`, full/piecewise capture including MTP prefill/decode):

| Path | HumanEval | Pass@1 |
|---|---:|---:|
| SlimQuant W8A8 default / LightOp Marlin | 32/32 | 1.0 |
| SlimQuant W8A8 explicit AITER | 32/32 | 1.0 |

The startup logs also confirm that the default run loads the LightOp Marlin MoE kernel, while the explicit run selects the official AITER INT8 MoE backend.

<!-- extended-model-validation:start -->

## Extended model validation (2026-09-05)

All runs used PR head `0fb870e`, CUDA Graphs, and the public backend selector. AITER environment switches were explicitly unset.

### HY3 Channel-FP8 W8A8 — TP4 / LightOp / MTP3

```bash
HIP_VISIBLE_DEVICES=0,1,2,3 \
VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1 \
vllm serve /models/Hy3-CHANNEL-FP8-w8a8-sero-ignore-from-script3 \
  --served-model-name hy3-pr68-lightop \
  --host 127.0.0.1 --port 20168 \
  --trust-remote-code --dtype bfloat16 \
  --max-model-len 4096 --quantization slimquant_marlin \
  --generation-config vllm --attention-backend FLASH_ATTN \
  --tensor-parallel-size 4 --block-size 64 \
  --gpu-memory-utilization 0.85 --kv-cache-dtype fp8_e4m3 \
  --max-num-batched-tokens 8192 --max-num-seqs 8 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
```

- Backend evidence: LightOp `moe_w8a8_fp8_marlin` modules loaded.
- CUDA Graph: mixed prefill/decode PIECEWISE `9/9`, decode FULL `5/5`; 6 s, 0.72 GiB.
- HumanEval: `32/32`, `mean_acc=1.0`, `mean_acc_pass@1=1.0`.

### GLM-5-W8A8 — TP8 / LightOp / MTP3

```bash
HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
vllm serve /models/GLM-5-W8A8 \
  --served-model-name glm5-w8a8-pr68-lightop \
  --host 127.0.0.1 --port 20170 \
  --trust-remote-code --dtype bfloat16 \
  --max-model-len 4096 --quantization slimquant_marlin \
  --generation-config vllm \
  --default-chat-template-kwargs '{"enable_thinking":false}' \
  --attention-backend FLASHMLA_SPARSE \
  --tensor-parallel-size 8 --block-size 64 \
  --gpu-memory-utilization 0.85 --kv-cache-dtype fp8_ds_mla \
  --max-num-batched-tokens 8192 --max-num-seqs 8 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
```

- Backend evidence: LightOp `moe_w8a8_i8_marlin` modules loaded. The separate `TritonInt8ScaledMMLinearKernel` log is for dense linear layers, not MoE.
- CUDA Graph: mixed prefill/decode PIECEWISE `9/9`, decode FULL `5/5`; 16 s, 0.54 GiB.
- HumanEval: `32/32`, `mean_acc=1.0`, `mean_acc_pass@1=1.0`.
- EvalScope: mean latency 2.9267 s, TTFT 218.29 ms, TPOT 20.56 ms, output throughput 45.61 tok/s.

HumanEval client pattern:

```bash
evalscope eval \
  --model <served-model-name> \
  --api-url http://127.0.0.1:<port>/v1 \
  --api-key EMPTY --eval-type openai_api \
  --generation-config '{"temperature":0,"do_sample":false,"max_tokens":2048,"timeout":7200,"stream":true,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}' \
  --eval-batch-size 1 --timeout 7200 --limit 32 \
  --datasets humaneval --dataset-args '{"humaneval":{}}' \
  --work-dir /tmp/vllm-hcu-evalscope/<run-name> --no-timestamp
```

### DeepSeek-V4-Flash-FP8-Channel — DSpark diagnostic

DeepSeek-V4-Flash should use DSpark rather than the generic MTP method. The attempted TP4 profile accepted the explicit Triton configuration and enabled CUDA Graph mode:

```bash
HIP_VISIBLE_DEVICES=0,1,2,3 \
vllm serve /models/DeepSeek-V4-Flash-FP8-Channel \
  --served-model-name deepseek-v4-pr68-dspark-triton \
  --host 127.0.0.1 --port 20169 \
  --trust-remote-code --dtype bfloat16 \
  --tokenizer-mode deepseek_v4 --max-model-len 4096 \
  --tensor-parallel-size 4 --block-size 256 \
  --gpu-memory-utilization 0.9 --kv-cache-dtype fp8 \
  --max-num-batched-tokens 512 --max-num-seqs 8 \
  --moe-backend triton \
  --speculative-config '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
```

This checkpoint cannot start DSpark because its `config.json`, backup config, and tokenizer metadata contain none of the required parallel-drafting token fields (`dflash_config.mask_token_id`, `mask_token_id`, `dspark_noise_token_id`, `pard_token`, or `ptd_token_id`). vLLM fails closed with the corresponding `ValueError`; no token ID was guessed. This occurs before model weight loading/backend execution and is independent of the MoE precedence change.


### HY3 Channel-FP8 W8A8 â TP4 / explicit AITER / MTP3

No quantization CLI override was supplied; the checkpoint's own quantization metadata was retained and auto-detected as `compressed-tensors`.

```bash
env -u VLLM_ROCM_USE_AITER -u VLLM_ROCM_USE_AITER_MOE \
  VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1 \
  HIP_VISIBLE_DEVICES=0,1,2,3 \
  vllm serve /models/Hy3-CHANNEL-FP8-w8a8-sero-ignore-from-script3 \
  --served-model-name hy3-pr68-aiter-autoquant \
  --host 127.0.0.1 --port 20174 \
  --trust-remote-code --dtype bfloat16 \
  --max-model-len 4096 --generation-config vllm \
  --attention-backend FLASH_ATTN \
  --tensor-parallel-size 4 --block-size 64 \
  --gpu-memory-utilization 0.85 --kv-cache-dtype fp8_e4m3 \
  --max-num-batched-tokens 8192 --max-num-seqs 8 \
  --moe-backend aiter \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
```

- Selector evidence: `kernel_config.moe_backend='aiter'` and `Using AITER Fp8 MoE backend`.
- CUDA Graph: `enforce_eager=False`; mixed prefill/decode PIECEWISE `9/9`, decode FULL `5/5`.
- HumanEval: `32/32`, `mean_acc=1.0`, `mean_acc_pass@1=1.0`.
- EvalScope: mean latency 3.058 s, TTFT 528.6 ms, TPOT 32.09 ms, output throughput 26.11 tok/s.
- Runtime note: AITER has no supported solution for the HY3 `M=1, E=192, fp8_w8a8` shape on this installation, so the official AITER implementation logs a per-shape fallback to vLLM Triton MoE. This is downstream of the public selector: the plugin selected AITER as requested, but this run does not prove an all-shapes-AITER execution path.

### GLM-5-W8A8 â TP8 / explicit AITER / MTP3

No quantization CLI override was supplied; the checkpoint's own quantization metadata was retained and auto-detected as `compressed-tensors`.

```bash
env -u VLLM_ROCM_USE_AITER -u VLLM_ROCM_USE_AITER_MOE \
  HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
  vllm serve /models/GLM-5-W8A8 \
  --served-model-name glm5-w8a8-pr68-aiter-autoquant \
  --host 127.0.0.1 --port 20175 \
  --trust-remote-code --dtype bfloat16 \
  --max-model-len 4096 --generation-config vllm \
  --default-chat-template-kwargs '{"enable_thinking":false}' \
  --attention-backend FLASHMLA_SPARSE \
  --tensor-parallel-size 8 --block-size 64 \
  --gpu-memory-utilization 0.85 --kv-cache-dtype fp8_ds_mla \
  --max-num-batched-tokens 8192 --max-num-seqs 8 \
  --moe-backend aiter \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
```

- Backend evidence: `kernel_config.moe_backend='aiter'`, `Using AITER Int8 MoE backend`, and AITER gfx938 `int8_w8a8` tuned configs loaded for all TP ranks.
- Dense linear remains independently selected as `TritonInt8ScaledMMLinearKernel`; this does not overlap the MoE backend choice.
- CUDA Graph: `enforce_eager=False`; mixed prefill/decode PIECEWISE `9/9`, decode FULL `5/5`.
- HumanEval: `32/32`, `mean_acc=1.0`, `mean_acc_pass@1=1.0`.
- EvalScope: mean latency 3.0083 s, TTFT 248.05 ms, TPOT 21.11 ms, output throughput 43.84 tok/s.
- No AITER fallback or Triton `fused_moe_kernel` JIT was observed during the 32-sample run.

Explicit-AITER HumanEval client:

```bash
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
  -u http_proxy -u https_proxy -u all_proxy \
  NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
  evalscope eval \
  --model <served-model-name> \
  --api-url http://127.0.0.1:<port>/v1 \
  --api-key EMPTY --eval-type openai_api \
  --generation-config '{"temperature":0,"do_sample":false,"max_tokens":2048,"timeout":7200,"stream":true,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}' \
  --eval-batch-size <8-for-HY3-or-1-for-GLM5> \
  --timeout 7200 --limit 32 \
  --datasets humaneval --dataset-args '{"humaneval":{}}' \
  --work-dir /tmp/vllm-hcu-evalscope/<run-name> --no-timestamp
```



### DeepSeek-V4-Flash-0731-FP8-Channel â TP4 / Triton / DSpark7

The replacement checkpoint contains `dspark_noise_token_id=128799`, so it passes the DSpark metadata validation that blocked the older checkpoint. No quantization CLI override was supplied; checkpoint metadata was auto-detected as `compressed-tensors`.

```bash
env -u VLLM_ROCM_USE_AITER -u VLLM_ROCM_USE_AITER_MOE \
  HIP_VISIBLE_DEVICES=0,1,2,3 \
  vllm serve /models/DeepSeek-V4-Flash-0731-FP8-Channel \
  --served-model-name deepseek-v4-0731-pr68-dspark-triton \
  --host 127.0.0.1 --port 20176 \
  --trust-remote-code --dtype bfloat16 \
  --tokenizer-mode deepseek_v4 --max-model-len 4096 \
  --generation-config vllm \
  --tensor-parallel-size 4 --block-size 256 \
  --gpu-memory-utilization 0.9 --kv-cache-dtype fp8 \
  --max-num-batched-tokens 512 --max-num-seqs 8 \
  --moe-backend triton \
  --speculative-config '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
```

```bash
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
  -u http_proxy -u https_proxy -u all_proxy \
  NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
  evalscope eval \
  --model deepseek-v4-0731-pr68-dspark-triton \
  --api-url http://127.0.0.1:20176/v1 \
  --api-key EMPTY --eval-type openai_api \
  --generation-config '{"temperature":0,"do_sample":false,"max_tokens":2048,"timeout":7200,"stream":true,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}' \
  --eval-batch-size 8 --timeout 7200 --limit 32 \
  --datasets humaneval --dataset-args '{"humaneval":{}}' \
  --work-dir /tmp/vllm-hcu-evalscope/pr68-deepseek-v4-0731-tp4-triton-dspark7-cudagraph \
  --no-timestamp
```

- Backend evidence: `kernel_config.moe_backend='triton'`, `Using TRITON Fp8 MoE backend`, channel-wise FP8 dense linear, and DSpark draft model loaded successfully.
- CUDA Graph: Breakable CUDA Graph enabled; main model PIECEWISE `19/19`, FULL `8/8`; DSpark FULL `8/8`; 24â25 s and 0.54 GiB per rank.
- DSpark: mean acceptance length 6.28â7.04 in the sampled windows; average draft acceptance rate 75.5%â86.3%.
- HumanEval run 1: formal `30/32`, `mean_acc_pass@1=0.9375`; mean latency 4.6684 s, TTFT 1887.17 ms, TPOT 23.81 ms, output throughput 25.22 tok/s.
- Identical rerun: formal `29/32`, `mean_acc_pass@1=0.9062`; mean latency 3.3610 s, TTFT 510.54 ms, TPOT 24.07 ms, output throughput 35.35 tok/s.
- Failure analysis: run 1 failed tasks 4 and 19; run 2 failed tasks 4, 19, and 21. Every failed response contained correct executable code but started an unclosed Markdown code fence, causing EvalScope to retain `` ```python `` and report `invalid syntax`. Removing only that leading fence makes all five failed samples pass their original HumanEval tests. The formal scores above are retained without post-processing and show output-format variability under probabilistic DSpark.
- No API, engine, OOM, or graph-replay error occurred during either 32-sample run.


<!-- extended-model-validation:end -->
