### PR TITLE
feat(eplb): common offline maps and locality-aware routing controls

### DIFF
--- a/docs/superpowers/plans/2026-09-06-common-static-eplb-direct-load.md
+++ b/docs/superpowers/plans/2026-09-06-common-static-eplb-direct-load.md
@@ -31,7 +31,7 @@
 - Modify: `vllm_hcu/patch/worker/framework_opt/__init__.py`
 - Modify: `vllm_hcu/patch/worker/__init__.py`
 - Create: `tests/runtime_patch/test_model_loader_static_eplb.py`
-- Modify: `tests/runtime_patch/test_worker_dispatcher.py`
+- Modify: `tests/patch/test_worker_dispatcher.py`
 
 **Interfaces:**
 
@@ -98,13 +98,13 @@ worker dispatcher before model-specific modules are imported.
 Run:
 
 ```bash
-pytest -q tests/model_executor/layers/fused_moe/test_static_eplb.py tests/runtime_patch/test_model_loader_static_eplb.py tests/runtime_patch/test_worker_dispatcher.py
+pytest -q tests/model_executor/layers/fused_moe/test_static_eplb.py tests/runtime_patch/test_model_loader_static_eplb.py tests/patch/test_worker_dispatcher.py
 ```
 
 Expected: all tests pass.  Commit:
 
 ```bash
-git add vllm_hcu/model_executor/layers/fused_moe/static_eplb.py vllm_hcu/patch/worker/framework_opt/patch_model_loader_static_eplb.py vllm_hcu/patch/worker/framework_opt/__init__.py vllm_hcu/patch/worker/__init__.py tests/runtime_patch/test_model_loader_static_eplb.py tests/runtime_patch/test_worker_dispatcher.py
+git add vllm_hcu/model_executor/layers/fused_moe/static_eplb.py vllm_hcu/patch/worker/framework_opt/patch_model_loader_static_eplb.py vllm_hcu/patch/worker/framework_opt/__init__.py vllm_hcu/patch/worker/__init__.py tests/runtime_patch/test_model_loader_static_eplb.py tests/patch/test_worker_dispatcher.py
 git commit -m "feat(eplb): bind static plans before common model loading"
 ```
 
@@ -379,7 +379,7 @@ pytest -q \
   tests/runtime_patch/test_moe_deepep.py \
   tests/runtime_patch/test_offline_eplb.py \
   tests/runtime_patch/test_platform_hcu_config.py \
-  tests/runtime_patch/test_worker_dispatcher.py
+  tests/patch/test_worker_dispatcher.py
 python -m compileall -q vllm_hcu
 git diff --check feat/hy-v4-mtp-blockwise-v0251..HEAD
 ```

--- a/docs/superpowers/plans/2026-09-06-common-static-eplb-direct-load.md
+++ b/docs/superpowers/plans/2026-09-06-common-static-eplb-direct-load.md
@@ -1,0 +1,446 @@
+# Common Static EPLB Direct-Load Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Direct-load offline EPLB checkpoint experts through the common MoE weight-loading layer for every compatible model, retain thin hooks only for exceptional checkpoint layouts, and validate the original `--eplb-config` CLI syntax.
+
+**Architecture:** A common pre-load binder creates one immutable `StaticEplbPlan` after model construction and attaches its rows to standard `RoutedExperts` layers. Common expert mappings enumerate logical experts, while the routed-expert weight loader fans each checkpoint tensor out to all mapped local physical slots; exceptional HY V4 fused tensors use the same fan-out helper through a thin adapter. Runtime registration requires the pre-load plan and commits only routing metadata, with no compatibility redistribution fallback.
+
+**Tech Stack:** Python 3.10, PyTorch, vLLM 0.25.1 model-loader and EPLB APIs, pytest, HCU/DeepEP runtime.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-common-static-eplb-direct-load-design.md`
+
+## Global Constraints
+
+- Static-map mode must perform zero post-load expert redistribution.
+- `expert_map_record_path` and `expert_map_path` remain mutually exclusive and are documented inside `--eplb-config`.
+- No-map loading, dynamic EPLB, record mode, and profile mode preserve upstream behavior.
+- Static offline EPLB remains incompatible with elastic EP and upstream EP weight filtering.
+- Map parsing and validation are model-neutral; model-specific hooks may not parse the JSON themselves.
+- Unsupported custom MoE loaders fail before checkpoint loading instead of falling back to startup redistribution.
+- Production changes are made test-first and each task ends with a focused passing test set.
+
+---
+
+### Task 1: Bind a static plan at the common pre-load boundary
+
+**Files:**
+
+- Modify: `vllm_hcu/model_executor/layers/fused_moe/static_eplb.py`
+- Create: `vllm_hcu/patch/worker/framework_opt/patch_model_loader_static_eplb.py`
+- Modify: `vllm_hcu/patch/worker/framework_opt/__init__.py`
+- Modify: `vllm_hcu/patch/worker/__init__.py`
+- Create: `tests/runtime_patch/test_model_loader_static_eplb.py`
+- Modify: `tests/runtime_patch/test_worker_dispatcher.py`
+
+**Interfaces:**
+
+- Consumes: `maybe_load_static_eplb_plan(vllm_config, *, model_key, num_moe_layers, num_logical_experts, num_physical_experts, num_redundant_experts) -> StaticEplbPlan | None`.
+- Produces: `bind_static_eplb_plan(vllm_config: object, model: object) -> StaticEplbPlan | None` and worker patch `patch_model_loader_static_eplb.apply_to_module(module: ModuleType) -> bool`.
+- Publishes: `model._vllm_hcu_static_eplb_plan` and `routed_experts._vllm_hcu_static_eplb_row` before `model.load_weights` can run.
+
+- [ ] **Step 1: Write failing binder tests**
+
+Create fake `MixtureOfExperts`-compatible models with two `moe_layers`, each
+holding `routed_experts`, and a two-row map.  Assert:
+
+```python
+plan = bind_static_eplb_plan(config, model)
+assert model._vllm_hcu_static_eplb_plan is plan
+assert model.moe_layers[0].routed_experts._vllm_hcu_static_eplb_row == (2, 1, 0, 2)
+assert model.moe_layers[1].routed_experts._vllm_hcu_static_eplb_row == (1, 0, 2, 1)
+```
+
+Add cases for no configured path returning `None`, a non-MoE model, layer
+count mismatch, a layer without `routed_experts`, and generic error messages
+that contain no hard-coded `HY V4` prefix.
+
+- [ ] **Step 2: Run the binder tests and observe RED**
+
+Run:
+
+```bash
+pytest -q tests/model_executor/layers/fused_moe/test_static_eplb.py tests/runtime_patch/test_model_loader_static_eplb.py
+```
+
+Expected: collection fails because `bind_static_eplb_plan` and the model-loader
+patch do not exist.
+
+- [ ] **Step 3: Implement the model-neutral binder**
+
+Add this public contract to `static_eplb.py`:
+
+```python
+def bind_static_eplb_plan(
+    vllm_config: object,
+    model: object,
+) -> StaticEplbPlan | None:
+    """Validate and bind a static EPLB plan before checkpoint loading."""
+```
+
+When a load path exists, validate the `MixtureOfExperts` attributes, load the
+plan using `model.__class__.__name__`, normalize each `MoERunner` to its
+`routed_experts` object, attach rows in sequence order, and fail before any
+attribute is published if the whole model cannot be bound.  Remove HY V4 from
+generic validation messages.
+
+- [ ] **Step 4: Implement and register the initialization patch**
+
+Wrap `vllm.model_executor.model_loader.utils.initialize_model` with the exact
+audited signature.  Call the original initializer, call
+`bind_static_eplb_plan(vllm_config, model)`, and return the same model.  Patch
+already-imported aliases only after verifying identity with the original;
+otherwise raise `PatchCompatibilityError`.  Register the callback in the
+worker dispatcher before model-specific modules are imported.
+
+- [ ] **Step 5: Verify GREEN and commit**
+
+Run:
+
+```bash
+pytest -q tests/model_executor/layers/fused_moe/test_static_eplb.py tests/runtime_patch/test_model_loader_static_eplb.py tests/runtime_patch/test_worker_dispatcher.py
+```
+
+Expected: all tests pass.  Commit:
+
+```bash
+git add vllm_hcu/model_executor/layers/fused_moe/static_eplb.py vllm_hcu/patch/worker/framework_opt/patch_model_loader_static_eplb.py vllm_hcu/patch/worker/framework_opt/__init__.py vllm_hcu/patch/worker/__init__.py tests/runtime_patch/test_model_loader_static_eplb.py tests/runtime_patch/test_worker_dispatcher.py
+git commit -m "feat(eplb): bind static plans before common model loading"
+```
+
+### Task 2: Fan logical checkpoint experts out in common `RoutedExperts`
+
+**Files:**
+
+- Modify: `vllm_hcu/model_executor/layers/fused_moe/static_eplb.py`
+- Modify: `vllm_hcu/patch/worker/op_opt/moe/patch_layer.py`
+- Modify: `tests/runtime_patch/test_moe_deepep.py`
+- Modify: `tests/model_executor/layers/fused_moe/test_static_eplb.py`
+
+**Interfaces:**
+
+- Consumes: `routed_experts._vllm_hcu_static_eplb_row: tuple[int, ...]` from Task 1.
+- Produces: `load_static_logical_expert(routed_experts, original_weight_loader, *, param, loaded_weight, weight_name, shard_id, logical_expert_id, return_success) -> bool | None`.
+- Preserves: original `RoutedExperts.get_expert_mapping`, `RoutedExperts.make_expert_params_mapping`, and `RoutedExperts.weight_loader` behavior when no row is bound.
+
+- [ ] **Step 1: Write failing common-loader tests**
+
+Extend the fake routed-expert class used by `test_moe_deepep.py` with an
+original loader that records physical IDs.  Bind rows `(2, 1, 0, 2)` and
+`(1, 0, 2, 1)` to two instances.  For logical expert `2`, assert the first
+instance loads physical IDs `[0, 3]` and the second loads `[2]`.  Add:
+
+```python
+assert patched.weight_loader(
+    param, tensor, "w13_weight", "w1", 2, return_success=True
+) is True
+```
+
+Cover a rank where none of the mapped physical slots are local, duplicate
+logical experts, `return_success=False`, split mapping generation, standard
+fused tensors, scale names, and no-row byte-for-byte delegation.
+
+- [ ] **Step 2: Run the common-loader tests and observe RED**
+
+Run:
+
+```bash
+pytest -q tests/runtime_patch/test_moe_deepep.py -k 'static_eplb or layer_patch'
+```
+
+Expected: the patched loader calls only the upstream initial-layout physical
+ID and fails the mapped-slot assertions.
+
+- [ ] **Step 3: Implement the shared fan-out helper**
+
+Add a helper that iterates `enumerate(row)`, selects entries equal to
+`logical_expert_id`, and calls the original loader once per selected physical
+slot with `return_success=True`.  Return `True` if at least one local slot was
+loaded, `False` if none was local, and `None` when the caller did not request a
+success result.  Validate logical IDs against the bound plan before copying.
+
+- [ ] **Step 4: Patch all three common mapping/loading entry points**
+
+In `patch_layer.py`, audit and wrap:
+
+```python
+RoutedExperts.weight_loader
+RoutedExperts.get_expert_mapping
+RoutedExperts.make_expert_params_mapping
+```
+
+With a static row, mapping methods call the existing mapping builder with
+`num_redundant_experts=0`, so tuple `expert_id` values represent checkpoint
+logical IDs exactly once.  Preserve the upstream fused-prefix tuples from
+`include_fused=True`; their shard indices remain shard selectors, while the
+logical IDs generated by unbinding the fused tensor are expanded by the
+patched weight loader.
+
+- [ ] **Step 5: Run common MoE regression tests and commit**
+
+Run:
+
+```bash
+pytest -q tests/runtime_patch/test_moe_deepep.py tests/model_executor/layers/fused_moe/test_static_eplb.py
+```
+
+Expected: all tests pass.  Commit:
+
+```bash
+git add vllm_hcu/model_executor/layers/fused_moe/static_eplb.py vllm_hcu/patch/worker/op_opt/moe/patch_layer.py tests/runtime_patch/test_moe_deepep.py tests/model_executor/layers/fused_moe/test_static_eplb.py
+git commit -m "feat(eplb): direct-load experts in common MoE layer"
+```
+
+### Task 3: Reduce HY V4 to exceptional fused-checkpoint hooks
+
+**Files:**
+
+- Modify: `vllm_hcu/models/hy_v4/model.py`
+- Modify: `vllm_hcu/models/hy_v4/mtp.py`
+- Modify: `vllm_hcu/model_executor/layers/fused_moe/static_eplb.py`
+- Modify: `tests/models/hy_v4/test_eplb.py`
+- Modify: `tests/models/hy_v4/test_weight_loading.py`
+- Modify: `tests/models/hy_v4/test_mtp.py`
+- Create: `tests/models/test_common_static_eplb_models.py`
+
+**Interfaces:**
+
+- Consumes: the bound plan/rows and `load_static_logical_expert` from Tasks 1-2.
+- Produces: HY V4 target/MTP fused adapters that accept a logical checkpoint expert ID and delegate slot fan-out to the common helper.
+- Removes: constructor calls to `maybe_load_static_eplb_plan`, private per-weight layer-name parsing, and duplicated split mapping generation from HY V4 files.
+
+- [ ] **Step 1: Change HY V4 tests to require common binding**
+
+Replace constructor assertions with a fake common-binder invocation and assert
+that target and MTP wrappers publish the same plan object as their inner model.
+For fused tensors containing distinguishable logical rows, assert each target
+physical slot equals `loaded_weight[plan.layer_map(layer)[physical_id]]` for
+weights, weight scales, and input scales.
+
+- [ ] **Step 2: Add a representative non-HY-V4 test and observe RED**
+
+Build a lightweight fake around `DeepseekV2MixtureOfExperts` or the audited
+DeepSeek loader mapping shape.  Bind a non-default row and assert its standard
+parameter loader receives only mapped local physical slots without importing
+or calling an HY V4 helper.  Run:
+
+```bash
+pytest -q tests/models/test_common_static_eplb_models.py tests/models/hy_v4/test_eplb.py tests/models/hy_v4/test_weight_loading.py tests/models/hy_v4/test_mtp.py
+```
+
+Expected: HY V4 still depends on constructor-specific direct-loading branches,
+so the new common-binding assertions fail.
+
+- [ ] **Step 3: Refactor HY V4 split loading to the common path**
+
+Remove `static_eplb_layer_map_for_weight` and
+`build_expert_params_mapping_for_row` calls from target and MTP split loading.
+Let `fused_moe_make_expert_params_mapping` emit logical IDs and let the bound
+common parameter loader perform row-specific fan-out.
+
+- [ ] **Step 4: Keep only the pre-fused tensor adapter**
+
+For a pre-fused `[logical_expert, ...]` tensor, iterate logical IDs and invoke
+the common fan-out helper through the destination routed-expert loader.  Do not
+re-parse the checkpoint layer number or map JSON.  Preserve the original path
+when no row is bound.
+
+- [ ] **Step 5: Audit other HCU MoE model loaders**
+
+Inspect DeepSeek V2/V4, HY V3, GLM4 MoE, and their MTP loaders.  For every
+loader ending in standard `param.weight_loader(... expert_id=...)`, add the
+representative common-path assertion only.  If a loader directly slices a
+fused all-expert tensor, add a thin adapter test and hook using the same common
+fan-out helper.  A model with neither route receives an explicit pre-load
+compatibility error test.
+
+- [ ] **Step 6: Verify tensor equivalence and commit**
+
+Run:
+
+```bash
+pytest -q tests/models/test_common_static_eplb_models.py tests/models/hy_v4/test_eplb.py tests/models/hy_v4/test_weight_loading.py tests/models/hy_v4/test_mtp.py
+```
+
+Expected: all tests pass, including bitwise equality between direct load and
+default load followed by rearrangement.  Commit:
+
+```bash
+git add vllm_hcu/models/hy_v4/model.py vllm_hcu/models/hy_v4/mtp.py vllm_hcu/model_executor/layers/fused_moe/static_eplb.py tests/models/test_common_static_eplb_models.py tests/models/hy_v4/test_eplb.py tests/models/hy_v4/test_weight_loading.py tests/models/hy_v4/test_mtp.py
+git commit -m "refactor(hy-v4): reuse common static EPLB loading"
+```
+
+### Task 4: Remove static-map redistribution fallback and lock the public CLI
+
+**Files:**
+
+- Modify: `vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py`
+- Modify: `tests/runtime_patch/test_offline_eplb.py`
+- Modify: `tests/runtime_patch/test_platform_hcu_config.py`
+
+**Interfaces:**
+
+- Consumes: `model._vllm_hcu_static_eplb_plan` bound before checkpoint loading.
+- Produces: static runtime registration that either commits that plan with zero transfer or raises `PatchCompatibilityError`.
+- Preserves: record-mode policy calculation/file output and no-path dynamic EPLB behavior.
+
+- [ ] **Step 1: Write failing no-fallback runtime tests**
+
+Change the existing non-HY-V4 compatibility test so a configured static path
+without an attached plan must raise:
+
+```python
+with pytest.raises(PatchCompatibilityError, match="before checkpoint loading"):
+    state.add_model(model, model_config)
+assert rearrangements == []
+```
+
+Retain tests proving a valid generic plan commits metadata, performs the
+cross-rank fingerprint check/barrier, and never calls rearrangement.  Retain
+dynamic and record-mode pass-through tests.
+
+- [ ] **Step 2: Run runtime tests and observe RED**
+
+Run:
+
+```bash
+pytest -q tests/runtime_patch/test_offline_eplb.py
+```
+
+Expected: the old compatibility branch calls
+`rearrange_expert_weights_inplace` instead of raising.
+
+- [ ] **Step 3: Remove the compatibility redistribution branch**
+
+In `hcu_add_model`, require a `StaticEplbPlan` whenever `load_path` is set.
+Use model-neutral path/key/count diagnostics, verify fingerprints, call only
+`original_commit`, synchronize, and leave later static steps disabled.  Delete
+the configured-static call to `load_offline_expert_map` followed by
+`original_rearrange_weights`.
+
+- [ ] **Step 4: Strengthen original CLI syntax tests**
+
+Use fresh vLLM subprocess parsing for both keys:
+
+```python
+namespace = parser.parse_args([
+    "--eplb-config",
+    json.dumps({"window_size": 2, path_key: path_value}),
+])
+args = EngineArgs.from_cli_args(namespace)
+config = args.create_engine_config()
+assert args.eplb_config.window_size == 2
+assert getattr(get_hcu_config(config), path_key) == path_value
+```
+
+Assert the HCU-only field is absent from the official `EPLBConfig` object and
+the two paths remain mutually exclusive.
+
+- [ ] **Step 5: Verify runtime/config tests and commit**
+
+Run:
+
+```bash
+pytest -q tests/runtime_patch/test_offline_eplb.py tests/runtime_patch/test_platform_hcu_config.py
+```
+
+Expected: all tests pass.  Commit:
+
+```bash
+git add vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py tests/runtime_patch/test_offline_eplb.py tests/runtime_patch/test_platform_hcu_config.py
+git commit -m "fix(eplb): require direct loading for static maps"
+```
+
+### Task 5: Review, full verification, runtime smoke test, and PR update
+
+**Files:**
+
+- Modify if needed: `docs/superpowers/specs/2026-09-06-common-static-eplb-direct-load-design.md`
+- Modify if needed: `docs/superpowers/plans/2026-09-06-common-static-eplb-direct-load.md`
+- Remote: GitHub PR #69 title, description, and review-thread replies.
+
+**Interfaces:**
+
+- Consumes: all production and test changes from Tasks 1-4.
+- Produces: reviewed commits on `perf/deepep-ll-scheduling-bubble`, verified remote head, original-syntax record/load commands, and review evidence on PR #69.
+
+- [ ] **Step 1: Run the focused regression matrix**
+
+Run:
+
+```bash
+pytest -q \
+  tests/model_executor/layers/fused_moe/test_static_eplb.py \
+  tests/models/test_common_static_eplb_models.py \
+  tests/models/hy_v4/test_eplb.py \
+  tests/models/hy_v4/test_weight_loading.py \
+  tests/models/hy_v4/test_mtp.py \
+  tests/runtime_patch/test_model_loader_static_eplb.py \
+  tests/runtime_patch/test_moe_deepep.py \
+  tests/runtime_patch/test_offline_eplb.py \
+  tests/runtime_patch/test_platform_hcu_config.py \
+  tests/runtime_patch/test_worker_dispatcher.py
+python -m compileall -q vllm_hcu
+git diff --check feat/hy-v4-mtp-blockwise-v0251..HEAD
+```
+
+Expected: every test passes, compileall is silent, and diff-check has no
+output.
+
+- [ ] **Step 2: Review the complete diff**
+
+Review against the spec with explicit checks for: no-map exact delegation,
+all static paths bound before loading, logical/physical ID separation,
+duplicate experts, scales, MTP model keys, PP layer order, no redistribution
+fallback, record-mode preservation, and public CLI compatibility.  Fix every
+Critical or Important finding and rerun Step 1.
+
+- [ ] **Step 3: Record a map with original CLI syntax**
+
+Run the existing DP8/EP8 HY V4 command, placing the path inside the JSON:
+
+```bash
+PYTHONPATH=/models/.worktrees/vllm-plugin-das-pr62-kv-fp8 \
+vllm serve /models/Hy4-preview-Channel-FP8-w8a8-v2 \
+  --served-model-name hy4-eplb-record \
+  --data-parallel-size 8 --enable-expert-parallel \
+  --all2all-backend deepep_low_latency --enable-eplb \
+  --eplb-config '{"window_size":2,"step_interval":100,"num_redundant_experts":0,"log_balancedness":true,"log_balancedness_interval":100,"use_async":false,"policy":"default","expert_map_record_path":"/tmp/hy4-pr69-common.json"}' \
+  --enforce-eager --moe-backend deep_gemm \
+  --gpu-memory-utilization 0.9 --kv-cache-memory-bytes 67108864 \
+  --kv-cache-dtype fp8_e4m3 --max-model-len 256 \
+  --max-num-batched-tokens 16 --max-num-seqs 1 \
+  --default-chat-template-kwargs '{"reasoning_effort":"no_think"}' \
+  --reasoning-parser hy_v4 --enable-auto-tool-choice \
+  --tool-call-parser hy_v4 --disable-log-stats --port 10187
+```
+
+Require a valid map, successful health/chat requests, and zero transfer,
+shared-memory timeout, traceback, or worker failure during recording.
+
+- [ ] **Step 4: Direct-load the recorded map with original CLI syntax**
+
+Run the same command with:
+
+```bash
+--served-model-name hy4-eplb-static \
+--eplb-config '{"window_size":2,"step_interval":100,"num_redundant_experts":0,"log_balancedness":true,"log_balancedness_interval":100,"use_async":false,"policy":"default","expert_map_path":"/tmp/hy4-pr69-common.json"}'
+```
+
+Require all eight ranks to report the same plan digest and zero expert
+rearrangement, plus HTTP 200 health/chat and zero shared-memory timeout, RPC
+timeout, traceback, or worker failure.
+
+- [ ] **Step 5: Verify, push, and update PR #69**
+
+Invoke verification-before-completion, then push:
+
+```bash
+git push origin perf/deepep-ll-scheduling-bubble
+git ls-remote origin refs/heads/perf/deepep-ll-scheduling-bubble
+```
+
+Update the PR title to describe common MoE direct loading.  Replace all
+`--additional-config` examples with the exact original-syntax commands from
+Steps 3-4.  Report unit/runtime evidence and the dual-node caveat, and reply to
+both review comments with the commit and validation summary.

--- a/docs/superpowers/plans/2026-09-06-hyv4-static-eplb-direct-load.md
+++ b/docs/superpowers/plans/2026-09-06-hyv4-static-eplb-direct-load.md
@@ -1,0 +1,240 @@
+# HY V4 Static EPLB Direct-Load Implementation Plan
+
+> Execute this plan task by task with tests failing before the corresponding
+> production change.  Keep the legacy post-load rearrangement path for models
+> that do not opt in to direct loading.
+
+**Goal:** Make HY V4 target and native MTP load checkpoint experts directly
+into the physical slots in a configured offline EPLB map, then register that
+map without any cross-rank expert rearrangement.
+
+**Architecture:** A neutral `StaticEplbPlan` parser owns map validation and
+fingerprinting.  HY V4 loaders attach a validated plan before consuming
+weights and use a layer-specific physical-to-logical row for split and fused
+expert tensors.  The EPLB runtime patch detects the plan, verifies it across
+EP ranks, commits routing metadata, and skips rearrangement; other model
+families retain the compatibility path.
+
+**Tech stack:** Python 3.10, PyTorch, vLLM EPLB APIs, pytest.
+
+---
+
+## Task 1: Add the immutable static-map plan and parser
+
+**Files:**
+
+- Create: `vllm_hcu/model_executor/layers/fused_moe/static_eplb.py`
+- Create: `tests/model_executor/layers/fused_moe/test_static_eplb.py`
+- Modify: `vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py`
+- Modify: `tests/runtime_patch/test_offline_eplb.py`
+
+1. Write tests that create v2 target/MTP maps and assert the returned plan has
+   a canonical path, SHA-256 digest, exact counts, an `int64` CPU tensor, and a
+   stable fingerprint.  Add failing cases for missing model keys, booleans or
+   floating IDs, shape mismatch, out-of-range IDs, missing logical experts,
+   and a redundant-count mismatch.  Add a cache-invalidation test that
+   rewrites the file and observes a new digest/map.
+2. Run:
+
+   ```bash
+   pytest -q tests/model_executor/layers/fused_moe/test_static_eplb.py
+   ```
+
+   Confirm collection/import fails because the helper does not exist.
+3. Implement this public contract:
+
+   ```python
+   @dataclass(frozen=True)
+   class StaticEplbPlan:
+       model_key: str
+       source_path: str
+       source_sha256: str
+       physical_to_logical_map: torch.Tensor
+       num_logical_experts: int
+       num_physical_experts: int
+       num_redundant_experts: int
+
+       def fingerprint(self) -> tuple[str, str, tuple[int, int], int, int, int]: ...
+       def layer_map(self, layer_idx: int) -> tuple[int, ...]: ...
+
+   def load_static_eplb_plan(
+       path: str | Path,
+       *,
+       model_key: str,
+       expected_shape: tuple[int, int],
+       num_logical_experts: int,
+       num_redundant_experts: int,
+   ) -> StaticEplbPlan: ...
+   ```
+
+   Cache decoded bytes by canonical path plus `(st_dev, st_ino, st_size,
+   st_mtime_ns)`; compute the digest from the exact bytes.  Clone the validated
+   CPU tensor on plan construction and return tuple rows from `layer_map` so a
+   caller cannot mutate cached state.  Keep legacy single-model JSON behavior,
+   including selecting the final rows for MTP.
+4. Make `load_offline_expert_map` delegate to the neutral parser so existing
+   imports and non-HY-V4 compatibility behavior remain intact.
+5. Run both focused suites and commit:
+
+   ```bash
+   pytest -q tests/model_executor/layers/fused_moe/test_static_eplb.py tests/runtime_patch/test_offline_eplb.py
+   git add vllm_hcu/model_executor/layers/fused_moe/static_eplb.py tests/model_executor/layers/fused_moe/test_static_eplb.py vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py tests/runtime_patch/test_offline_eplb.py
+   git commit -m "feat(eplb): add validated static expert plans"
+   ```
+
+## Task 2: Attach plans before HY V4 checkpoint loading
+
+**Files:**
+
+- Modify: `vllm_hcu/model_executor/layers/fused_moe/static_eplb.py`
+- Modify: `vllm_hcu/models/hy_v4/model.py`
+- Modify: `vllm_hcu/models/hy_v4/mtp.py`
+- Modify: `tests/models/hy_v4/test_eplb.py`
+
+1. Add failing tests for target and MTP constructors using a minimal fake
+   config.  Assert that a configured path attaches `_vllm_hcu_static_eplb_plan`
+   to both the EPLB wrapper and the actual object that implements
+   `load_weights`, while an absent path leaves the attribute unset.
+2. Add a helper which reads `_vllm_hcu_expert_map_path` from
+   `vllm_config.parallel_config`, verifies EPLB/expert-parallel prerequisites,
+   rejects `enable_ep_weight_filter=True` with a precise compatibility error,
+   and loads the plan using the model's observed MoE layer/expert counts.
+3. At the end of `HYV4Model` and `HYV4MultiTokenPredictor` construction, attach
+   the target (`HYV4ForCausalLM`) or draft (`HYV4MTP`) plan.  The wrappers must
+   expose the same object so runtime registration can find it without knowing
+   the internal model layout.
+4. Run and commit:
+
+   ```bash
+   pytest -q tests/models/hy_v4/test_eplb.py tests/models/hy_v4/test_runtime_config.py tests/models/hy_v4/test_mtp_config.py
+   git add vllm_hcu/model_executor/layers/fused_moe/static_eplb.py vllm_hcu/models/hy_v4/model.py vllm_hcu/models/hy_v4/mtp.py tests/models/hy_v4/test_eplb.py
+   git commit -m "feat(hy-v4): attach static EPLB plans before load"
+   ```
+
+## Task 3: Direct-load split and fused expert checkpoints
+
+**Files:**
+
+- Modify: `vllm_hcu/model_executor/layers/fused_moe/static_eplb.py`
+- Modify: `vllm_hcu/models/hy_v4/model.py`
+- Modify: `vllm_hcu/models/hy_v4/mtp.py`
+- Modify: `tests/models/hy_v4/test_eplb.py`
+- Modify: `tests/models/hy_v4/test_weight_loading.py`
+- Modify: `tests/models/hy_v4/test_mtp.py`
+
+1. Extend the existing fused-loader tests with distinct layer maps such as
+   `(3, 2, 1, 0, 3, 2)`.  Assert every physical slot receives the checkpoint
+   tensor for the mapped logical ID, for target and MTP, including `w1`, `w2`,
+   `w3`, weight scales, and input/activation scales.
+2. Add split-format tests for two MoE layers with different rows.  A checkpoint
+   name containing `layers.<absolute_layer>.experts.<logical>` must call the
+   weight loader once for every matching physical slot in that layer, including
+   duplicate replicas, and never use another layer's row.
+3. Implement helpers to extract the absolute layer number from a weight name
+   and map it to the MoE-row order recorded at construction.  Replace the
+   default modulo rule in both fused loaders with:
+
+   ```python
+   logical_expert_id = (
+       physical_to_logical[physical_expert_id]
+       if physical_to_logical is not None
+       else physical_expert_id % num_experts
+   )
+   ```
+
+4. Generate split mappings per map row: for checkpoint logical expert `l`,
+   emit a tuple for every physical slot `p` where `row[p] == l`.  Preserve the
+   upstream mapping when no static plan is attached.
+5. Add a tensor-level equivalence test.  Simulate the previous default-layout
+   load followed by rearrangement and compare every final physical-slot tensor
+   bit-for-bit with direct load for the same map.
+6. Run and commit:
+
+   ```bash
+   pytest -q tests/models/hy_v4/test_eplb.py tests/models/hy_v4/test_weight_loading.py tests/models/hy_v4/test_mtp.py
+   git add vllm_hcu/model_executor/layers/fused_moe/static_eplb.py vllm_hcu/models/hy_v4/model.py vllm_hcu/models/hy_v4/mtp.py tests/models/hy_v4/test_eplb.py tests/models/hy_v4/test_weight_loading.py tests/models/hy_v4/test_mtp.py
+   git commit -m "perf(hy-v4): load static EPLB experts directly"
+   ```
+
+## Task 4: Commit direct-loaded maps without expert transfer
+
+**Files:**
+
+- Modify: `vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py`
+- Modify: `tests/runtime_patch/test_offline_eplb.py`
+
+1. Change the static-load runtime regression test to attach a valid plan and
+   assert `rearrangements == []`, map metadata is committed, dynamic steps are
+   disabled, and a synchronization barrier is reached.  Add tests for a plan
+   fingerprint mismatch and for the legacy non-HY-V4 path still rearranging.
+2. Implement `_find_static_eplb_plan(model)` and startup-only rank
+   synchronization.  Exchange a deterministic UTF-8 fingerprint through the
+   EP group's CPU process group when available; otherwise use a fixed-size
+   `uint8` tensor on the EP device group.  Raise before commit if any rank
+   differs, and call a device-group barrier after commit.
+3. In `hcu_add_model`, verify the attached plan matches the configured path,
+   model key, and EPLB-state shape/counts.  For a valid direct plan, call only:
+
+   ```python
+   original_commit(model_state, new_physical_to_logical_map=plan.map_for(...))
+   ```
+
+   Do not invoke `rearrange_expert_weights_inplace`.  Preserve the current
+   load-and-rearrange compatibility path when no direct plan is attached.
+4. Log one unambiguous message containing `direct-loaded`, the model key, map
+   digest, and `zero expert rearrangement`, making runtime verification
+   searchable.
+5. Run and commit:
+
+   ```bash
+   pytest -q tests/runtime_patch/test_offline_eplb.py tests/models/hy_v4/test_eplb.py
+   git add vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py tests/runtime_patch/test_offline_eplb.py
+   git commit -m "fix(eplb): commit HY V4 static maps without transfer"
+   ```
+
+## Task 5: Focused and broad verification
+
+**Files:** No production changes unless a regression is found.
+
+1. Run focused tests:
+
+   ```bash
+   pytest -q tests/runtime_patch/test_offline_eplb.py tests/models/hy_v4/test_eplb.py tests/models/hy_v4/test_weight_loading.py tests/models/hy_v4/test_mtp.py tests/models/hy_v4/test_runtime_config.py tests/models/hy_v4/test_mtp_config.py tests/runtime_patch/test_multiproc_executor.py tests/runtime_patch/test_worker_dispatcher.py
+   ```
+
+2. Run syntax and repository hygiene checks:
+
+   ```bash
+   python -m compileall -q vllm_hcu
+   git diff --check b52da21..HEAD
+   ```
+
+3. Review the complete diff against the approved design, with special
+   attention to no-map behavior, record mode, dynamic EPLB, MTP map selection,
+   and exception behavior.  Fix and retest any issue before claiming success.
+
+## Task 6: One-node full-model validation and PR update
+
+**Files:** Runtime logs and temporary request outputs stay outside git.
+
+1. Start `/models/Hy4-preview-Channel-FP8-w8a8-v2` on all eight local HCUs with
+   the existing verified launch settings: DP8/EP8, native MTP2, static EPLB
+   map, `fp8_e4m3` KV cache, DeepGEMM, and a deliberately short EPLB
+   `step_interval`.
+2. Wait for API readiness while continuously checking worker exits.  Send
+   deterministic chat/completions requests and require HTTP 200 responses.
+3. Inspect the complete log and require:
+
+   - target and MTP direct-load messages,
+   - zero `rearrange_expert_weights_inplace` or transfer operations,
+   - zero dynamic EPLB map commits after startup,
+   - zero `No available shared memory broadcast block` messages,
+   - zero traceback or engine/RPC timeout.
+
+4. Compare the generated first tokens with the prior legacy-layout result and
+   report exact matches.  If a second node is unavailable, state explicitly
+   that the root two-node timeout is structurally removed and unit/single-node
+   verified, but dual-node validation remains pending.
+5. Push all commits to `perf/deepep-ll-scheduling-bubble`, verify the remote
+   head, and update PR #69 with the design, test evidence, actual launch
+   command, and remaining dual-node caveat.

--- a/docs/superpowers/specs/2026-09-06-common-static-eplb-direct-load-design.md
+++ b/docs/superpowers/specs/2026-09-06-common-static-eplb-direct-load-design.md
@@ -1,0 +1,216 @@
+# Common Static EPLB Direct-Load Design
+
+## Problem
+
+PR #69 removes the startup expert redistribution for HY V4 by loading
+checkpoint experts directly into the physical slots selected by an offline
+EPLB map.  The implementation currently attaches the map in HY V4 target and
+MTP constructors and performs the remapping in their private weight loaders.
+Other models implementing vLLM's `MixtureOfExperts` interface still load the
+initial placement and enter the compatibility redistribution path during
+`EplbState.add_model`.  On a multi-node deployment that transfer can block
+workers long enough to exhaust the scheduler-output shared-memory broadcast
+blocks.
+
+The command examples also put `expert_map_record_path` and `expert_map_path`
+in `--additional-config`, even though the established public interface puts
+all offline EPLB fields in `--eplb-config`.  The parser already extracts those
+plugin fields before constructing vLLM's official `EPLBConfig`, so the code and
+documentation currently describe different interfaces.
+
+## Goals
+
+1. Make direct checkpoint loading the required static-map path for every model
+   that supports vLLM offline EPLB through `MixtureOfExperts` and the standard
+   routed-expert weight-loader contract.
+2. Keep model-specific code only for checkpoint layouts that bypass the
+   standard routed-expert loader, such as HY V4's pre-fused expert tensors.
+3. Remove startup expert redistribution as a fallback for configured static
+   maps.  Unsupported models must fail before checkpoint loading with an
+   actionable error instead of entering the potentially hanging transfer.
+4. Preserve ordinary loading, dynamic EPLB, plan-only recording, and profile
+   behavior when no static map is configured.
+5. Keep `expert_map_record_path` and `expert_map_path` in `--eplb-config` as
+   the documented and validated public CLI interface.
+
+## Non-goals
+
+- Changing the EPLB placement policy or recorded JSON schema.
+- Rewriting checkpoint files on disk.
+- Supporting static maps together with elastic EP.
+- Making DeepEP low-latency accept unsupported redundant-expert counts.
+- Changing inference-time kernels, KV-cache formats, or quantization policy.
+
+## Architecture
+
+### 1. Model-independent static plan
+
+`StaticEplbPlan` remains the immutable, cached representation of one model's
+physical-to-logical map.  Its validation and diagnostics become model-neutral:
+no helper or exception identifies HY V4 unless the supplied model key itself
+is HY V4.
+
+The plan continues to contain the canonical path, file digest, model key,
+expert counts, and one map row per MoE layer.  It accepts the existing v2
+multi-model file and legacy single-model file.  Structural validation occurs
+before any checkpoint tensor is consumed.
+
+### 2. Common pre-load binding
+
+A worker patch wraps vLLM's common model-initialization boundary.  After the
+model object has been constructed and before any model loader invokes
+`model.load_weights`, the wrapper performs the following operation when
+`expert_map_path` is configured:
+
+1. Require the returned model to satisfy vLLM's `MixtureOfExperts` contract.
+2. Load a plan using `model.__class__.__name__` and the model's observed MoE
+   layer and expert counts.
+3. Require `len(model.moe_layers) == model.num_moe_layers`.
+4. Attach the immutable plan to the model and attach exactly one plan row to
+   each layer's standard `RoutedExperts` object in `model.moe_layers` order.
+5. Verify that every layer exposes the common expert-loading contract or an
+   explicitly registered model hook.
+
+The layer order is intentionally the same order used later by
+`MixtureOfExperts.set_eplb_state`.  This avoids parsing architecture-specific
+checkpoint layer numbers in the common path.  Pipeline-local models use the
+map rows represented by their `moe_layers` sequence; model-specific row
+selection is permitted only when a model's public sequence is not sufficient.
+
+The initialization wrapper is installed before vLLM model-loader modules are
+imported.  Compatibility checks verify the audited v0.25.1 function signature
+and any already-imported aliases, so a stale or partially applied patch fails
+at worker setup rather than silently loading the wrong layout.
+
+### 3. Logical-expert loading in `RoutedExperts`
+
+The common MoE weight-loading layer owns static remapping:
+
+- Without a bound static row, `RoutedExperts` delegates unchanged to vLLM.
+- With a bound row, expert mappings enumerate each checkpoint logical expert
+  once instead of encoding the initial redundant-expert placement.
+- The bound parameter `weight_loader` expands one checkpoint logical expert
+  to every physical slot whose map-row value equals that logical ID.  The
+  existing vLLM global-to-local expert map decides which slots are local to the
+  current EP rank, so checkpoint tensors are never transferred between ranks.
+- Standard split checkpoints and standard all-expert fused tensors use this
+  same path.  Weights, weight scales, input scales, and metadata handled by
+  the existing loader receive identical logical-to-physical expansion.
+
+The legacy `fused_moe_make_expert_params_mapping(model, ...)` entry point is
+also routed through the common behavior.  This covers models with hand-written
+outer `load_weights` loops as long as they delegate the final tensor copy to a
+standard `RoutedExperts.weight_loader`.
+
+### 4. Model-specific hooks
+
+A model-specific hook is required only when checkpoint code copies or slices
+expert tensors without delegating logical expert IDs to the standard routed
+expert loader.  The hook receives the already validated common plan and uses
+the common row/fan-out helper; it must not parse JSON or implement its own map
+validation.
+
+HY V4 target and MTP retain thin adapters for their pre-fused checkpoint
+tensors.  Their constructor-specific plan loading and duplicated split-map
+builders are removed.  Other HCU MoE models are audited against the standard
+contract.  Any model that needs an adapter gets a focused hook and regression
+test; otherwise it inherits direct loading without model-file changes.
+
+### 5. EPLB runtime registration
+
+`EplbState.add_model` remains responsible only for runtime metadata.  When a
+static path is configured it requires the common pre-load plan, verifies the
+path, model key, counts, shape, and cross-rank fingerprint, then calls
+`_commit_eplb_maps` without calling `rearrange_expert_weights_inplace`.
+
+The previous no-plan compatibility redistribution is removed for static-map
+mode.  Reaching runtime registration without a plan is a compatibility error,
+because the model weights can no longer be proven to match the configured map.
+Static `step` remains disabled for the lifetime of the service.  Dynamic EPLB
+and record mode continue to use their existing paths.
+
+## Public CLI contract
+
+The public commands place the plugin-owned path in the same JSON object as the
+official EPLB options:
+
+```bash
+--eplb-config '{"window_size":2,"step_interval":100,"num_redundant_experts":0,"use_async":false,"policy":"default","expert_map_record_path":"/tmp/eplb-map.json"}'
+```
+
+or:
+
+```bash
+--eplb-config '{"window_size":2,"step_interval":100,"num_redundant_experts":0,"use_async":false,"policy":"default","expert_map_path":"/tmp/eplb-map.json"}'
+```
+
+The EngineArgs adapter extracts the two HCU-only keys before calling the
+official `EPLBConfig` parser and stores them in the HCU sidecar internally.
+That storage detail is not a public migration requirement.  The two paths
+remain mutually exclusive.  Existing programmatic sidecar input remains
+backward compatible, but PR examples and validation use only
+`--eplb-config`.
+
+## Error handling
+
+- A missing or malformed map, wrong model key, invalid expert ID, count/shape
+  mismatch, or missing logical expert fails before checkpoint loading.
+- A model that does not implement `MixtureOfExperts` while a static path is
+  configured fails before checkpoint loading.
+- A MoE layer that exposes neither standard `RoutedExperts` loading nor an
+  audited model hook fails with the model and layer type in the message.
+- `enable_ep_weight_filter` remains rejected because upstream filtering does
+  not express a different logical-expert set for every layer.
+- A missing plan at `EplbState.add_model` fails closed; it never triggers
+  startup redistribution.
+- Cross-rank fingerprint disagreement fails before routing metadata commit.
+- When no static path is configured, the wrapper and common loader are strict
+  no-ops and preserve upstream errors and return values.
+
+## Testing
+
+All behavior changes follow red-green TDD.
+
+1. Plan tests verify model-neutral diagnostics and immutable per-layer rows.
+2. Initialization-patch tests verify plan binding before weight loading for a
+   generic fake `MixtureOfExperts`, no-map pass-through, incompatible models,
+   layer-count mismatches, and idempotent patching.
+3. Common `RoutedExperts` tests verify two layers with different maps,
+   duplicate logical experts, per-rank slot filtering, split checkpoints,
+   fused checkpoints, scales, and unchanged no-map behavior.
+4. A representative non-HY-V4 HCU model test verifies it acquires direct load
+   through the common path without a private static-map implementation.
+5. HY V4 target and MTP tests verify their exceptional fused layouts use the
+   shared plan and produce tensors bitwise equal to default load followed by
+   rearrangement.
+6. EPLB runtime tests require zero rearrangement for every static-map model and
+   require a hard failure when the pre-load plan is absent.
+7. Real CLI parser tests cover both record and direct-load JSON using only
+   `--eplb-config`.
+
+## Runtime validation
+
+Run a single-node DP8/EP8 record-to-load smoke test with
+`/models/Hy4-preview-Channel-FP8-w8a8-v2`, `deepep_low_latency`, DeepGEMM,
+`fp8_e4m3` KV cache, and the original `--eplb-config` syntax.  Record mode must
+write a valid map after a short interval without transferring weights.  Static
+mode must load the same map on all ranks, answer health and deterministic chat
+requests, log zero expert rearrangements, and show no shared-memory 60-second
+warning, RPC timeout, traceback, or worker failure.
+
+Focused unit suites, worker-dispatch subprocess tests, `compileall`, and
+`git diff --check` must pass before push.  The PR description will contain the
+exact commands used and explicitly retain the dual-node acceptance caveat if a
+second node is unavailable.
+
+## Success criteria
+
+- Static-map startup has no post-load expert redistribution path.
+- Standard MoE models direct-load mapped experts through the common
+  `RoutedExperts` layer without model-specific JSON handling.
+- HY V4 target and MTP use only thin hooks for their exceptional fused layout.
+- Recorded and loaded map commands work with paths inside `--eplb-config`.
+- Static-map routing metadata matches the physical tensors before the service
+  becomes ready, and later dynamic rearrangement remains disabled.
+- Tests and the single-node full-model smoke validation pass before PR #69 is
+  updated.

--- a/docs/superpowers/specs/2026-09-06-hyv4-static-eplb-direct-load-design.md
+++ b/docs/superpowers/specs/2026-09-06-hyv4-static-eplb-direct-load-design.md
@@ -1,0 +1,189 @@
+# HY V4 Static EPLB Direct-Load Design
+
+## Problem
+
+The HCU offline EPLB adapter currently applies a static expert map after model
+weights have been loaded with vLLM's default physical-to-logical layout.  Its
+`EplbState.add_model` wrapper calls `rearrange_expert_weights_inplace` to move
+all target and MTP expert weights into the saved layout and only then commits
+the map.
+
+For HY V4 this means transferring 77 target MoE layers plus the MTP layer.
+On two nodes, one or more workers can remain inside the NIXL/UCX transfer long
+enough that the engine's scheduler-output ring buffer is not consumed.  vLLM
+then emits `No available shared memory broadcast block found in 60 seconds`,
+and a later RPC or engine deadline can fail the request.  Increasing the
+ring-buffer warning interval hides the symptom but does not remove the
+transfer or control-plane stall.
+
+## Scope
+
+This change makes static offline EPLB direct-load authoritative for the HCU
+HY V4 target model and its native MTP model.  It covers both split per-expert
+checkpoints and fused all-expert tensors, including FP8 weights and scales.
+
+Dynamic EPLB, offline recording, elastic-EP rejection, and non-HY-V4 models
+retain their existing behavior.  This change does not alter expert-selection
+policy, generate a new map, change KV-cache precision, or change DeepEP's
+high-throughput/low-latency selection.
+
+## Goals
+
+1. Load each HY V4 physical expert slot directly from the logical expert named
+   by the static map.
+2. Commit the same map into vLLM EPLB routing state without calling any expert
+   weight rearrangement function.
+3. Validate the map before it can influence checkpoint loading and verify that
+   all EP ranks use identical map content before the service becomes ready.
+4. Keep a static map immutable for the lifetime of the loaded model.
+5. Preserve current dynamic EPLB and record-mode semantics.
+6. Fail clearly instead of silently falling back to a mismatched layout.
+
+## Non-goals
+
+- A generic direct-load implementation for every upstream vLLM MoE model.
+- Runtime switching between static and dynamic expert layouts.
+- Reformatting or rewriting the checkpoint on disk.
+- Masking a genuinely hung worker by making RPC timeouts unbounded.
+
+## Architecture
+
+### Neutral static-map plan
+
+Move map selection and structural validation out of the runtime patch wrapper
+into a neutral HCU fused-MoE helper.  The helper returns an immutable CPU plan
+containing:
+
+- model key (`HYV4ForCausalLM` or `HYV4MTP`),
+- normalized source path,
+- full-file SHA-256 digest,
+- physical-to-logical tensor with shape
+  `[num_moe_layers, num_physical_experts]`, and
+- logical/physical/redundant expert counts.
+
+The existing v2 multi-model JSON and legacy single-model JSON formats remain
+accepted.  Validation continues to reject non-integer IDs, wrong shapes,
+negative/out-of-range IDs, missing logical experts, and incorrect redundant
+slot counts.  File content is cached per normalized path and file identity so
+the target and MTP loaders do not repeatedly parse the JSON.
+
+When no `expert_map_path` is configured, the helper returns no plan and the
+current loader behavior is unchanged.
+
+### HY V4 checkpoint loading
+
+HY V4 target and MTP model construction select their own plan before weights
+are consumed and attach it to the model.  MoE layers are paired with map rows
+in the same order used by `set_eplb_state`; a mismatch is an initialization
+error.
+
+For split checkpoints, the generated expert-parameter mapping becomes
+layer-specific.  For each physical slot `p` in layer `l`, checkpoint weights
+for logical expert `plan[l, p]` are loaded into physical slot `p`.
+
+For fused checkpoints, the loader selects `loaded_weight[plan[l, p]]` instead
+of the current `loaded_weight[p % num_logical_experts]`.  Weight tensors,
+weight scales, and activation/input scales all use the same slot mapping.
+Only local physical slots are materialized by the existing expert-map manager;
+no inter-rank weight transfer is needed.
+
+If upstream EP weight filtering is enabled, the filter must include the union
+of logical experts referenced by the local physical slots.  If that contract
+cannot be established for the audited vLLM version, startup fails with an
+explicit incompatibility error rather than loading incomplete experts.
+
+### EPLB runtime registration
+
+The offline EPLB adapter recognizes a model carrying a validated direct-load
+plan.  It lets upstream `EplbState.add_model` allocate normal routing/load
+state, then commits the plan's map directly with `_commit_eplb_maps`.
+It must not call `rearrange_expert_weights_inplace` for this path because the
+weights are already in the committed physical layout.
+
+The adapter clears `should_record_tensor`, forces `is_async=False`, and makes
+all later `EplbState.step` calls no-ops while a load path is configured.  The
+existing post-load rearrangement remains only as compatibility behavior for
+non-HY-V4 models that do not advertise a direct-load plan.
+
+### Cross-rank consistency
+
+Before committing routing metadata, all ranks exchange a compact plan
+fingerprint consisting of the model key, shape, counts, and SHA-256 digest.
+Every fingerprint must match.  A mismatch raises a descriptive startup error
+that includes the local rank and mismatched fingerprints.  A device-group
+barrier after commit prevents any rank from entering warmup or inference with
+partially committed routing state.
+
+This synchronization is startup-only and is not placed in the inference hot
+path.
+
+## Error handling
+
+- Missing model key: report available keys and stop before weight loading.
+- Shape/count/ID errors: report path, model key, layer, and expected values.
+- Model layer-order mismatch: report the model class and observed layer count.
+- Rank fingerprint mismatch: stop all ranks before API readiness.
+- Direct-loaded model without an attached plan at EPLB registration: reject
+  the inconsistent state rather than rearranging it silently.
+- Non-HY-V4 model: retain the current validated post-load compatibility path.
+
+## Compatibility and rollout
+
+Direct load is automatically selected when all of the following are true:
+
+1. `expert_map_path` is configured,
+2. EPLB and expert parallelism are enabled,
+3. the model is HCU HY V4 target or native MTP, and
+4. the map validates for that model.
+
+No new user-facing flag is required.  Removing `expert_map_path` restores the
+standard initial layout and dynamic/record behavior.  The existing rejection
+of static offline EPLB with elastic EP remains in force.
+
+## Testing
+
+### Unit and patch tests
+
+- Parse and validate target/MTP plans, including cache invalidation when the
+  file identity changes.
+- Reject missing keys, invalid IDs, missing experts, wrong redundancy, and
+  mismatched layer counts before checkpoint loading.
+- Verify split checkpoint mappings for two layers with different layouts.
+- Verify fused target and MTP weights/scales load into the mapped physical
+  slots, including duplicated logical experts.
+- Verify local EP filtering uses all logical experts needed by local slots or
+  raises an explicit compatibility error.
+- Verify direct-loaded registration calls commit but never calls rearrange.
+- Verify rank fingerprint mismatch and commit-barrier failure stop startup.
+- Verify static `step` remains a no-op.
+- Verify record mode and dynamic EPLB still call the original paths.
+- Verify a non-HY-V4 model retains the compatibility rearrangement path.
+
+Every behavior change is implemented test-first with a failing regression
+test observed before production code is written.
+
+### Runtime verification
+
+1. Run the focused offline-EPLB, HY V4 weight-loading, MTP, worker-dispatch,
+   multiprocess-timeout, and platform-config suites.
+2. Run the broader patch/model regression set and `compileall`/`diff --check`.
+3. On one node, start the 8-HCU DP8/EP8 HY V4 Channel-FP8 model with MTP2,
+   `fp8_e4m3` KV cache, DeepGEMM, and a static map using a short
+   `step_interval`.  Require all requests to return HTTP 200, no dynamic
+   rearrangement, no map write, no shared-memory warning, and no traceback.
+4. Compare deterministic prompts against the legacy post-load layout using
+   the same map.  Require matching first generated tokens; report any later
+   token divergence separately because FP8 kernels can be nondeterministic.
+5. On two nodes when available, require startup and inference without a
+   shared-memory 60-second warning or RPC timeout, and confirm logs show
+   direct load plus metadata commit with zero expert-transfer operations.
+
+## Success criteria
+
+- HY V4 static-map startup performs zero calls to expert rearrangement.
+- Target and MTP weights occupy the physical slots specified by the map.
+- All ranks commit an identical map before API readiness.
+- Static-map inference never schedules a later dynamic rearrangement.
+- Dynamic and record modes retain their existing behavior.
+- Single-node full-model validation passes, and dual-node validation passes
+  when the second node is available.

--- a/tests/accuracy/test_environment_routing.py
+++ b/tests/accuracy/test_environment_routing.py
@@ -117,6 +117,21 @@ def test_lightop_hy_v4_indexer_defaults_enabled_and_allows_opt_out(
     assert hcu_envs.is_set(name) is True
 
 
+def test_eplb_locality_fair_dispatch_defaults_enabled_and_allows_opt_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    name = "VLLM_HCU_USE_EPLB_LOCALITY_FAIR_DISPATCH"
+    monkeypatch.delenv(name, raising=False)
+
+    assert getattr(hcu_envs, name) is True
+    assert hcu_envs.is_set(name) is False
+
+    monkeypatch.setenv(name, "0")
+
+    assert getattr(hcu_envs, name) is False
+    assert hcu_envs.is_set(name) is True
+
+
 @pytest.mark.parametrize(
     "name",
     [

--- a/tests/accuracy/test_hcu_kernel_accuracy.py
+++ b/tests/accuracy/test_hcu_kernel_accuracy.py
@@ -573,6 +573,51 @@ def test_hcu_indexer_fp8_cache_roundtrip_matches_ue8m0_reference(
     )
 
 
+def test_hcu_indexer_cache_writer_masks_negative_slots_during_capture() -> None:
+    """Catch dummy decode slots writing through during HCU graph capture."""
+    device = _hcu_device()
+    from vllm_hcu.v1.attention.ops.rocm_aiter_mla_sparse import (
+        indexer_k_quant_and_cache_triton,
+    )
+
+    source = torch.stack(
+        (
+            torch.ones(128, device=device),
+            torch.full((128,), 7.0, device=device),
+        )
+    ).to(torch.bfloat16)
+    cache = torch.zeros((4, 1, 132), device=device, dtype=torch.uint8)
+    slots = torch.tensor([1, -1], device=device, dtype=torch.int64)
+
+    # Compile the Triton specialization before capture. The captured launch must
+    # retain a fixed shape while suppressing the dummy ``-1`` slot on-device.
+    indexer_k_quant_and_cache_triton(
+        source,
+        cache,
+        torch.tensor([1, 2], device=device, dtype=torch.int64),
+        quant_block_size=128,
+        scale_fmt="ue8m0",
+    )
+    torch.cuda.synchronize()
+    cache.zero_()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        indexer_k_quant_and_cache_triton(
+            source,
+            cache,
+            slots,
+            quant_block_size=128,
+            scale_fmt="ue8m0",
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert torch.count_nonzero(cache[1]).item() > 0
+    assert torch.count_nonzero(cache[0]).item() == 0
+    assert torch.count_nonzero(cache[-1]).item() == 0
+
+
 @pytest.mark.parametrize("block_size", [16, 64])
 def test_lightop_indexer_cache_roundtrip_uses_normal_layout(
     block_size: int,

--- a/tests/model_executor/layers/fused_moe/test_static_eplb.py
+++ b/tests/model_executor/layers/fused_moe/test_static_eplb.py
@@ -12,6 +12,7 @@ import pytest
 import torch
 
 from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    bind_static_eplb_plan,
     load_static_eplb_plan,
     maybe_load_static_eplb_plan,
 )
@@ -231,3 +232,124 @@ def test_maybe_load_plan_rejects_unsupported_parallel_modes(
             num_physical_experts=6,
             num_redundant_experts=2,
         )
+
+
+class _FakeMoERunner:
+    def __init__(self) -> None:
+        self.routed_experts = type("RoutedExperts", (), {})()
+
+
+class _FakeMoEModel:
+    def __init__(self, *, runners: list[object] | None = None) -> None:
+        self.expert_weights = []
+        self.num_moe_layers = 2
+        self.num_expert_groups = 1
+        self.num_logical_experts = 3
+        self.num_physical_experts = 4
+        self.num_local_physical_experts = 4
+        self.num_routed_experts = 3
+        self.num_shared_experts = 0
+        self.num_redundant_experts = 1
+        self.moe_layers = (
+            [_FakeMoERunner(), _FakeMoERunner()] if runners is None else runners
+        )
+
+    def set_eplb_state(self, *args: object) -> None:
+        del args
+
+    def update_physical_experts_metadata(self, *args: object) -> None:
+        del args
+
+
+def _write_binder_map(path: Path) -> None:
+    _write_map(
+        path,
+        [[2, 1, 0, 2], [1, 0, 2, 1]],
+        key="_FakeMoEModel",
+    )
+
+
+def test_bind_plan_publishes_each_row_to_routed_experts(tmp_path: Path) -> None:
+    path = tmp_path / "maps.json"
+    _write_binder_map(path)
+    config = _config_for_path(path)
+    model = _FakeMoEModel()
+
+    plan = bind_static_eplb_plan(config, model)
+
+    assert model._vllm_hcu_static_eplb_plan is plan
+    assert model.moe_layers[0].routed_experts._vllm_hcu_static_eplb_row == (
+        2,
+        1,
+        0,
+        2,
+    )
+    assert model.moe_layers[1].routed_experts._vllm_hcu_static_eplb_row == (
+        1,
+        0,
+        2,
+        1,
+    )
+
+
+def test_bind_plan_returns_none_without_a_configured_path() -> None:
+    assert bind_static_eplb_plan(_config_for_path(None), object()) is None
+
+
+def test_bind_plan_rejects_a_non_moe_model_without_hyv4_prefix(tmp_path: Path) -> None:
+    path = tmp_path / "maps.json"
+    _write_binder_map(path)
+
+    with pytest.raises(ValueError, match="MixtureOfExperts") as error:
+        bind_static_eplb_plan(_config_for_path(path), object())
+
+    assert "HY V4" not in str(error.value)
+
+
+def test_bind_plan_rejects_layer_count_mismatch_before_publishing(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "maps.json"
+    _write_binder_map(path)
+    model = _FakeMoEModel(runners=[_FakeMoERunner()])
+
+    with pytest.raises(ValueError, match="moe_layers"):
+        bind_static_eplb_plan(_config_for_path(path), model)
+
+    assert not hasattr(model, "_vllm_hcu_static_eplb_plan")
+    assert not hasattr(
+        model.moe_layers[0].routed_experts,
+        "_vllm_hcu_static_eplb_row",
+    )
+
+
+def test_bind_plan_rejects_missing_routed_experts_before_publishing(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "maps.json"
+    _write_binder_map(path)
+    first = _FakeMoERunner()
+    model = _FakeMoEModel(runners=[first, object()])
+
+    with pytest.raises(ValueError, match="routed_experts"):
+        bind_static_eplb_plan(_config_for_path(path), model)
+
+    assert not hasattr(model, "_vllm_hcu_static_eplb_plan")
+    assert not hasattr(first.routed_experts, "_vllm_hcu_static_eplb_row")
+
+
+def test_maybe_load_plan_uses_generic_validation_errors(tmp_path: Path) -> None:
+    path = tmp_path / "maps.json"
+    _write_binder_map(path)
+
+    with pytest.raises(ValueError, match="expert parallel") as error:
+        maybe_load_static_eplb_plan(
+            _config_for_path(path, enable_expert_parallel=False),
+            model_key="_FakeMoEModel",
+            num_moe_layers=2,
+            num_logical_experts=3,
+            num_physical_experts=4,
+            num_redundant_experts=1,
+        )
+
+    assert "HY V4" not in str(error.value)

--- a/tests/model_executor/layers/fused_moe/test_static_eplb.py
+++ b/tests/model_executor/layers/fused_moe/test_static_eplb.py
@@ -13,6 +13,7 @@ import torch
 
 from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
     load_static_eplb_plan,
+    maybe_load_static_eplb_plan,
 )
 
 
@@ -160,3 +161,73 @@ def test_legacy_mtp_plan_selects_final_rows(tmp_path: Path) -> None:
     )
 
     assert plan.layer_map(0) == (3, 2, 1, 0, 3, 2)
+
+
+def _config_for_path(path: Path | None, **overrides):
+    values = {
+        "_vllm_hcu_expert_map_path": str(path) if path else None,
+        "enable_expert_parallel": True,
+        "enable_eplb": True,
+        "enable_ep_weight_filter": False,
+    }
+    values.update(overrides)
+    return type(
+        "Config",
+        (),
+        {"parallel_config": type("Parallel", (), values)()},
+    )()
+
+
+def test_maybe_load_plan_uses_parallel_config_before_weight_load(tmp_path: Path) -> None:
+    path = tmp_path / "maps.json"
+    _write_map(path, [[3, 2, 1, 0, 3, 2]])
+
+    plan = maybe_load_static_eplb_plan(
+        _config_for_path(path),
+        model_key="HYV4ForCausalLM",
+        num_moe_layers=1,
+        num_logical_experts=4,
+        num_physical_experts=6,
+        num_redundant_experts=2,
+    )
+
+    assert plan is not None
+    assert plan.layer_map(0) == (3, 2, 1, 0, 3, 2)
+    assert (
+        maybe_load_static_eplb_plan(
+            _config_for_path(None),
+            model_key="HYV4ForCausalLM",
+            num_moe_layers=1,
+            num_logical_experts=4,
+            num_physical_experts=6,
+            num_redundant_experts=2,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"enable_expert_parallel": False}, "expert parallel"),
+        ({"enable_eplb": False}, "EPLB"),
+        ({"enable_ep_weight_filter": True}, "EP weight filtering"),
+    ],
+)
+def test_maybe_load_plan_rejects_unsupported_parallel_modes(
+    tmp_path: Path,
+    override: dict,
+    message: str,
+) -> None:
+    path = tmp_path / "maps.json"
+    _write_map(path, [[0, 1, 2, 3, 0, 1]])
+
+    with pytest.raises(ValueError, match=message):
+        maybe_load_static_eplb_plan(
+            _config_for_path(path, **override),
+            model_key="HYV4ForCausalLM",
+            num_moe_layers=1,
+            num_logical_experts=4,
+            num_physical_experts=6,
+            num_redundant_experts=2,
+        )

--- a/tests/model_executor/layers/fused_moe/test_static_eplb.py
+++ b/tests/model_executor/layers/fused_moe/test_static_eplb.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -165,12 +166,60 @@ def test_legacy_mtp_plan_selects_final_rows(tmp_path: Path) -> None:
     assert plan.layer_map(0) == (3, 2, 1, 0, 3, 2)
 
 
+def test_keyed_v2_plan_rejects_oversized_rows_instead_of_taking_a_suffix(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "keyed-v2.json"
+    _write_map(
+        path,
+        [
+            [0, 1, 2, 3, 0, 1],
+            [3, 2, 1, 0, 3, 2],
+        ],
+        key="HYV4MTP",
+    )
+
+    with pytest.raises(ValueError, match=r"shape \(2, 6\).+expected \(1, 6\)"):
+        load_static_eplb_plan(
+            path,
+            model_key="HYV4MTP",
+            expected_shape=(1, 6),
+            num_logical_experts=4,
+            num_redundant_experts=2,
+        )
+
+
+def test_legacy_non_mtp_plan_rejects_oversized_rows(tmp_path: Path) -> None:
+    path = tmp_path / "legacy-main.json"
+    path.write_text(
+        json.dumps(
+            {
+                "physical_to_logical_map": [
+                    [0, 1, 2, 3, 0, 1],
+                    [3, 2, 1, 0, 3, 2],
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"shape \(2, 6\).+expected \(1, 6\)"):
+        load_static_eplb_plan(
+            path,
+            model_key="HYV4ForCausalLM",
+            expected_shape=(1, 6),
+            num_logical_experts=4,
+            num_redundant_experts=2,
+        )
+
+
 def _config_for_path(path: Path | None, **overrides):
     values = {
         "_vllm_hcu_expert_map_path": str(path) if path else None,
         "enable_expert_parallel": True,
         "enable_eplb": True,
         "enable_ep_weight_filter": False,
+        "pipeline_parallel_size": 1,
     }
     values.update(overrides)
     return type(
@@ -262,6 +311,21 @@ class _FakeMoEModel:
         del args
 
 
+class _FakePipelineMoEModel(_FakeMoEModel):
+    def __init__(self, *, runners: list[object]) -> None:
+        super().__init__(runners=runners)
+        # DeepSeek V2 and GLM expose a global count even though this sequence
+        # contains only the current PP stage's MoE layers.
+        self.num_moe_layers = 3
+
+
+class Llama4ForConditionalGeneration(_FakeMoEModel):
+    def __init__(self) -> None:
+        super().__init__()
+        self.language_model = _FakeMoEModel(runners=self.moe_layers)
+        self.language_model.moe_layers = self.moe_layers
+
+
 def _write_binder_map(path: Path) -> None:
     _write_map(
         path,
@@ -291,6 +355,106 @@ def test_bind_plan_publishes_each_row_to_routed_experts(tmp_path: Path) -> None:
         2,
         1,
     )
+
+
+def test_bind_plan_selects_pp_local_rows_by_stage_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "pipeline-maps.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "model_maps": {
+                    "_FakePipelineMoEModel#pp_rank=0": {
+                        "physical_to_logical_map": [
+                            [2, 1, 0, 2],
+                            [1, 0, 2, 1],
+                        ]
+                    },
+                    "_FakePipelineMoEModel#pp_rank=1": {
+                        "physical_to_logical_map": [[0, 2, 1, 0]]
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    stage_zero = _FakePipelineMoEModel(
+        runners=[_FakeMoERunner(), _FakeMoERunner()]
+    )
+    stage_one = _FakePipelineMoEModel(runners=[_FakeMoERunner()])
+    current_pp_rank = [0]
+    monkeypatch.setattr(
+        "vllm.distributed.get_pp_group",
+        lambda: SimpleNamespace(rank_in_group=current_pp_rank[0]),
+    )
+
+    stage_zero_plan = bind_static_eplb_plan(
+        _config_for_path(
+            path,
+            pipeline_parallel_size=2,
+        ),
+        stage_zero,
+    )
+    current_pp_rank[0] = 1
+    stage_one_plan = bind_static_eplb_plan(
+        _config_for_path(
+            path,
+            pipeline_parallel_size=2,
+        ),
+        stage_one,
+    )
+
+    assert stage_zero_plan is not None
+    assert stage_zero_plan.model_key == "_FakePipelineMoEModel#pp_rank=0"
+    assert stage_zero_plan._map_values == ((2, 1, 0, 2), (1, 0, 2, 1))
+    assert stage_one_plan is not None
+    assert stage_one_plan.model_key == "_FakePipelineMoEModel#pp_rank=1"
+    assert stage_one_plan._map_values == ((0, 2, 1, 0),)
+    assert stage_zero.num_moe_layers == 3
+    assert stage_one.num_moe_layers == 3
+
+
+def test_bind_plan_cannot_fall_back_to_another_pp_stage_key(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "stage-zero-only.json"
+    _write_map(
+        path,
+        [[2, 1, 0, 2], [1, 0, 2, 1]],
+        key="_FakePipelineMoEModel#pp_rank=0",
+    )
+
+    with pytest.raises(ValueError, match=r"_FakePipelineMoEModel#pp_rank=1"):
+        bind_static_eplb_plan(
+            _config_for_path(
+                path,
+                pipeline_parallel_size=2,
+                pipeline_parallel_rank=1,
+            ),
+            _FakePipelineMoEModel(runners=[_FakeMoERunner()]),
+        )
+
+
+def test_bind_plan_uses_the_public_mllama_owner_for_nested_language_model(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "mllama-map.json"
+    _write_map(
+        path,
+        [[2, 1, 0, 2], [1, 0, 2, 1]],
+        key="Llama4ForConditionalGeneration",
+    )
+    model = Llama4ForConditionalGeneration()
+
+    plan = bind_static_eplb_plan(_config_for_path(path), model)
+
+    assert plan is not None
+    assert plan.model_key == "Llama4ForConditionalGeneration"
+    assert model._vllm_hcu_static_eplb_plan is plan
+    assert model.language_model._vllm_hcu_static_eplb_plan is plan
 
 
 def test_bind_plan_returns_none_without_a_configured_path() -> None:

--- a/tests/model_executor/layers/fused_moe/test_static_eplb.py
+++ b/tests/model_executor/layers/fused_moe/test_static_eplb.py
@@ -13,6 +13,7 @@ import torch
 
 from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
     bind_static_eplb_plan,
+    load_static_logical_expert,
     load_static_eplb_plan,
     maybe_load_static_eplb_plan,
 )
@@ -353,3 +354,111 @@ def test_maybe_load_plan_uses_generic_validation_errors(tmp_path: Path) -> None:
         )
 
     assert "HY V4" not in str(error.value)
+
+
+def test_load_static_logical_expert_fans_out_and_reports_local_success() -> None:
+    calls: list[tuple[int, bool, str]] = []
+    routed_experts = type(
+        "RoutedExperts",
+        (),
+        {
+            "_vllm_hcu_static_eplb_row": (2, 1, 0, 2),
+            "local_physical_ids": {0, 3},
+        },
+    )()
+
+    def original_weight_loader(
+        self,
+        param,
+        loaded_weight,
+        weight_name,
+        shard_id,
+        expert_id,
+        return_success=False,
+    ):
+        assert self is routed_experts
+        assert param == "param"
+        assert loaded_weight == "tensor"
+        assert shard_id == "w1"
+        calls.append((expert_id, return_success, weight_name))
+        loaded = expert_id in self.local_physical_ids
+        return loaded if return_success else None
+
+    assert (
+        load_static_logical_expert(
+            routed_experts,
+            original_weight_loader,
+            param="param",
+            loaded_weight="tensor",
+            weight_name="w13_weight_scale",
+            shard_id="w1",
+            logical_expert_id=2,
+            return_success=True,
+        )
+        is True
+    )
+    assert calls == [
+        (0, True, "w13_weight_scale"),
+        (3, True, "w13_weight_scale"),
+    ]
+
+    calls.clear()
+    routed_experts.local_physical_ids = {1}
+    assert (
+        load_static_logical_expert(
+            routed_experts,
+            original_weight_loader,
+            param="param",
+            loaded_weight="tensor",
+            weight_name="w13_weight",
+            shard_id="w1",
+            logical_expert_id=2,
+            return_success=True,
+        )
+        is False
+    )
+    assert [expert_id for expert_id, _, _ in calls] == [0, 3]
+
+    calls.clear()
+    routed_experts.local_physical_ids = {0, 3}
+    assert (
+        load_static_logical_expert(
+            routed_experts,
+            original_weight_loader,
+            param="param",
+            loaded_weight="tensor",
+            weight_name="w13_weight",
+            shard_id="w1",
+            logical_expert_id=2,
+            return_success=False,
+        )
+        is None
+    )
+    assert [expert_id for expert_id, _, _ in calls] == [0, 3]
+
+
+@pytest.mark.parametrize("logical_expert_id", [-1, 3, True])
+def test_load_static_logical_expert_rejects_invalid_logical_ids_before_copy(
+    logical_expert_id: int,
+) -> None:
+    routed_experts = type(
+        "RoutedExperts",
+        (),
+        {"_vllm_hcu_static_eplb_row": (2, 1, 0, 2)},
+    )()
+
+    def unexpected_loader(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("an invalid logical expert must not copy a tensor")
+
+    with pytest.raises(ValueError, match="logical expert id"):
+        load_static_logical_expert(
+            routed_experts,
+            unexpected_loader,
+            param="param",
+            loaded_weight="tensor",
+            weight_name="w13_weight",
+            shard_id="w1",
+            logical_expert_id=logical_expert_id,
+            return_success=True,
+        )

--- a/tests/model_executor/layers/fused_moe/test_static_eplb.py
+++ b/tests/model_executor/layers/fused_moe/test_static_eplb.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    load_static_eplb_plan,
+)
+
+
+def _write_map(path: Path, rows: list[list[int]], key: str = "HYV4ForCausalLM") -> bytes:
+    raw = json.dumps(
+        {"version": 2, "model_maps": {key: {"physical_to_logical_map": rows}}}
+    ).encode()
+    path.write_bytes(raw)
+    return raw
+
+
+def test_load_plan_selects_model_and_builds_stable_fingerprint(tmp_path: Path) -> None:
+    path = tmp_path / "maps.json"
+    raw = json.dumps(
+        {
+            "version": 2,
+            "model_maps": {
+                "HYV4ForCausalLM": {
+                    "physical_to_logical_map": [[0, 1, 2, 3, 0, 1]]
+                },
+                "HYV4MTP": {
+                    "physical_to_logical_map": [[3, 2, 1, 0, 3, 2]]
+                },
+            },
+        }
+    ).encode()
+    path.write_bytes(raw)
+
+    plan = load_static_eplb_plan(
+        path,
+        model_key="HYV4MTP",
+        expected_shape=(1, 6),
+        num_logical_experts=4,
+        num_redundant_experts=2,
+    )
+
+    assert plan.model_key == "HYV4MTP"
+    assert plan.source_path == str(path.resolve())
+    assert plan.source_sha256 == hashlib.sha256(raw).hexdigest()
+    assert plan.physical_to_logical_map.dtype == torch.int64
+    assert plan.physical_to_logical_map.device.type == "cpu"
+    assert plan.layer_map(0) == (3, 2, 1, 0, 3, 2)
+    assert plan.num_logical_experts == 4
+    assert plan.num_physical_experts == 6
+    assert plan.num_redundant_experts == 2
+    assert plan.fingerprint() == (
+        "HYV4MTP",
+        hashlib.sha256(raw).hexdigest(),
+        (1, 6),
+        4,
+        6,
+        2,
+    )
+
+    leaked = plan.physical_to_logical_map
+    leaked[0, 0] = 0
+    assert plan.layer_map(0) == (3, 2, 1, 0, 3, 2)
+
+
+def test_plan_cache_invalidates_when_file_identity_changes(tmp_path: Path) -> None:
+    path = tmp_path / "maps.json"
+    first_raw = _write_map(path, [[0, 1, 2, 3, 0, 1]])
+    first = load_static_eplb_plan(
+        path,
+        model_key="HYV4ForCausalLM",
+        expected_shape=(1, 6),
+        num_logical_experts=4,
+        num_redundant_experts=2,
+    )
+    second_raw = _write_map(path, [[3, 2, 1, 0, 3, 2]])
+    stat = path.stat()
+    os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+    second = load_static_eplb_plan(
+        path,
+        model_key="HYV4ForCausalLM",
+        expected_shape=(1, 6),
+        num_logical_experts=4,
+        num_redundant_experts=2,
+    )
+
+    assert first.source_sha256 == hashlib.sha256(first_raw).hexdigest()
+    assert second.source_sha256 == hashlib.sha256(second_raw).hexdigest()
+    assert first.source_sha256 != second.source_sha256
+    assert second.layer_map(0) == (3, 2, 1, 0, 3, 2)
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_shape", "redundant", "message"),
+    [
+        (
+            {"model_maps": {"HYV4MTP": {"physical_to_logical_map": [[0, 1, 2, 3, 0, 1]]}}},
+            (1, 6),
+            2,
+            "does not contain key",
+        ),
+        ({"physical_to_logical_map": [[0, 1, 2, 3, 0, True]]}, (1, 6), 2, "integer expert ids"),
+        ({"physical_to_logical_map": [[0, 1, 2, 3, 0, 1.0]]}, (1, 6), 2, "integer expert ids"),
+        ({"physical_to_logical_map": [[0, 1, 2, 3, 0]]}, (1, 6), 2, "has shape"),
+        ({"physical_to_logical_map": [[0, 1, 2, 4, 0, 1]]}, (1, 6), 2, ">= 4"),
+        ({"physical_to_logical_map": [[0, 1, 2, 0, 1, 2]]}, (1, 6), 2, "misses logical experts"),
+        ({"physical_to_logical_map": [[0, 1, 2, 3, 0, 1]]}, (1, 6), 1, "redundant"),
+    ],
+)
+def test_load_plan_rejects_invalid_contracts(
+    tmp_path: Path,
+    payload: dict,
+    expected_shape: tuple[int, int],
+    redundant: int,
+    message: str,
+) -> None:
+    path = tmp_path / "invalid.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        load_static_eplb_plan(
+            path,
+            model_key="HYV4ForCausalLM",
+            expected_shape=expected_shape,
+            num_logical_experts=4,
+            num_redundant_experts=redundant,
+        )
+
+
+def test_legacy_mtp_plan_selects_final_rows(tmp_path: Path) -> None:
+    path = tmp_path / "legacy.json"
+    path.write_text(
+        json.dumps(
+            {
+                "physical_to_logical_map": [
+                    [0, 1, 2, 3, 0, 1],
+                    [1, 0, 2, 3, 1, 0],
+                    [3, 2, 1, 0, 3, 2],
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    plan = load_static_eplb_plan(
+        path,
+        model_key="HYV4MTP",
+        expected_shape=(1, 6),
+        num_logical_experts=4,
+        num_redundant_experts=2,
+    )
+
+    assert plan.layer_map(0) == (3, 2, 1, 0, 3, 2)

--- a/tests/models/hy_v4/test_eplb.py
+++ b/tests/models/hy_v4/test_eplb.py
@@ -67,11 +67,13 @@ def test_target_registers_expert_weights_and_routing_state() -> None:
 
 def test_target_wrapper_exposes_mixture_of_experts_contract(monkeypatch) -> None:
     layer = _FakeMoELayer()
+    static_plan = object()
 
     class FakeInnerModel(nn.Module):
         def __init__(self, **kwargs) -> None:
             super().__init__()
             self.make_empty_intermediate_tensors = object()
+            self._vllm_hcu_static_eplb_plan = static_plan
             _set_moe_metadata(self, layer)
 
         def set_eplb_state(self, *args) -> None:
@@ -114,6 +116,7 @@ def test_target_wrapper_exposes_mixture_of_experts_contract(monkeypatch) -> None
     assert model.num_physical_experts == 8
     assert model.num_local_physical_experts == 2
     assert model.num_redundant_experts == 4
+    assert model._vllm_hcu_static_eplb_plan is static_plan
 
 
 def test_mtp_registers_expert_weights_and_routing_state() -> None:
@@ -139,11 +142,13 @@ def test_mtp_registers_expert_weights_and_routing_state() -> None:
 
 def test_mtp_wrapper_exposes_mixture_of_experts_contract(monkeypatch) -> None:
     layer = _FakeMoELayer()
+    static_plan = object()
 
     class FakePredictor(nn.Module):
         def __init__(self, **kwargs) -> None:
             super().__init__()
             self.quant_config = None
+            self._vllm_hcu_static_eplb_plan = static_plan
             _set_moe_metadata(self, layer)
 
         def set_eplb_state(self, *args) -> None:
@@ -173,6 +178,7 @@ def test_mtp_wrapper_exposes_mixture_of_experts_contract(monkeypatch) -> None:
     assert model.num_physical_experts == 8
     assert model.num_local_physical_experts == 2
     assert model.num_redundant_experts == 4
+    assert model._vllm_hcu_static_eplb_plan is static_plan
 
 
 def test_target_fused_loader_copies_logical_weights_to_redundant_experts() -> None:

--- a/tests/models/hy_v4/test_eplb.py
+++ b/tests/models/hy_v4/test_eplb.py
@@ -9,6 +9,9 @@ import pytest
 import torch
 from torch import nn
 
+from vllm.distributed.eplb.rebalance_execute import (
+    rearrange_expert_weights_inplace,
+)
 from vllm.model_executor.models.interfaces import is_mixture_of_experts
 
 from vllm_hcu.models.hy_v4 import model as hy_v4_model
@@ -401,13 +404,125 @@ def test_direct_load_is_tensor_equivalent_to_legacy_rearrangement() -> None:
     checkpoint = torch.arange(4 * 3, dtype=torch.float32).reshape(4, 3)
     source_map = (0, 1, 2, 3, 0, 1)
     target_map = (3, 2, 1, 0, 3, 2)
-    legacy_loaded = torch.stack([checkpoint[logical] for logical in source_map])
-    legacy_rearranged = torch.stack(
-        [
-            legacy_loaded[source_map.index(logical)]
-            for logical in target_map
-        ]
-    )
-    direct_loaded = torch.stack([checkpoint[logical] for logical in target_map])
 
-    torch.testing.assert_close(direct_loaded, legacy_rearranged, rtol=0, atol=0)
+    class RoutedExperts:
+        @staticmethod
+        def original_weight_loader(
+            routed_experts,
+            param,
+            loaded_weight,
+            weight_name,
+            shard_id,
+            expert_id,
+            return_success=False,
+        ):
+            del routed_experts, weight_name, shard_id
+            with torch.no_grad():
+                param[expert_id].copy_(loaded_weight)
+            return True if return_success else None
+
+        def weight_loader(
+            self,
+            param,
+            loaded_weight,
+            weight_name,
+            shard_id,
+            expert_id,
+            return_success=False,
+        ):
+            if hasattr(self, "_vllm_hcu_static_eplb_row"):
+                return static_eplb.load_static_logical_expert(
+                    self,
+                    self.original_weight_loader,
+                    param=param,
+                    loaded_weight=loaded_weight,
+                    weight_name=weight_name,
+                    shard_id=shard_id,
+                    logical_expert_id=expert_id,
+                    return_success=return_success,
+                )
+            return self.original_weight_loader(
+                self,
+                param,
+                loaded_weight,
+                weight_name,
+                shard_id,
+                expert_id,
+                return_success,
+            )
+
+    model = object.__new__(hy_v4_model.HYV4Model)
+    nn.Module.__init__(model)
+    parameter_name = "experts.w2_weight"
+
+    direct_loaded = nn.Parameter(
+        torch.full((6, 3), float("nan")),
+        requires_grad=False,
+    )
+    direct_experts = RoutedExperts()
+    direct_experts._vllm_hcu_static_eplb_row = target_map
+    direct_loaded.weight_loader = direct_experts.weight_loader
+    assert model.load_fused_expert_weights(
+        parameter_name,
+        {parameter_name: direct_loaded},
+        checkpoint,
+        "w2",
+        num_experts=4,
+        num_redundant_experts=2,
+    )
+
+    legacy_rearranged = nn.Parameter(
+        torch.full((6, 3), float("nan")),
+        requires_grad=False,
+    )
+    legacy_experts = RoutedExperts()
+    legacy_rearranged.weight_loader = legacy_experts.weight_loader
+    assert model.load_fused_expert_weights(
+        parameter_name,
+        {parameter_name: legacy_rearranged},
+        checkpoint,
+        "w2",
+        num_experts=4,
+        num_redundant_experts=2,
+    )
+
+    class SingleRankGroup:
+        @staticmethod
+        def size() -> int:
+            return 1
+
+        @staticmethod
+        def rank() -> int:
+            return 0
+
+    class NoRemoteTransfers:
+        needs_profile_buffer_reservation = False
+
+        @staticmethod
+        def set_transfer_context(*args) -> None:
+            del args
+
+        @staticmethod
+        def add_send(*args, **kwargs) -> None:
+            del args, kwargs
+            pytest.fail("single-rank rearrangement must not send expert weights")
+
+        @staticmethod
+        def add_recv(*args, **kwargs) -> None:
+            del args, kwargs
+            pytest.fail("single-rank rearrangement must not receive expert weights")
+
+        @staticmethod
+        def execute() -> None:
+            return None
+
+    rearrange_expert_weights_inplace(
+        torch.tensor([source_map]),
+        torch.tensor([target_map]),
+        [[legacy_rearranged]],
+        [torch.empty_like(legacy_rearranged)],
+        SingleRankGroup(),
+        NoRemoteTransfers(),
+    )
+
+    assert torch.equal(direct_loaded, legacy_rearranged)

--- a/tests/models/hy_v4/test_eplb.py
+++ b/tests/models/hy_v4/test_eplb.py
@@ -13,11 +13,7 @@ from vllm.model_executor.models.interfaces import is_mixture_of_experts
 
 from vllm_hcu.models.hy_v4 import model as hy_v4_model
 from vllm_hcu.models.hy_v4 import mtp as hy_v4_mtp
-from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
-    StaticEplbPlan,
-    build_expert_params_mapping_for_row,
-    static_eplb_layer_map_for_weight,
-)
+from vllm_hcu.model_executor.layers.fused_moe import static_eplb
 
 
 class _FakeMoELayer(nn.Module):
@@ -25,6 +21,7 @@ class _FakeMoELayer(nn.Module):
         super().__init__()
         self.weight = nn.Parameter(torch.arange(8).reshape(2, 4).float())
         self.eplb_state = None
+        self.routed_experts = SimpleNamespace()
 
     def get_expert_weights(self):
         return [self.weight]
@@ -73,14 +70,12 @@ def test_target_registers_expert_weights_and_routing_state() -> None:
 
 def test_target_wrapper_exposes_mixture_of_experts_contract(monkeypatch) -> None:
     layer = _FakeMoELayer()
-    static_plan = object()
+    static_plan = _static_plan(((3, 2, 1, 0, 3, 2),))
 
     class FakeInnerModel(nn.Module):
         def __init__(self, **kwargs) -> None:
             super().__init__()
             self.make_empty_intermediate_tensors = object()
-            self._vllm_hcu_static_eplb_plan = static_plan
-            self._vllm_hcu_moe_layer_indices = [0]
             _set_moe_metadata(self, layer)
 
         def set_eplb_state(self, *args) -> None:
@@ -112,11 +107,20 @@ def test_target_wrapper_exposes_mixture_of_experts_contract(monkeypatch) -> None
         model_config=SimpleNamespace(hf_config=config),
         quant_config=None,
         parallel_config=SimpleNamespace(
-            eplb_config=SimpleNamespace(num_redundant_experts=2)
+            eplb_config=SimpleNamespace(num_redundant_experts=2),
+            _vllm_hcu_expert_map_path="fake-map.json",
         ),
+    )
+    monkeypatch.setattr(
+        static_eplb,
+        "maybe_load_static_eplb_plan",
+        lambda *args, **kwargs: static_plan,
     )
 
     model = hy_v4_model.HYV4ForCausalLM(vllm_config=vllm_config)
+    assert not hasattr(model, "_vllm_hcu_static_eplb_plan")
+
+    assert static_eplb.bind_static_eplb_plan(vllm_config, model) is static_plan
 
     assert is_mixture_of_experts(model)
     model.update_physical_experts_metadata(8, 2)
@@ -124,6 +128,7 @@ def test_target_wrapper_exposes_mixture_of_experts_contract(monkeypatch) -> None
     assert model.num_local_physical_experts == 2
     assert model.num_redundant_experts == 4
     assert model._vllm_hcu_static_eplb_plan is static_plan
+    assert model.model._vllm_hcu_static_eplb_plan is static_plan
 
 
 def test_mtp_registers_expert_weights_and_routing_state() -> None:
@@ -149,14 +154,12 @@ def test_mtp_registers_expert_weights_and_routing_state() -> None:
 
 def test_mtp_wrapper_exposes_mixture_of_experts_contract(monkeypatch) -> None:
     layer = _FakeMoELayer()
-    static_plan = object()
+    static_plan = _static_plan(((3, 2, 1, 0, 3, 2),))
 
     class FakePredictor(nn.Module):
         def __init__(self, **kwargs) -> None:
             super().__init__()
             self.quant_config = None
-            self._vllm_hcu_static_eplb_plan = static_plan
-            self._vllm_hcu_moe_layer_indices = [0]
             _set_moe_metadata(self, layer)
 
         def set_eplb_state(self, *args) -> None:
@@ -177,9 +180,20 @@ def test_mtp_wrapper_exposes_mixture_of_experts_contract(monkeypatch) -> None:
     config = SimpleNamespace()
     vllm_config = SimpleNamespace(
         model_config=SimpleNamespace(hf_config=config),
+        parallel_config=SimpleNamespace(
+            _vllm_hcu_expert_map_path="fake-map.json",
+        ),
+    )
+    monkeypatch.setattr(
+        static_eplb,
+        "maybe_load_static_eplb_plan",
+        lambda *args, **kwargs: static_plan,
     )
 
     model = hy_v4_mtp.HYV4MTP(vllm_config=vllm_config)
+    assert not hasattr(model, "_vllm_hcu_static_eplb_plan")
+
+    assert static_eplb.bind_static_eplb_plan(vllm_config, model) is static_plan
 
     assert is_mixture_of_experts(model)
     model.update_physical_experts_metadata(8, 2)
@@ -187,6 +201,7 @@ def test_mtp_wrapper_exposes_mixture_of_experts_contract(monkeypatch) -> None:
     assert model.num_local_physical_experts == 2
     assert model.num_redundant_experts == 4
     assert model._vllm_hcu_static_eplb_plan is static_plan
+    assert model.model._vllm_hcu_static_eplb_plan is static_plan
 
 
 def test_target_fused_loader_copies_logical_weights_to_redundant_experts() -> None:
@@ -273,8 +288,8 @@ def test_mtp_fused_loader_copies_logical_weights_to_redundant_experts() -> None:
     ]
 
 
-def _static_plan(rows: tuple[tuple[int, ...], ...]) -> StaticEplbPlan:
-    return StaticEplbPlan(
+def _static_plan(rows: tuple[tuple[int, ...], ...]) -> static_eplb.StaticEplbPlan:
+    return static_eplb.StaticEplbPlan(
         model_key="HYV4ForCausalLM",
         source_path="/tmp/map.json",
         source_sha256="a" * 64,
@@ -285,62 +300,73 @@ def _static_plan(rows: tuple[tuple[int, ...], ...]) -> StaticEplbPlan:
     )
 
 
-def test_static_layer_map_uses_absolute_moe_layer_order() -> None:
-    plan = _static_plan(
-        (
-            (0, 1, 2, 3, 0, 1),
-            (3, 2, 1, 0, 3, 2),
-        )
-    )
-
-    assert static_eplb_layer_map_for_weight(
-        plan, (3, 7), "model.layers.7.mlp.experts.gate_up_proj.weight"
-    ) == (3, 2, 1, 0, 3, 2)
-    with pytest.raises(ValueError, match="not an MoE layer"):
-        static_eplb_layer_map_for_weight(
-            plan, (3, 7), "model.layers.5.mlp.experts.0.gate_proj.weight"
-        )
-
-
-def test_static_split_mapping_targets_all_physical_replicas() -> None:
-    model = nn.Module()
-    mapping = build_expert_params_mapping_for_row(
-        model,
-        ckpt_gate_proj_name="gate_proj",
-        ckpt_down_proj_name="down_proj",
-        ckpt_up_proj_name="up_proj",
-        physical_to_logical=(3, 2, 1, 0, 3, 2),
-    )
-
-    gate_logical_three = [
-        item for item in mapping if item[1] == "experts.3.gate_proj."
-    ]
-    assert gate_logical_three == [
-        ("experts.routed_experts.w13_", "experts.3.gate_proj.", 0, "w1"),
-        ("experts.routed_experts.w13_", "experts.3.gate_proj.", 4, "w1"),
-    ]
-
-
 @pytest.mark.parametrize("owner", ["target", "mtp"])
-def test_static_fused_loader_uses_mapped_logical_experts(owner: str) -> None:
-    calls: list[tuple[int, float]] = []
+@pytest.mark.parametrize(
+    ("parameter_name", "checkpoint"),
+    [
+        (
+            "experts.w13_weight",
+            torch.arange(4 * 2 * 3, dtype=torch.float32).reshape(4, 2, 3),
+        ),
+        (
+            "experts.w13_weight_scale",
+            torch.arange(4 * 2, dtype=torch.float32).reshape(4, 2, 1),
+        ),
+        ("experts.w13_input_scale", torch.arange(4, dtype=torch.float32)),
+    ],
+)
+def test_static_fused_loader_delegates_logical_rows_to_common_fan_out(
+    owner: str,
+    parameter_name: str,
+    checkpoint: torch.Tensor,
+) -> None:
+    row = (3, 2, 1, 0, 3, 2)
+    destination = torch.full(
+        (len(row), *checkpoint.shape[1:]),
+        float("nan"),
+        dtype=checkpoint.dtype,
+    )
+
+    class RoutedExperts:
+        _vllm_hcu_static_eplb_row = row
+
+        @staticmethod
+        def original_weight_loader(
+            routed_experts,
+            param,
+            loaded_weight,
+            weight_name,
+            shard_id,
+            expert_id,
+            return_success=False,
+        ):
+            del routed_experts, param, weight_name, shard_id
+            destination[expert_id].copy_(loaded_weight)
+            return True if return_success else None
+
+        def weight_loader(
+            self,
+            param,
+            loaded_weight,
+            weight_name,
+            shard_id,
+            expert_id,
+            return_success=False,
+        ):
+            return static_eplb.load_static_logical_expert(
+                self,
+                self.original_weight_loader,
+                param=param,
+                loaded_weight=loaded_weight,
+                weight_name=weight_name,
+                shard_id=shard_id,
+                logical_expert_id=expert_id,
+                return_success=return_success,
+            )
+
+    routed_experts = RoutedExperts()
     param = nn.Parameter(torch.empty(1))
-
-    def weight_loader(
-        param,
-        loaded_weight,
-        name,
-        shard_id,
-        expert_id,
-        return_success,
-    ) -> bool:
-        del param, name, shard_id
-        assert return_success is True
-        calls.append((expert_id, loaded_weight.item()))
-        return True
-
-    param.weight_loader = weight_loader
-    checkpoint = torch.tensor([[10.0], [20.0], [30.0], [40.0]])
+    param.weight_loader = routed_experts.weight_loader
     model_class = (
         hy_v4_model.HYV4Model if owner == "target" else hy_v4_mtp.HYV4MTP
     )
@@ -353,24 +379,22 @@ def test_static_fused_loader_uses_mapped_logical_experts(owner: str) -> None:
     )
 
     loaded = loader(
-        "experts.w13_weight",
-        {"experts.w13_weight": param},
+        parameter_name,
+        {parameter_name: param},
         checkpoint,
         "w1",
         num_experts=4,
         num_redundant_experts=2,
-        physical_to_logical=(3, 2, 1, 0, 3, 2),
     )
 
     assert loaded is True
-    assert calls == [
-        (0, 40.0),
-        (1, 30.0),
-        (2, 20.0),
-        (3, 10.0),
-        (4, 40.0),
-        (5, 30.0),
-    ]
+    for physical_expert_id, logical_expert_id in enumerate(row):
+        torch.testing.assert_close(
+            destination[physical_expert_id],
+            checkpoint[logical_expert_id],
+            rtol=0,
+            atol=0,
+        )
 
 
 def test_direct_load_is_tensor_equivalent_to_legacy_rearrangement() -> None:

--- a/tests/models/hy_v4/test_eplb.py
+++ b/tests/models/hy_v4/test_eplb.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 from torch import nn
 
@@ -12,6 +13,11 @@ from vllm.model_executor.models.interfaces import is_mixture_of_experts
 
 from vllm_hcu.models.hy_v4 import model as hy_v4_model
 from vllm_hcu.models.hy_v4 import mtp as hy_v4_mtp
+from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    StaticEplbPlan,
+    build_expert_params_mapping_for_row,
+    static_eplb_layer_map_for_weight,
+)
 
 
 class _FakeMoELayer(nn.Module):
@@ -74,6 +80,7 @@ def test_target_wrapper_exposes_mixture_of_experts_contract(monkeypatch) -> None
             super().__init__()
             self.make_empty_intermediate_tensors = object()
             self._vllm_hcu_static_eplb_plan = static_plan
+            self._vllm_hcu_moe_layer_indices = [0]
             _set_moe_metadata(self, layer)
 
         def set_eplb_state(self, *args) -> None:
@@ -149,6 +156,7 @@ def test_mtp_wrapper_exposes_mixture_of_experts_contract(monkeypatch) -> None:
             super().__init__()
             self.quant_config = None
             self._vllm_hcu_static_eplb_plan = static_plan
+            self._vllm_hcu_moe_layer_indices = [0]
             _set_moe_metadata(self, layer)
 
         def set_eplb_state(self, *args) -> None:
@@ -263,3 +271,119 @@ def test_mtp_fused_loader_copies_logical_weights_to_redundant_experts() -> None:
         (4, 10.0),
         (5, 20.0),
     ]
+
+
+def _static_plan(rows: tuple[tuple[int, ...], ...]) -> StaticEplbPlan:
+    return StaticEplbPlan(
+        model_key="HYV4ForCausalLM",
+        source_path="/tmp/map.json",
+        source_sha256="a" * 64,
+        _map_values=rows,
+        num_logical_experts=4,
+        num_physical_experts=6,
+        num_redundant_experts=2,
+    )
+
+
+def test_static_layer_map_uses_absolute_moe_layer_order() -> None:
+    plan = _static_plan(
+        (
+            (0, 1, 2, 3, 0, 1),
+            (3, 2, 1, 0, 3, 2),
+        )
+    )
+
+    assert static_eplb_layer_map_for_weight(
+        plan, (3, 7), "model.layers.7.mlp.experts.gate_up_proj.weight"
+    ) == (3, 2, 1, 0, 3, 2)
+    with pytest.raises(ValueError, match="not an MoE layer"):
+        static_eplb_layer_map_for_weight(
+            plan, (3, 7), "model.layers.5.mlp.experts.0.gate_proj.weight"
+        )
+
+
+def test_static_split_mapping_targets_all_physical_replicas() -> None:
+    model = nn.Module()
+    mapping = build_expert_params_mapping_for_row(
+        model,
+        ckpt_gate_proj_name="gate_proj",
+        ckpt_down_proj_name="down_proj",
+        ckpt_up_proj_name="up_proj",
+        physical_to_logical=(3, 2, 1, 0, 3, 2),
+    )
+
+    gate_logical_three = [
+        item for item in mapping if item[1] == "experts.3.gate_proj."
+    ]
+    assert gate_logical_three == [
+        ("experts.routed_experts.w13_", "experts.3.gate_proj.", 0, "w1"),
+        ("experts.routed_experts.w13_", "experts.3.gate_proj.", 4, "w1"),
+    ]
+
+
+@pytest.mark.parametrize("owner", ["target", "mtp"])
+def test_static_fused_loader_uses_mapped_logical_experts(owner: str) -> None:
+    calls: list[tuple[int, float]] = []
+    param = nn.Parameter(torch.empty(1))
+
+    def weight_loader(
+        param,
+        loaded_weight,
+        name,
+        shard_id,
+        expert_id,
+        return_success,
+    ) -> bool:
+        del param, name, shard_id
+        assert return_success is True
+        calls.append((expert_id, loaded_weight.item()))
+        return True
+
+    param.weight_loader = weight_loader
+    checkpoint = torch.tensor([[10.0], [20.0], [30.0], [40.0]])
+    model_class = (
+        hy_v4_model.HYV4Model if owner == "target" else hy_v4_mtp.HYV4MTP
+    )
+    model = object.__new__(model_class)
+    nn.Module.__init__(model)
+    loader = (
+        model.load_fused_expert_weights
+        if owner == "target"
+        else model._load_fused_expert_weights
+    )
+
+    loaded = loader(
+        "experts.w13_weight",
+        {"experts.w13_weight": param},
+        checkpoint,
+        "w1",
+        num_experts=4,
+        num_redundant_experts=2,
+        physical_to_logical=(3, 2, 1, 0, 3, 2),
+    )
+
+    assert loaded is True
+    assert calls == [
+        (0, 40.0),
+        (1, 30.0),
+        (2, 20.0),
+        (3, 10.0),
+        (4, 40.0),
+        (5, 30.0),
+    ]
+
+
+def test_direct_load_is_tensor_equivalent_to_legacy_rearrangement() -> None:
+    checkpoint = torch.arange(4 * 3, dtype=torch.float32).reshape(4, 3)
+    source_map = (0, 1, 2, 3, 0, 1)
+    target_map = (3, 2, 1, 0, 3, 2)
+    legacy_loaded = torch.stack([checkpoint[logical] for logical in source_map])
+    legacy_rearranged = torch.stack(
+        [
+            legacy_loaded[source_map.index(logical)]
+            for logical in target_map
+        ]
+    )
+    direct_loaded = torch.stack([checkpoint[logical] for logical in target_map])
+
+    torch.testing.assert_close(direct_loaded, legacy_rearranged, rtol=0, atol=0)

--- a/tests/models/hy_v4/test_mtp.py
+++ b/tests/models/hy_v4/test_mtp.py
@@ -9,9 +9,9 @@ import torch
 import pytest
 from torch import nn
 
+from tests.models.static_eplb_test_utils import apply_real_moe_layer_patch
 from vllm_hcu.models.hy_v4 import mtp as hy_v4_mtp
 from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
-    StaticEplbPlan,
     load_static_logical_expert,
 )
 
@@ -388,13 +388,14 @@ def test_fused_expert_scale_loader_targets_scale_parameter() -> None:
     torch.testing.assert_close(calls[2][0], checkpoint_scale[0, 2:])
 
 
-def test_mtp_split_expert_loading_passes_logical_id_to_common_loader() -> None:
+def test_mtp_split_expert_loading_passes_logical_id_to_common_loader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    apply_real_moe_layer_patch(monkeypatch)
     parameter_name = (
         "model.layers.78.mtp_block.mlp.experts.routed_experts.w13_weight"
     )
-    checkpoint_name = (
-        "model.layers.78.mtp_block.mlp.experts.3.gate_proj.weight"
-    )
+    checkpoint_name = "model.layers.78.mlp.experts.3.gate_proj.weight"
     checkpoint = torch.tensor([[7.0, 8.0], [9.0, 10.0]])
     row = (3, 2, 1, 0, 3, 2)
     parameter = nn.Parameter(
@@ -441,38 +442,43 @@ def test_mtp_split_expert_loading_passes_logical_id_to_common_loader() -> None:
 
     routed_experts = RoutedExperts()
     parameter.weight_loader = routed_experts.weight_loader
-    mtp = object.__new__(hy_v4_mtp.HYV4MTP)
+
+    class MinimalMTP(hy_v4_mtp.HYV4MTP):
+        def named_parameters(self, *args, **kwargs):
+            del args, kwargs
+            return iter([(parameter_name, parameter)])
+
+    mtp = object.__new__(MinimalMTP)
     nn.Module.__init__(mtp)
+    mtp.config = SimpleNamespace(
+        num_hidden_layers=78,
+        n_routed_experts=4,
+        num_attention_heads=8,
+    )
     mtp.num_redundant_experts = 2
-    mtp._vllm_hcu_static_eplb_plan = StaticEplbPlan(
-        model_key="HYV4MTP",
-        source_path="/tmp/map.json",
-        source_sha256="a" * 64,
-        _map_values=(row,),
-        num_logical_experts=4,
-        num_physical_experts=6,
+    mtp.quant_config = None
+    mtp._vllm_hcu_static_eplb_plan = object()
+    monkeypatch.setattr(hy_v4_mtp, "get_pp_missing_layer_names", lambda model: set())
+    monkeypatch.setattr(
+        hy_v4_mtp,
+        "is_pp_missing_parameter",
+        lambda name, model: False,
+    )
+    monkeypatch.setattr(hy_v4_mtp, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(hy_v4_mtp, "get_tensor_model_parallel_rank", lambda: 0)
+
+    mapping = hy_v4_mtp.fused_moe_make_expert_params_mapping(
+        mtp,
+        ckpt_gate_proj_name="gate_proj",
+        ckpt_down_proj_name="down_proj",
+        ckpt_up_proj_name="up_proj",
+        num_experts=4,
         num_redundant_experts=2,
     )
-    loaded_params: set[str] = set()
+    assert sorted({entry[2] for entry in mapping}) == [0, 1, 2, 3]
 
-    consumed = mtp._load_expert_weight(
-        checkpoint_name,
-        checkpoint,
-        {parameter_name: parameter},
-        loaded_params,
-        [
-            (
-                "experts.routed_experts.w13_",
-                "experts.3.gate_proj.",
-                3,
-                "w1",
-            )
-        ],
-        {},
-        num_experts=4,
-    )
+    loaded_params = mtp.load_weights([(checkpoint_name, checkpoint)])
 
-    assert consumed is True
     assert loaded_params == {parameter_name}
     for physical_expert_id in (0, 4):
         torch.testing.assert_close(parameter[physical_expert_id], checkpoint)

--- a/tests/models/hy_v4/test_mtp.py
+++ b/tests/models/hy_v4/test_mtp.py
@@ -10,6 +10,10 @@ import pytest
 from torch import nn
 
 from vllm_hcu.models.hy_v4 import mtp as hy_v4_mtp
+from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    StaticEplbPlan,
+    load_static_logical_expert,
+)
 
 
 def test_shared_head_uses_backbone_lm_head_quant_prefix(monkeypatch) -> None:
@@ -382,6 +386,98 @@ def test_fused_expert_scale_loader_targets_scale_parameter() -> None:
     ]
     torch.testing.assert_close(calls[0][0], checkpoint_scale[0, :2])
     torch.testing.assert_close(calls[2][0], checkpoint_scale[0, 2:])
+
+
+def test_mtp_split_expert_loading_passes_logical_id_to_common_loader() -> None:
+    parameter_name = (
+        "model.layers.78.mtp_block.mlp.experts.routed_experts.w13_weight"
+    )
+    checkpoint_name = (
+        "model.layers.78.mtp_block.mlp.experts.3.gate_proj.weight"
+    )
+    checkpoint = torch.tensor([[7.0, 8.0], [9.0, 10.0]])
+    row = (3, 2, 1, 0, 3, 2)
+    parameter = nn.Parameter(
+        torch.full((len(row), *checkpoint.shape), float("nan"))
+    )
+
+    class RoutedExperts:
+        _vllm_hcu_static_eplb_row = row
+
+        @staticmethod
+        def original_weight_loader(
+            routed_experts,
+            param,
+            loaded_weight,
+            weight_name,
+            shard_id,
+            expert_id,
+            return_success=False,
+        ):
+            del routed_experts, weight_name, shard_id
+            with torch.no_grad():
+                param[expert_id].copy_(loaded_weight)
+            return True if return_success else None
+
+        def weight_loader(
+            self,
+            param,
+            loaded_weight,
+            weight_name,
+            shard_id,
+            expert_id,
+            return_success=False,
+        ):
+            return load_static_logical_expert(
+                self,
+                self.original_weight_loader,
+                param=param,
+                loaded_weight=loaded_weight,
+                weight_name=weight_name,
+                shard_id=shard_id,
+                logical_expert_id=expert_id,
+                return_success=return_success,
+            )
+
+    routed_experts = RoutedExperts()
+    parameter.weight_loader = routed_experts.weight_loader
+    mtp = object.__new__(hy_v4_mtp.HYV4MTP)
+    nn.Module.__init__(mtp)
+    mtp.num_redundant_experts = 2
+    mtp._vllm_hcu_static_eplb_plan = StaticEplbPlan(
+        model_key="HYV4MTP",
+        source_path="/tmp/map.json",
+        source_sha256="a" * 64,
+        _map_values=(row,),
+        num_logical_experts=4,
+        num_physical_experts=6,
+        num_redundant_experts=2,
+    )
+    loaded_params: set[str] = set()
+
+    consumed = mtp._load_expert_weight(
+        checkpoint_name,
+        checkpoint,
+        {parameter_name: parameter},
+        loaded_params,
+        [
+            (
+                "experts.routed_experts.w13_",
+                "experts.3.gate_proj.",
+                3,
+                "w1",
+            )
+        ],
+        {},
+        num_experts=4,
+    )
+
+    assert consumed is True
+    assert loaded_params == {parameter_name}
+    for physical_expert_id in (0, 4):
+        torch.testing.assert_close(parameter[physical_expert_id], checkpoint)
+    assert torch.isnan(parameter[1:4]).all()
+    assert torch.isnan(parameter[5]).all()
 
 
 def test_mtp_load_weights_rewrites_wrapper_weight_and_is_strict(monkeypatch) -> None:

--- a/tests/models/hy_v4/test_weight_loading.py
+++ b/tests/models/hy_v4/test_weight_loading.py
@@ -25,6 +25,10 @@ from vllm_hcu.models.hy_v4.model import (
     _try_load_fp8_indexer_projection,
     _try_load_fp8_router_gate,
 )
+from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    StaticEplbPlan,
+    load_static_logical_expert,
+)
 from vllm_hcu.patch.platform.core_fix import patch_logits_processor_head_dtype
 
 
@@ -293,6 +297,114 @@ def test_load_weights_maps_router_correction_bias_before_unknown_bias_filter(
 
     assert loaded == {parameter_name}
     torch.testing.assert_close(parameter, loaded_weight)
+
+
+def test_split_expert_loading_passes_logical_id_to_common_loader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parameter_name = "layers.7.mlp.experts.routed_experts.w13_weight"
+    checkpoint_name = "layers.7.mlp.experts.3.gate_proj.weight"
+    checkpoint = torch.tensor([[7.0, 8.0], [9.0, 10.0]])
+    row = (3, 2, 1, 0, 3, 2)
+    parameter = torch.nn.Parameter(
+        torch.full((len(row), *checkpoint.shape), float("nan"))
+    )
+
+    class RoutedExperts:
+        _vllm_hcu_static_eplb_row = row
+
+        @staticmethod
+        def original_weight_loader(
+            routed_experts,
+            param,
+            loaded_weight,
+            weight_name,
+            shard_id,
+            expert_id,
+            return_success=False,
+        ):
+            del routed_experts, weight_name, shard_id
+            with torch.no_grad():
+                param[expert_id].copy_(loaded_weight)
+            return True if return_success else None
+
+        def weight_loader(
+            self,
+            param,
+            loaded_weight,
+            weight_name,
+            shard_id,
+            expert_id,
+            return_success=False,
+        ):
+            return load_static_logical_expert(
+                self,
+                self.original_weight_loader,
+                param=param,
+                loaded_weight=loaded_weight,
+                weight_name=weight_name,
+                shard_id=shard_id,
+                logical_expert_id=expert_id,
+                return_success=return_success,
+            )
+
+    routed_experts = RoutedExperts()
+    parameter.weight_loader = routed_experts.weight_loader
+
+    class MinimalModel:
+        config = SimpleNamespace(
+            tie_word_embeddings=False,
+            num_experts=4,
+            num_attention_heads=8,
+        )
+        num_redundant_experts = 2
+        _vllm_hcu_static_eplb_plan = StaticEplbPlan(
+            model_key="HYV4ForCausalLM",
+            source_path="/tmp/map.json",
+            source_sha256="a" * 64,
+            _map_values=(row,),
+            num_logical_experts=4,
+            num_physical_experts=6,
+            num_redundant_experts=2,
+        )
+
+        @staticmethod
+        def named_parameters():
+            return [(parameter_name, parameter)]
+
+        @staticmethod
+        def get_expert_mapping():
+            return [
+                (
+                    "experts.routed_experts.w13_",
+                    "experts.3.gate_proj.",
+                    3,
+                    "w1",
+                )
+            ]
+
+    monkeypatch.setattr(
+        hy_v4_model, "get_pp_missing_layer_names", lambda model: set()
+    )
+    monkeypatch.setattr(hy_v4_model, "compute_skip_topk_layers", lambda config: set())
+    monkeypatch.setattr(
+        hy_v4_model, "is_pp_missing_parameter", lambda name, model: False
+    )
+    monkeypatch.setattr(
+        hy_v4_model, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    monkeypatch.setattr(hy_v4_model, "get_tensor_model_parallel_rank", lambda: 0)
+
+    loaded = HYV4Model.load_weights(
+        MinimalModel(),
+        [(checkpoint_name, checkpoint)],
+    )
+
+    assert loaded == {parameter_name}
+    for physical_expert_id in (0, 4):
+        torch.testing.assert_close(parameter[physical_expert_id], checkpoint)
+    assert torch.isnan(parameter[1:4]).all()
+    assert torch.isnan(parameter[5]).all()
 
 
 def test_outer_load_weights_checks_correction_biases_after_all_prefix_groups(

--- a/tests/models/hy_v4/test_weight_loading.py
+++ b/tests/models/hy_v4/test_weight_loading.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.quantization.kv_cache import KVCacheScaleParamet
 from vllm.model_executor.layers import vocab_parallel_embedding as vocab_module
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 
+from tests.models.static_eplb_test_utils import apply_real_moe_layer_patch
 from vllm_hcu.models.hy_v4 import model as hy_v4_model
 from vllm_hcu.models.hy_v4.model import (
     HYV4ForCausalLM,
@@ -26,7 +27,6 @@ from vllm_hcu.models.hy_v4.model import (
     _try_load_fp8_router_gate,
 )
 from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
-    StaticEplbPlan,
     load_static_logical_expert,
 )
 from vllm_hcu.patch.platform.core_fix import patch_logits_processor_head_dtype
@@ -302,6 +302,7 @@ def test_load_weights_maps_router_correction_bias_before_unknown_bias_filter(
 def test_split_expert_loading_passes_logical_id_to_common_loader(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    apply_real_moe_layer_patch(monkeypatch)
     parameter_name = "layers.7.mlp.experts.routed_experts.w13_weight"
     checkpoint_name = "layers.7.mlp.experts.3.gate_proj.weight"
     checkpoint = torch.tensor([[7.0, 8.0], [9.0, 10.0]])
@@ -358,30 +359,13 @@ def test_split_expert_loading_passes_logical_id_to_common_loader(
             num_attention_heads=8,
         )
         num_redundant_experts = 2
-        _vllm_hcu_static_eplb_plan = StaticEplbPlan(
-            model_key="HYV4ForCausalLM",
-            source_path="/tmp/map.json",
-            source_sha256="a" * 64,
-            _map_values=(row,),
-            num_logical_experts=4,
-            num_physical_experts=6,
-            num_redundant_experts=2,
-        )
+        _vllm_hcu_static_eplb_plan = object()
 
         @staticmethod
         def named_parameters():
             return [(parameter_name, parameter)]
 
-        @staticmethod
-        def get_expert_mapping():
-            return [
-                (
-                    "experts.routed_experts.w13_",
-                    "experts.3.gate_proj.",
-                    3,
-                    "w1",
-                )
-            ]
+        get_expert_mapping = HYV4Model.get_expert_mapping
 
     monkeypatch.setattr(
         hy_v4_model, "get_pp_missing_layer_names", lambda model: set()
@@ -395,8 +379,11 @@ def test_split_expert_loading_passes_logical_id_to_common_loader(
     )
     monkeypatch.setattr(hy_v4_model, "get_tensor_model_parallel_rank", lambda: 0)
 
+    model = MinimalModel()
+    assert sorted({entry[2] for entry in model.get_expert_mapping()}) == [0, 1, 2, 3]
+
     loaded = HYV4Model.load_weights(
-        MinimalModel(),
+        model,
         [(checkpoint_name, checkpoint)],
     )
 

--- a/tests/models/static_eplb_test_utils.py
+++ b/tests/models/static_eplb_test_utils.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+
+from __future__ import annotations
+
+import inspect
+from importlib import import_module
+from typing import Callable
+
+from pytest import MonkeyPatch
+
+from vllm_hcu.patch.worker.op_opt.moe import patch_layer
+
+
+def _track_direct_patch(
+    monkeypatch: MonkeyPatch,
+    owner: object,
+    name: str,
+) -> None:
+    """Record an attribute so pytest restores a direct patch-layer mutation."""
+
+    try:
+        value = inspect.getattr_static(owner, name)
+    except AttributeError:
+        monkeypatch.setattr(owner, name, None, raising=False)
+    else:
+        monkeypatch.setattr(owner, name, value)
+
+
+def apply_real_moe_layer_patch(
+    monkeypatch: MonkeyPatch,
+) -> Callable[..., list[tuple[str, str, int, str]]]:
+    """Apply the production mapping patch and arrange complete test cleanup."""
+
+    fused_moe = import_module(patch_layer.TARGET_MODULE)
+    layer = import_module(patch_layer.LAYER_MODULE)
+    if getattr(fused_moe, patch_layer._MARKER, False):
+        return fused_moe.fused_moe_make_expert_params_mapping
+
+    routed_experts = fused_moe.RoutedExperts
+    tracked: tuple[tuple[object, str], ...] = (
+        (fused_moe, "FusedMoE"),
+        (fused_moe, patch_layer._MARKER),
+        (fused_moe, "_vllm_hcu_original_fused_moe_factory"),
+        (layer, "FusedMoE"),
+        (layer, "_vllm_hcu_original_fused_moe_factory"),
+        (routed_experts, "get_expert_weights"),
+        (routed_experts, "load_weights"),
+        (routed_experts, "weight_loader"),
+        (routed_experts, "get_expert_mapping"),
+        (routed_experts, "make_expert_params_mapping"),
+        (routed_experts, "_vllm_hcu_original_get_expert_weights"),
+        (routed_experts, "_vllm_hcu_original_load_weights"),
+        (routed_experts, "_vllm_hcu_original_weight_loader"),
+        (routed_experts, "_vllm_hcu_original_get_expert_mapping"),
+        (routed_experts, "_vllm_hcu_original_make_expert_params_mapping"),
+    )
+    for owner, name in tracked:
+        _track_direct_patch(monkeypatch, owner, name)
+
+    assert patch_layer.apply_to_module(fused_moe) is True
+    return fused_moe.fused_moe_make_expert_params_mapping
+
+
+__all__ = ["apply_real_moe_layer_patch"]

--- a/tests/models/test_common_static_eplb_models.py
+++ b/tests/models/test_common_static_eplb_models.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 from torch import nn
 
+from tests.models.static_eplb_test_utils import apply_real_moe_layer_patch
 from vllm_hcu.model_executor.layers.fused_moe import static_eplb
 
 
@@ -112,7 +113,7 @@ def _config() -> SimpleNamespace:
     )
 
 
-def test_deepseek_style_standard_loader_fans_out_a_logical_mapping(
+def test_patched_standard_mapping_feeds_logical_id_to_common_loader(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     routed_experts = _RoutedExperts(local_physical_ids={3})
@@ -126,7 +127,23 @@ def test_deepseek_style_standard_loader_fans_out_a_logical_mapping(
 
     assert static_eplb.bind_static_eplb_plan(_config(), model) is plan
 
-    # This is the terminal call shape shared by the audited DeepSeek V2/V4,
+    make_expert_mapping = apply_real_moe_layer_patch(monkeypatch)
+    mapping = make_expert_mapping(
+        model,
+        ckpt_gate_proj_name="gate_proj",
+        ckpt_down_proj_name="down_proj",
+        ckpt_up_proj_name="up_proj",
+        num_experts=3,
+        num_redundant_experts=1,
+    )
+    assert sorted({entry[2] for entry in mapping}) == [0, 1, 2]
+    parameter_name, checkpoint_prefix, expert_id, shard_id = next(
+        entry
+        for entry in mapping
+        if entry[1] == "experts.2.down_proj."
+    )
+
+    # This mapping-to-loader handoff is shared by the audited DeepSeek V2/V4,
     # HY V3, GLM4 MoE, and ordinary MTP split-expert loaders.
     parameter = nn.Parameter(torch.empty(1))
     parameter.weight_loader = routed_experts.parameter_weight_loader
@@ -134,12 +151,13 @@ def test_deepseek_style_standard_loader_fans_out_a_logical_mapping(
     loaded = parameter.weight_loader(
         parameter,
         checkpoint_expert,
-        "model.layers.1.mlp.experts.routed_experts.w2_weight",
-        shard_id="w2",
-        expert_id=2,
+        f"model.layers.1.mlp.{parameter_name}weight",
+        shard_id=shard_id,
+        expert_id=expert_id,
         return_success=True,
     )
 
+    assert checkpoint_prefix == "experts.2.down_proj."
     assert loaded is True
     assert routed_experts.attempted_physical_ids == [0, 3]
     assert set(routed_experts.loaded) == {3}

--- a/tests/models/test_common_static_eplb_models.py
+++ b/tests/models/test_common_static_eplb_models.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from importlib import import_module
 from types import SimpleNamespace
 
 import pytest
@@ -11,6 +12,7 @@ from torch import nn
 
 from tests.models.static_eplb_test_utils import apply_real_moe_layer_patch
 from vllm_hcu.model_executor.layers.fused_moe import static_eplb
+from vllm_hcu.patch.worker.framework_opt import patch_llama4_static_eplb
 
 
 class _RoutedExperts:
@@ -18,6 +20,7 @@ class _RoutedExperts:
         self.local_physical_ids = local_physical_ids
         self.attempted_physical_ids: list[int] = []
         self.loaded: dict[int, torch.Tensor] = {}
+        self.loaded_by_shard: dict[tuple[int, object], torch.Tensor] = {}
         # vLLM quant methods capture this standard bound callback while their
         # parameters are created.
         self.parameter_weight_loader = self.weight_loader
@@ -31,11 +34,12 @@ class _RoutedExperts:
         expert_id,
         return_success=False,
     ):
-        del param, weight_name, shard_id
+        del param, weight_name
         self.attempted_physical_ids.append(expert_id)
         loaded = expert_id in self.local_physical_ids
         if loaded:
             self.loaded[expert_id] = loaded_weight.clone()
+            self.loaded_by_shard[expert_id, shard_id] = loaded_weight.clone()
         return loaded if return_success else None
 
     def weight_loader(
@@ -184,3 +188,129 @@ def test_custom_mega_moe_layer_is_rejected_before_checkpoint_loading(
         static_eplb.bind_static_eplb_plan(_config(), model)
 
     assert not hasattr(model, "_vllm_hcu_static_eplb_plan")
+
+
+def test_real_llama4_fused_loader_direct_loads_configured_logical_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise the audited vLLM all-expert 3-D checkpoint path."""
+
+    llama4 = import_module(patch_llama4_static_eplb.TARGET_MODULE)
+    llama4_model = llama4.Llama4Model
+    original = llama4_model.load_moe_expert_weights
+    monkeypatch.setattr(llama4_model, "load_moe_expert_weights", original)
+    for attribute in (
+        patch_llama4_static_eplb._MODULE_MARKER,
+        "_vllm_hcu_original_load_moe_expert_weights",
+    ):
+        current = getattr(llama4, attribute, None)
+        monkeypatch.setattr(llama4, attribute, current, raising=False)
+
+    assert patch_llama4_static_eplb.apply_to_module(llama4) is True
+    assert patch_llama4_static_eplb.apply_to_module(llama4) is False
+
+    routed_experts = _RoutedExperts(local_physical_ids={0, 1, 2, 3})
+    setattr(routed_experts, "_vllm_hcu_static_eplb_row", (2, 1, 0, 2))
+    runner = SimpleNamespace(
+        routed_experts=routed_experts,
+        # This is the initial EPLB placement that the audited upstream method
+        # uses to slice the all-expert tensor.  Static loading must ignore it.
+        expert_map=torch.tensor([0, 1, 2, -1]),
+    )
+    model = SimpleNamespace(
+        layers=[
+            SimpleNamespace(
+                feed_forward=SimpleNamespace(experts=runner),
+            )
+        ],
+        named_modules=lambda: (),
+    )
+
+    parameter = nn.Parameter(torch.empty(1))
+    parameter.weight_loader = routed_experts.parameter_weight_loader
+    full_param_name = (
+        "model.layers.0.feed_forward.experts.routed_experts.w2_weight"
+    )
+    checkpoint_name = "model.layers.0.feed_forward.experts.down_proj"
+    checkpoint_weight = torch.arange(18, dtype=torch.float32).reshape(3, 2, 3)
+    loaded_params: set[str] = set()
+    mapping = [
+        (
+            "experts.routed_experts.w2_",
+            "experts.0.down_proj.",
+            0,
+            "w2",
+        )
+    ]
+
+    assert llama4_model.load_moe_expert_weights(
+        model,
+        checkpoint_name,
+        checkpoint_weight,
+        {full_param_name: parameter},
+        loaded_params,
+        mapping,
+        fused=True,
+    ) is True
+
+    assert routed_experts.attempted_physical_ids == [2, 1, 0, 3]
+    assert set(routed_experts.loaded) == {0, 1, 2, 3}
+    expected = checkpoint_weight.transpose(-1, -2)
+    for physical_id, logical_id in enumerate((2, 1, 0, 2)):
+        torch.testing.assert_close(
+            routed_experts.loaded[physical_id],
+            expected[logical_id],
+        )
+    assert loaded_params == {full_param_name}
+
+    routed_experts.attempted_physical_ids.clear()
+    routed_experts.loaded_by_shard.clear()
+    gate_up_param_name = (
+        "model.layers.0.feed_forward.experts.routed_experts.w13_weight"
+    )
+    gate_up_parameter = nn.Parameter(torch.empty(1))
+    gate_up_parameter.weight_loader = routed_experts.parameter_weight_loader
+    gate_up_weight = torch.arange(24, dtype=torch.float32).reshape(3, 2, 4)
+    gate_up_mapping = [
+        (
+            "experts.routed_experts.w13_",
+            "experts.0.gate_up_proj.",
+            0,
+            "w1",
+        ),
+        (
+            "experts.routed_experts.w13_",
+            "experts.0.gate_up_proj.",
+            0,
+            "w3",
+        ),
+    ]
+    assert llama4_model.load_moe_expert_weights(
+        model,
+        "model.layers.0.feed_forward.experts.gate_up_proj",
+        gate_up_weight,
+        {gate_up_param_name: gate_up_parameter},
+        set(),
+        gate_up_mapping,
+        fused=True,
+    ) is True
+    gate_up_shards = gate_up_weight.transpose(-1, -2).chunk(2, dim=-2)
+    for shard_id, shard in zip(("w1", "w3"), gate_up_shards, strict=True):
+        for physical_id, logical_id in enumerate((2, 1, 0, 2)):
+            torch.testing.assert_close(
+                routed_experts.loaded_by_shard[physical_id, shard_id],
+                shard[logical_id],
+            )
+
+    routed_experts.attempted_physical_ids.clear()
+    with pytest.raises(ValueError, match="expected 3 rows"):
+        llama4_model.load_moe_expert_weights(
+            model,
+            checkpoint_name,
+            checkpoint_weight[:2],
+            {full_param_name: parameter},
+            set(),
+            mapping,
+            fused=True,
+        )
+    assert routed_experts.attempted_physical_ids == []

--- a/tests/models/test_common_static_eplb_models.py
+++ b/tests/models/test_common_static_eplb_models.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vllm_hcu.model_executor.layers.fused_moe import static_eplb
+
+
+class _RoutedExperts:
+    def __init__(self, local_physical_ids: set[int]) -> None:
+        self.local_physical_ids = local_physical_ids
+        self.attempted_physical_ids: list[int] = []
+        self.loaded: dict[int, torch.Tensor] = {}
+        # vLLM quant methods capture this standard bound callback while their
+        # parameters are created.
+        self.parameter_weight_loader = self.weight_loader
+
+    def original_weight_loader(
+        self,
+        param,
+        loaded_weight,
+        weight_name,
+        shard_id,
+        expert_id,
+        return_success=False,
+    ):
+        del param, weight_name, shard_id
+        self.attempted_physical_ids.append(expert_id)
+        loaded = expert_id in self.local_physical_ids
+        if loaded:
+            self.loaded[expert_id] = loaded_weight.clone()
+        return loaded if return_success else None
+
+    def weight_loader(
+        self,
+        param,
+        loaded_weight,
+        weight_name,
+        shard_id,
+        expert_id,
+        return_success=False,
+    ):
+        return static_eplb.load_static_logical_expert(
+            self,
+            type(self).original_weight_loader,
+            param=param,
+            loaded_weight=loaded_weight,
+            weight_name=weight_name,
+            shard_id=shard_id,
+            logical_expert_id=expert_id,
+            return_success=return_success,
+        )
+
+
+class _MoERunner:
+    def __init__(self, routed_experts: object) -> None:
+        self.routed_experts = routed_experts
+
+    def get_expert_weights(self):
+        return []
+
+    def set_eplb_state(self, **kwargs) -> None:
+        del kwargs
+
+
+class _DeepseekV2Like(nn.Module):
+    """Small structural fake for the audited DeepSeek V2 loader contract."""
+
+    def __init__(self, runner: object) -> None:
+        super().__init__()
+        self.expert_weights = []
+        self.num_moe_layers = 1
+        self.num_expert_groups = 1
+        self.num_logical_experts = 3
+        self.num_physical_experts = 4
+        self.num_local_physical_experts = 1
+        self.num_routed_experts = 3
+        self.num_shared_experts = 0
+        self.num_redundant_experts = 1
+        self.moe_layers = [runner]
+
+    def set_eplb_state(self, *args) -> None:
+        del args
+
+    def update_physical_experts_metadata(self, *args) -> None:
+        del args
+
+
+def _plan() -> static_eplb.StaticEplbPlan:
+    return static_eplb.StaticEplbPlan(
+        model_key="_DeepseekV2Like",
+        source_path="/tmp/map.json",
+        source_sha256="a" * 64,
+        _map_values=((2, 1, 0, 2),),
+        num_logical_experts=3,
+        num_physical_experts=4,
+        num_redundant_experts=1,
+    )
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            _vllm_hcu_expert_map_path="fake-map.json",
+        )
+    )
+
+
+def test_deepseek_style_standard_loader_fans_out_a_logical_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routed_experts = _RoutedExperts(local_physical_ids={3})
+    model = _DeepseekV2Like(_MoERunner(routed_experts))
+    plan = _plan()
+    monkeypatch.setattr(
+        static_eplb,
+        "maybe_load_static_eplb_plan",
+        lambda *args, **kwargs: plan,
+    )
+
+    assert static_eplb.bind_static_eplb_plan(_config(), model) is plan
+
+    # This is the terminal call shape shared by the audited DeepSeek V2/V4,
+    # HY V3, GLM4 MoE, and ordinary MTP split-expert loaders.
+    parameter = nn.Parameter(torch.empty(1))
+    parameter.weight_loader = routed_experts.parameter_weight_loader
+    checkpoint_expert = torch.tensor([20.0, 21.0])
+    loaded = parameter.weight_loader(
+        parameter,
+        checkpoint_expert,
+        "model.layers.1.mlp.experts.routed_experts.w2_weight",
+        shard_id="w2",
+        expert_id=2,
+        return_success=True,
+    )
+
+    assert loaded is True
+    assert routed_experts.attempted_physical_ids == [0, 3]
+    assert set(routed_experts.loaded) == {3}
+    torch.testing.assert_close(routed_experts.loaded[3], checkpoint_expert)
+
+
+def test_custom_mega_moe_layer_is_rejected_before_checkpoint_loading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DeepseekV4MegaMoEExperts:
+        @staticmethod
+        def weight_loader(*args, **kwargs):
+            del args, kwargs
+
+    model = _DeepseekV2Like(DeepseekV4MegaMoEExperts())
+    plan = _plan()
+    monkeypatch.setattr(
+        static_eplb,
+        "maybe_load_static_eplb_plan",
+        lambda *args, **kwargs: plan,
+    )
+
+    with pytest.raises(ValueError, match="routed_experts"):
+        static_eplb.bind_static_eplb_plan(_config(), model)
+
+    assert not hasattr(model, "_vllm_hcu_static_eplb_plan")

--- a/tests/patch/test_config.py
+++ b/tests/patch/test_config.py
@@ -58,6 +58,7 @@ def test_dict_vllm_config_uses_canonical_storage_path() -> None:
                 "expert_map_record_path": None,
                 "expert_map_path": None,
                 "eplb_disable_rearrange": False,
+                "eplb_static_dispatch_policy": "nearest",
             }
         }
     }
@@ -131,6 +132,7 @@ def test_legacy_deep_gemm_sidecar_is_normalized_with_one_warning(
         ),
         ({"expert_map_record_path": 7}, TypeError),
         ({"eplb_disable_rearrange": 1}, TypeError),
+        ({"eplb_static_dispatch_policy": 1}, TypeError),
         (
             {
                 "expert_map_record_path": "/tmp/record.json",
@@ -163,3 +165,19 @@ def test_disable_eplb_rearrange_round_trips_through_sidecar() -> None:
 
     assert config.eplb_disable_rearrange is True
     assert HcuFeatureConfig.from_mapping(config.to_dict()) == config
+
+
+def test_locality_fair_eplb_dispatch_round_trips_through_sidecar() -> None:
+    config = HcuFeatureConfig.from_mapping(
+        {"eplb_static_dispatch_policy": "locality_fair"}
+    )
+
+    assert config.eplb_static_dispatch_policy == "locality_fair"
+    assert HcuFeatureConfig.from_mapping(config.to_dict()) == config
+
+
+def test_invalid_eplb_static_dispatch_policy_is_rejected() -> None:
+    with pytest.raises(ValueError, match="eplb_static_dispatch_policy"):
+        HcuFeatureConfig.from_mapping(
+            {"eplb_static_dispatch_policy": "first_replica"}
+        )

--- a/tests/patch/test_config.py
+++ b/tests/patch/test_config.py
@@ -57,6 +57,7 @@ def test_dict_vllm_config_uses_canonical_storage_path() -> None:
                 "hcu_flash_attn_mode": None,
                 "expert_map_record_path": None,
                 "expert_map_path": None,
+                "eplb_disable_rearrange": False,
             }
         }
     }
@@ -129,6 +130,14 @@ def test_legacy_deep_gemm_sidecar_is_normalized_with_one_warning(
             ValueError,
         ),
         ({"expert_map_record_path": 7}, TypeError),
+        ({"eplb_disable_rearrange": 1}, TypeError),
+        (
+            {
+                "expert_map_record_path": "/tmp/record.json",
+                "eplb_disable_rearrange": True,
+            },
+            ValueError,
+        ),
     ],
 )
 def test_invalid_values_are_rejected(payload: dict[str, object], error: type[Exception]) -> None:
@@ -147,3 +156,10 @@ def test_offline_eplb_paths_round_trip_through_sidecar() -> None:
 
     assert HcuFeatureConfig.from_mapping(record.to_dict()) == record
     assert pickle.loads(pickle.dumps(load)) == load
+
+
+def test_disable_eplb_rearrange_round_trips_through_sidecar() -> None:
+    config = HcuFeatureConfig.from_mapping({"eplb_disable_rearrange": True})
+
+    assert config.eplb_disable_rearrange is True
+    assert HcuFeatureConfig.from_mapping(config.to_dict()) == config

--- a/tests/patch/test_module_exchange.py
+++ b/tests/patch/test_module_exchange.py
@@ -618,6 +618,7 @@ def test_sparse_replacements_preserve_v0251_definition_surface_and_signatures(
     if replacement_relative.endswith("sparse_attn_indexer.py"):
         assert hcu_owned_definitions == {
             "V32SparseAttnIndexer",
+            "_hcu_indexer_k_quant_and_cache",
             "lightop_indexer_qk_quant_and_store",
         }
     else:

--- a/tests/patch/test_worker_dispatcher.py
+++ b/tests/patch/test_worker_dispatcher.py
@@ -17,6 +17,7 @@ import pytest
 import vllm_hcu.patch.worker as worker_dispatcher
 from vllm_hcu.patch.import_coordinator import ExactImportCoordinator
 from vllm_hcu.patch.runtime_state import LatchedPatchError, PatchRegistry, PatchStatus
+from vllm_hcu.patch.worker.framework_opt import patch_model_loader_static_eplb_gate
 
 
 REPO = Path(__file__).resolve().parents[2]
@@ -195,6 +196,13 @@ def test_pcp_model_state_dispatcher_inventory_is_always_enabled():
         "vllm.v1.worker.gpu.model_states.default",
     ) in worker_dispatcher.worker_callback_names()
     assert worker_dispatcher._patch_features()[patch_id] == "always"
+
+
+def test_static_eplb_loader_gate_has_auditable_dispatch_metadata():
+    assert (
+        patch_model_loader_static_eplb_gate.PATCH_ID,
+        patch_model_loader_static_eplb_gate.TARGET_MODULE,
+    ) in worker_dispatcher.worker_callback_names()
 
 
 def test_cold_replacement_metadata_matches_lazy_adapter_contracts():

--- a/tests/patch/test_worker_dispatcher.py
+++ b/tests/patch/test_worker_dispatcher.py
@@ -97,6 +97,7 @@ def test_worker_inventory_is_complete_explicit_and_dependency_ordered():
         "worker.op_opt.attention.fused_qkv_public_export"
     ]
     framework_order = (
+        "worker.framework_opt.model_loader.static_eplb_preload",
         "worker.framework_opt.dp.deepep_low_latency",
         "worker.framework_opt.forward_context.hcu_runtime_fields",
         "worker.framework_opt.communicator.base_custom_sp",

--- a/tests/patch/test_worker_dispatcher.py
+++ b/tests/patch/test_worker_dispatcher.py
@@ -145,6 +145,49 @@ def test_worker_inventory_is_complete_explicit_and_dependency_ordered():
     assert "os.walk(" not in source
 
 
+def test_static_eplb_callbacks_apply_during_cold_model_loader_import():
+    result = _run_fresh(
+        """
+import json
+
+from vllm_hcu.patch.worker import prepare_worker_patches
+
+prepare_worker_patches()
+import vllm.model_executor.model_loader as model_loader
+from vllm.model_executor.model_loader import base_loader, utils
+from vllm.model_executor.models import llama4
+
+print(json.dumps({
+    "initializer_wrapped": bool(getattr(
+        utils.initialize_model,
+        "_vllm_hcu_static_eplb_model_loader_wrapper",
+        False,
+    )),
+    "base_alias_current": base_loader.initialize_model is utils.initialize_model,
+    "entrypoint_wrapped": bool(getattr(
+        model_loader.get_model_loader,
+        "_vllm_hcu_static_eplb_loader_gate_wrapper",
+        False,
+    )),
+    "llama4_fused_wrapped": bool(getattr(
+        llama4.Llama4Model.load_moe_expert_weights,
+        "_vllm_hcu_llama4_static_eplb_fused_wrapper",
+        False,
+    )),
+}))
+""",
+        timeout=180,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload == {
+        "initializer_wrapped": True,
+        "base_alias_current": True,
+        "entrypoint_wrapped": True,
+        "llama4_fused_wrapped": True,
+    }
+
+
 def test_pcp_model_state_dispatcher_inventory_is_always_enabled():
     patch_id = "worker.framework_opt.pcp.default_model_state_metadata"
     assert (

--- a/tests/patch/test_worker_dispatcher.py
+++ b/tests/patch/test_worker_dispatcher.py
@@ -779,6 +779,24 @@ def test_worker_binds_disable_eplb_rearrange_to_parallel_config():
     assert payload == {"disable": True}
 
 
+def test_worker_binds_eplb_static_dispatch_policy_to_parallel_config():
+    result = _run_fresh(
+        "import json; from types import SimpleNamespace; "
+        "CompilationConfig=type('CompilationConfig',(),{}); "
+        "from vllm_hcu.patch.worker import apply_worker_patches; "
+        "parallel=SimpleNamespace(all2all_backend='allgather_reducescatter'); "
+        "config=SimpleNamespace(additional_config={'hcu':{"
+        "'eplb_static_dispatch_policy':'locality_fair'}},"
+        "compilation_config=CompilationConfig(),parallel_config=parallel); "
+        "apply_worker_patches(config); "
+        "print(json.dumps({'policy':getattr(parallel,"
+        "'_vllm_hcu_eplb_static_dispatch_policy',None)}))"
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload == {"policy": "locality_fair"}
+
+
 def test_pcp_model_state_adapter_matches_exact_v0251_target():
     result = _run_fresh(
         """

--- a/tests/patch/test_worker_dispatcher.py
+++ b/tests/patch/test_worker_dispatcher.py
@@ -761,6 +761,24 @@ def test_worker_binds_offline_eplb_paths_to_parallel_config():
     assert payload == {"record": "/models/maps/hy4.json", "load": None}
 
 
+def test_worker_binds_disable_eplb_rearrange_to_parallel_config():
+    result = _run_fresh(
+        "import json; from types import SimpleNamespace; "
+        "CompilationConfig=type('CompilationConfig',(),{}); "
+        "from vllm_hcu.patch.worker import apply_worker_patches; "
+        "parallel=SimpleNamespace(all2all_backend='allgather_reducescatter'); "
+        "config=SimpleNamespace(additional_config={'hcu':{"
+        "'eplb_disable_rearrange':True}},"
+        "compilation_config=CompilationConfig(),parallel_config=parallel); "
+        "apply_worker_patches(config); "
+        "print(json.dumps({'disable':getattr(parallel,"
+        "'_vllm_hcu_eplb_disable_rearrange',None)}))"
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload == {"disable": True}
+
+
 def test_pcp_model_state_adapter_matches_exact_v0251_target():
     result = _run_fresh(
         """

--- a/tests/runtime_patch/test_eplb_locality_fair_dispatch.py
+++ b/tests/runtime_patch/test_eplb_locality_fair_dispatch.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+import torch
+
+
+def test_locality_fair_removes_same_node_first_replica_bias() -> None:
+    from vllm_hcu.model_executor.layers.fused_moe.eplb_dispatch import (
+        build_locality_fair_replica_order,
+    )
+
+    logical_to_physical_map = torch.tensor([[[0, 1]]], dtype=torch.int64)
+
+    rank_maps = [
+        build_locality_fair_replica_order(
+            logical_to_physical_map,
+            ep_rank=ep_rank,
+            ep_size=8,
+            num_nodes=1,
+            num_physical_experts=8,
+            seed=42,
+        )
+        for ep_rank in range(8)
+    ]
+
+    assert rank_maps[0].tolist() == [[[0, 1]]]
+    assert rank_maps[1].tolist() == [[[1, 0]]]
+    assert Counter(rank_map[0, 0, 0].item() for rank_map in rank_maps) == {
+        0: 4,
+        1: 4,
+    }
+    assert all(sorted(rank_map[0, 0].tolist()) == [0, 1] for rank_map in rank_maps)
+
+
+def test_locality_fair_rejects_non_divisible_expert_topology() -> None:
+    from vllm_hcu.model_executor.layers.fused_moe.eplb_dispatch import (
+        build_locality_fair_replica_order,
+    )
+
+    with pytest.raises(ValueError, match="num_physical_experts.*ep_size"):
+        build_locality_fair_replica_order(
+            torch.tensor([[[0, 1]]], dtype=torch.int64),
+            ep_rank=0,
+            ep_size=8,
+            num_nodes=1,
+            num_physical_experts=10,
+        )
+
+
+@pytest.mark.parametrize(
+    ("mapping", "kwargs", "message"),
+    [
+        (
+            torch.tensor([[0, 1]], dtype=torch.int64),
+            {"ep_rank": 0, "ep_size": 2, "num_nodes": 1, "num_physical_experts": 2},
+            "three-dimensional",
+        ),
+        (
+            torch.tensor([[[0, 1]]], dtype=torch.float32),
+            {"ep_rank": 0, "ep_size": 2, "num_nodes": 1, "num_physical_experts": 2},
+            "integer dtype",
+        ),
+        (
+            torch.tensor([[[0, 1]]], dtype=torch.int64),
+            {"ep_rank": 2, "ep_size": 2, "num_nodes": 1, "num_physical_experts": 2},
+            "ep_rank",
+        ),
+        (
+            torch.tensor([[[0, 1]]], dtype=torch.int64),
+            {"ep_rank": 0, "ep_size": 2, "num_nodes": 3, "num_physical_experts": 2},
+            "ep_size.*num_nodes",
+        ),
+        (
+            torch.tensor([[[0, 2]]], dtype=torch.int64),
+            {"ep_rank": 0, "ep_size": 2, "num_nodes": 1, "num_physical_experts": 2},
+            "physical expert id",
+        ),
+        (
+            torch.tensor([[[-1, -1]]], dtype=torch.int64),
+            {"ep_rank": 0, "ep_size": 2, "num_nodes": 1, "num_physical_experts": 2},
+            "no physical replicas",
+        ),
+        (
+            torch.tensor([[[0, 0]]], dtype=torch.int64),
+            {"ep_rank": 0, "ep_size": 2, "num_nodes": 1, "num_physical_experts": 2},
+            "duplicate physical replicas",
+        ),
+    ],
+)
+def test_locality_fair_rejects_invalid_mapping_contract(
+    mapping: torch.Tensor,
+    kwargs: dict[str, int],
+    message: str,
+) -> None:
+    from vllm_hcu.model_executor.layers.fused_moe.eplb_dispatch import (
+        build_locality_fair_replica_order,
+    )
+
+    with pytest.raises((TypeError, ValueError), match=message):
+        build_locality_fair_replica_order(mapping, **kwargs)
+
+
+def test_locality_fair_layer_commit_matches_full_commit_order() -> None:
+    from vllm_hcu.model_executor.layers.fused_moe.eplb_dispatch import (
+        build_locality_fair_replica_order,
+    )
+
+    mapping = torch.tensor(
+        [
+            [[0, 1, 2, 3], [4, 5, 6, 7]],
+            [[0, 2, 4, 6], [1, 3, 5, 7]],
+        ],
+        dtype=torch.int64,
+    )
+    kwargs = {
+        "ep_rank": 5,
+        "ep_size": 8,
+        "num_nodes": 2,
+        "num_physical_experts": 8,
+        "seed": 42,
+    }
+
+    full = build_locality_fair_replica_order(mapping, **kwargs)
+    second_layer = build_locality_fair_replica_order(
+        mapping[1:2],
+        layer_offset=1,
+        **kwargs,
+    )
+
+    torch.testing.assert_close(second_layer, full[1:2], rtol=0, atol=0)
+
+
+def test_locality_fair_preserves_node_locality_before_global_fairness() -> None:
+    from vllm_hcu.model_executor.layers.fused_moe.eplb_dispatch import (
+        build_locality_fair_replica_order,
+    )
+
+    mapping = torch.tensor([[[0, 1, 4]]], dtype=torch.int64)
+    primaries = []
+    for ep_rank in range(8):
+        rank_map = build_locality_fair_replica_order(
+            mapping,
+            ep_rank=ep_rank,
+            ep_size=8,
+            num_nodes=2,
+            num_physical_experts=8,
+        )
+        primary = rank_map[0, 0, 0].item()
+        primaries.append(primary)
+        assert primary // 4 == ep_rank // 4
+
+    assert Counter(primaries) == {0: 2, 1: 2, 4: 4}

--- a/tests/runtime_patch/test_eplb_routing_simulation.py
+++ b/tests/runtime_patch/test_eplb_routing_simulation.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Contracts for deterministic EPLB routing simulation."""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+import pytest
+import torch
+
+from vllm_hcu.model_executor.layers.fused_moe import router_runtime
+from vllm_hcu.platforms import envs as henvs
+
+
+def _strategy(ep_size: int):
+    factory = getattr(
+        router_runtime,
+        "make_hcu_eplb_balancedness_strategy",
+        None,
+    )
+    assert callable(factory), "HCU EPLB balancedness strategy is not implemented"
+
+    class RoutingStrategy:
+        pass
+
+    strategy_type = factory(RoutingStrategy)
+    return strategy_type(ep_size_getter=lambda: ep_size)
+
+
+def _rank_balancedness(ids: torch.Tensor, num_experts: int, ep_size: int) -> float:
+    experts_per_rank = num_experts // ep_size
+    ranks = torch.div(ids.long(), experts_per_rank, rounding_mode="floor")
+    loads = torch.bincount(ranks.flatten(), minlength=ep_size).float()
+    return float(loads.mean() / loads.max())
+
+
+@pytest.mark.parametrize("target", [1.0, 0.8, 0.6, 0.4, 0.2])
+def test_strategy_generates_requested_ep_rank_balancedness(
+    monkeypatch: pytest.MonkeyPatch,
+    target: float,
+) -> None:
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS",
+        target,
+        raising=False,
+    )
+    strategy = _strategy(ep_size=8)
+    hidden_states = torch.zeros((4096, 16))
+    router_logits = torch.zeros((4096, 256))
+
+    weights, ids = strategy.route_tokens(
+        hidden_states,
+        router_logits,
+        top_k=2,
+        indices_type=torch.int32,
+    )
+
+    assert weights.shape == (4096, 2)
+    assert weights.dtype == torch.float32
+    assert torch.equal(weights, torch.ones_like(weights))
+    assert ids.shape == (4096, 2)
+    assert ids.dtype == torch.int32
+    assert ids.min().item() >= 0
+    assert ids.max().item() < 256
+    assert _rank_balancedness(ids, num_experts=256, ep_size=8) == pytest.approx(
+        target,
+        abs=1e-3,
+    )
+
+
+def test_strategy_uses_nearest_representable_small_batch_balancedness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS",
+        0.8,
+        raising=False,
+    )
+    strategy = _strategy(ep_size=8)
+
+    _, ids = strategy.route_tokens(
+        torch.zeros((8, 16)),
+        torch.zeros((8, 256)),
+        top_k=2,
+    )
+
+    # Sixteen assignments have mean rank load 2. The nearest possible
+    # max load is 3 (2 / 3), not 2 (1.0).
+    assert _rank_balancedness(ids, 256, 8) == pytest.approx(2 / 3)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 16, 256])
+def test_strategy_is_reproducible_for_fake_prefill_and_fixed_mtp_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+    num_tokens: int,
+) -> None:
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS",
+        0.6,
+        raising=False,
+    )
+    strategy = _strategy(ep_size=8)
+    hidden_states = torch.randn((num_tokens, 16))
+    router_logits = torch.randn((num_tokens, 256))
+
+    first = strategy.route_tokens(hidden_states, router_logits, top_k=8)
+    second = strategy.route_tokens(
+        torch.randn_like(hidden_states),
+        torch.randn_like(router_logits),
+        top_k=8,
+    )
+
+    assert torch.equal(first[0], second[0])
+    assert torch.equal(first[1], second[1])
+    assert all(len(set(row.tolist())) == 8 for row in first[1])
+
+
+@pytest.mark.parametrize(
+    ("ep_size", "target", "message"),
+    [
+        (4, 0.2, r"minimum.*0\.25"),
+        (8, 0.0, r"minimum.*0\.125"),
+        (8, 1.01, r"at most 1\.0"),
+    ],
+)
+def test_strategy_rejects_unachievable_balancedness(
+    monkeypatch: pytest.MonkeyPatch,
+    ep_size: int,
+    target: float,
+    message: str,
+) -> None:
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS",
+        target,
+        raising=False,
+    )
+    strategy = _strategy(ep_size=ep_size)
+
+    with pytest.raises(ValueError, match=message):
+        strategy.route_tokens(
+            torch.zeros((32, 8)),
+            torch.zeros((32, 64)),
+            top_k=2,
+        )
+
+
+def test_strategy_rejects_topk_that_can_duplicate_experts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS",
+        0.8,
+        raising=False,
+    )
+    strategy = _strategy(ep_size=8)
+
+    with pytest.raises(ValueError, match=r"top_k=2.*minimum experts per rank=1"):
+        strategy.route_tokens(
+            torch.zeros((8, 16)),
+            torch.zeros((8, 8)),
+            top_k=2,
+        )
+
+
+def test_balancedness_environment_is_lazy_and_defaults_to_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    name = "VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS"
+    henvs.__dict__.pop(name, None)
+    monkeypatch.delenv(name, raising=False)
+    assert getattr(henvs, name) == 1.0
+
+    monkeypatch.setenv(name, "0.4")
+    assert getattr(henvs, name) == 0.4
+
+
+def test_patch_registers_strategy_once() -> None:
+    try:
+        patch = importlib.import_module(
+            "vllm_hcu.patch.worker.op_opt.moe.patch_routing_simulator"
+        )
+    except ModuleNotFoundError:
+        pytest.fail("routing simulator patch is not implemented")
+
+    class RoutingStrategy:
+        pass
+
+    class RoutingSimulator:
+        strategies: dict[str, object] = {}
+
+        @classmethod
+        def register_strategy(cls, name: str, strategy: object) -> None:
+            cls.strategies[name] = strategy
+
+        @classmethod
+        def get_available_strategies(cls) -> list[str]:
+            return list(cls.strategies)
+
+    module = ModuleType(patch.TARGET_MODULE)
+    module.RoutingStrategy = RoutingStrategy
+    module.RoutingSimulator = RoutingSimulator
+
+    assert patch.apply_to_module(module) is True
+    assert patch.apply_to_module(module) is False
+    assert "hcu_eplb_balancedness" in RoutingSimulator.strategies

--- a/tests/runtime_patch/test_model_loader_static_eplb.py
+++ b/tests/runtime_patch/test_model_loader_static_eplb.py
@@ -4,11 +4,22 @@
 from __future__ import annotations
 
 import sys
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
 from vllm_hcu.patch.worker.framework_opt import patch_model_loader_static_eplb
+
+
+@pytest.fixture(autouse=True)
+def _isolate_initializer_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep alias-validation tests independent of prior vLLM imports."""
+
+    for module_name in (
+        *patch_model_loader_static_eplb._INITIALIZER_ALIASES,
+        *patch_model_loader_static_eplb._LOADER_FACTORY_ALIASES,
+    ):
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
 
 
 def _initializer_module() -> ModuleType:
@@ -62,7 +73,9 @@ def test_initializer_binds_the_constructed_model_before_returning(
     monkeypatch.setattr(patch_model_loader_static_eplb, "bind_static_eplb_plan", bind)
 
     assert patch_model_loader_static_eplb.apply_to_module(module) is True
-    config = object()
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(_vllm_hcu_expert_map_path="map.json")
+    )
     model = module.initialize_model(config)
 
     assert model is result_holder["model"]
@@ -70,11 +83,16 @@ def test_initializer_binds_the_constructed_model_before_returning(
     assert patch_model_loader_static_eplb.apply_to_module(module) is False
 
 
-def test_initializer_patch_updates_an_existing_verified_loader_alias(
+@pytest.mark.parametrize(
+    "alias_name",
+    patch_model_loader_static_eplb._INITIALIZER_ALIASES,
+)
+def test_initializer_patch_updates_every_existing_verified_loader_alias(
     monkeypatch: pytest.MonkeyPatch,
+    alias_name: str,
 ) -> None:
     module = _initializer_module()
-    alias = ModuleType("vllm.model_executor.model_loader.base_loader")
+    alias = ModuleType(alias_name)
     alias.initialize_model = module.initialize_model
     monkeypatch.setitem(sys.modules, alias.__name__, alias)
 
@@ -82,11 +100,16 @@ def test_initializer_patch_updates_an_existing_verified_loader_alias(
     assert alias.initialize_model is module.initialize_model
 
 
-def test_initializer_patch_rejects_an_existing_stale_loader_alias(
+@pytest.mark.parametrize(
+    "alias_name",
+    patch_model_loader_static_eplb._INITIALIZER_ALIASES,
+)
+def test_initializer_patch_rejects_every_existing_stale_loader_alias(
     monkeypatch: pytest.MonkeyPatch,
+    alias_name: str,
 ) -> None:
     module = _initializer_module()
-    alias = ModuleType("vllm.model_executor.model_loader.base_loader")
+    alias = ModuleType(alias_name)
     alias.initialize_model = lambda *args, **kwargs: None
     monkeypatch.setitem(sys.modules, alias.__name__, alias)
 
@@ -95,3 +118,355 @@ def test_initializer_patch_rejects_an_existing_stale_loader_alias(
         match="already-imported alias",
     ):
         patch_model_loader_static_eplb.apply_to_module(module)
+
+
+def test_initializer_no_map_delegates_without_running_static_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _initializer_module()
+    original = module.initialize_model
+    sentinel = object()
+
+    def initialize_model(
+        vllm_config: object,
+        *,
+        prefix: str = "",
+        model_class: type | None = None,
+        model_config: object | None = None,
+    ) -> object:
+        assert prefix == "prefix"
+        assert model_class is int
+        assert model_config is sentinel
+        return original(
+            vllm_config,
+            prefix=prefix,
+            model_class=model_class,
+            model_config=model_config,
+        )
+
+    module.initialize_model = initialize_model
+    monkeypatch.setattr(
+        patch_model_loader_static_eplb,
+        "bind_static_eplb_plan",
+        lambda *args, **kwargs: pytest.fail("no-map initialization must not bind"),
+    )
+    assert patch_model_loader_static_eplb.apply_to_module(module) is True
+
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(_vllm_hcu_expert_map_path=None)
+    )
+    result = module.initialize_model(
+        config,
+        prefix="prefix",
+        model_class=int,
+        model_config=sentinel,
+    )
+
+    assert type(result) is object
+
+
+def test_nested_static_initializer_binds_only_the_public_outer_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _initializer_module()
+    alias_name = "vllm.model_executor.models.mllama4"
+    alias = ModuleType(alias_name)
+    bound_models: list[object] = []
+
+    class Llama4ForCausalLM:
+        pass
+
+    class Llama4ForConditionalGeneration:
+        def __init__(self, language_model: object) -> None:
+            self.language_model = language_model
+
+    def initialize_model(
+        vllm_config: object,
+        *,
+        prefix: str = "",
+        model_class: type | None = None,
+        model_config: object | None = None,
+    ) -> object:
+        del prefix, model_config
+        if model_class is Llama4ForCausalLM:
+            return Llama4ForCausalLM()
+        language_model = alias.initialize_model(
+            vllm_config,
+            model_class=Llama4ForCausalLM,
+        )
+        return Llama4ForConditionalGeneration(language_model)
+
+    module.initialize_model = initialize_model
+    alias.initialize_model = initialize_model
+    monkeypatch.setitem(sys.modules, alias_name, alias)
+    monkeypatch.setattr(
+        patch_model_loader_static_eplb,
+        "bind_static_eplb_plan",
+        lambda _config, model: bound_models.append(model),
+    )
+    assert patch_model_loader_static_eplb.apply_to_module(module) is True
+
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(_vllm_hcu_expert_map_path="map.json")
+    )
+    model = module.initialize_model(config)
+
+    assert isinstance(model, Llama4ForConditionalGeneration)
+    assert isinstance(model.language_model, Llama4ForCausalLM)
+    assert bound_models == [model]
+
+
+class _FakeLoader:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    def load_model(
+        self,
+        vllm_config: object,
+        model_config: object,
+        prefix: str = "",
+    ) -> object:
+        del vllm_config, model_config, prefix
+        self.events.append("checkpoint-consumed")
+        return self
+
+
+class _DefaultModelLoader(_FakeLoader):
+    pass
+
+
+class _BitsAndBytesModelLoader(_FakeLoader):
+    pass
+
+
+class _RunaiModelStreamerLoader(_FakeLoader):
+    pass
+
+
+class _ShardedStateLoader(_FakeLoader):
+    pass
+
+
+class _TensorizerLoader(_FakeLoader):
+    tensorizer_config = object()
+
+
+class _DummyModelLoader(_FakeLoader):
+    pass
+
+
+class _ModelExpressModelLoader(_FakeLoader):
+    pass
+
+
+def _model_loader_entrypoint_module(
+    loader: _FakeLoader,
+    original_calls: list[tuple[object, object, str, object]],
+) -> ModuleType:
+    module = ModuleType("vllm.model_executor.model_loader")
+
+    def get_model_loader(load_config: object) -> _FakeLoader:
+        del load_config
+        return loader
+
+    def get_model(
+        *,
+        vllm_config: object,
+        model_config: object | None = None,
+        prefix: str = "",
+        load_config: object | None = None,
+    ) -> object:
+        original_calls.append((vllm_config, model_config, prefix, load_config))
+        selected = module.get_model_loader(load_config or vllm_config.load_config)
+        if model_config is None:
+            model_config = vllm_config.model_config
+        return selected.load_model(
+            vllm_config=vllm_config,
+            model_config=model_config,
+            prefix=prefix,
+        )
+
+    module.get_model_loader = get_model_loader
+    module.get_model = get_model
+    module.DefaultModelLoader = _DefaultModelLoader
+    module.BitsAndBytesModelLoader = _BitsAndBytesModelLoader
+    module.RunaiModelStreamerLoader = _RunaiModelStreamerLoader
+    module.ShardedStateLoader = _ShardedStateLoader
+    module.TensorizerLoader = _TensorizerLoader
+    module.DummyModelLoader = _DummyModelLoader
+    module.ModelExpressModelLoader = _ModelExpressModelLoader
+    module._LOAD_FORMAT_TO_MODEL_LOADER = {"test": type(loader)}
+    return module
+
+
+def _loader_config(*, static: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            _vllm_hcu_expert_map_path="map.json" if static else None
+        ),
+        load_config=SimpleNamespace(load_format="test"),
+        model_config=object(),
+    )
+
+
+def _install_bound_initializer(monkeypatch: pytest.MonkeyPatch) -> None:
+    utils = ModuleType(patch_model_loader_static_eplb.TARGET_MODULE)
+    utils.initialize_model = lambda *args, **kwargs: None
+    setattr(
+        utils.initialize_model,
+        patch_model_loader_static_eplb._WRAPPER_MARKER,
+        True,
+    )
+    monkeypatch.setitem(sys.modules, utils.__name__, utils)
+
+
+def test_model_entrypoint_no_map_delegates_byte_for_byte(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    original_calls: list[tuple[object, object, str, object]] = []
+
+    class ExternalLoader(_DefaultModelLoader):
+        pass
+
+    loader = ExternalLoader(events)
+    module = _model_loader_entrypoint_module(loader, original_calls)
+    assert patch_model_loader_static_eplb.apply_entrypoint_to_module(module) is True
+    config = _loader_config(static=False)
+    model_config = object()
+    load_config = object()
+
+    result = module.get_model(
+        vllm_config=config,
+        model_config=model_config,
+        prefix="prefix",
+        load_config=load_config,
+    )
+
+    assert result is loader
+    assert original_calls == [(config, model_config, "prefix", load_config)]
+    assert events == ["checkpoint-consumed"]
+
+
+@pytest.mark.parametrize(
+    "loader_type",
+    (_ShardedStateLoader, _DummyModelLoader, _ModelExpressModelLoader),
+)
+def test_static_model_entrypoint_rejects_unsafe_builtin_loader_before_consumption(
+    monkeypatch: pytest.MonkeyPatch,
+    loader_type: type[_FakeLoader],
+) -> None:
+    events: list[str] = []
+    loader = loader_type(events)
+    module = _model_loader_entrypoint_module(loader, [])
+    _install_bound_initializer(monkeypatch)
+    assert patch_model_loader_static_eplb.apply_entrypoint_to_module(module) is True
+
+    with pytest.raises(
+        patch_model_loader_static_eplb.PatchCompatibilityError,
+        match="does not support static EPLB direct loading",
+    ):
+        module.get_model(vllm_config=_loader_config(static=True))
+
+    assert events == []
+
+
+def test_static_model_entrypoint_rejects_external_loader_before_consumption(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class ExternalLoader(_DefaultModelLoader):
+        pass
+
+    module = _model_loader_entrypoint_module(ExternalLoader(events), [])
+    _install_bound_initializer(monkeypatch)
+    assert patch_model_loader_static_eplb.apply_entrypoint_to_module(module) is True
+
+    with pytest.raises(
+        patch_model_loader_static_eplb.PatchCompatibilityError,
+        match="ExternalLoader.+does not support",
+    ):
+        module.get_model(vllm_config=_loader_config(static=True))
+
+    assert events == []
+
+
+def test_static_loader_factory_gate_covers_primary_gpu_runner_call_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    loader = _ShardedStateLoader(events)
+    module = _model_loader_entrypoint_module(loader, [])
+    _install_bound_initializer(monkeypatch)
+    assert patch_model_loader_static_eplb.apply_entrypoint_to_module(module) is True
+    config = _loader_config(static=True)
+
+    selected_loader = module.get_model_loader(config.load_config)
+    with pytest.raises(
+        patch_model_loader_static_eplb.PatchCompatibilityError,
+        match="does not support static EPLB direct loading",
+    ):
+        selected_loader.load_model(
+            vllm_config=config,
+            model_config=config.model_config,
+        )
+
+    assert events == []
+
+
+def test_vllm_tensorized_loader_fails_before_direct_deserialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    module = _model_loader_entrypoint_module(_TensorizerLoader(events), [])
+    _install_bound_initializer(monkeypatch)
+    monkeypatch.setattr(
+        patch_model_loader_static_eplb,
+        "_is_vllm_tensorized_loader",
+        lambda loader: True,
+    )
+    assert patch_model_loader_static_eplb.apply_entrypoint_to_module(module) is True
+
+    with pytest.raises(
+        patch_model_loader_static_eplb.PatchCompatibilityError,
+        match="vLLM-tensorized Tensorizer",
+    ):
+        module.get_model(vllm_config=_loader_config(static=True))
+
+    assert events == []
+
+
+@pytest.mark.parametrize(
+    "loader_type",
+    (
+        _DefaultModelLoader,
+        _BitsAndBytesModelLoader,
+        _RunaiModelStreamerLoader,
+        _TensorizerLoader,
+    ),
+)
+def test_static_model_entrypoint_allows_only_audited_common_loaders(
+    monkeypatch: pytest.MonkeyPatch,
+    loader_type: type[_FakeLoader],
+) -> None:
+    events: list[str] = []
+    loader = loader_type(events)
+    module = _model_loader_entrypoint_module(loader, [])
+    _install_bound_initializer(monkeypatch)
+    monkeypatch.setattr(
+        patch_model_loader_static_eplb,
+        "_is_vllm_tensorized_loader",
+        lambda candidate: False,
+    )
+    assert patch_model_loader_static_eplb.apply_entrypoint_to_module(module) is True
+    config = _loader_config(static=True)
+
+    result = module.get_model(
+        vllm_config=config,
+        model_config=config.model_config,
+        prefix="prefix",
+    )
+
+    assert result is loader
+    assert events == ["checkpoint-consumed"]

--- a/tests/runtime_patch/test_model_loader_static_eplb.py
+++ b/tests/runtime_patch/test_model_loader_static_eplb.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from vllm_hcu.patch.worker.framework_opt import patch_model_loader_static_eplb
+
+
+def _initializer_module() -> ModuleType:
+    module = ModuleType(patch_model_loader_static_eplb.TARGET_MODULE)
+
+    def initialize_model(
+        vllm_config: object,
+        *,
+        prefix: str = "",
+        model_class: type | None = None,
+        model_config: object | None = None,
+    ) -> object:
+        del vllm_config, prefix, model_class, model_config
+        return object()
+
+    module.initialize_model = initialize_model
+    return module
+
+
+def test_initializer_binds_the_constructed_model_before_returning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _initializer_module()
+    events: list[tuple[str, object]] = []
+
+    def bind(vllm_config: object, model: object) -> None:
+        events.append(("bind", vllm_config))
+        assert model is result_holder["model"]
+
+    result_holder: dict[str, object] = {}
+    original = module.initialize_model
+
+    def initialize_model(
+        vllm_config: object,
+        *,
+        prefix: str = "",
+        model_class: type | None = None,
+        model_config: object | None = None,
+    ) -> object:
+        model = original(
+            vllm_config,
+            prefix=prefix,
+            model_class=model_class,
+            model_config=model_config,
+        )
+        result_holder["model"] = model
+        events.append(("initialize", vllm_config))
+        return model
+
+    module.initialize_model = initialize_model
+    monkeypatch.setattr(patch_model_loader_static_eplb, "bind_static_eplb_plan", bind)
+
+    assert patch_model_loader_static_eplb.apply_to_module(module) is True
+    config = object()
+    model = module.initialize_model(config)
+
+    assert model is result_holder["model"]
+    assert events == [("initialize", config), ("bind", config)]
+    assert patch_model_loader_static_eplb.apply_to_module(module) is False
+
+
+def test_initializer_patch_updates_an_existing_verified_loader_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _initializer_module()
+    alias = ModuleType("vllm.model_executor.model_loader.base_loader")
+    alias.initialize_model = module.initialize_model
+    monkeypatch.setitem(sys.modules, alias.__name__, alias)
+
+    assert patch_model_loader_static_eplb.apply_to_module(module) is True
+    assert alias.initialize_model is module.initialize_model
+
+
+def test_initializer_patch_rejects_an_existing_stale_loader_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _initializer_module()
+    alias = ModuleType("vllm.model_executor.model_loader.base_loader")
+    alias.initialize_model = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, alias.__name__, alias)
+
+    with pytest.raises(
+        patch_model_loader_static_eplb.PatchCompatibilityError,
+        match="already-imported alias",
+    ):
+        patch_model_loader_static_eplb.apply_to_module(module)

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -1775,6 +1775,27 @@ def test_moe_layer_patch_forward_and_repacked_weight_contract(
         [4.0, 5.0],
     ]
 
+    static_experts.expert_map_manager.num_fused_shared_experts = 1
+    shared_mapping = static_experts.get_expert_mapping()
+    assert len(shared_mapping) == 12
+    assert [entry[2] for entry in shared_mapping[::3]] == [0, 1, 2, 3]
+
+    static_experts.weight_loader_calls.clear()
+    static_experts.local_physical_ids = {4}
+    assert (
+        static_experts.parameter_weight_loader(
+            param,
+            tensor,
+            "w13_weight",
+            "w1",
+            3,
+            return_success=True,
+        )
+        is True
+    )
+    assert [call[4] for call in static_experts.weight_loader_calls] == [4]
+    static_experts.expert_map_manager.num_fused_shared_experts = 0
+
     static_model = SimpleNamespace(
         named_parameters=lambda: iter(()),
         modules=lambda: iter((static_experts,)),

--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -1429,7 +1429,7 @@ def test_hash_router_normalizes_index_dtypes():
     assert captured == {"input": torch.int32, "hash": torch.int32}
 
 
-def test_moe_layer_forward_and_repacked_weight_contract(
+def test_moe_layer_patch_forward_and_repacked_weight_contract(
     monkeypatch: pytest.MonkeyPatch,
 ):
     factory_names = (
@@ -1452,14 +1452,28 @@ def test_moe_layer_forward_and_repacked_weight_contract(
             self.moe_quant_config = "official-config"
 
     class RoutedExperts:
+        build_calls = []
+
         def __init__(self):
-            self.moe_config = "moe-config"
+            self.moe_config = SimpleNamespace(
+                num_logical_experts=3,
+                num_experts=4,
+            )
             self.quant_method = UnquantizedFusedMoEMethod()
             self.local_num_experts = 2
             self._dsv4_channel_deepgemm_repacked = False
             self.layer_name = "model.layers.0.mlp"
+            self.ckpt_gate_proj_name = "gate_proj"
+            self.ckpt_down_proj_name = "down_proj"
+            self.ckpt_up_proj_name = "up_proj"
+            self.lora_base_layer_prefix = ""
             self.expert_mapping = []
+            self.expert_map_manager = SimpleNamespace(num_fused_shared_experts=0)
             self.official_loads = []
+            self.weight_loader_calls = []
+            self.local_physical_ids = set(range(4))
+            # Quantization methods capture this bound callback in create_weights.
+            self.parameter_weight_loader = self.weight_loader
 
         def _replace_quant_method(self, method):
             self.quant_method = method
@@ -1467,11 +1481,131 @@ def test_moe_layer_forward_and_repacked_weight_contract(
         def get_expert_weights(self):
             return "official-weights"
 
-        def get_expert_mapping(self, include_fused=False):
+        def weight_loader(
+            self,
+            param,
+            loaded_weight,
+            weight_name,
+            shard_id,
+            expert_id,
+            return_success=False,
+        ):
+            self.weight_loader_calls.append(
+                (
+                    param,
+                    loaded_weight,
+                    weight_name,
+                    shard_id,
+                    expert_id,
+                    return_success,
+                )
+            )
+            loaded = expert_id in self.local_physical_ids
+            return loaded if return_success else None
+
+        def get_expert_mapping(
+            self,
+            ckpt_gate_proj_name=None,
+            ckpt_down_proj_name=None,
+            ckpt_up_proj_name=None,
+            include_fused=False,
+        ):
             assert include_fused is True
             return self.expert_mapping
 
+        @staticmethod
+        def make_expert_params_mapping(
+            model,
+            ckpt_gate_proj_name,
+            ckpt_down_proj_name,
+            ckpt_up_proj_name,
+            num_experts,
+            num_redundant_experts=0,
+            routed_experts_prefix="routed_experts",
+        ):
+            base_layer_prefix = (
+                "base_layer."
+                if any(".base_layer." in name for name, _ in model.named_parameters())
+                else ""
+            )
+            return RoutedExperts.build_expert_params_mapping(
+                ckpt_gate_proj_name,
+                ckpt_down_proj_name,
+                ckpt_up_proj_name,
+                num_experts,
+                num_redundant_experts,
+                routed_experts_prefix,
+                base_layer_prefix,
+            )
+
+        @staticmethod
+        def build_expert_params_mapping(
+            ckpt_gate_proj_name,
+            ckpt_down_proj_name,
+            ckpt_up_proj_name,
+            num_experts,
+            num_redundant_experts=0,
+            routed_experts_prefix="routed_experts",
+            lora_base_layer_prefix="",
+            include_fused=False,
+        ):
+            RoutedExperts.build_calls.append(
+                (
+                    ckpt_gate_proj_name,
+                    ckpt_down_proj_name,
+                    ckpt_up_proj_name,
+                    num_experts,
+                    num_redundant_experts,
+                    routed_experts_prefix,
+                    lora_base_layer_prefix,
+                    include_fused,
+                )
+            )
+            routed_prefix = (
+                f"{routed_experts_prefix}." if routed_experts_prefix else ""
+            )
+            w13 = f"experts.{routed_prefix}{lora_base_layer_prefix}w13_"
+            w2 = f"experts.{routed_prefix}{lora_base_layer_prefix}w2_"
+            fused = []
+            if include_fused:
+                fused = [
+                    (f"{w13}weight", "experts.gate_up_proj", 0, "w1"),
+                    (f"{w13}weight", "experts.gate_up_proj", 1, "w3"),
+                    (f"{w2}weight", "experts.down_proj", 0, "w2"),
+                ]
+            split = [
+                (
+                    w13 if shard_id in {"w1", "w3"} else w2,
+                    f"experts.{expert_id}.{weight_name}.{lora_base_layer_prefix}",
+                    expert_id,
+                    shard_id,
+                )
+                for expert_id in range(num_experts + num_redundant_experts)
+                for shard_id, weight_name in (
+                    ("w1", ckpt_gate_proj_name),
+                    ("w2", ckpt_down_proj_name),
+                    ("w3", ckpt_up_proj_name),
+                )
+            ]
+            return fused + split
+
         def load_weights(self, weights):
+            if hasattr(self, "standard_fused_param"):
+                for weight_name, loaded_weight in weights:
+                    for logical_expert_id, loaded_expert in enumerate(
+                        loaded_weight.unbind()
+                    ):
+                        success = self.standard_fused_param.weight_loader(
+                            param=self.standard_fused_param,
+                            loaded_weight=loaded_expert,
+                            weight_name=weight_name,
+                            shard_id="w2",
+                            expert_id=logical_expert_id,
+                            return_success=True,
+                        )
+                        if success:
+                            yield "w2_weight"
+                return
             self.official_loads.extend(weights)
             yield "official-load"
 
@@ -1534,6 +1668,164 @@ def test_moe_layer_forward_and_repacked_weight_contract(
     assert isinstance(experts.quant_method, HcuUnquantizedFusedMoEMethod)
     assert experts.quant_method.moe_quant_config == "official-config"
     assert runner.replaced is experts.quant_method
+
+    static_experts = fused_moe_package.FusedMoE().routed_experts
+    static_experts._vllm_hcu_static_eplb_row = (2, 1, 0, 2)
+    static_experts.local_physical_ids = {0, 3}
+    param = object()
+    tensor = torch.tensor([7.0])
+    assert (
+        static_experts.parameter_weight_loader(
+            param,
+            tensor,
+            "w13_weight",
+            "w1",
+            2,
+            return_success=True,
+        )
+        is True
+    )
+    assert [call[4] for call in static_experts.weight_loader_calls] == [0, 3]
+    assert all(call[0] is param for call in static_experts.weight_loader_calls)
+    assert all(call[1] is tensor for call in static_experts.weight_loader_calls)
+
+    second_experts = fused_moe_package.FusedMoE().routed_experts
+    second_experts._vllm_hcu_static_eplb_row = (1, 0, 2, 1)
+    second_experts.local_physical_ids = {2}
+    assert (
+        second_experts.parameter_weight_loader(
+            param,
+            tensor,
+            "w13_weight",
+            "w1",
+            2,
+            return_success=True,
+        )
+        is True
+    )
+    assert [call[4] for call in second_experts.weight_loader_calls] == [2]
+
+    static_experts.weight_loader_calls.clear()
+    static_experts.local_physical_ids = {1}
+    assert (
+        static_experts.weight_loader(
+            param,
+            tensor,
+            "w13_weight_scale",
+            "w1",
+            2,
+            return_success=True,
+        )
+        is False
+    )
+    assert [call[4] for call in static_experts.weight_loader_calls] == [0, 3]
+    assert all(
+        call[2] == "w13_weight_scale"
+        for call in static_experts.weight_loader_calls
+    )
+    assert all(call[5] is True for call in static_experts.weight_loader_calls)
+
+    static_experts.weight_loader_calls.clear()
+    static_experts.local_physical_ids = {0, 3}
+    assert (
+        static_experts.weight_loader(
+            param,
+            tensor,
+            "w13_weight",
+            "w1",
+            2,
+            return_success=False,
+        )
+        is None
+    )
+    assert [call[4] for call in static_experts.weight_loader_calls] == [0, 3]
+
+    split_mapping = static_experts.get_expert_mapping()
+    assert len(split_mapping) == 9
+    assert [entry[2] for entry in split_mapping[::3]] == [0, 1, 2]
+    assert RoutedExperts.build_calls[-1][4] == 0
+
+    fused_mapping = static_experts.get_expert_mapping(include_fused=True)
+    assert fused_mapping[:3] == [
+        ("experts.w13_weight", "experts.gate_up_proj", 0, "w1"),
+        ("experts.w13_weight", "experts.gate_up_proj", 1, "w3"),
+        ("experts.w2_weight", "experts.down_proj", 0, "w2"),
+    ]
+    assert len(fused_mapping) == 12
+
+    static_experts.weight_loader_calls.clear()
+    static_experts.local_physical_ids = {0, 1, 2, 3}
+    static_experts.standard_fused_param = SimpleNamespace(
+        weight_loader=static_experts.parameter_weight_loader
+    )
+    fused_tensor = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+    assert list(
+        static_experts.load_weights([("experts.down_proj", fused_tensor)])
+    ) == ["w2_weight"] * 3
+    assert [call[4] for call in static_experts.weight_loader_calls] == [
+        2,
+        1,
+        0,
+        3,
+    ]
+    assert [call[1].tolist() for call in static_experts.weight_loader_calls] == [
+        [0.0, 1.0],
+        [2.0, 3.0],
+        [4.0, 5.0],
+        [4.0, 5.0],
+    ]
+
+    static_model = SimpleNamespace(
+        named_parameters=lambda: iter(()),
+        modules=lambda: iter((static_experts,)),
+    )
+    legacy_mapping = RoutedExperts.make_expert_params_mapping(
+        static_model,
+        "gate_proj",
+        "down_proj",
+        "up_proj",
+        3,
+        1,
+    )
+    assert len(legacy_mapping) == 9
+    assert RoutedExperts.build_calls[-1][4] == 0
+
+    upstream_param = object()
+    upstream_tensor = torch.tensor([11.0])
+    assert (
+        experts.parameter_weight_loader(
+            upstream_param,
+            upstream_tensor,
+            "ordinary.weight",
+            "w2",
+            1,
+            return_success=True,
+        )
+        is True
+    )
+    assert experts.weight_loader_calls[-1] == (
+        upstream_param,
+        upstream_tensor,
+        "ordinary.weight",
+        "w2",
+        1,
+        True,
+    )
+    ordinary_mapping = [("ordinary", "checkpoint", 7, "w1")]
+    experts.expert_mapping = ordinary_mapping
+    assert experts.get_expert_mapping(include_fused=True) is ordinary_mapping
+
+    ordinary_model = SimpleNamespace(named_parameters=lambda: iter(()))
+    ordinary_legacy_mapping = RoutedExperts.make_expert_params_mapping(
+        ordinary_model,
+        "gate_proj",
+        "down_proj",
+        "up_proj",
+        3,
+        1,
+    )
+    assert len(ordinary_legacy_mapping) == 12
+    assert RoutedExperts.build_calls[-1][4] == 1
 
     experts._dsv4_channel_deepgemm_repacked = True
     experts.w13_weight = torch.arange(24).reshape(2, 3, 4)

--- a/tests/runtime_patch/test_offline_eplb.py
+++ b/tests/runtime_patch/test_offline_eplb.py
@@ -197,6 +197,9 @@ def _make_eplb_module(
             )
             self.device = torch.device("cpu")
             self.model_states: dict[str, EplbModelState] = {}
+            self.should_record_tensor = torch.tensor(True)
+            self.is_async = True
+            self.official_steps = 0
             self.official_profile_steps = 0
 
         def add_model(self, model, model_config) -> None:
@@ -215,6 +218,7 @@ def _make_eplb_module(
 
         def step(self, is_dummy=False, is_profile=False, log_stats=False):
             del is_dummy, log_stats
+            self.official_steps += 1
             if is_profile:
                 self.official_profile_steps += 1
             return "official-step"
@@ -274,7 +278,7 @@ def test_runtime_patch_records_initial_and_committed_maps(tmp_path: Path) -> Non
     ] == committed.tolist()
 
 
-def test_runtime_patch_loads_map_and_skips_profile_rearrangement(
+def test_runtime_patch_loads_static_map_and_freezes_dynamic_eplb(
     tmp_path: Path,
 ) -> None:
     source = tmp_path / "load.json"
@@ -301,7 +305,25 @@ def test_runtime_patch_loads_map_and_skips_profile_rearrangement(
     assert state.model_states["hy4-hash"].physical_to_logical_map.tolist() == [
         [3, 2, 1, 0, 3, 2]
     ]
+    assert state.should_record_tensor.item() is False
+    assert state.is_async is False
 
     assert state.step(is_profile=True) is None
     assert state.official_profile_steps == 0
+    assert state.step(is_profile=False) is None
+    assert state.official_steps == 0
+
+
+def test_runtime_patch_record_mode_preserves_dynamic_eplb_steps(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "record.json"
+    module, _ = _make_eplb_module(record_path=output)
+    assert apply_to_module(module)
+    state = module.EplbState()
+    state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+
     assert state.step(is_profile=False) == "official-step"
+    assert state.official_steps == 1
+    assert state.should_record_tensor.item() is True
+    assert state.is_async is True

--- a/tests/runtime_patch/test_offline_eplb.py
+++ b/tests/runtime_patch/test_offline_eplb.py
@@ -333,6 +333,14 @@ def _make_eplb_module(
                         self.expert_load_window_step + 1
                     ) % self.expert_load_window_size
                 self._update_layer_should_record(log_stats=log_stats)
+            if getattr(self, "simulate_official_rearrange_step", False):
+                self.expert_rearrangement_step += 1
+                if (
+                    self.expert_rearrangement_step
+                    >= self.expert_rearrangement_step_interval
+                ):
+                    self.expert_rearrangement_step = 0
+                    self.rearrange()
             return "official-step"
 
         def _sync_load_pass(self):
@@ -765,6 +773,42 @@ def test_runtime_patch_keeps_online_rearrangement_without_offline_paths() -> Non
     assert state.model_states["hy4-hash"].physical_to_logical_map.tolist() == [
         [3, 2, 1, 0, 3, 2]
     ]
+
+
+def test_runtime_patch_logs_load_but_skips_disabled_dynamic_rearrangement() -> None:
+    module, rearrangements, _ = _make_eplb_module()
+    log_calls: list[tuple[object, ...]] = []
+    module.logger.info = lambda _message, *args: log_calls.append(args)
+    module.get_ep_group = lambda: SimpleNamespace(
+        device_group=SimpleNamespace(size=lambda: 2, rank=lambda: 0),
+    )
+    assert apply_to_module(module)
+
+    state = module.EplbState()
+    state.parallel_config._vllm_hcu_eplb_disable_rearrange = True
+    state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+    assert state.is_async is False
+    model_state = state.model_states["hy4-hash"]
+    model_state.expert_load_pass = torch.tensor([[8, 2]])
+    model_state.expert_load_window = torch.zeros((1, 1, 2), dtype=torch.int64)
+    state.expert_rearrangement_step = 0
+    state.expert_rearrangement_step_interval = 1
+    state.expert_load_window_step = 0
+    state.expert_load_window_size = 1
+    state.parallel_config.eplb_config = SimpleNamespace(
+        log_balancedness_interval=1,
+    )
+    state.simulate_official_rearrange_step = True
+
+    assert state.step(log_stats=True) == "official-step"
+
+    assert state.official_steps == 1
+    assert state.expert_rearrangement_step == 0
+    assert rearrangements == []
+    assert any(args[4] == 0.625 for args in log_calls if len(args) == 6)
+
+    assert state.rearrange(is_profile=True) == "official-rearrange"
+    assert len(rearrangements) == 1
 
 
 def test_runtime_patch_rejects_configured_static_map_without_plan(

--- a/tests/runtime_patch/test_offline_eplb.py
+++ b/tests/runtime_patch/test_offline_eplb.py
@@ -11,6 +11,11 @@ from types import ModuleType, SimpleNamespace
 import pytest
 import torch
 
+from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    load_static_eplb_plan,
+)
+from vllm_hcu.patch.worker import worker_callback_names
+from vllm_hcu.patch.worker.framework_opt._common import PatchCompatibilityError
 from vllm_hcu.patch.worker.framework_opt.patch_offline_eplb import (
     PATCH_ID,
     TARGET_MODULE,
@@ -18,10 +23,6 @@ from vllm_hcu.patch.worker.framework_opt.patch_offline_eplb import (
     load_offline_expert_map,
     record_offline_expert_map,
 )
-from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
-    load_static_eplb_plan,
-)
-from vllm_hcu.patch.worker import worker_callback_names
 
 
 def _record_map_in_process(output: str, model_index: int, start_event) -> None:
@@ -216,6 +217,10 @@ class HYV4ForCausalLM:
     expert_weights = [[torch.zeros(1)]]
 
 
+class GenericMoEForCausalLM(HYV4ForCausalLM):
+    pass
+
+
 def test_offline_eplb_patch_is_registered_in_worker_inventory() -> None:
     assert (PATCH_ID, TARGET_MODULE) in worker_callback_names()
 
@@ -349,15 +354,16 @@ def test_runtime_patch_records_initial_and_committed_maps(tmp_path: Path) -> Non
     ] == committed.tolist()
 
 
-def test_runtime_patch_loads_static_map_and_freezes_dynamic_eplb(
+def test_runtime_patch_commits_generic_static_plan_without_rearrangement(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source = tmp_path / "load.json"
     source.write_text(
         json.dumps(
             {
                 "model_maps": {
-                    "HYV4ForCausalLM": {
+                    "GenericMoEForCausalLM": {
                         "physical_to_logical_map": [[3, 2, 1, 0, 3, 2]],
                     }
                 }
@@ -365,20 +371,38 @@ def test_runtime_patch_loads_static_map_and_freezes_dynamic_eplb(
         ),
         encoding="utf-8",
     )
-    model = HYV4ForCausalLM()
+    model = GenericMoEForCausalLM()
     model._vllm_hcu_static_eplb_plan = load_static_eplb_plan(
         source,
-        model_key="HYV4ForCausalLM",
+        model_key="GenericMoEForCausalLM",
         expected_shape=(1, 6),
         num_logical_experts=4,
         num_redundant_experts=2,
     )
     module, rearrangements, ep_group = _make_eplb_module(load_path=source)
+    ep_group.world_size = 2
+    fingerprint_checks: list[tuple[object, object]] = []
+
+    def gather_fingerprints(output, value, group=None) -> None:
+        fingerprint_checks.append((value, group))
+        output[:] = [value, value]
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", gather_fingerprints)
+    cpu_group = object()
+    module.get_ep_group = lambda: SimpleNamespace(
+        device_group=ep_group,
+        cpu_group=cpu_group,
+        world_size=2,
+        rank_in_group=0,
+        barrier=ep_group.barrier,
+    )
     assert apply_to_module(module)
     state = module.EplbState()
     state.add_model(model, _FakeModelConfig())
 
     assert rearrangements == []
+    expected_fingerprint = model._vllm_hcu_static_eplb_plan.fingerprint()
+    assert fingerprint_checks == [(expected_fingerprint, cpu_group)]
     assert ep_group.barrier_calls == 1
     assert state.model_states["hy4-hash"].physical_to_logical_map.tolist() == [
         [3, 2, 1, 0, 3, 2]
@@ -446,7 +470,7 @@ def test_runtime_patch_keeps_online_rearrangement_without_offline_paths() -> Non
     ]
 
 
-def test_runtime_patch_keeps_compatibility_rearrangement_without_plan(
+def test_runtime_patch_rejects_configured_static_map_without_plan(
     tmp_path: Path,
 ) -> None:
     source = tmp_path / "load.json"
@@ -457,10 +481,12 @@ def test_runtime_patch_keeps_compatibility_rearrangement_without_plan(
     module, rearrangements, ep_group = _make_eplb_module(load_path=source)
     assert apply_to_module(module)
     state = module.EplbState()
+    model = GenericMoEForCausalLM()
 
-    state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+    with pytest.raises(PatchCompatibilityError, match="before checkpoint loading"):
+        state.add_model(model, _FakeModelConfig())
 
-    assert len(rearrangements) == 1
+    assert rearrangements == []
     assert ep_group.barrier_calls == 0
 
 

--- a/tests/runtime_patch/test_offline_eplb.py
+++ b/tests/runtime_patch/test_offline_eplb.py
@@ -17,6 +17,9 @@ from vllm_hcu.patch.worker.framework_opt.patch_offline_eplb import (
     load_offline_expert_map,
     record_offline_expert_map,
 )
+from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    load_static_eplb_plan,
+)
 from vllm_hcu.patch.worker import worker_callback_names
 
 
@@ -149,8 +152,17 @@ def test_load_rejects_invalid_maps(
 
 
 class _FakeDeviceGroup:
+    world_size = 1
+    rank_in_group = 0
+
+    def __init__(self) -> None:
+        self.barrier_calls = 0
+
     def rank(self) -> int:
         return 0
+
+    def barrier(self) -> None:
+        self.barrier_calls += 1
 
 
 class _FakeModelConfig:
@@ -176,11 +188,12 @@ def _make_eplb_module(
     *,
     record_path: Path | None = None,
     load_path: Path | None = None,
-) -> tuple[ModuleType, list[tuple[torch.Tensor, torch.Tensor]]]:
+) -> tuple[ModuleType, list[tuple[torch.Tensor, torch.Tensor]], _FakeDeviceGroup]:
     module = ModuleType(
         "vllm.distributed.eplb.eplb_state"
     )
     rearrangements: list[tuple[torch.Tensor, torch.Tensor]] = []
+    ep_group = _FakeDeviceGroup()
 
     class EplbModelState:
         pass
@@ -251,14 +264,19 @@ def _make_eplb_module(
     module._commit_eplb_maps = commit
     module._commit_eplb_maps_for_layer = commit_layer
     module._move_to_workspace = move_to_workspace
-    module.get_ep_group = lambda: SimpleNamespace(device_group=_FakeDeviceGroup())
+    module.get_ep_group = lambda: SimpleNamespace(
+        device_group=ep_group,
+        world_size=ep_group.world_size,
+        rank_in_group=ep_group.rank_in_group,
+        barrier=ep_group.barrier,
+    )
     module.logger = SimpleNamespace(info=lambda *args, **kwargs: None)
-    return module, rearrangements
+    return module, rearrangements, ep_group
 
 
 def test_runtime_patch_records_initial_and_committed_maps(tmp_path: Path) -> None:
     output = tmp_path / "record.json"
-    module, _ = _make_eplb_module(record_path=output)
+    module, _, _ = _make_eplb_module(record_path=output)
     assert apply_to_module(module)
     state = module.EplbState()
     model = HYV4ForCausalLM()
@@ -294,14 +312,21 @@ def test_runtime_patch_loads_static_map_and_freezes_dynamic_eplb(
         ),
         encoding="utf-8",
     )
-    module, rearrangements = _make_eplb_module(load_path=source)
+    model = HYV4ForCausalLM()
+    model._vllm_hcu_static_eplb_plan = load_static_eplb_plan(
+        source,
+        model_key="HYV4ForCausalLM",
+        expected_shape=(1, 6),
+        num_logical_experts=4,
+        num_redundant_experts=2,
+    )
+    module, rearrangements, ep_group = _make_eplb_module(load_path=source)
     assert apply_to_module(module)
     state = module.EplbState()
-    state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+    state.add_model(model, _FakeModelConfig())
 
-    assert len(rearrangements) == 1
-    assert rearrangements[0][0].tolist() == [[0, 1, 2, 3, 0, 1]]
-    assert rearrangements[0][1].tolist() == [[3, 2, 1, 0, 3, 2]]
+    assert rearrangements == []
+    assert ep_group.barrier_calls == 1
     assert state.model_states["hy4-hash"].physical_to_logical_map.tolist() == [
         [3, 2, 1, 0, 3, 2]
     ]
@@ -318,7 +343,7 @@ def test_runtime_patch_record_mode_preserves_dynamic_eplb_steps(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "record.json"
-    module, _ = _make_eplb_module(record_path=output)
+    module, _, _ = _make_eplb_module(record_path=output)
     assert apply_to_module(module)
     state = module.EplbState()
     state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
@@ -327,3 +352,62 @@ def test_runtime_patch_record_mode_preserves_dynamic_eplb_steps(
     assert state.official_steps == 1
     assert state.should_record_tensor.item() is True
     assert state.is_async is True
+
+
+def test_runtime_patch_keeps_compatibility_rearrangement_without_plan(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "load.json"
+    source.write_text(
+        json.dumps({"physical_to_logical_map": [[3, 2, 1, 0, 3, 2]]}),
+        encoding="utf-8",
+    )
+    module, rearrangements, ep_group = _make_eplb_module(load_path=source)
+    assert apply_to_module(module)
+    state = module.EplbState()
+
+    state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+
+    assert len(rearrangements) == 1
+    assert ep_group.barrier_calls == 0
+
+
+def test_runtime_patch_rejects_cross_rank_plan_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "load.json"
+    source.write_text(
+        json.dumps({"physical_to_logical_map": [[3, 2, 1, 0, 3, 2]]}),
+        encoding="utf-8",
+    )
+    model = HYV4ForCausalLM()
+    model._vllm_hcu_static_eplb_plan = load_static_eplb_plan(
+        source,
+        model_key="HYV4ForCausalLM",
+        expected_shape=(1, 6),
+        num_logical_experts=4,
+        num_redundant_experts=2,
+    )
+    module, rearrangements, ep_group = _make_eplb_module(load_path=source)
+    ep_group.world_size = 2
+    monkeypatch.setattr(
+        torch.distributed,
+        "all_gather_object",
+        lambda output, value, group=None: output.__setitem__(slice(None), [value, ("bad",)]),
+    )
+    module.get_ep_group = lambda: SimpleNamespace(
+        device_group=ep_group,
+        cpu_group=object(),
+        world_size=2,
+        rank_in_group=0,
+        barrier=ep_group.barrier,
+    )
+    assert apply_to_module(module)
+    state = module.EplbState()
+
+    with pytest.raises(RuntimeError, match="fingerprints differ"):
+        state.add_model(model, _FakeModelConfig())
+
+    assert rearrangements == []
+    assert ep_group.barrier_calls == 0

--- a/tests/runtime_patch/test_offline_eplb.py
+++ b/tests/runtime_patch/test_offline_eplb.py
@@ -190,14 +190,16 @@ def test_load_rejects_invalid_maps(
 
 
 class _FakeDeviceGroup:
-    world_size = 1
-    rank_in_group = 0
-
-    def __init__(self) -> None:
+    def __init__(self, *, rank: int = 0, world_size: int = 1) -> None:
+        self.world_size = world_size
+        self.rank_in_group = rank
         self.barrier_calls = 0
 
     def rank(self) -> int:
-        return 0
+        return self.rank_in_group
+
+    def size(self) -> int:
+        return self.world_size
 
     def barrier(self) -> None:
         self.barrier_calls += 1
@@ -221,6 +223,12 @@ class HYV4ForCausalLM:
 
 class GenericMoEForCausalLM(HYV4ForCausalLM):
     pass
+
+
+class DenseExpertPlacementForCausalLM(HYV4ForCausalLM):
+    num_logical_experts = 4
+    num_redundant_experts = 0
+    num_physical_experts = 4
 
 
 class _StageMoERunner:
@@ -270,12 +278,15 @@ def _make_eplb_module(
     load_path: Path | None = None,
     pipeline_parallel_size: int = 1,
     pipeline_parallel_rank: int = 0,
+    ep_size: int = 1,
+    ep_rank: int = 0,
+    num_nodes: int = 1,
 ) -> tuple[ModuleType, list[tuple[torch.Tensor, torch.Tensor]], _FakeDeviceGroup]:
     module = ModuleType(
         "vllm.distributed.eplb.eplb_state"
     )
     rearrangements: list[tuple[torch.Tensor, torch.Tensor]] = []
-    ep_group = _FakeDeviceGroup()
+    ep_group = _FakeDeviceGroup(rank=ep_rank, world_size=ep_size)
 
     class EplbModelState:
         pass
@@ -289,6 +300,7 @@ def _make_eplb_module(
                 _vllm_hcu_expert_map_path=(
                     str(load_path) if load_path is not None else None
                 ),
+                _vllm_hcu_eplb_static_dispatch_policy="nearest",
                 eplb_config=SimpleNamespace(
                     log_balancedness=False,
                     log_balancedness_interval=1,
@@ -306,13 +318,38 @@ def _make_eplb_module(
         def add_model(self, model, model_config) -> None:
             state = EplbModelState()
             state.physical_to_logical_map = (
-                torch.tensor([0, 1, 2, 3, 0, 1], dtype=torch.int64)
+                (
+                    torch.arange(model.num_physical_experts, dtype=torch.int64)
+                    % model.num_logical_experts
+                )
                 .unsqueeze(0)
                 .expand(model.num_moe_layers, -1)
                 .clone()
             )
-            state.logical_to_physical_map = torch.empty(0)
-            state.logical_replica_count = torch.empty(0)
+            state.logical_to_physical_map = torch.full(
+                (
+                    model.num_moe_layers,
+                    model.num_logical_experts,
+                    model.num_redundant_experts + 1,
+                ),
+                -1,
+                dtype=torch.int64,
+            )
+            state.logical_replica_count = torch.zeros(
+                (model.num_moe_layers, model.num_logical_experts),
+                dtype=torch.int64,
+            )
+            for layer_id in range(model.num_moe_layers):
+                for physical_id, logical_id in enumerate(
+                    state.physical_to_logical_map[layer_id].tolist()
+                ):
+                    replica_id = state.logical_replica_count[
+                        layer_id, logical_id
+                    ].item()
+                    state.logical_to_physical_map[
+                        layer_id, logical_id, replica_id
+                    ] = physical_id
+                    state.logical_replica_count[layer_id, logical_id] += 1
             state.expert_load_pass = torch.zeros(
                 (model.num_moe_layers, model.num_physical_experts),
                 dtype=torch.int64,
@@ -400,11 +437,31 @@ def _make_eplb_module(
         del expert_weights, expert_buffer, ep_group, communicator, is_profile, rank_mapping
         rearrangements.append((source_map.clone(), target_map.clone()))
 
+    def update_logical_maps(model_state, *, layers: tuple[int, ...]) -> None:
+        for layer_id in layers:
+            model_state.logical_to_physical_map[layer_id].fill_(-1)
+            model_state.logical_replica_count[layer_id].zero_()
+            for physical_id, logical_id in enumerate(
+                model_state.physical_to_logical_map[layer_id].tolist()
+            ):
+                replica_id = model_state.logical_replica_count[
+                    layer_id, logical_id
+                ].item()
+                model_state.logical_to_physical_map[
+                    layer_id, logical_id, replica_id
+                ] = physical_id
+                model_state.logical_replica_count[layer_id, logical_id] += 1
+
     def commit(model_state, new_physical_to_logical_map) -> None:
         model_state.physical_to_logical_map.copy_(new_physical_to_logical_map)
+        update_logical_maps(
+            model_state,
+            layers=tuple(range(model_state.physical_to_logical_map.shape[0])),
+        )
 
     def commit_layer(model_state, new_physical_to_logical_map, layer) -> None:
         model_state.physical_to_logical_map[layer].copy_(new_physical_to_logical_map)
+        update_logical_maps(model_state, layers=(layer,))
 
     def move_to_workspace(model_state, ep_rank) -> None:
         del model_state, ep_rank
@@ -417,12 +474,231 @@ def _make_eplb_module(
     module._move_to_workspace = move_to_workspace
     module.get_ep_group = lambda: SimpleNamespace(
         device_group=ep_group,
+        cpu_group=object(),
         world_size=ep_group.world_size,
         rank_in_group=ep_group.rank_in_group,
         barrier=ep_group.barrier,
     )
+    module.get_node_count = lambda: num_nodes
     module.logger = SimpleNamespace(info=lambda *args, **kwargs: None)
     return module, rearrangements, ep_group
+
+
+def test_runtime_patch_applies_rank_local_replica_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True, raising=False)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_EPLB_LOCALITY_FAIR_DISPATCH",
+        True,
+        raising=False,
+    )
+    rank_maps = []
+    for ep_rank in range(2):
+        module, _, _ = _make_eplb_module(ep_size=2, ep_rank=ep_rank)
+        assert apply_to_module(module)
+        state = module.EplbState()
+        state.parallel_config._vllm_hcu_eplb_static_dispatch_policy = (
+            "locality_fair"
+        )
+        state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+        rank_maps.append(
+            state.model_states["hy4-hash"].logical_to_physical_map.tolist()
+        )
+
+    assert rank_maps == [
+        [[[0, 4, -1], [1, 5, -1], [2, -1, -1], [3, -1, -1]]],
+        [[[4, 0, -1], [5, 1, -1], [2, -1, -1], [3, -1, -1]]],
+    ]
+
+
+def test_runtime_patch_reapplies_rank_local_order_after_layer_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True, raising=False)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_EPLB_LOCALITY_FAIR_DISPATCH",
+        True,
+        raising=False,
+    )
+    module, _, _ = _make_eplb_module(ep_size=2, ep_rank=1)
+    assert apply_to_module(module)
+    state = module.EplbState()
+    state.parallel_config._vllm_hcu_eplb_static_dispatch_policy = "locality_fair"
+    state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+    model_state = state.model_states["hy4-hash"]
+
+    module._commit_eplb_maps_for_layer(
+        model_state,
+        torch.tensor([3, 2, 1, 0, 3, 2], dtype=torch.int64),
+        0,
+    )
+
+    assert model_state.logical_to_physical_map.tolist() == [
+        [[3, -1, -1], [2, -1, -1], [5, 1, -1], [4, 0, -1]]
+    ]
+
+
+def test_runtime_patch_reapplies_rank_local_order_after_full_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True, raising=False)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_EPLB_LOCALITY_FAIR_DISPATCH",
+        True,
+        raising=False,
+    )
+    module, _, _ = _make_eplb_module(ep_size=2, ep_rank=1)
+    assert apply_to_module(module)
+    state = module.EplbState()
+    state.parallel_config._vllm_hcu_eplb_static_dispatch_policy = "locality_fair"
+    state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+    model_state = state.model_states["hy4-hash"]
+
+    module._commit_eplb_maps(
+        model_state,
+        torch.tensor([[3, 2, 1, 0, 3, 2]], dtype=torch.int64),
+    )
+
+    assert model_state.logical_to_physical_map.tolist() == [
+        [[3, -1, -1], [2, -1, -1], [5, 1, -1], [4, 0, -1]]
+    ]
+
+
+def test_runtime_patch_applies_rank_local_order_to_static_map(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.platforms import envs as henvs
+
+    source = tmp_path / "static.json"
+    source.write_text(
+        json.dumps(
+            {
+                "model_maps": {
+                    "GenericMoEForCausalLM": {
+                        "physical_to_logical_map": [[3, 2, 1, 0, 3, 2]],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    model = GenericMoEForCausalLM()
+    model._vllm_hcu_static_eplb_plan = load_static_eplb_plan(
+        source,
+        model_key="GenericMoEForCausalLM",
+        expected_shape=(1, 6),
+        num_logical_experts=4,
+        num_redundant_experts=2,
+    )
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True, raising=False)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_EPLB_LOCALITY_FAIR_DISPATCH",
+        True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        torch.distributed,
+        "all_gather_object",
+        lambda output, value, group=None: output.__setitem__(
+            slice(None), [value] * len(output)
+        ),
+    )
+    module, rearrangements, _ = _make_eplb_module(
+        load_path=source,
+        ep_size=2,
+        ep_rank=1,
+    )
+    assert apply_to_module(module)
+    state = module.EplbState()
+    state.parallel_config._vllm_hcu_eplb_static_dispatch_policy = "locality_fair"
+
+    state.add_model(model, _FakeModelConfig())
+
+    model_state = state.model_states["hy4-hash"]
+    assert rearrangements == []
+    assert model_state.physical_to_logical_map.tolist() == [[3, 2, 1, 0, 3, 2]]
+    assert model_state.logical_to_physical_map.tolist() == [
+        [[3, -1, -1], [2, -1, -1], [5, 1, -1], [4, 0, -1]]
+    ]
+
+
+@pytest.mark.parametrize(
+    ("policy", "master_enabled", "leaf_enabled"),
+    [
+        ("nearest", True, True),
+        ("locality_fair", False, True),
+        ("locality_fair", True, False),
+    ],
+)
+def test_runtime_patch_keeps_official_order_when_locality_fair_is_disabled(
+    policy: str,
+    master_enabled: bool,
+    leaf_enabled: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_CUSTOM_OPS",
+        master_enabled,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_EPLB_LOCALITY_FAIR_DISPATCH",
+        leaf_enabled,
+        raising=False,
+    )
+    module, _, _ = _make_eplb_module(ep_size=2, ep_rank=1)
+    assert apply_to_module(module)
+    state = module.EplbState()
+    state.parallel_config._vllm_hcu_eplb_static_dispatch_policy = policy
+
+    state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+
+    assert state.model_states["hy4-hash"].logical_to_physical_map.tolist() == [
+        [[0, 4, -1], [1, 5, -1], [2, -1, -1], [3, -1, -1]]
+    ]
+
+
+def test_runtime_patch_skips_locality_fair_without_redundant_experts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True, raising=False)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_EPLB_LOCALITY_FAIR_DISPATCH",
+        True,
+        raising=False,
+    )
+    log_calls: list[tuple[object, ...]] = []
+    module, _, _ = _make_eplb_module(ep_size=2, ep_rank=1)
+    module.logger.info = lambda *args: log_calls.append(args)
+    assert apply_to_module(module)
+    state = module.EplbState()
+    state.parallel_config._vllm_hcu_eplb_static_dispatch_policy = "locality_fair"
+
+    state.add_model(DenseExpertPlacementForCausalLM(), _FakeModelConfig())
+
+    assert state.model_states["hy4-hash"].logical_to_physical_map.tolist() == [
+        [[0], [1], [2], [3]]
+    ]
+    assert not any("locality-fair" in str(call[0]) for call in log_calls)
 
 
 def test_runtime_patch_records_initial_and_committed_maps(tmp_path: Path) -> None:

--- a/tests/runtime_patch/test_offline_eplb.py
+++ b/tests/runtime_patch/test_offline_eplb.py
@@ -317,11 +317,37 @@ def _make_eplb_module(
             self.model_states[model_config.compute_hash()] = state
 
         def step(self, is_dummy=False, is_profile=False, log_stats=False):
-            del is_dummy, log_stats
             self.official_steps += 1
             if is_profile:
                 self.official_profile_steps += 1
+            if getattr(self, "simulate_official_window_step", False):
+                if not is_dummy and self._should_record_current_step(
+                    log_stats=log_stats
+                ):
+                    for model_state in self.model_states.values():
+                        model_state.expert_load_window[
+                            self.expert_load_window_step
+                        ].copy_(model_state.expert_load_pass)
+                        model_state.expert_load_pass.zero_()
+                    self.expert_load_window_step = (
+                        self.expert_load_window_step + 1
+                    ) % self.expert_load_window_size
+                self._update_layer_should_record(log_stats=log_stats)
             return "official-step"
+
+        def _sync_load_pass(self):
+            return [
+                model_state.expert_load_pass.clone()
+                for model_state in self.model_states.values()
+            ]
+
+        def _should_record_current_step(self, log_stats=False):
+            return log_stats
+
+        def _update_layer_should_record(self, log_stats=False):
+            self.should_record_tensor.fill_(
+                self._should_record_current_step(log_stats=log_stats)
+            )
 
         def rearrange(self, is_profile=False, rank_mapping=None):
             model_state = self.model_states["hy4-hash"]
@@ -616,6 +642,101 @@ def test_runtime_patch_record_mode_plans_without_live_rearrangement(
     assert recorded["model_maps"]["HYV4ForCausalLM"][
         "physical_to_logical_map"
     ] == [[3, 2, 1, 0, 3, 2]]
+
+
+def test_runtime_patch_logs_balancedness_across_ep_ranks_per_layer() -> None:
+    module, _, _ = _make_eplb_module()
+    log_calls: list[tuple[object, ...]] = []
+    module.logger.info = lambda _message, *args: log_calls.append(args)
+    module.get_ep_group = lambda: SimpleNamespace(
+        device_group=SimpleNamespace(size=lambda: 2, rank=lambda: 0),
+    )
+    assert apply_to_module(module)
+
+    state = module.EplbState()
+    state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+    model_state = state.model_states["hy4-hash"]
+    # Both layers put 8 tokens on rank 0 and 2 on rank 1. The correct
+    # aggregate is avg=(5 + 5)=10, max=(8 + 8)=16, ratio=0.625.
+    model_state.expert_load_pass = torch.tensor([[8, 2], [8, 2]])
+    model_state.expert_load_window = torch.zeros((1, 2, 2), dtype=torch.int64)
+    state.expert_rearrangement_step = 0
+    state.expert_rearrangement_step_interval = 100
+    state.expert_load_window_step = 0
+    state.expert_load_window_size = 1
+    state.parallel_config.eplb_config = SimpleNamespace(
+        log_balancedness_interval=1,
+    )
+    state._sync_load_pass = lambda: [model_state.expert_load_pass.clone()]
+    state._should_record_current_step = lambda log_stats=False: log_stats
+    state._update_layer_should_record = lambda log_stats=False: None
+
+    assert state.step(log_stats=True) == "official-step"
+
+    assert len(log_calls) == 1
+    _, model_name, avg_tokens, max_tokens, balancedness, _ = log_calls[0]
+    assert model_name == "/models/Hy4-preview-Channel-FP8-w8a8-v2"
+    assert avg_tokens == 10.0
+    assert max_tokens == 16.0
+    assert balancedness == 0.625
+    assert model_state.expert_load_window.tolist() == [[[8, 2], [8, 2]]]
+    assert model_state.expert_load_pass.tolist() == [[0, 0], [0, 0]]
+
+
+def test_runtime_patch_does_not_double_record_near_rearrangement() -> None:
+    module, _, _ = _make_eplb_module()
+    module.get_ep_group = lambda: SimpleNamespace(
+        device_group=SimpleNamespace(size=lambda: 2, rank=lambda: 0),
+    )
+    assert apply_to_module(module)
+
+    state = module.EplbState()
+    state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+    model_state = state.model_states["hy4-hash"]
+    model_state.expert_load_pass = torch.tensor([[8, 2]])
+    model_state.expert_load_window = torch.zeros((2, 1, 2), dtype=torch.int64)
+    state.expert_rearrangement_step = 0
+    state.expert_rearrangement_step_interval = 1
+    state.expert_load_window_step = 0
+    state.expert_load_window_size = 2
+    state.parallel_config.eplb_config = SimpleNamespace(
+        log_balancedness_interval=1,
+    )
+    state.simulate_official_window_step = True
+
+    sync_calls = 0
+    original_sync = state._sync_load_pass
+
+    def sync_load_pass():
+        nonlocal sync_calls
+        sync_calls += 1
+        return original_sync()
+
+    should_record_calls: list[bool] = []
+    update_calls: list[bool] = []
+    state._sync_load_pass = sync_load_pass
+    state._should_record_current_step = lambda log_stats=False: (
+        should_record_calls.append(log_stats) or True
+    )
+
+    def update_layer_should_record(log_stats=False):
+        update_calls.append(log_stats)
+        state.should_record_tensor.fill_(log_stats)
+
+    state._update_layer_should_record = update_layer_should_record
+
+    assert state.step(log_stats=True) == "official-step"
+
+    assert sync_calls == 1
+    assert model_state.expert_load_window.tolist() == [
+        [[8, 2]],
+        [[0, 0]],
+    ]
+    assert model_state.expert_load_pass.tolist() == [[0, 0]]
+    assert state.expert_load_window_step == 1
+    assert should_record_calls == [False, False]
+    assert update_calls == [False, True]
+    assert state.should_record_tensor.item() is True
 
 
 def test_runtime_patch_record_mode_keeps_profile_rearrangement(

--- a/tests/runtime_patch/test_offline_eplb.py
+++ b/tests/runtime_patch/test_offline_eplb.py
@@ -12,6 +12,7 @@ import pytest
 import torch
 
 from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    bind_static_eplb_plan,
     load_static_eplb_plan,
 )
 from vllm_hcu.patch.worker import worker_callback_names
@@ -214,11 +215,49 @@ class HYV4ForCausalLM:
     num_redundant_experts = 2
     num_physical_experts = 6
     num_moe_layers = 1
+    moe_layers = [SimpleNamespace()]
     expert_weights = [[torch.zeros(1)]]
 
 
 class GenericMoEForCausalLM(HYV4ForCausalLM):
     pass
+
+
+class _StageMoERunner:
+    def __init__(self) -> None:
+        self.routed_experts = SimpleNamespace()
+
+    def get_expert_weights(self) -> list[torch.Tensor]:
+        return [torch.zeros(1)]
+
+    def set_eplb_state(self, **kwargs: object) -> None:
+        del kwargs
+
+
+class PipelineMoEForCausalLM(HYV4ForCausalLM):
+    def __init__(self, local_moe_layers: int) -> None:
+        self.num_moe_layers = 3
+        self.num_expert_groups = 1
+        self.num_local_physical_experts = 6
+        self.num_routed_experts = 4
+        self.num_shared_experts = 0
+        self.moe_layers = [_StageMoERunner() for _ in range(local_moe_layers)]
+        self.expert_weights = [[torch.zeros(1)] for _ in self.moe_layers]
+
+    def set_eplb_state(self, *args: object) -> None:
+        del args
+
+    def update_physical_experts_metadata(self, *args: object) -> None:
+        del args
+
+
+class Llama4ForConditionalGeneration(PipelineMoEForCausalLM):
+    def __init__(self) -> None:
+        super().__init__(local_moe_layers=1)
+        self.num_moe_layers = 1
+        self.language_model = PipelineMoEForCausalLM(local_moe_layers=1)
+        self.language_model.num_moe_layers = 1
+        self.language_model.moe_layers = self.moe_layers
 
 
 def test_offline_eplb_patch_is_registered_in_worker_inventory() -> None:
@@ -229,6 +268,8 @@ def _make_eplb_module(
     *,
     record_path: Path | None = None,
     load_path: Path | None = None,
+    pipeline_parallel_size: int = 1,
+    pipeline_parallel_rank: int = 0,
 ) -> tuple[ModuleType, list[tuple[torch.Tensor, torch.Tensor]], _FakeDeviceGroup]:
     module = ModuleType(
         "vllm.distributed.eplb.eplb_state"
@@ -248,6 +289,8 @@ def _make_eplb_module(
                 _vllm_hcu_expert_map_path=(
                     str(load_path) if load_path is not None else None
                 ),
+                pipeline_parallel_size=pipeline_parallel_size,
+                pipeline_parallel_rank=pipeline_parallel_rank,
             )
             self.device = torch.device("cpu")
             self.model_states: dict[str, EplbModelState] = {}
@@ -258,8 +301,11 @@ def _make_eplb_module(
 
         def add_model(self, model, model_config) -> None:
             state = EplbModelState()
-            state.physical_to_logical_map = torch.tensor(
-                [[0, 1, 2, 3, 0, 1]], dtype=torch.int64
+            state.physical_to_logical_map = (
+                torch.tensor([0, 1, 2, 3, 0, 1], dtype=torch.int64)
+                .unsqueeze(0)
+                .expand(model.num_moe_layers, -1)
+                .clone()
             )
             state.logical_to_physical_map = torch.empty(0)
             state.logical_replica_count = torch.empty(0)
@@ -279,7 +325,12 @@ def _make_eplb_module(
 
         def rearrange(self, is_profile=False, rank_mapping=None):
             model_state = self.model_states["hy4-hash"]
-            candidate = torch.tensor([[3, 2, 1, 0, 3, 2]], dtype=torch.int64)
+            candidate = (
+                torch.tensor([3, 2, 1, 0, 3, 2], dtype=torch.int64)
+                .unsqueeze(0)
+                .expand_as(model_state.physical_to_logical_map)
+                .clone()
+            )
             module.rearrange_expert_weights_inplace(
                 model_state.physical_to_logical_map,
                 candidate,
@@ -352,6 +403,131 @@ def test_runtime_patch_records_initial_and_committed_maps(tmp_path: Path) -> Non
     assert recorded["model_maps"]["HYV4ForCausalLM"][
         "physical_to_logical_map"
     ] == committed.tolist()
+
+
+def test_two_pp_stages_record_and_load_independent_local_maps(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "pipeline.json"
+    stage_maps = (
+        torch.tensor(
+            [
+                [3, 2, 1, 0, 3, 2],
+                [2, 3, 0, 1, 2, 3],
+            ],
+            dtype=torch.int64,
+        ),
+        torch.tensor([[1, 0, 3, 2, 1, 0]], dtype=torch.int64),
+    )
+
+    for pp_rank, stage_map in enumerate(stage_maps):
+        module, rearrangements, _ = _make_eplb_module(
+            record_path=output,
+            pipeline_parallel_size=2,
+            pipeline_parallel_rank=pp_rank,
+        )
+        assert apply_to_module(module)
+        state = module.EplbState()
+        model = PipelineMoEForCausalLM(local_moe_layers=stage_map.shape[0])
+        state.add_model(model, _FakeModelConfig())
+        model_state = state.model_states["hy4-hash"]
+
+        assert model.num_moe_layers == stage_map.shape[0]
+        assert model_state.physical_to_logical_map.shape == stage_map.shape
+        module._commit_eplb_maps(model_state, stage_map)
+        assert rearrangements == []
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert set(payload["model_maps"]) == {
+        "PipelineMoEForCausalLM#pp_rank=0",
+        "PipelineMoEForCausalLM#pp_rank=1",
+    }
+    for pp_rank, stage_map in enumerate(stage_maps):
+        key = f"PipelineMoEForCausalLM#pp_rank={pp_rank}"
+        assert payload["model_maps"][key]["physical_to_logical_map"] == (
+            stage_map.tolist()
+        )
+
+        model = PipelineMoEForCausalLM(local_moe_layers=stage_map.shape[0])
+        config = SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                _vllm_hcu_expert_map_path=str(output),
+                enable_expert_parallel=True,
+                enable_eplb=True,
+                enable_ep_weight_filter=False,
+                pipeline_parallel_size=2,
+                pipeline_parallel_rank=pp_rank,
+            )
+        )
+        plan = bind_static_eplb_plan(config, model)
+        assert plan is not None
+        assert plan.model_key == key
+        assert plan.physical_to_logical_map.tolist() == stage_map.tolist()
+
+        load_module, rearrangements, _ = _make_eplb_module(
+            load_path=output,
+            pipeline_parallel_size=2,
+            pipeline_parallel_rank=pp_rank,
+        )
+        assert apply_to_module(load_module)
+        load_state = load_module.EplbState()
+        load_state.add_model(model, _FakeModelConfig())
+        assert rearrangements == []
+        assert load_state.model_states[
+            "hy4-hash"
+        ].physical_to_logical_map.tolist() == stage_map.tolist()
+
+
+def test_dynamic_eplb_keeps_the_models_declared_global_layer_count() -> None:
+    module, _, _ = _make_eplb_module()
+    assert apply_to_module(module)
+    state = module.EplbState()
+    model = PipelineMoEForCausalLM(local_moe_layers=1)
+
+    state.add_model(model, _FakeModelConfig())
+
+    assert model.num_moe_layers == 3
+    assert state.model_states["hy4-hash"].physical_to_logical_map.shape == (3, 6)
+
+
+def test_nested_mllama_record_is_loadable_under_the_same_public_key(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "mllama.json"
+    record_module, _, _ = _make_eplb_module(record_path=output)
+    assert apply_to_module(record_module)
+    record_state = record_module.EplbState()
+    record_state.add_model(Llama4ForConditionalGeneration(), _FakeModelConfig())
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert set(payload["model_maps"]) == {"Llama4ForConditionalGeneration"}
+
+    model = Llama4ForConditionalGeneration()
+    plan = bind_static_eplb_plan(
+        SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                _vllm_hcu_expert_map_path=str(output),
+                enable_expert_parallel=True,
+                enable_eplb=True,
+                enable_ep_weight_filter=False,
+                pipeline_parallel_size=1,
+            )
+        ),
+        model,
+    )
+    assert plan is not None
+    assert plan.model_key == "Llama4ForConditionalGeneration"
+    assert model.language_model._vllm_hcu_static_eplb_plan is plan
+
+    load_module, rearrangements, _ = _make_eplb_module(load_path=output)
+    assert apply_to_module(load_module)
+    load_state = load_module.EplbState()
+    load_state.add_model(model, _FakeModelConfig())
+
+    assert rearrangements == []
+    assert load_state.model_states[
+        "hy4-hash"
+    ].physical_to_logical_map.tolist() == [[0, 1, 2, 3, 0, 1]]
 
 
 def test_runtime_patch_commits_generic_static_plan_without_rearrangement(

--- a/tests/runtime_patch/test_offline_eplb.py
+++ b/tests/runtime_patch/test_offline_eplb.py
@@ -289,6 +289,10 @@ def _make_eplb_module(
                 _vllm_hcu_expert_map_path=(
                     str(load_path) if load_path is not None else None
                 ),
+                eplb_config=SimpleNamespace(
+                    log_balancedness=False,
+                    log_balancedness_interval=1,
+                ),
                 pipeline_parallel_size=pipeline_parallel_size,
                 pipeline_parallel_rank=pipeline_parallel_rank,
             )
@@ -309,6 +313,10 @@ def _make_eplb_module(
             )
             state.logical_to_physical_map = torch.empty(0)
             state.logical_replica_count = torch.empty(0)
+            state.expert_load_pass = torch.zeros(
+                (model.num_moe_layers, model.num_physical_experts),
+                dtype=torch.int64,
+            )
             state.model_name = model_config.model
             state.model = model
             state.expert_buffer = [torch.zeros(1)]
@@ -624,6 +632,72 @@ def test_runtime_patch_commits_generic_static_plan_without_rearrangement(
     assert state.official_profile_steps == 0
     assert state.step(is_profile=False) is None
     assert state.official_steps == 0
+
+
+def test_runtime_patch_static_map_logs_load_without_rearrangement(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "load.json"
+    source.write_text(
+        json.dumps(
+            {
+                "model_maps": {
+                    "GenericMoEForCausalLM": {
+                        "physical_to_logical_map": [[3, 2, 1, 0, 3, 2]],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    model = GenericMoEForCausalLM()
+    model._vllm_hcu_static_eplb_plan = load_static_eplb_plan(
+        source,
+        model_key="GenericMoEForCausalLM",
+        expected_shape=(1, 6),
+        num_logical_experts=4,
+        num_redundant_experts=2,
+    )
+    module, rearrangements, ep_group = _make_eplb_module(load_path=source)
+    log_calls: list[tuple[object, ...]] = []
+    module.logger.info = lambda _message, *args: log_calls.append(args)
+    module.get_ep_group = lambda: SimpleNamespace(
+        device_group=SimpleNamespace(size=lambda: 2, rank=lambda: 0),
+        world_size=1,
+        barrier=ep_group.barrier,
+    )
+    assert apply_to_module(module)
+
+    state = module.EplbState()
+    state.parallel_config.eplb_config = SimpleNamespace(
+        log_balancedness=True,
+        log_balancedness_interval=1,
+    )
+    state.add_model(model, _FakeModelConfig())
+    model_state = state.model_states["hy4-hash"]
+    static_map = model_state.physical_to_logical_map.clone()
+    model_state.expert_load_pass = torch.tensor([[80, 20]])
+
+    assert state.step(is_profile=True, log_stats=True) is None
+    assert state.official_profile_steps == 0
+    assert model_state.expert_load_pass.tolist() == [[0, 0]]
+
+    model_state.expert_load_pass = torch.tensor([[8, 2]])
+    model_state.expert_load_window = torch.zeros((1, 1, 2), dtype=torch.int64)
+    state.expert_rearrangement_step = 0
+    state.expert_rearrangement_step_interval = 1
+    state.expert_load_window_step = 0
+    state.expert_load_window_size = 1
+    state.simulate_official_rearrange_step = True
+
+    assert state.should_record_tensor.item() is True
+    assert state.is_async is False
+    assert state.step(log_stats=True) == "official-step"
+
+    assert state.official_steps == 1
+    assert rearrangements == []
+    assert torch.equal(model_state.physical_to_logical_map, static_map)
+    assert any(args[4] == 0.625 for args in log_calls if len(args) == 6)
 
 
 def test_runtime_patch_record_mode_plans_without_live_rearrangement(

--- a/tests/runtime_patch/test_offline_eplb.py
+++ b/tests/runtime_patch/test_offline_eplb.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import multiprocessing
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -21,6 +22,19 @@ from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
     load_static_eplb_plan,
 )
 from vllm_hcu.patch.worker import worker_callback_names
+
+
+def _record_map_in_process(output: str, model_index: int, start_event) -> None:
+    start_event.wait()
+    record_offline_expert_map(
+        output,
+        model_key=f"model-{model_index}",
+        model_name=f"/models/model-{model_index}",
+        model_class=f"Model{model_index}",
+        physical_to_logical_map=torch.tensor([[0, 1, 2, 3]]),
+        num_logical_experts=4,
+        num_redundant_experts=0,
+    )
 
 
 def test_record_merges_main_and_mtp_maps_atomically(tmp_path: Path) -> None:
@@ -56,6 +70,28 @@ def test_record_merges_main_and_mtp_maps_atomically(tmp_path: Path) -> None:
     ] == main_map.tolist()
     assert payload["model_maps"]["HYV4MTP"]["physical_to_logical_map"] == mtp_map.tolist()
     assert not output.with_suffix(".json.tmp").exists()
+
+
+def test_record_serializes_writers_across_processes(tmp_path: Path) -> None:
+    output = tmp_path / "shared-eplb.json"
+    context = multiprocessing.get_context("fork")
+    start_event = context.Event()
+    processes = [
+        context.Process(
+            target=_record_map_in_process,
+            args=(str(output), model_index, start_event),
+        )
+        for model_index in range(8)
+    ]
+    for process in processes:
+        process.start()
+    start_event.set()
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert sorted(payload["model_maps"]) == [f"model-{index}" for index in range(8)]
 
 
 def test_load_selects_requested_model_and_preserves_dtype(tmp_path: Path) -> None:
@@ -236,6 +272,23 @@ def _make_eplb_module(
                 self.official_profile_steps += 1
             return "official-step"
 
+        def rearrange(self, is_profile=False, rank_mapping=None):
+            model_state = self.model_states["hy4-hash"]
+            candidate = torch.tensor([[3, 2, 1, 0, 3, 2]], dtype=torch.int64)
+            module.rearrange_expert_weights_inplace(
+                model_state.physical_to_logical_map,
+                candidate,
+                model_state.model.expert_weights,
+                model_state.expert_buffer,
+                ep_group,
+                model_state.communicator,
+                is_profile,
+                rank_mapping,
+            )
+            if not is_profile:
+                module._commit_eplb_maps(model_state, candidate)
+            return "official-rearrange"
+
     def rearrange_expert_weights_inplace(
         source_map,
         target_map,
@@ -339,11 +392,11 @@ def test_runtime_patch_loads_static_map_and_freezes_dynamic_eplb(
     assert state.official_steps == 0
 
 
-def test_runtime_patch_record_mode_preserves_dynamic_eplb_steps(
+def test_runtime_patch_record_mode_plans_without_live_rearrangement(
     tmp_path: Path,
 ) -> None:
     output = tmp_path / "record.json"
-    module, _, _ = _make_eplb_module(record_path=output)
+    module, rearrangements, _ = _make_eplb_module(record_path=output)
     assert apply_to_module(module)
     state = module.EplbState()
     state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
@@ -351,7 +404,46 @@ def test_runtime_patch_record_mode_preserves_dynamic_eplb_steps(
     assert state.step(is_profile=False) == "official-step"
     assert state.official_steps == 1
     assert state.should_record_tensor.item() is True
+    assert state.is_async is False
+
+    model_state = state.model_states["hy4-hash"]
+    initial_map = model_state.physical_to_logical_map.clone()
+    assert state.rearrange() == "official-rearrange"
+
+    assert rearrangements == []
+    assert torch.equal(model_state.physical_to_logical_map, initial_map)
+    recorded = json.loads(output.read_text(encoding="utf-8"))
+    assert recorded["model_maps"]["HYV4ForCausalLM"][
+        "physical_to_logical_map"
+    ] == [[3, 2, 1, 0, 3, 2]]
+
+
+def test_runtime_patch_record_mode_keeps_profile_rearrangement(
+    tmp_path: Path,
+) -> None:
+    module, rearrangements, _ = _make_eplb_module(
+        record_path=tmp_path / "record.json"
+    )
+    assert apply_to_module(module)
+    state = module.EplbState()
+    state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+
+    assert state.rearrange(is_profile=True) == "official-rearrange"
+    assert len(rearrangements) == 1
+
+
+def test_runtime_patch_keeps_online_rearrangement_without_offline_paths() -> None:
+    module, rearrangements, _ = _make_eplb_module()
+    assert apply_to_module(module)
+    state = module.EplbState()
+    state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+
     assert state.is_async is True
+    assert state.rearrange() == "official-rearrange"
+    assert len(rearrangements) == 1
+    assert state.model_states["hy4-hash"].physical_to_logical_map.tolist() == [
+        [3, 2, 1, 0, 3, 2]
+    ]
 
 
 def test_runtime_patch_keeps_compatibility_rearrangement_without_plan(

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -1102,6 +1102,7 @@ def _validation_config(feature_config: HcuFeatureConfig) -> object:
             decode_context_parallel_size=1,
             data_parallel_size=1,
             enable_expert_parallel=False,
+            enable_elastic_ep=False,
         ),
         scheduler_config=SimpleNamespace(max_num_batched_tokens=256),
         speculative_config=None,
@@ -1156,6 +1157,19 @@ def test_deepep_auto_rejects_eplb_before_model_loading() -> None:
     with pytest.raises(
         ValueError,
         match="deepep_auto.*EPLB.*not supported",
+    ):
+        patch_vllm_config.validate_and_update_hcu_config(config)
+
+
+def test_static_offline_eplb_rejects_elastic_ep_before_model_loading() -> None:
+    config = _validation_config(
+        HcuFeatureConfig(expert_map_path="/models/maps/static.json")
+    )
+    config.parallel_config.enable_elastic_ep = True
+
+    with pytest.raises(
+        ValueError,
+        match="static offline EPLB.*elastic EP.*not supported",
     ):
         patch_vllm_config.validate_and_update_hcu_config(config)
 

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -533,6 +533,36 @@ print("offline-eplb-cli-conflict-rejected")
     assert "offline-eplb-cli-conflict-rejected" in result.stdout
 
 
+def test_real_v0251_cli_extracts_disable_rearrange_before_validation() -> None:
+    result = _run_fresh_v0251(
+        r'''
+import argparse
+import json
+
+from vllm.engine import arg_utils
+from vllm_hcu.patch.config import get_hcu_config
+from vllm_hcu.patch.platform.core_fix import patch_engine_args
+
+arg_utils.current_platform.device_type = "cpu"
+patch_engine_args.apply_to_module(arg_utils)
+parser = argparse.ArgumentParser()
+arg_utils.EngineArgs.add_cli_args(parser)
+namespace = parser.parse_args([
+    "--eplb-config",
+    json.dumps({"window_size": 8, "disable_rearrange": True}),
+])
+args = arg_utils.EngineArgs.from_cli_args(namespace)
+config = args.create_engine_config()
+assert args.eplb_config.window_size == 8
+assert not hasattr(args.eplb_config, "disable_rearrange")
+assert get_hcu_config(config).eplb_disable_rearrange is True
+print("disable-rearrange-cli-normalized")
+'''
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "disable-rearrange-cli-normalized" in result.stdout
+
+
 def test_nested_speculative_multi_mtp_is_extracted_before_official_config() -> None:
     module = _make_arg_utils_module()
     patch_engine_args.apply_to_module(module)
@@ -603,6 +633,24 @@ def test_nested_offline_eplb_paths_reject_conflicts() -> None:
                 "expert_map_path": "/models/maps/load.json",
             }
         )
+
+
+def test_nested_eplb_disable_rearrange_is_extracted() -> None:
+    module = _make_arg_utils_module()
+    patch_engine_args.apply_to_module(module)
+
+    args = module.EngineArgs(
+        eplb_config={
+            "window_size": 8,
+            "disable_rearrange": True,
+        }
+    )
+
+    assert args.eplb_config == {"window_size": 8}
+    assert get_hcu_config(args).eplb_disable_rearrange is True
+    assert get_hcu_config(
+        args.create_engine_config()
+    ).eplb_disable_rearrange is True
 
 
 def test_positional_additional_config_is_merged_not_overwritten() -> None:
@@ -1210,6 +1258,19 @@ def test_static_offline_eplb_rejects_elastic_ep_before_model_loading() -> None:
     with pytest.raises(
         ValueError,
         match="static offline EPLB.*elastic EP.*not supported",
+    ):
+        patch_vllm_config.validate_and_update_hcu_config(config)
+
+
+def test_disable_eplb_rearrange_rejects_elastic_ep_before_loading() -> None:
+    config = _validation_config(
+        HcuFeatureConfig(eplb_disable_rearrange=True)
+    )
+    config.parallel_config.enable_elastic_ep = True
+
+    with pytest.raises(
+        ValueError,
+        match="disable_rearrange.*elastic EP.*not supported",
     ):
         patch_vllm_config.validate_and_update_hcu_config(config)
 

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -458,7 +458,17 @@ print("legacy-backend-normalized")
     assert "legacy-backend-normalized" in result.stdout
 
 
-def test_real_v0251_cli_extracts_offline_eplb_path_before_validation() -> None:
+@pytest.mark.parametrize(
+    ("path_key", "path_value"),
+    [
+        ("expert_map_record_path", "/models/maps/hy4-record.json"),
+        ("expert_map_path", "/models/maps/hy4-load.json"),
+    ],
+)
+def test_real_v0251_cli_extracts_offline_eplb_path_before_validation(
+    path_key: str,
+    path_value: str,
+) -> None:
     result = _run_fresh_v0251(
         r'''
 import argparse
@@ -472,25 +482,55 @@ arg_utils.current_platform.device_type = "cpu"
 patch_engine_args.apply_to_module(arg_utils)
 parser = argparse.ArgumentParser()
 arg_utils.EngineArgs.add_cli_args(parser)
+path_key = PATH_KEY
+path_value = PATH_VALUE
 namespace = parser.parse_args([
     "--eplb-config",
-    json.dumps({
-        "window_size": 8,
-        "step_interval": 16,
-        "expert_map_record_path": "/models/maps/hy4.json",
-    }),
+    json.dumps({"window_size": 2, path_key: path_value}),
 ])
 args = arg_utils.EngineArgs.from_cli_args(namespace)
-feature = get_hcu_config(args)
-assert args.eplb_config.window_size == 8
-assert args.eplb_config.step_interval == 16
-assert feature.expert_map_record_path == "/models/maps/hy4.json"
-assert feature.expert_map_path is None
+config = args.create_engine_config()
+assert args.eplb_config.window_size == 2
+assert not hasattr(args.eplb_config, path_key)
+assert getattr(get_hcu_config(config), path_key) == path_value
 print("offline-eplb-cli-normalized")
-'''
+'''.replace("PATH_KEY", repr(path_key)).replace("PATH_VALUE", repr(path_value))
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "offline-eplb-cli-normalized" in result.stdout
+
+
+def test_real_v0251_cli_rejects_conflicting_offline_eplb_paths() -> None:
+    result = _run_fresh_v0251(
+        r'''
+import argparse
+import json
+
+from vllm.engine import arg_utils
+from vllm_hcu.patch.platform.core_fix import patch_engine_args
+
+arg_utils.current_platform.device_type = "cpu"
+patch_engine_args.apply_to_module(arg_utils)
+parser = argparse.ArgumentParser()
+arg_utils.EngineArgs.add_cli_args(parser)
+namespace = parser.parse_args([
+    "--eplb-config",
+    json.dumps({
+        "expert_map_record_path": "/models/maps/record.json",
+        "expert_map_path": "/models/maps/load.json",
+    }),
+])
+try:
+    arg_utils.EngineArgs.from_cli_args(namespace)
+except ValueError as error:
+    assert "mutually exclusive" in str(error)
+else:
+    raise AssertionError("conflicting offline EPLB paths were accepted")
+print("offline-eplb-cli-conflict-rejected")
+'''
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "offline-eplb-cli-conflict-rejected" in result.stdout
 
 
 def test_nested_speculative_multi_mtp_is_extracted_before_official_config() -> None:

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -563,6 +563,39 @@ print("disable-rearrange-cli-normalized")
     assert "disable-rearrange-cli-normalized" in result.stdout
 
 
+def test_real_v0251_cli_extracts_static_dispatch_policy_before_validation() -> None:
+    result = _run_fresh_v0251(
+        r'''
+import argparse
+import json
+
+from vllm.engine import arg_utils
+from vllm_hcu.patch.config import get_hcu_config
+from vllm_hcu.patch.platform.core_fix import patch_engine_args
+
+arg_utils.current_platform.device_type = "cpu"
+patch_engine_args.apply_to_module(arg_utils)
+parser = argparse.ArgumentParser()
+arg_utils.EngineArgs.add_cli_args(parser)
+namespace = parser.parse_args([
+    "--eplb-config",
+    json.dumps({
+        "window_size": 8,
+        "static_dispatch_policy": "locality_fair",
+    }),
+])
+args = arg_utils.EngineArgs.from_cli_args(namespace)
+config = args.create_engine_config()
+assert args.eplb_config.window_size == 8
+assert not hasattr(args.eplb_config, "static_dispatch_policy")
+assert get_hcu_config(config).eplb_static_dispatch_policy == "locality_fair"
+print("static-dispatch-policy-cli-normalized")
+'''
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "static-dispatch-policy-cli-normalized" in result.stdout
+
+
 def test_nested_speculative_multi_mtp_is_extracted_before_official_config() -> None:
     module = _make_arg_utils_module()
     patch_engine_args.apply_to_module(module)
@@ -651,6 +684,30 @@ def test_nested_eplb_disable_rearrange_is_extracted() -> None:
     assert get_hcu_config(
         args.create_engine_config()
     ).eplb_disable_rearrange is True
+
+
+def test_nested_eplb_static_dispatch_policy_is_extracted() -> None:
+    module = _make_arg_utils_module()
+    patch_engine_args.apply_to_module(module)
+
+    args = module.EngineArgs(
+        eplb_config={
+            "window_size": 8,
+            "static_dispatch_policy": "locality_fair",
+        }
+    )
+
+    assert args.eplb_config == {"window_size": 8}
+    assert (
+        get_hcu_config(args).eplb_static_dispatch_policy
+        == "locality_fair"
+    )
+    assert (
+        get_hcu_config(
+            args.create_engine_config()
+        ).eplb_static_dispatch_policy
+        == "locality_fair"
+    )
 
 
 def test_positional_additional_config_is_merged_not_overwritten() -> None:

--- a/tests/runtime_patch/test_sparse_indexer_loading.py
+++ b/tests/runtime_patch/test_sparse_indexer_loading.py
@@ -529,6 +529,85 @@ def test_hy_v4_lightop_filters_negative_slots_on_idle_dp_rank(
     assert torch.equal(events[0][1], torch.tensor([3], dtype=torch.int64))
 
 
+def test_hy_v4_lightop_capture_uses_fixed_shape_safe_cache_writer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catch dynamic boolean compaction while the HCU stream is capturing."""
+    events: list[tuple[object, ...]] = []
+    fp8_dtype = torch.float8_e4m3fn
+    metadata = SimpleNamespace(
+        slot_mapping=torch.tensor([2, -1], dtype=torch.int64),
+        num_kv_actual_tokens=2,
+    )
+    cache = torch.zeros((1, 4, 132), dtype=torch.uint8)
+    fused_q = torch.ones((2, 3, 128), dtype=fp8_dtype)
+    fused_weights = torch.ones((2, 3), dtype=torch.float32)
+
+    def quant_without_cache(q, k, _cache, slots, _weights, **_kwargs):
+        events.append(("fuse", k, slots))
+        return fused_q, fused_weights
+
+    def safe_cache_writer(k, _cache, slots, _block_size, _scale_fmt):
+        events.append(("safe_cache", k, slots))
+
+    monkeypatch.setattr(
+        torch.cuda,
+        "is_current_stream_capturing",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "vllm_hcu.v1.attention.ops.rocm_aiter_mla_sparse."
+        "rocm_aiter_sparse_attn_indexer_native",
+        lambda *args, **kwargs: events.append(("topk", kwargs)) or args[3],
+    )
+    forward_hip = _load_sparse_indexer_contract(
+        torch=torch,
+        current_platform=SimpleNamespace(fp8_dtype=lambda: fp8_dtype),
+        get_forward_context=lambda: SimpleNamespace(
+            attn_metadata={"indexer": metadata}
+        ),
+        effective_pcp_world_size=lambda _value: 1,
+        maybe_gather_indexer_k=lambda *args: pytest.fail(
+            "single-rank Hy4 unexpectedly gathered PCP inputs"
+        ),
+        lightop_indexer_qk_quant_and_store=quant_without_cache,
+        _hcu_indexer_k_quant_and_cache=safe_cache_writer,
+        rocm_aiter_ops=SimpleNamespace(is_enabled=lambda: True),
+        _encode_layer_name=lambda value: value,
+    )
+    indexer = SimpleNamespace(
+        use_fp4_cache=False,
+        use_lightop_hy_v4_indexer=True,
+        skip_k_cache_insert=False,
+        pcp_world_size=1,
+        dcp_world_size=1,
+        k_cache=SimpleNamespace(prefix="indexer", kv_cache=cache),
+        quant_block_size=128,
+        scale_fmt="ue8m0",
+        topk_tokens=64,
+        head_dim=128,
+        max_model_len=4096,
+        max_total_seq_len=4096,
+        topk_indices_buffer=torch.empty((2, 64), dtype=torch.int32),
+    )
+    k_bf16 = torch.ones((2, 128), dtype=torch.bfloat16)
+
+    forward_hip(
+        indexer,
+        torch.empty((2, 1)),
+        torch.ones((2, 3, 128), dtype=torch.bfloat16),
+        k_bf16,
+        torch.ones((2, 3), dtype=torch.bfloat16),
+    )
+
+    assert [event[0] for event in events] == ["fuse", "safe_cache", "topk"]
+    assert events[0][1].shape == (0, 128)
+    assert events[0][2].numel() == 0
+    assert torch.equal(events[1][1], k_bf16)
+    assert torch.equal(events[1][2], metadata.slot_mapping)
+    assert events[2][1]["indexer_cache_layout"] is None
+
+
 def test_hy_v4_lightop_avoids_unsafe_negative_slot_cache_writes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -566,7 +645,7 @@ def test_hy_v4_lightop_avoids_unsafe_negative_slot_cache_writes(
         ),
         lightop_indexer_qk_quant_and_store=quant_without_cache,
         rocm_aiter_ops=SimpleNamespace(is_enabled=lambda: True),
-        ops=SimpleNamespace(indexer_k_quant_and_cache=safe_cache_writer),
+        _hcu_indexer_k_quant_and_cache=safe_cache_writer,
         _encode_layer_name=lambda value: value,
     )
     indexer = SimpleNamespace(

--- a/vllm_hcu/model_executor/layers/fused_moe/eplb_dispatch.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/eplb_dispatch.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Rank-local replica ordering for vLLM EPLB routing maps."""
+
+from __future__ import annotations
+
+import random
+
+import torch
+
+
+def _choose_least_assigned(
+    candidates: list[int],
+    assignment_counts: dict[int, int],
+    rng: random.Random,
+) -> int:
+    shuffled = candidates.copy()
+    rng.shuffle(shuffled)
+    return min(shuffled, key=assignment_counts.__getitem__)
+
+
+def build_locality_fair_replica_order(
+    logical_to_physical_map: torch.Tensor,
+    *,
+    ep_rank: int,
+    ep_size: int,
+    num_nodes: int,
+    num_physical_experts: int,
+    seed: int = 42,
+    layer_offset: int = 0,
+) -> torch.Tensor:
+    """Put a locality-fair primary replica first for one source EP rank.
+
+    vLLM hashes token positions into replica columns. Each EP rank receives a
+    different cyclic ordering, so every hash column remains balanced across
+    source ranks while column zero preserves GPU/node locality for decode.
+    The three-pass assignment follows SGLang-DAS commit 1cc92e0d.
+    """
+
+    if not isinstance(logical_to_physical_map, torch.Tensor):
+        raise TypeError("logical_to_physical_map must be a torch.Tensor")
+    if logical_to_physical_map.ndim != 3:
+        raise ValueError("logical_to_physical_map must be three-dimensional")
+    if logical_to_physical_map.dtype not in {
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+        torch.uint8,
+    }:
+        raise TypeError("logical_to_physical_map must use an integer dtype")
+    if ep_size <= 0:
+        raise ValueError(f"ep_size must be positive, got {ep_size}")
+    if not 0 <= ep_rank < ep_size:
+        raise ValueError(f"ep_rank must be in [0, {ep_size}), got {ep_rank}")
+    if num_nodes <= 0 or ep_size % num_nodes != 0:
+        raise ValueError(
+            "ep_size must be divisible by a positive num_nodes, got "
+            f"{ep_size} and {num_nodes}"
+        )
+    if num_physical_experts <= 0:
+        raise ValueError(
+            "num_physical_experts must be positive, got "
+            f"{num_physical_experts}"
+        )
+    if num_physical_experts % ep_size != 0:
+        raise ValueError(
+            "num_physical_experts must be divisible by ep_size, got "
+            f"{num_physical_experts} and {ep_size}"
+        )
+    source_device = logical_to_physical_map.device
+    result = logical_to_physical_map.detach().to(device="cpu").clone()
+    invalid_ids = (result < -1) | (result >= num_physical_experts)
+    if torch.any(invalid_ids):
+        raise ValueError(
+            "logical_to_physical_map contains an invalid physical expert id"
+        )
+    replica_counts = (result >= 0).sum(dim=-1)
+    empty_rows = torch.nonzero(replica_counts == 0, as_tuple=False)
+    if empty_rows.numel() > 0:
+        layer_id, logical_expert_id = empty_rows[0].tolist()
+        raise ValueError(
+            f"logical expert {logical_expert_id} in layer {layer_id} "
+            "has no physical replicas"
+        )
+    num_local_experts = num_physical_experts // ep_size
+    num_gpus_per_node = ep_size // num_nodes
+    num_node_experts = num_local_experts * num_gpus_per_node
+
+    redundant_rows = torch.nonzero(replica_counts > 1, as_tuple=False).tolist()
+    for layer_id, logical_expert_id in redundant_rows:
+        rng = random.Random(
+            seed
+            + (layer_offset + layer_id) * 1_000_003
+            + logical_expert_id * 9_176
+        )
+        row = result[layer_id, logical_expert_id]
+        candidates = [int(value) for value in row.tolist() if value >= 0]
+        if len(candidates) != len(set(candidates)):
+            raise ValueError(
+                f"logical expert {logical_expert_id} has duplicate physical replicas"
+            )
+        assignments = [-1] * ep_size
+        assignment_counts = {candidate: 0 for candidate in candidates}
+
+        candidates_by_gpu = [[] for _ in range(ep_size)]
+        candidates_by_node = [[] for _ in range(num_nodes)]
+        for candidate in candidates:
+            candidates_by_gpu[candidate // num_local_experts].append(candidate)
+            candidates_by_node[candidate // num_node_experts].append(candidate)
+
+        # Strongest preference: a source rank always starts with a same-GPU
+        # replica when one exists.
+        for rank, local_candidates in enumerate(candidates_by_gpu):
+            if local_candidates:
+                choice = _choose_least_assigned(
+                    local_candidates,
+                    assignment_counts,
+                    rng,
+                )
+                assignments[rank] = choice
+                assignment_counts[choice] += 1
+
+        # Then balance remaining source ranks over replicas on their node.
+        for node_id, node_candidates in enumerate(candidates_by_node):
+            if not node_candidates:
+                continue
+            first_rank = node_id * num_gpus_per_node
+            remaining_ranks = [
+                rank
+                for rank in range(first_rank, first_rank + num_gpus_per_node)
+                if assignments[rank] == -1
+            ]
+            rng.shuffle(remaining_ranks)
+            for rank in remaining_ranks:
+                choice = _choose_least_assigned(
+                    node_candidates,
+                    assignment_counts,
+                    rng,
+                )
+                assignments[rank] = choice
+                assignment_counts[choice] += 1
+
+        # Only ranks whose node has no replica reach the global fallback.
+        remaining_ranks = [
+            rank for rank, assignment in enumerate(assignments) if assignment == -1
+        ]
+        rng.shuffle(remaining_ranks)
+        for rank in remaining_ranks:
+            choice = _choose_least_assigned(
+                candidates,
+                assignment_counts,
+                rng,
+            )
+            assignments[rank] = choice
+            assignment_counts[choice] += 1
+
+        primary_index = candidates.index(assignments[ep_rank])
+        ordered = candidates[primary_index:] + candidates[:primary_index]
+        row.fill_(-1)
+        row[: len(ordered)] = torch.tensor(ordered, dtype=row.dtype)
+
+    return result.to(device=source_device)
+
+
+__all__ = ["build_locality_fair_replica_order"]

--- a/vllm_hcu/model_executor/layers/fused_moe/router_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/router_runtime.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+import math
+from collections.abc import Callable
+
 from .lightop_routing import lightop_moe_gate_kwargs
 
 
@@ -148,4 +151,149 @@ def make_hcu_grouped_topk_router(base_class):
     return HcuGroupedTopKRouter
 
 
-__all__ = ["eplb_map_to_physical_and_record", "make_hcu_grouped_topk_router"]
+def _ep_world_size() -> int:
+    from vllm.distributed.parallel_state import get_ep_group
+
+    return get_ep_group().world_size
+
+
+def _nearest_max_rank_load(
+    num_assignments: int,
+    ep_size: int,
+    target: float,
+) -> int:
+    """Choose the integer max load whose mean/max ratio is nearest target."""
+    minimum_load = math.ceil(num_assignments / ep_size)
+    ideal_load = num_assignments / (ep_size * target)
+    candidates = {
+        max(minimum_load, min(num_assignments, math.floor(ideal_load))),
+        max(minimum_load, min(num_assignments, math.ceil(ideal_load))),
+    }
+    return min(
+        candidates,
+        key=lambda load: (
+            abs(num_assignments / (ep_size * load) - target),
+            load,
+        ),
+    )
+
+
+def make_hcu_eplb_balancedness_strategy(base_class):
+    class HcuEplbBalancednessRouting(base_class):
+        def __init__(
+            self,
+            ep_size_getter: Callable[[], int] = _ep_world_size,
+        ) -> None:
+            self._ep_size_getter = ep_size_getter
+
+        def route_tokens(
+            self,
+            hidden_states,
+            router_logits,
+            top_k,
+            indices_type=None,
+        ):
+            import torch
+
+            from vllm_hcu.platforms import envs as henvs
+
+            ep_size = int(self._ep_size_getter())
+            num_tokens = hidden_states.shape[0]
+            num_experts = router_logits.shape[-1]
+            target = float(
+                henvs.VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS
+            )
+
+            if ep_size < 1:
+                raise ValueError(f"EP size must be positive, got {ep_size}")
+            if num_experts < ep_size:
+                raise ValueError(
+                    f"Routing simulation needs at least one expert per EP rank; "
+                    f"got {num_experts} experts for EP size {ep_size}"
+                )
+            minimum = 1.0 / ep_size
+            if not math.isfinite(target) or target < minimum:
+                raise ValueError(
+                    "VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS must be "
+                    f"at least the EP-size minimum {minimum:g}, got {target}"
+                )
+            if target > 1.0:
+                raise ValueError(
+                    "VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS must be "
+                    f"at most 1.0, got {target}"
+                )
+            if top_k < 1:
+                raise ValueError(f"top_k must be positive, got {top_k}")
+            minimum_experts_per_rank = num_experts // ep_size
+            if top_k > minimum_experts_per_rank:
+                raise ValueError(
+                    "HCU EPLB routing simulation requires top_k to be no "
+                    "larger than the smallest EP-rank expert partition so "
+                    "each token receives distinct experts; "
+                    f"got top_k={top_k}, minimum experts per rank="
+                    f"{minimum_experts_per_rank}"
+                )
+
+            output_shape = (num_tokens, top_k)
+            weights = torch.ones(
+                output_shape,
+                dtype=torch.float32,
+                device=hidden_states.device,
+            )
+            num_assignments = num_tokens * top_k
+            if num_assignments == 0:
+                dtype = indices_type if indices_type is not None else torch.long
+                return weights, torch.empty(
+                    output_shape,
+                    dtype=dtype,
+                    device=hidden_states.device,
+                )
+
+            assignment_ids = torch.arange(
+                num_assignments,
+                dtype=torch.long,
+                device=hidden_states.device,
+            )
+            if ep_size == 1:
+                rank_ids = torch.zeros_like(assignment_ids)
+            else:
+                hot_count = _nearest_max_rank_load(
+                    num_assignments,
+                    ep_size,
+                    target,
+                )
+                cool_ids = 1 + (assignment_ids - hot_count).clamp_min(0) % (
+                    ep_size - 1
+                )
+                rank_ids = torch.where(
+                    assignment_ids < hot_count,
+                    torch.zeros_like(assignment_ids),
+                    cool_ids,
+                )
+
+            experts_per_rank = num_experts // ep_size
+            extra_experts = num_experts % ep_size
+            rank_sizes = experts_per_rank + (rank_ids < extra_experts).long()
+            rank_starts = (
+                rank_ids * experts_per_rank
+                + torch.minimum(
+                    rank_ids,
+                    torch.full_like(rank_ids, extra_experts),
+                )
+            )
+            expert_ids = rank_starts + assignment_ids % rank_sizes
+            if indices_type is None:
+                indices_type = torch.long
+            return weights, expert_ids.reshape(output_shape).to(indices_type)
+
+    HcuEplbBalancednessRouting.__name__ = "HcuEplbBalancednessRouting"
+    HcuEplbBalancednessRouting.__qualname__ = "HcuEplbBalancednessRouting"
+    HcuEplbBalancednessRouting.__module__ = __name__
+    return HcuEplbBalancednessRouting
+
+
+__all__ = [
+    "eplb_map_to_physical_and_record",
+    "make_hcu_eplb_balancedness_strategy",
+    "make_hcu_grouped_topk_router",
+]

--- a/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import lru_cache
@@ -247,7 +246,8 @@ def bind_static_eplb_plan(
             )
         counts[name] = value
 
-    moe_layers = tuple(model.moe_layers)
+    model_moe_layers = model.moe_layers
+    moe_layers = tuple(model_moe_layers)
     if len(moe_layers) != counts["num_moe_layers"]:
         raise ValueError(
             "Static EPLB direct load found a MixtureOfExperts.moe_layers "
@@ -284,14 +284,24 @@ def bind_static_eplb_plan(
         )
 
     # Validate the entire model before publishing any plan state.  The routed
-    # expert object is the checkpoint-loader consumer, while the model-level
-    # plan is consumed later by EPLB-state initialization.
+    # expert object is the checkpoint-loader consumer, while model wrappers
+    # and their backing model share the plan used later by EPLB initialization.
     rows = tuple(
         plan.layer_map(layer_idx) for layer_idx in range(len(routed_experts))
     )
+    plan_owners = []
+    inner_model = getattr(model, "model", None)
+    if (
+        inner_model is not None
+        and inner_model is not model
+        and getattr(inner_model, "moe_layers", None) is model_moe_layers
+    ):
+        plan_owners.append(inner_model)
+    plan_owners.append(model)
     for routed_experts_layer, row in zip(routed_experts, rows, strict=True):
         setattr(routed_experts_layer, "_vllm_hcu_static_eplb_row", row)
-    setattr(model, "_vllm_hcu_static_eplb_plan", plan)
+    for owner in plan_owners:
+        setattr(owner, "_vllm_hcu_static_eplb_plan", plan)
     return plan
 
 
@@ -338,70 +348,10 @@ def load_static_logical_expert(
     return loaded_any if return_success else None
 
 
-def static_eplb_layer_map_for_weight(
-    plan: StaticEplbPlan,
-    moe_layer_indices: tuple[int, ...],
-    weight_name: str,
-) -> tuple[int, ...]:
-    """Resolve an absolute checkpoint layer name to its static map row."""
-
-    match = re.search(r"(?:^|\.)layers\.(\d+)\.", weight_name)
-    if match is None:
-        raise ValueError(
-            f"Cannot resolve a HY V4 MoE layer from checkpoint weight {weight_name!r}."
-        )
-    absolute_layer_idx = int(match.group(1))
-    try:
-        moe_layer_idx = moe_layer_indices.index(absolute_layer_idx)
-    except ValueError as error:
-        raise ValueError(
-            f"HY V4 checkpoint layer {absolute_layer_idx} is not an MoE layer "
-            f"in static EPLB order {moe_layer_indices}."
-        ) from error
-    return plan.layer_map(moe_layer_idx)
-
-
-def build_expert_params_mapping_for_row(
-    model: torch.nn.Module,
-    *,
-    ckpt_gate_proj_name: str,
-    ckpt_down_proj_name: str,
-    ckpt_up_proj_name: str,
-    physical_to_logical: tuple[int, ...],
-    routed_experts_prefix: str = "routed_experts",
-) -> list[tuple[str, str, int, str]]:
-    """Build vLLM split-expert mappings from an authoritative map row."""
-
-    has_base_layer = any(".base_layer." in name for name, _ in model.named_parameters())
-    base_layer_prefix = "base_layer." if has_base_layer else ""
-    routed_prefix = f"{routed_experts_prefix}." if routed_experts_prefix else ""
-    w13 = f"experts.{routed_prefix}{base_layer_prefix}w13_"
-    w2 = f"experts.{routed_prefix}{base_layer_prefix}w2_"
-    result: list[tuple[str, str, int, str]] = []
-    for physical_expert_id, logical_expert_id in enumerate(physical_to_logical):
-        for shard_id, weight_name in (
-            ("w1", ckpt_gate_proj_name),
-            ("w2", ckpt_down_proj_name),
-            ("w3", ckpt_up_proj_name),
-        ):
-            param_name = w13 if shard_id in ("w1", "w3") else w2
-            result.append(
-                (
-                    param_name,
-                    f"experts.{logical_expert_id}.{weight_name}.{base_layer_prefix}",
-                    physical_expert_id,
-                    shard_id,
-                )
-            )
-    return result
-
-
 __all__ = [
     "StaticEplbPlan",
     "bind_static_eplb_plan",
-    "build_expert_params_mapping_for_row",
     "load_static_logical_expert",
     "load_static_eplb_plan",
     "maybe_load_static_eplb_plan",
-    "static_eplb_layer_map_for_weight",
 ]

--- a/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
@@ -15,6 +15,9 @@ from typing import Any
 import torch
 
 
+_OFFLINE_MODEL_KEY_ATTR = "_vllm_hcu_offline_eplb_model_key"
+
+
 @dataclass(frozen=True)
 class StaticEplbPlan:
     """A checkpoint-loading layout that cannot be mutated by its consumers."""
@@ -69,10 +72,10 @@ def _select_model_payload(
     path: str,
     payload: dict[str, Any],
     model_key: str,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], bool]:
     model_maps = payload.get("model_maps")
     if model_maps is None:
-        return payload
+        return payload, False
     if not isinstance(model_maps, dict):
         raise ValueError(f"Offline EPLB map {path!r} has invalid model_maps.")
     if model_key not in model_maps:
@@ -83,7 +86,60 @@ def _select_model_payload(
     selected = model_maps[model_key]
     if not isinstance(selected, dict):
         raise ValueError(f"Offline EPLB map {path!r} key {model_key!r} is invalid.")
-    return selected
+    return selected, True
+
+
+def _pipeline_parallel_stage(parallel_config: object) -> int | None:
+    pipeline_parallel_size = getattr(parallel_config, "pipeline_parallel_size", 1)
+    if (
+        isinstance(pipeline_parallel_size, bool)
+        or not isinstance(pipeline_parallel_size, int)
+        or pipeline_parallel_size <= 0
+    ):
+        raise ValueError(
+            "Static EPLB requires pipeline_parallel_size to be a positive integer."
+        )
+    if pipeline_parallel_size == 1:
+        return None
+
+    pipeline_parallel_rank = getattr(
+        parallel_config,
+        "pipeline_parallel_rank",
+        None,
+    )
+    if pipeline_parallel_rank is None:
+        from vllm.distributed import get_pp_group
+
+        pipeline_parallel_rank = get_pp_group().rank_in_group
+    if (
+        isinstance(pipeline_parallel_rank, bool)
+        or not isinstance(pipeline_parallel_rank, int)
+        or not 0 <= pipeline_parallel_rank < pipeline_parallel_size
+    ):
+        raise ValueError(
+            "Static EPLB requires a valid pipeline-parallel rank; "
+            f"got rank={pipeline_parallel_rank!r}, size={pipeline_parallel_size}."
+        )
+    return pipeline_parallel_rank
+
+
+def resolve_offline_eplb_model_key(
+    model: object,
+    parallel_config: object,
+) -> str:
+    """Resolve the public model owner and PP stage used by record and load."""
+
+    bound_key = getattr(model, _OFFLINE_MODEL_KEY_ATTR, None)
+    if bound_key is not None:
+        if not isinstance(bound_key, str) or not bound_key:
+            raise ValueError("Static EPLB model published an invalid offline key.")
+        return bound_key
+
+    model_key = model.__class__.__name__
+    pipeline_parallel_rank = _pipeline_parallel_stage(parallel_config)
+    if pipeline_parallel_rank is not None:
+        model_key = f"{model_key}#pp_rank={pipeline_parallel_rank}"
+    return model_key
 
 
 def _validate_raw_map(path: str, raw_map: Any) -> list[list[int]]:
@@ -116,7 +172,11 @@ def load_static_eplb_plan(
 
     canonical_path = str(Path(path).expanduser().resolve(strict=True))
     payload, digest = _read_json(canonical_path, _file_identity(Path(canonical_path)))
-    selected = _select_model_payload(canonical_path, payload, model_key)
+    selected, is_keyed_map = _select_model_payload(
+        canonical_path,
+        payload,
+        model_key,
+    )
     raw_map = selected.get("physical_to_logical_map", selected.get("expert_map"))
     if raw_map is None:
         raise ValueError(
@@ -129,7 +189,12 @@ def load_static_eplb_plan(
     if any(len(row) != loaded_shape[1] for row in rows):
         raise ValueError(f"Offline EPLB map {canonical_path!r} has ragged rows.")
     if loaded_shape != expected_shape:
-        if loaded_shape[0] > expected_shape[0] and loaded_shape[1] == expected_shape[1]:
+        if (
+            not is_keyed_map
+            and model_key == "HYV4MTP"
+            and loaded_shape[0] > expected_shape[0]
+            and loaded_shape[1] == expected_shape[1]
+        ):
             rows = rows[-expected_shape[0] :]
             loaded_shape = expected_shape
         else:
@@ -224,7 +289,7 @@ def bind_static_eplb_plan(
 
     from vllm.model_executor.models.interfaces import is_mixture_of_experts
 
-    model_key = model.__class__.__name__
+    model_key = resolve_offline_eplb_model_key(model, parallel_config)
     if not is_mixture_of_experts(model):
         raise ValueError(
             "Static EPLB direct load requires a MixtureOfExperts model with "
@@ -248,17 +313,21 @@ def bind_static_eplb_plan(
 
     model_moe_layers = model.moe_layers
     moe_layers = tuple(model_moe_layers)
-    if len(moe_layers) != counts["num_moe_layers"]:
+    local_num_moe_layers = len(moe_layers)
+    if (
+        getattr(parallel_config, "pipeline_parallel_size", 1) == 1
+        and local_num_moe_layers != counts["num_moe_layers"]
+    ):
         raise ValueError(
             "Static EPLB direct load found a MixtureOfExperts.moe_layers "
-            f"count of {len(moe_layers)} for {model_key}; expected "
+            f"count of {local_num_moe_layers} for {model_key}; expected "
             f"{counts['num_moe_layers']}."
         )
 
     plan = maybe_load_static_eplb_plan(
         vllm_config,
         model_key=model_key,
-        num_moe_layers=counts["num_moe_layers"],
+        num_moe_layers=local_num_moe_layers,
         num_logical_experts=counts["num_logical_experts"],
         num_physical_experts=counts["num_physical_experts"],
         num_redundant_experts=counts["num_redundant_experts"],
@@ -289,19 +358,22 @@ def bind_static_eplb_plan(
     rows = tuple(
         plan.layer_map(layer_idx) for layer_idx in range(len(routed_experts))
     )
-    plan_owners = []
-    inner_model = getattr(model, "model", None)
-    if (
-        inner_model is not None
-        and inner_model is not model
-        and getattr(inner_model, "moe_layers", None) is model_moe_layers
-    ):
-        plan_owners.append(inner_model)
+    plan_owners: list[object] = []
+    for attribute in ("model", "language_model"):
+        inner_model = getattr(model, attribute, None)
+        if (
+            inner_model is not None
+            and inner_model is not model
+            and getattr(inner_model, "moe_layers", None) is model_moe_layers
+            and inner_model not in plan_owners
+        ):
+            plan_owners.append(inner_model)
     plan_owners.append(model)
     for routed_experts_layer, row in zip(routed_experts, rows, strict=True):
         setattr(routed_experts_layer, "_vllm_hcu_static_eplb_row", row)
     for owner in plan_owners:
         setattr(owner, "_vllm_hcu_static_eplb_plan", plan)
+        setattr(owner, _OFFLINE_MODEL_KEY_ATTR, model_key)
     return plan
 
 
@@ -354,4 +426,5 @@ __all__ = [
     "load_static_logical_expert",
     "load_static_eplb_plan",
     "maybe_load_static_eplb_plan",
+    "resolve_offline_eplb_model_key",
 ]

--- a/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
@@ -191,17 +191,17 @@ def maybe_load_static_eplb_plan(
     if not path:
         return None
     if not getattr(parallel_config, "enable_expert_parallel", False):
-        raise ValueError("HY V4 static EPLB direct load requires expert parallel.")
+        raise ValueError("Static EPLB direct load requires expert parallel.")
     if not getattr(parallel_config, "enable_eplb", False):
-        raise ValueError("HY V4 static EPLB direct load requires EPLB.")
+        raise ValueError("Static EPLB direct load requires EPLB.")
     if getattr(parallel_config, "enable_ep_weight_filter", False):
         raise ValueError(
-            "HY V4 static EPLB direct load does not support upstream EP weight "
+            "Static EPLB direct load does not support upstream EP weight "
             "filtering because the filter cannot express per-layer offline maps."
         )
     if num_moe_layers <= 0:
         raise ValueError(
-            f"HY V4 static EPLB direct load found no MoE layers for {model_key}."
+            f"Static EPLB direct load found no MoE layers for {model_key}."
         )
     return load_static_eplb_plan(
         path,
@@ -210,6 +210,88 @@ def maybe_load_static_eplb_plan(
         num_logical_experts=num_logical_experts,
         num_redundant_experts=num_redundant_experts,
     )
+
+
+def bind_static_eplb_plan(
+    vllm_config: object,
+    model: object,
+) -> StaticEplbPlan | None:
+    """Validate and bind a static EPLB plan before checkpoint loading."""
+
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    if not getattr(parallel_config, "_vllm_hcu_expert_map_path", None):
+        return None
+
+    from vllm.model_executor.models.interfaces import is_mixture_of_experts
+
+    model_key = model.__class__.__name__
+    if not is_mixture_of_experts(model):
+        raise ValueError(
+            "Static EPLB direct load requires a MixtureOfExperts model with "
+            f"MoE layers; got {model_key}."
+        )
+
+    counts: dict[str, int] = {}
+    for name in (
+        "num_moe_layers",
+        "num_logical_experts",
+        "num_physical_experts",
+        "num_redundant_experts",
+    ):
+        value = getattr(model, name)
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(
+                "Static EPLB direct load requires "
+                f"MixtureOfExperts.{name} to be an integer for {model_key}."
+            )
+        counts[name] = value
+
+    moe_layers = tuple(model.moe_layers)
+    if len(moe_layers) != counts["num_moe_layers"]:
+        raise ValueError(
+            "Static EPLB direct load found a MixtureOfExperts.moe_layers "
+            f"count of {len(moe_layers)} for {model_key}; expected "
+            f"{counts['num_moe_layers']}."
+        )
+
+    plan = maybe_load_static_eplb_plan(
+        vllm_config,
+        model_key=model_key,
+        num_moe_layers=counts["num_moe_layers"],
+        num_logical_experts=counts["num_logical_experts"],
+        num_physical_experts=counts["num_physical_experts"],
+        num_redundant_experts=counts["num_redundant_experts"],
+    )
+    if plan is None:
+        return None
+
+    routed_experts = []
+    for layer_idx, moe_layer in enumerate(moe_layers):
+        runner_routed_experts = getattr(moe_layer, "routed_experts", None)
+        if runner_routed_experts is None:
+            raise ValueError(
+                "Static EPLB direct load requires "
+                "MixtureOfExperts.moe_layers to expose routed_experts; "
+                f"layer {layer_idx} of {model_key} does not."
+            )
+        routed_experts.append(runner_routed_experts)
+
+    if len(plan._map_values) != len(routed_experts):
+        raise ValueError(
+            "Static EPLB direct-load plan row count does not match "
+            f"MixtureOfExperts.moe_layers for {model_key}."
+        )
+
+    # Validate the entire model before publishing any plan state.  The routed
+    # expert object is the checkpoint-loader consumer, while the model-level
+    # plan is consumed later by EPLB-state initialization.
+    rows = tuple(
+        plan.layer_map(layer_idx) for layer_idx in range(len(routed_experts))
+    )
+    for routed_experts_layer, row in zip(routed_experts, rows, strict=True):
+        setattr(routed_experts_layer, "_vllm_hcu_static_eplb_row", row)
+    setattr(model, "_vllm_hcu_static_eplb_plan", plan)
+    return plan
 
 
 def static_eplb_layer_map_for_weight(
@@ -272,6 +354,7 @@ def build_expert_params_mapping_for_row(
 
 __all__ = [
     "StaticEplbPlan",
+    "bind_static_eplb_plan",
     "build_expert_params_mapping_for_row",
     "load_static_eplb_plan",
     "maybe_load_static_eplb_plan",

--- a/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -294,6 +295,49 @@ def bind_static_eplb_plan(
     return plan
 
 
+def load_static_logical_expert(
+    routed_experts: object,
+    original_weight_loader: Callable[..., bool | None],
+    *,
+    param: object,
+    loaded_weight: object,
+    weight_name: str,
+    shard_id: str,
+    logical_expert_id: int,
+    return_success: bool,
+) -> bool | None:
+    """Load one checkpoint expert into every mapped local physical slot."""
+
+    row = getattr(routed_experts, "_vllm_hcu_static_eplb_row")
+    if (
+        isinstance(logical_expert_id, bool)
+        or not isinstance(logical_expert_id, int)
+        or logical_expert_id < 0
+        or logical_expert_id not in row
+    ):
+        raise ValueError(
+            "Static EPLB logical expert id "
+            f"{logical_expert_id!r} is not present in the bound plan row."
+        )
+
+    loaded_any = False
+    for physical_expert_id, mapped_logical_expert_id in enumerate(row):
+        if mapped_logical_expert_id != logical_expert_id:
+            continue
+        loaded = original_weight_loader(
+            routed_experts,
+            param=param,
+            loaded_weight=loaded_weight,
+            weight_name=weight_name,
+            shard_id=shard_id,
+            expert_id=physical_expert_id,
+            return_success=True,
+        )
+        loaded_any = bool(loaded) or loaded_any
+
+    return loaded_any if return_success else None
+
+
 def static_eplb_layer_map_for_weight(
     plan: StaticEplbPlan,
     moe_layer_indices: tuple[int, ...],
@@ -356,6 +400,7 @@ __all__ = [
     "StaticEplbPlan",
     "bind_static_eplb_plan",
     "build_expert_params_mapping_for_row",
+    "load_static_logical_expert",
     "load_static_eplb_plan",
     "maybe_load_static_eplb_plan",
     "static_eplb_layer_map_for_weight",

--- a/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
@@ -174,4 +174,45 @@ def load_static_eplb_plan(
     )
 
 
-__all__ = ["StaticEplbPlan", "load_static_eplb_plan"]
+def maybe_load_static_eplb_plan(
+    vllm_config: object,
+    *,
+    model_key: str,
+    num_moe_layers: int,
+    num_logical_experts: int,
+    num_physical_experts: int,
+    num_redundant_experts: int,
+) -> StaticEplbPlan | None:
+    """Build a static plan from the worker-propagated parallel config."""
+
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    path = getattr(parallel_config, "_vllm_hcu_expert_map_path", None)
+    if not path:
+        return None
+    if not getattr(parallel_config, "enable_expert_parallel", False):
+        raise ValueError("HY V4 static EPLB direct load requires expert parallel.")
+    if not getattr(parallel_config, "enable_eplb", False):
+        raise ValueError("HY V4 static EPLB direct load requires EPLB.")
+    if getattr(parallel_config, "enable_ep_weight_filter", False):
+        raise ValueError(
+            "HY V4 static EPLB direct load does not support upstream EP weight "
+            "filtering because the filter cannot express per-layer offline maps."
+        )
+    if num_moe_layers <= 0:
+        raise ValueError(
+            f"HY V4 static EPLB direct load found no MoE layers for {model_key}."
+        )
+    return load_static_eplb_plan(
+        path,
+        model_key=model_key,
+        expected_shape=(num_moe_layers, num_physical_experts),
+        num_logical_experts=num_logical_experts,
+        num_redundant_experts=num_redundant_experts,
+    )
+
+
+__all__ = [
+    "StaticEplbPlan",
+    "load_static_eplb_plan",
+    "maybe_load_static_eplb_plan",
+]

--- a/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Validated, immutable static EPLB loading plans."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import torch
+
+
+@dataclass(frozen=True)
+class StaticEplbPlan:
+    """A checkpoint-loading layout that cannot be mutated by its consumers."""
+
+    model_key: str
+    source_path: str
+    source_sha256: str
+    _map_values: tuple[tuple[int, ...], ...]
+    num_logical_experts: int
+    num_physical_experts: int
+    num_redundant_experts: int
+
+    @property
+    def physical_to_logical_map(self) -> torch.Tensor:
+        """Return a private CPU copy so cached plan state remains immutable."""
+
+        return torch.tensor(self._map_values, dtype=torch.int64, device="cpu")
+
+    def layer_map(self, layer_idx: int) -> tuple[int, ...]:
+        return self._map_values[layer_idx]
+
+    def fingerprint(self) -> tuple[str, str, tuple[int, int], int, int, int]:
+        return (
+            self.model_key,
+            self.source_sha256,
+            (len(self._map_values), self.num_physical_experts),
+            self.num_logical_experts,
+            self.num_physical_experts,
+            self.num_redundant_experts,
+        )
+
+
+def _file_identity(path: Path) -> tuple[int, int, int, int]:
+    stat = path.stat()
+    return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+
+
+@lru_cache(maxsize=16)
+def _read_json(
+    canonical_path: str,
+    identity: tuple[int, int, int, int],
+) -> tuple[dict[str, Any], str]:
+    del identity
+    raw = Path(canonical_path).read_bytes()
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError(f"Offline EPLB map {canonical_path!r} must be an object.")
+    return payload, hashlib.sha256(raw).hexdigest()
+
+
+def _select_model_payload(
+    path: str,
+    payload: dict[str, Any],
+    model_key: str,
+) -> dict[str, Any]:
+    model_maps = payload.get("model_maps")
+    if model_maps is None:
+        return payload
+    if not isinstance(model_maps, dict):
+        raise ValueError(f"Offline EPLB map {path!r} has invalid model_maps.")
+    if model_key not in model_maps:
+        raise ValueError(
+            f"Offline EPLB map {path!r} does not contain key {model_key!r}; "
+            f"available keys: {sorted(model_maps)}."
+        )
+    selected = model_maps[model_key]
+    if not isinstance(selected, dict):
+        raise ValueError(f"Offline EPLB map {path!r} key {model_key!r} is invalid.")
+    return selected
+
+
+def _validate_raw_map(path: str, raw_map: Any) -> list[list[int]]:
+    if not isinstance(raw_map, list) or not raw_map:
+        raise ValueError(f"Offline EPLB map {path!r} must be a non-empty 2D list.")
+    result: list[list[int]] = []
+    for row in raw_map:
+        if not isinstance(row, list):
+            raise ValueError(f"Offline EPLB map {path!r} must be a 2D list.")
+        checked_row: list[int] = []
+        for expert_id in row:
+            if isinstance(expert_id, bool) or not isinstance(expert_id, int):
+                raise ValueError(
+                    f"Offline EPLB map {path!r} must contain integer expert ids."
+                )
+            checked_row.append(expert_id)
+        result.append(checked_row)
+    return result
+
+
+def load_static_eplb_plan(
+    path: str | Path,
+    *,
+    model_key: str,
+    expected_shape: tuple[int, int],
+    num_logical_experts: int,
+    num_redundant_experts: int,
+) -> StaticEplbPlan:
+    """Load and validate one model's physical-to-logical expert layout."""
+
+    canonical_path = str(Path(path).expanduser().resolve(strict=True))
+    payload, digest = _read_json(canonical_path, _file_identity(Path(canonical_path)))
+    selected = _select_model_payload(canonical_path, payload, model_key)
+    raw_map = selected.get("physical_to_logical_map", selected.get("expert_map"))
+    if raw_map is None:
+        raise ValueError(
+            f"Offline EPLB map {canonical_path!r} must contain "
+            "physical_to_logical_map."
+        )
+    rows = _validate_raw_map(canonical_path, raw_map)
+
+    loaded_shape = (len(rows), len(rows[0]))
+    if any(len(row) != loaded_shape[1] for row in rows):
+        raise ValueError(f"Offline EPLB map {canonical_path!r} has ragged rows.")
+    if loaded_shape != expected_shape:
+        if loaded_shape[0] > expected_shape[0] and loaded_shape[1] == expected_shape[1]:
+            rows = rows[-expected_shape[0] :]
+            loaded_shape = expected_shape
+        else:
+            raise ValueError(
+                f"Offline EPLB map {canonical_path!r} has shape {loaded_shape}, "
+                f"expected {expected_shape}."
+            )
+
+    expected_redundant = expected_shape[1] - num_logical_experts
+    if num_redundant_experts != expected_redundant:
+        raise ValueError(
+            f"Offline EPLB map {canonical_path!r} redundant expert count "
+            f"{num_redundant_experts} does not match physical-logical count "
+            f"{expected_redundant}."
+        )
+    for layer_idx, row in enumerate(rows):
+        negative = [value for value in row if value < 0]
+        if negative:
+            raise ValueError(
+                f"Offline EPLB map {canonical_path!r} contains negative expert ids."
+            )
+        invalid = [value for value in row if value >= num_logical_experts]
+        if invalid:
+            raise ValueError(
+                f"Offline EPLB map {canonical_path!r} contains logical expert id "
+                f">= {num_logical_experts}."
+            )
+        missing = sorted(set(range(num_logical_experts)) - set(row))
+        if missing:
+            raise ValueError(
+                f"Offline EPLB map {canonical_path!r} layer {layer_idx} misses "
+                f"logical experts {missing}."
+            )
+
+    return StaticEplbPlan(
+        model_key=model_key,
+        source_path=canonical_path,
+        source_sha256=digest,
+        _map_values=tuple(tuple(row) for row in rows),
+        num_logical_experts=num_logical_experts,
+        num_physical_experts=expected_shape[1],
+        num_redundant_experts=num_redundant_experts,
+    )
+
+
+__all__ = ["StaticEplbPlan", "load_static_eplb_plan"]

--- a/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/static_eplb.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -211,8 +212,68 @@ def maybe_load_static_eplb_plan(
     )
 
 
+def static_eplb_layer_map_for_weight(
+    plan: StaticEplbPlan,
+    moe_layer_indices: tuple[int, ...],
+    weight_name: str,
+) -> tuple[int, ...]:
+    """Resolve an absolute checkpoint layer name to its static map row."""
+
+    match = re.search(r"(?:^|\.)layers\.(\d+)\.", weight_name)
+    if match is None:
+        raise ValueError(
+            f"Cannot resolve a HY V4 MoE layer from checkpoint weight {weight_name!r}."
+        )
+    absolute_layer_idx = int(match.group(1))
+    try:
+        moe_layer_idx = moe_layer_indices.index(absolute_layer_idx)
+    except ValueError as error:
+        raise ValueError(
+            f"HY V4 checkpoint layer {absolute_layer_idx} is not an MoE layer "
+            f"in static EPLB order {moe_layer_indices}."
+        ) from error
+    return plan.layer_map(moe_layer_idx)
+
+
+def build_expert_params_mapping_for_row(
+    model: torch.nn.Module,
+    *,
+    ckpt_gate_proj_name: str,
+    ckpt_down_proj_name: str,
+    ckpt_up_proj_name: str,
+    physical_to_logical: tuple[int, ...],
+    routed_experts_prefix: str = "routed_experts",
+) -> list[tuple[str, str, int, str]]:
+    """Build vLLM split-expert mappings from an authoritative map row."""
+
+    has_base_layer = any(".base_layer." in name for name, _ in model.named_parameters())
+    base_layer_prefix = "base_layer." if has_base_layer else ""
+    routed_prefix = f"{routed_experts_prefix}." if routed_experts_prefix else ""
+    w13 = f"experts.{routed_prefix}{base_layer_prefix}w13_"
+    w2 = f"experts.{routed_prefix}{base_layer_prefix}w2_"
+    result: list[tuple[str, str, int, str]] = []
+    for physical_expert_id, logical_expert_id in enumerate(physical_to_logical):
+        for shard_id, weight_name in (
+            ("w1", ckpt_gate_proj_name),
+            ("w2", ckpt_down_proj_name),
+            ("w3", ckpt_up_proj_name),
+        ):
+            param_name = w13 if shard_id in ("w1", "w3") else w2
+            result.append(
+                (
+                    param_name,
+                    f"experts.{logical_expert_id}.{weight_name}.{base_layer_prefix}",
+                    physical_expert_id,
+                    shard_id,
+                )
+            )
+    return result
+
+
 __all__ = [
     "StaticEplbPlan",
+    "build_expert_params_mapping_for_row",
     "load_static_eplb_plan",
     "maybe_load_static_eplb_plan",
+    "static_eplb_layer_map_for_weight",
 ]

--- a/vllm_hcu/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm_hcu/model_executor/layers/sparse_attn_indexer.py
@@ -51,6 +51,27 @@ RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
 MXFP4_BLOCK_SIZE = 32
 
 
+def _hcu_indexer_k_quant_and_cache(
+    k: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    quant_block_size: int,
+    scale_fmt: str,
+) -> None:
+    """Write HCU indexer cache with fixed-shape, negative-slot handling."""
+    from vllm_hcu.v1.attention.ops.rocm_aiter_mla_sparse import (
+        indexer_k_quant_and_cache_triton,
+    )
+
+    indexer_k_quant_and_cache_triton(
+        k,
+        kv_cache,
+        slot_mapping,
+        quant_block_size,
+        scale_fmt,
+    )
+
+
 def _assert_cutedsl_dcp_merge_supported(
     logits: torch.Tensor,
     topk_indices: torch.Tensor,
@@ -971,7 +992,15 @@ class SparseAttnIndexer(CustomOp):
                         slot_mapping,
                         layer_metadata,
                     )
-                use_safe_cache_writer = self.dcp_world_size > 1
+                # Boolean compaction (``cache_k[slot_mapping >= 0]``) creates a
+                # dynamic-shaped tensor and is forbidden during HIP graph
+                # capture. Keep the captured launch fixed-shape and let the HCU
+                # cache writer suppress dummy ``-1`` slots on-device. DCP uses
+                # the same path because each rank can receive dummy tokens.
+                use_safe_cache_writer = (
+                    self.dcp_world_size > 1
+                    or torch.cuda.is_current_stream_capturing()
+                )
                 if use_safe_cache_writer:
                     lightop_k = cache_k[:0]
                     lightop_slots = slot_mapping[:0]
@@ -990,7 +1019,7 @@ class SparseAttnIndexer(CustomOp):
                 )
                 if use_safe_cache_writer:
                     assert self.scale_fmt is not None
-                    ops.indexer_k_quant_and_cache(
+                    _hcu_indexer_k_quant_and_cache(
                         cache_k,
                         self.k_cache.kv_cache,
                         slot_mapping,

--- a/vllm_hcu/models/hy_v4/model.py
+++ b/vllm_hcu/models/hy_v4/model.py
@@ -77,6 +77,10 @@ from vllm.model_executor.models.utils import (
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
+from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    maybe_load_static_eplb_plan,
+)
+
 from .attention import (
     HYV4MLAAttention,
     compute_skip_topk_layers,
@@ -555,6 +559,16 @@ class HYV4Model(nn.Module, MixtureOfExperts):
         self.num_routed_experts = example_layer.n_routed_experts
         self.num_shared_experts = config.num_shared_experts
         self.num_redundant_experts = example_layer.n_redundant_experts
+        static_plan = maybe_load_static_eplb_plan(
+            vllm_config,
+            model_key="HYV4ForCausalLM",
+            num_moe_layers=self.num_moe_layers,
+            num_logical_experts=self.num_logical_experts,
+            num_physical_experts=self.num_physical_experts,
+            num_redundant_experts=self.num_redundant_experts,
+        )
+        if static_plan is not None:
+            self._vllm_hcu_static_eplb_plan = static_plan
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -1017,6 +1031,9 @@ class HYV4ForCausalLM(nn.Module, SupportsPP, SupportsLoRA, MixtureOfExperts):
         self.num_shared_experts = self.model.num_shared_experts
         self.num_redundant_experts = self.model.num_redundant_experts
         self.moe_layers = self.model.moe_layers
+        static_plan = getattr(self.model, "_vllm_hcu_static_eplb_plan", None)
+        if static_plan is not None:
+            self._vllm_hcu_static_eplb_plan = static_plan
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)

--- a/vllm_hcu/models/hy_v4/model.py
+++ b/vllm_hcu/models/hy_v4/model.py
@@ -77,12 +77,6 @@ from vllm.model_executor.models.utils import (
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
-from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
-    build_expert_params_mapping_for_row,
-    maybe_load_static_eplb_plan,
-    static_eplb_layer_map_for_weight,
-)
-
 from .attention import (
     HYV4MLAAttention,
     compute_skip_topk_layers,
@@ -533,9 +527,8 @@ class HYV4Model(nn.Module, MixtureOfExperts):
         self.expert_weights: MutableSequence[Sequence[torch.Tensor]] = []
         self.num_expert_groups = 1
         self.moe_layers: list[nn.Module] = []
-        self._vllm_hcu_moe_layer_indices: list[int] = []
         example_layer: HYV4MoEFused | None = None
-        for layer_idx, layer in enumerate(self.layers):
+        for layer in self.layers:
             if isinstance(layer, PPMissingLayer):
                 continue
 
@@ -544,7 +537,6 @@ class HYV4Model(nn.Module, MixtureOfExperts):
                 assert isinstance(layer.mlp, HYV4MoEFused)
                 example_layer = layer.mlp
                 self.moe_layers.append(layer.mlp.experts)
-                self._vllm_hcu_moe_layer_indices.append(layer_idx)
 
         if example_layer is None:
             self.num_moe_layers = 0
@@ -563,16 +555,6 @@ class HYV4Model(nn.Module, MixtureOfExperts):
         self.num_routed_experts = example_layer.n_routed_experts
         self.num_shared_experts = config.num_shared_experts
         self.num_redundant_experts = example_layer.n_redundant_experts
-        static_plan = maybe_load_static_eplb_plan(
-            vllm_config,
-            model_key="HYV4ForCausalLM",
-            num_moe_layers=self.num_moe_layers,
-            num_logical_experts=self.num_logical_experts,
-            num_physical_experts=self.num_physical_experts,
-            num_redundant_experts=self.num_redundant_experts,
-        )
-        if static_plan is not None:
-            self._vllm_hcu_static_eplb_plan = static_plan
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -675,17 +657,18 @@ class HYV4Model(nn.Module, MixtureOfExperts):
         shard_id: str,
         num_experts: int,
         num_redundant_experts: int = 0,
-        physical_to_logical: Sequence[int] | None = None,
     ) -> bool:
         param = params_dict[name]
         weight_loader = typing.cast(Callable[..., bool], param.weight_loader)
+        routed_experts = getattr(weight_loader, "__self__", None)
+        num_checkpoint_experts = (
+            num_experts
+            if hasattr(routed_experts, "_vllm_hcu_static_eplb_row")
+            else num_experts + num_redundant_experts
+        )
         loaded_local_expert = False
-        for expert_id in range(num_experts + num_redundant_experts):
-            logical_expert_id = (
-                physical_to_logical[expert_id]
-                if physical_to_logical is not None
-                else expert_id % num_experts
-            )
+        for expert_id in range(num_checkpoint_experts):
+            logical_expert_id = expert_id % num_experts
             curr_expert_weight = loaded_weight[logical_expert_id]
             success = weight_loader(
                 param,
@@ -836,24 +819,8 @@ class HYV4Model(nn.Module, MixtureOfExperts):
 
             # Determine per-weight whether this is fused or split format.
             is_fused_expert = _is_fused_expert_weight(name)
-            physical_to_logical = None
-            static_plan = getattr(self, "_vllm_hcu_static_eplb_plan", None)
-            if static_plan is not None and ".experts." in name:
-                physical_to_logical = static_eplb_layer_map_for_weight(
-                    static_plan,
-                    tuple(self._vllm_hcu_moe_layer_indices),
-                    name,
-                )
             if is_fused_expert:
                 expert_params_mapping = fused_expert_params_mapping
-            elif physical_to_logical is not None:
-                expert_params_mapping = build_expert_params_mapping_for_row(
-                    self,
-                    ckpt_gate_proj_name="gate_proj",
-                    ckpt_down_proj_name="down_proj",
-                    ckpt_up_proj_name="up_proj",
-                    physical_to_logical=physical_to_logical,
-                )
             else:
                 expert_params_mapping = split_expert_params_mapping
 
@@ -882,7 +849,6 @@ class HYV4Model(nn.Module, MixtureOfExperts):
                             "w1",
                             num_experts,
                             self.num_redundant_experts,
-                            physical_to_logical,
                         )
                         success_w3 = self.load_fused_expert_weights(
                             name_mapped,
@@ -891,7 +857,6 @@ class HYV4Model(nn.Module, MixtureOfExperts):
                             "w3",
                             num_experts,
                             self.num_redundant_experts,
-                            physical_to_logical,
                         )
                         success = success_w1 and success_w3
                     else:
@@ -902,7 +867,6 @@ class HYV4Model(nn.Module, MixtureOfExperts):
                             shard_id,
                             num_experts,
                             self.num_redundant_experts,
-                            physical_to_logical,
                         )
                     if success:
                         name = name_mapped
@@ -1059,14 +1023,6 @@ class HYV4ForCausalLM(nn.Module, SupportsPP, SupportsLoRA, MixtureOfExperts):
         self.num_shared_experts = self.model.num_shared_experts
         self.num_redundant_experts = self.model.num_redundant_experts
         self.moe_layers = self.model.moe_layers
-        self._vllm_hcu_moe_layer_indices = getattr(
-            self.model,
-            "_vllm_hcu_moe_layer_indices",
-            list(range(self.num_moe_layers)),
-        )
-        static_plan = getattr(self.model, "_vllm_hcu_static_eplb_plan", None)
-        if static_plan is not None:
-            self._vllm_hcu_static_eplb_plan = static_plan
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)

--- a/vllm_hcu/models/hy_v4/model.py
+++ b/vllm_hcu/models/hy_v4/model.py
@@ -78,7 +78,9 @@ from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
 from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    build_expert_params_mapping_for_row,
     maybe_load_static_eplb_plan,
+    static_eplb_layer_map_for_weight,
 )
 
 from .attention import (
@@ -531,8 +533,9 @@ class HYV4Model(nn.Module, MixtureOfExperts):
         self.expert_weights: MutableSequence[Sequence[torch.Tensor]] = []
         self.num_expert_groups = 1
         self.moe_layers: list[nn.Module] = []
+        self._vllm_hcu_moe_layer_indices: list[int] = []
         example_layer: HYV4MoEFused | None = None
-        for layer in self.layers:
+        for layer_idx, layer in enumerate(self.layers):
             if isinstance(layer, PPMissingLayer):
                 continue
 
@@ -541,6 +544,7 @@ class HYV4Model(nn.Module, MixtureOfExperts):
                 assert isinstance(layer.mlp, HYV4MoEFused)
                 example_layer = layer.mlp
                 self.moe_layers.append(layer.mlp.experts)
+                self._vllm_hcu_moe_layer_indices.append(layer_idx)
 
         if example_layer is None:
             self.num_moe_layers = 0
@@ -671,12 +675,18 @@ class HYV4Model(nn.Module, MixtureOfExperts):
         shard_id: str,
         num_experts: int,
         num_redundant_experts: int = 0,
+        physical_to_logical: Sequence[int] | None = None,
     ) -> bool:
         param = params_dict[name]
         weight_loader = typing.cast(Callable[..., bool], param.weight_loader)
         loaded_local_expert = False
         for expert_id in range(num_experts + num_redundant_experts):
-            curr_expert_weight = loaded_weight[expert_id % num_experts]
+            logical_expert_id = (
+                physical_to_logical[expert_id]
+                if physical_to_logical is not None
+                else expert_id % num_experts
+            )
+            curr_expert_weight = loaded_weight[logical_expert_id]
             success = weight_loader(
                 param,
                 curr_expert_weight,
@@ -826,11 +836,26 @@ class HYV4Model(nn.Module, MixtureOfExperts):
 
             # Determine per-weight whether this is fused or split format.
             is_fused_expert = _is_fused_expert_weight(name)
-            expert_params_mapping = (
-                fused_expert_params_mapping
-                if is_fused_expert
-                else split_expert_params_mapping
-            )
+            physical_to_logical = None
+            static_plan = getattr(self, "_vllm_hcu_static_eplb_plan", None)
+            if static_plan is not None and ".experts." in name:
+                physical_to_logical = static_eplb_layer_map_for_weight(
+                    static_plan,
+                    tuple(self._vllm_hcu_moe_layer_indices),
+                    name,
+                )
+            if is_fused_expert:
+                expert_params_mapping = fused_expert_params_mapping
+            elif physical_to_logical is not None:
+                expert_params_mapping = build_expert_params_mapping_for_row(
+                    self,
+                    ckpt_gate_proj_name="gate_proj",
+                    ckpt_down_proj_name="down_proj",
+                    ckpt_up_proj_name="up_proj",
+                    physical_to_logical=physical_to_logical,
+                )
+            else:
+                expert_params_mapping = split_expert_params_mapping
 
             is_expert_weight = False
             loaded_expert_param_names: set[str] = set()
@@ -857,6 +882,7 @@ class HYV4Model(nn.Module, MixtureOfExperts):
                             "w1",
                             num_experts,
                             self.num_redundant_experts,
+                            physical_to_logical,
                         )
                         success_w3 = self.load_fused_expert_weights(
                             name_mapped,
@@ -865,6 +891,7 @@ class HYV4Model(nn.Module, MixtureOfExperts):
                             "w3",
                             num_experts,
                             self.num_redundant_experts,
+                            physical_to_logical,
                         )
                         success = success_w1 and success_w3
                     else:
@@ -875,6 +902,7 @@ class HYV4Model(nn.Module, MixtureOfExperts):
                             shard_id,
                             num_experts,
                             self.num_redundant_experts,
+                            physical_to_logical,
                         )
                     if success:
                         name = name_mapped
@@ -1031,6 +1059,11 @@ class HYV4ForCausalLM(nn.Module, SupportsPP, SupportsLoRA, MixtureOfExperts):
         self.num_shared_experts = self.model.num_shared_experts
         self.num_redundant_experts = self.model.num_redundant_experts
         self.moe_layers = self.model.moe_layers
+        self._vllm_hcu_moe_layer_indices = getattr(
+            self.model,
+            "_vllm_hcu_moe_layer_indices",
+            list(range(self.num_moe_layers)),
+        )
         static_plan = getattr(self.model, "_vllm_hcu_static_eplb_plan", None)
         if static_plan is not None:
             self._vllm_hcu_static_eplb_plan = static_plan

--- a/vllm_hcu/models/hy_v4/mtp.py
+++ b/vllm_hcu/models/hy_v4/mtp.py
@@ -42,6 +42,10 @@ from vllm.v1.outputs import SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
+from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    maybe_load_static_eplb_plan,
+)
+
 from .model import (
     HYV4DecoderLayer,
     _is_modelopt_layer_excluded,
@@ -419,6 +423,16 @@ class HYV4MultiTokenPredictor(nn.Module, MixtureOfExperts):
             self.num_routed_experts = example_layer.n_routed_experts
             self.num_shared_experts = config.num_shared_experts
             self.num_redundant_experts = example_layer.n_redundant_experts
+        static_plan = maybe_load_static_eplb_plan(
+            vllm_config,
+            model_key="HYV4MTP",
+            num_moe_layers=self.num_moe_layers,
+            num_logical_experts=self.num_logical_experts,
+            num_physical_experts=self.num_physical_experts,
+            num_redundant_experts=self.num_redundant_experts,
+        )
+        if static_plan is not None:
+            self._vllm_hcu_static_eplb_plan = static_plan
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -528,6 +542,9 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
         self.num_shared_experts = self.model.num_shared_experts
         self.num_redundant_experts = self.model.num_redundant_experts
         self.moe_layers = self.model.moe_layers
+        static_plan = getattr(self.model, "_vllm_hcu_static_eplb_plan", None)
+        if static_plan is not None:
+            self._vllm_hcu_static_eplb_plan = static_plan
 
     def set_eplb_state(
         self,

--- a/vllm_hcu/models/hy_v4/mtp.py
+++ b/vllm_hcu/models/hy_v4/mtp.py
@@ -43,7 +43,9 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    build_expert_params_mapping_for_row,
     maybe_load_static_eplb_plan,
+    static_eplb_layer_map_for_weight,
 )
 
 from .model import (
@@ -398,12 +400,16 @@ class HYV4MultiTokenPredictor(nn.Module, MixtureOfExperts):
         self.expert_weights: MutableSequence[Sequence[torch.Tensor]] = []
         self.num_expert_groups = 1
         self.moe_layers: list[nn.Module] = []
+        self._vllm_hcu_moe_layer_indices: list[int] = []
         example_layer = None
-        for layer in self.layers.values():
+        for absolute_layer_idx, layer in (
+            (int(key), value) for key, value in self.layers.items()
+        ):
             mtp_block = layer.mtp_block
             if mtp_block.block_type == "moe":
                 example_layer = mtp_block.mlp
                 self.moe_layers.append(mtp_block.mlp.experts)
+                self._vllm_hcu_moe_layer_indices.append(absolute_layer_idx)
 
         if example_layer is None:
             self.num_moe_layers = 0
@@ -542,6 +548,11 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
         self.num_shared_experts = self.model.num_shared_experts
         self.num_redundant_experts = self.model.num_redundant_experts
         self.moe_layers = self.model.moe_layers
+        self._vllm_hcu_moe_layer_indices = getattr(
+            self.model,
+            "_vllm_hcu_moe_layer_indices",
+            list(range(self.num_moe_layers)),
+        )
         static_plan = getattr(self.model, "_vllm_hcu_static_eplb_plan", None)
         if static_plan is not None:
             self._vllm_hcu_static_eplb_plan = static_plan
@@ -643,6 +654,7 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
         shard_id: str,
         num_experts: int,
         num_redundant_experts: int = 0,
+        physical_to_logical: Sequence[int] | None = None,
     ) -> bool:
         if name not in params_dict:
             return False
@@ -650,9 +662,14 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
         weight_loader = typing.cast(Callable[..., bool], param.weight_loader)
         loaded_local_expert = False
         for expert_id in range(num_experts + num_redundant_experts):
+            logical_expert_id = (
+                physical_to_logical[expert_id]
+                if physical_to_logical is not None
+                else expert_id % num_experts
+            )
             success = weight_loader(
                 param,
-                loaded_weight[expert_id % num_experts],
+                loaded_weight[logical_expert_id],
                 name,
                 shard_id,
                 expert_id,
@@ -673,6 +690,14 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
         num_experts: int,
     ) -> bool:
         num_redundant_experts = getattr(self, "num_redundant_experts", 0)
+        physical_to_logical = None
+        static_plan = getattr(self, "_vllm_hcu_static_eplb_plan", None)
+        if static_plan is not None:
+            physical_to_logical = static_eplb_layer_map_for_weight(
+                static_plan,
+                tuple(self._vllm_hcu_moe_layer_indices),
+                name,
+            )
         base = name.split(".experts.")[0]
         for checkpoint_projection, parameter_tag in (
             (".experts.gate_up_proj", "w13_weight"),
@@ -699,6 +724,7 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
                     "w1",
                     num_experts,
                     num_redundant_experts,
+                    physical_to_logical,
                 ) and self._load_fused_expert_weights(
                     target,
                     params_dict,
@@ -706,6 +732,7 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
                     "w3",
                     num_experts,
                     num_redundant_experts,
+                    physical_to_logical,
                 )
             else:
                 loaded = self._load_fused_expert_weights(
@@ -715,15 +742,22 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
                     "w2",
                     num_experts,
                     num_redundant_experts,
+                    physical_to_logical,
                 )
             if loaded:
                 loaded_params.add(target)
             return True
 
+        if physical_to_logical is not None:
+            split_expert_params_mapping = build_expert_params_mapping_for_row(
+                self,
+                ckpt_gate_proj_name="gate_proj",
+                ckpt_down_proj_name="down_proj",
+                ckpt_up_proj_name="up_proj",
+                physical_to_logical=physical_to_logical,
+            )
         consumed = False
-        for param_name, weight_name, expert_id, shard_id in (
-            split_expert_params_mapping
-        ):
+        for param_name, weight_name, expert_id, shard_id in split_expert_params_mapping:
             if weight_name not in name:
                 continue
             consumed = True

--- a/vllm_hcu/models/hy_v4/mtp.py
+++ b/vllm_hcu/models/hy_v4/mtp.py
@@ -42,12 +42,6 @@ from vllm.v1.outputs import SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
-from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
-    build_expert_params_mapping_for_row,
-    maybe_load_static_eplb_plan,
-    static_eplb_layer_map_for_weight,
-)
-
 from .model import (
     HYV4DecoderLayer,
     _is_modelopt_layer_excluded,
@@ -400,16 +394,12 @@ class HYV4MultiTokenPredictor(nn.Module, MixtureOfExperts):
         self.expert_weights: MutableSequence[Sequence[torch.Tensor]] = []
         self.num_expert_groups = 1
         self.moe_layers: list[nn.Module] = []
-        self._vllm_hcu_moe_layer_indices: list[int] = []
         example_layer = None
-        for absolute_layer_idx, layer in (
-            (int(key), value) for key, value in self.layers.items()
-        ):
+        for layer in self.layers.values():
             mtp_block = layer.mtp_block
             if mtp_block.block_type == "moe":
                 example_layer = mtp_block.mlp
                 self.moe_layers.append(mtp_block.mlp.experts)
-                self._vllm_hcu_moe_layer_indices.append(absolute_layer_idx)
 
         if example_layer is None:
             self.num_moe_layers = 0
@@ -429,16 +419,6 @@ class HYV4MultiTokenPredictor(nn.Module, MixtureOfExperts):
             self.num_routed_experts = example_layer.n_routed_experts
             self.num_shared_experts = config.num_shared_experts
             self.num_redundant_experts = example_layer.n_redundant_experts
-        static_plan = maybe_load_static_eplb_plan(
-            vllm_config,
-            model_key="HYV4MTP",
-            num_moe_layers=self.num_moe_layers,
-            num_logical_experts=self.num_logical_experts,
-            num_physical_experts=self.num_physical_experts,
-            num_redundant_experts=self.num_redundant_experts,
-        )
-        if static_plan is not None:
-            self._vllm_hcu_static_eplb_plan = static_plan
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -548,14 +528,6 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
         self.num_shared_experts = self.model.num_shared_experts
         self.num_redundant_experts = self.model.num_redundant_experts
         self.moe_layers = self.model.moe_layers
-        self._vllm_hcu_moe_layer_indices = getattr(
-            self.model,
-            "_vllm_hcu_moe_layer_indices",
-            list(range(self.num_moe_layers)),
-        )
-        static_plan = getattr(self.model, "_vllm_hcu_static_eplb_plan", None)
-        if static_plan is not None:
-            self._vllm_hcu_static_eplb_plan = static_plan
 
     def set_eplb_state(
         self,
@@ -654,19 +626,20 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
         shard_id: str,
         num_experts: int,
         num_redundant_experts: int = 0,
-        physical_to_logical: Sequence[int] | None = None,
     ) -> bool:
         if name not in params_dict:
             return False
         param = params_dict[name]
         weight_loader = typing.cast(Callable[..., bool], param.weight_loader)
+        routed_experts = getattr(weight_loader, "__self__", None)
+        num_checkpoint_experts = (
+            num_experts
+            if hasattr(routed_experts, "_vllm_hcu_static_eplb_row")
+            else num_experts + num_redundant_experts
+        )
         loaded_local_expert = False
-        for expert_id in range(num_experts + num_redundant_experts):
-            logical_expert_id = (
-                physical_to_logical[expert_id]
-                if physical_to_logical is not None
-                else expert_id % num_experts
-            )
+        for expert_id in range(num_checkpoint_experts):
+            logical_expert_id = expert_id % num_experts
             success = weight_loader(
                 param,
                 loaded_weight[logical_expert_id],
@@ -690,14 +663,6 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
         num_experts: int,
     ) -> bool:
         num_redundant_experts = getattr(self, "num_redundant_experts", 0)
-        physical_to_logical = None
-        static_plan = getattr(self, "_vllm_hcu_static_eplb_plan", None)
-        if static_plan is not None:
-            physical_to_logical = static_eplb_layer_map_for_weight(
-                static_plan,
-                tuple(self._vllm_hcu_moe_layer_indices),
-                name,
-            )
         base = name.split(".experts.")[0]
         for checkpoint_projection, parameter_tag in (
             (".experts.gate_up_proj", "w13_weight"),
@@ -724,7 +689,6 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
                     "w1",
                     num_experts,
                     num_redundant_experts,
-                    physical_to_logical,
                 ) and self._load_fused_expert_weights(
                     target,
                     params_dict,
@@ -732,7 +696,6 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
                     "w3",
                     num_experts,
                     num_redundant_experts,
-                    physical_to_logical,
                 )
             else:
                 loaded = self._load_fused_expert_weights(
@@ -742,20 +705,11 @@ class HYV4MTP(nn.Module, MixtureOfExperts):
                     "w2",
                     num_experts,
                     num_redundant_experts,
-                    physical_to_logical,
                 )
             if loaded:
                 loaded_params.add(target)
             return True
 
-        if physical_to_logical is not None:
-            split_expert_params_mapping = build_expert_params_mapping_for_row(
-                self,
-                ckpt_gate_proj_name="gate_proj",
-                ckpt_down_proj_name="down_proj",
-                ckpt_up_proj_name="up_proj",
-                physical_to_logical=physical_to_logical,
-            )
         consumed = False
         for param_name, weight_name, expert_id, shard_id in split_expert_params_mapping:
             if weight_name not in name:

--- a/vllm_hcu/patch/config.py
+++ b/vllm_hcu/patch/config.py
@@ -26,6 +26,7 @@ _FEATURE_FIELDS = (
     "expert_map_record_path",
     "expert_map_path",
     "eplb_disable_rearrange",
+    "eplb_static_dispatch_policy",
 )
 _BOOLEAN_FIELDS = (
     "enable_lightly_cp",
@@ -36,6 +37,9 @@ _BOOLEAN_FIELDS = (
     "eplb_disable_rearrange",
 )
 _SUPPORTED_MOE_BACKENDS = frozenset({"auto", "deep_gemm"})
+_SUPPORTED_EPLB_STATIC_DISPATCH_POLICIES = frozenset(
+    {"nearest", "locality_fair"}
+)
 _LEGACY_DEEP_GEMM_BACKEND = "dpsk_deep_gemm"
 _DEEP_GEMM_BACKEND = "deep_gemm"
 _legacy_backend_warning_emitted = False
@@ -82,6 +86,7 @@ class HcuFeatureConfig:
     expert_map_record_path: str | None = None
     expert_map_path: str | None = None
     eplb_disable_rearrange: bool = False
+    eplb_static_dispatch_policy: str = "nearest"
 
     def __post_init__(self) -> None:
         for name in _BOOLEAN_FIELDS:
@@ -130,6 +135,22 @@ class HcuFeatureConfig:
         if self.expert_map_record_path and self.eplb_disable_rearrange:
             raise ValueError(
                 "expert_map_record_path and disable_rearrange are mutually exclusive"
+            )
+        if not isinstance(self.eplb_static_dispatch_policy, str):
+            raise TypeError(
+                "HCU config field 'eplb_static_dispatch_policy' must be str, "
+                f"got {type(self.eplb_static_dispatch_policy).__name__}"
+            )
+        if (
+            self.eplb_static_dispatch_policy
+            not in _SUPPORTED_EPLB_STATIC_DISPATCH_POLICIES
+        ):
+            supported = ", ".join(
+                sorted(_SUPPORTED_EPLB_STATIC_DISPATCH_POLICIES)
+            )
+            raise ValueError(
+                "unsupported HCU eplb_static_dispatch_policy "
+                f"{self.eplb_static_dispatch_policy!r}; expected one of {supported}"
             )
         if self.enable_lightly_cplb and not self.enable_lightly_cp:
             raise ValueError("enable_lightly_cplb requires enable_lightly_cp")

--- a/vllm_hcu/patch/config.py
+++ b/vllm_hcu/patch/config.py
@@ -25,8 +25,16 @@ _FEATURE_FIELDS = (
     "hcu_flash_attn_mode",
     "expert_map_record_path",
     "expert_map_path",
+    "eplb_disable_rearrange",
 )
-_BOOLEAN_FIELDS = _FEATURE_FIELDS[:5]
+_BOOLEAN_FIELDS = (
+    "enable_lightly_cp",
+    "enable_lightly_cplb",
+    "enable_custom_sp",
+    "enable_multi_layers_mtp",
+    "deepep_auto",
+    "eplb_disable_rearrange",
+)
 _SUPPORTED_MOE_BACKENDS = frozenset({"auto", "deep_gemm"})
 _LEGACY_DEEP_GEMM_BACKEND = "dpsk_deep_gemm"
 _DEEP_GEMM_BACKEND = "deep_gemm"
@@ -73,6 +81,7 @@ class HcuFeatureConfig:
     hcu_flash_attn_mode: str | None = None
     expert_map_record_path: str | None = None
     expert_map_path: str | None = None
+    eplb_disable_rearrange: bool = False
 
     def __post_init__(self) -> None:
         for name in _BOOLEAN_FIELDS:
@@ -117,6 +126,10 @@ class HcuFeatureConfig:
         if self.expert_map_record_path and self.expert_map_path:
             raise ValueError(
                 "expert_map_record_path and expert_map_path are mutually exclusive"
+            )
+        if self.expert_map_record_path and self.eplb_disable_rearrange:
+            raise ValueError(
+                "expert_map_record_path and disable_rearrange are mutually exclusive"
             )
         if self.enable_lightly_cplb and not self.enable_lightly_cp:
             raise ValueError("enable_lightly_cplb requires enable_lightly_cp")

--- a/vllm_hcu/patch/platform/core_fix/patch_engine_args.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_engine_args.py
@@ -50,11 +50,13 @@ _HCU_EPLB_FIELDS = {
     "expert_map_record_path": "expert_map_record_path",
     "expert_map_path": "expert_map_path",
     "disable_rearrange": "eplb_disable_rearrange",
+    "static_dispatch_policy": "eplb_static_dispatch_policy",
 }
 _HCU_EPLB_ATTRS = {
     "expert_map_record_path": "_vllm_hcu_expert_map_record_path",
     "expert_map_path": "_vllm_hcu_expert_map_path",
     "disable_rearrange": "_vllm_hcu_eplb_disable_rearrange",
+    "static_dispatch_policy": "_vllm_hcu_eplb_static_dispatch_policy",
 }
 _DEEP_GEMM_BACKEND = "deep_gemm"
 _LEGACY_DEEP_GEMM_BACKEND = "dpsk_deep_gemm"

--- a/vllm_hcu/patch/platform/core_fix/patch_engine_args.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_engine_args.py
@@ -46,12 +46,15 @@ _HCU_BOOLEAN_KWARGS = (
     "enable_custom_sp",
     "enable_multi_layers_mtp",
 )
-_OFFLINE_EPLB_KEYS = (
-    "expert_map_record_path",
-    "expert_map_path",
-)
-_OFFLINE_EPLB_ATTRS = {
-    name: f"_vllm_hcu_{name}" for name in _OFFLINE_EPLB_KEYS
+_HCU_EPLB_FIELDS = {
+    "expert_map_record_path": "expert_map_record_path",
+    "expert_map_path": "expert_map_path",
+    "disable_rearrange": "eplb_disable_rearrange",
+}
+_HCU_EPLB_ATTRS = {
+    "expert_map_record_path": "_vllm_hcu_expert_map_record_path",
+    "expert_map_path": "_vllm_hcu_expert_map_path",
+    "disable_rearrange": "_vllm_hcu_eplb_disable_rearrange",
 }
 _DEEP_GEMM_BACKEND = "deep_gemm"
 _LEGACY_DEEP_GEMM_BACKEND = "dpsk_deep_gemm"
@@ -317,38 +320,40 @@ def _normalise_constructor_kwargs(
 
     eplb_config = bound.arguments.get("eplb_config")
     if isinstance(eplb_config, Mapping):
-        nested_offline_paths = {
+        nested_hcu_eplb = {
             name: eplb_config[name]
-            for name in _OFFLINE_EPLB_KEYS
+            for name in _HCU_EPLB_FIELDS
             if name in eplb_config
         }
-        if nested_offline_paths:
+        if nested_hcu_eplb:
             if "eplb_config" not in kwargs:
                 raise TypeError(
-                    "positional eplb_config containing offline EPLB paths is "
+                    "positional eplb_config containing HCU EPLB options is "
                     "not supported; pass eplb_config by keyword"
                 )
             normalized_eplb = dict(eplb_config)
-            for name, value in nested_offline_paths.items():
+            for name, value in nested_hcu_eplb.items():
                 normalized_eplb.pop(name)
-                explicit_value = explicit_sidecar.get(name)
+                feature_name = _HCU_EPLB_FIELDS[name]
+                explicit_value = explicit_sidecar.get(feature_name)
                 if explicit_value is not None and explicit_value != value:
                     raise ValueError(
                         f"conflicting {name} values in HCU sidecar and eplb_config"
                     )
-                updates[name] = value
+                updates[feature_name] = value
             kwargs["eplb_config"] = normalized_eplb
     elif eplb_config is not None:
-        for name, attr_name in _OFFLINE_EPLB_ATTRS.items():
+        for name, attr_name in _HCU_EPLB_ATTRS.items():
             if not hasattr(eplb_config, attr_name):
                 continue
             value = getattr(eplb_config, attr_name)
-            explicit_value = explicit_sidecar.get(name)
+            feature_name = _HCU_EPLB_FIELDS[name]
+            explicit_value = explicit_sidecar.get(feature_name)
             if explicit_value is not None and explicit_value != value:
                 raise ValueError(
                     f"conflicting {name} values in HCU sidecar and eplb_config"
                 )
-            updates[name] = value
+            updates[feature_name] = value
 
     if requested_deep_gemm:
         updates["moe_backend"] = _DEEP_GEMM_BACKEND
@@ -598,19 +603,19 @@ def apply_to_module(module: ModuleType) -> bool:
                     return official_eplb_parser(value)
                 if not isinstance(raw_config, Mapping):
                     return official_eplb_parser(value)
-                offline_paths = {
+                hcu_eplb_options = {
                     name: raw_config[name]
-                    for name in _OFFLINE_EPLB_KEYS
+                    for name in _HCU_EPLB_FIELDS
                     if name in raw_config
                 }
-                if not offline_paths:
+                if not hcu_eplb_options:
                     return official_eplb_parser(value)
                 normalized = dict(raw_config)
-                for name in offline_paths:
+                for name in hcu_eplb_options:
                     normalized.pop(name)
                 parsed = official_eplb_parser(json.dumps(normalized))
-                for name, path in offline_paths.items():
-                    setattr(parsed, _OFFLINE_EPLB_ATTRS[name], path)
+                for name, option_value in hcu_eplb_options.items():
+                    setattr(parsed, _HCU_EPLB_ATTRS[name], option_value)
                 return parsed
 
             action.type = hcu_parse_eplb_config

--- a/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
@@ -242,6 +242,17 @@ def validate_and_update_hcu_config(vllm_config: object) -> HcuFeatureConfig:
     model_config = getattr(vllm_config, "model_config", None)
     kernel_config = getattr(vllm_config, "kernel_config", None)
 
+    if feature_config.expert_map_path:
+        if parallel_config is None:
+            raise PatchCompatibilityError(
+                "static offline EPLB requires VllmConfig.parallel_config"
+            )
+        if getattr(parallel_config, "enable_elastic_ep", False):
+            raise ValueError(
+                "static offline EPLB with elastic EP is not supported because "
+                "elastic reshuffling would replace the loaded expert map"
+            )
+
     if parallel_config is not None:
         setattr(
             parallel_config,

--- a/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
@@ -253,6 +253,16 @@ def validate_and_update_hcu_config(vllm_config: object) -> HcuFeatureConfig:
                 "elastic reshuffling would replace the loaded expert map"
             )
 
+    if (
+        feature_config.eplb_disable_rearrange
+        and parallel_config is not None
+        and getattr(parallel_config, "enable_elastic_ep", False)
+    ):
+        raise ValueError(
+            "EPLB disable_rearrange with elastic EP is not supported because "
+            "elastic scaling requires expert rearrangement"
+        )
+
     if parallel_config is not None:
         setattr(
             parallel_config,

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -808,6 +808,9 @@ def apply_worker_patches(vllm_config: object | None = None) -> None:
                 parallel_config["_vllm_hcu_expert_map_path"] = (
                     config.expert_map_path
                 )
+                parallel_config["_vllm_hcu_eplb_disable_rearrange"] = (
+                    config.eplb_disable_rearrange
+                )
             elif parallel_config is not None:
                 setattr(
                     parallel_config,
@@ -823,6 +826,11 @@ def apply_worker_patches(vllm_config: object | None = None) -> None:
                     parallel_config,
                     "_vllm_hcu_expert_map_path",
                     config.expert_map_path,
+                )
+                setattr(
+                    parallel_config,
+                    "_vllm_hcu_eplb_disable_rearrange",
+                    config.eplb_disable_rearrange,
                 )
             rebound = _bind_deserialized_hcu_config(vllm_config)
             if rebound != config:

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -208,6 +208,14 @@ _MOE_FOUNDATION_CALLBACKS: tuple[_CallbackSpec, ...] = (
 )
 
 
+# Model construction is the last common boundary before the loader can invoke
+# ``model.load_weights``. Arm this callback before any model-specific adapter
+# can import a model module.
+_MODEL_LOADER_CALLBACKS: tuple[_CallbackSpec, ...] = (
+    _CallbackSpec(_adapter("framework_opt", "patch_model_loader_static_eplb")),
+)
+
+
 _CORE_CALLBACKS: tuple[_CallbackSpec, ...] = (
     _CallbackSpec(_adapter("core_fix", "patch_mhc_backend")),
     _CallbackSpec(_adapter("core_fix", "patch_deepseek_v32_config")),
@@ -373,6 +381,7 @@ _FRAMEWORK_CALLBACKS: tuple[_CallbackSpec, ...] = (
 
 
 _ALL_CALLBACK_GROUPS: tuple[tuple[_CallbackSpec, ...], ...] = (
+    _MODEL_LOADER_CALLBACKS,
     _MOE_FOUNDATION_CALLBACKS,
     _CORE_CALLBACKS,
     _OP_CALLBACKS,

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -282,6 +282,7 @@ _MOE_RUNTIME_CALLBACKS: tuple[_CallbackSpec, ...] = (
     _CallbackSpec(_adapter("op_opt.moe", "patch_rocm_aiter_moe")),
     _CallbackSpec(_adapter("op_opt.moe", "patch_triton_moe")),
     _CallbackSpec(_adapter("op_opt.moe", "patch_base_router")),
+    _CallbackSpec(_adapter("op_opt.moe", "patch_routing_simulator")),
     _CallbackSpec(_adapter("op_opt.moe", "patch_fused_topk_bias_router")),
     _CallbackSpec(_adapter("op_opt.moe", "patch_router_factory")),
     _CallbackSpec(

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -212,7 +212,11 @@ _MOE_FOUNDATION_CALLBACKS: tuple[_CallbackSpec, ...] = (
 # ``model.load_weights``. Arm this callback before any model-specific adapter
 # can import a model module.
 _MODEL_LOADER_CALLBACKS: tuple[_CallbackSpec, ...] = (
+    _CallbackSpec(
+        _adapter("framework_opt", "patch_model_loader_static_eplb_gate")
+    ),
     _CallbackSpec(_adapter("framework_opt", "patch_model_loader_static_eplb")),
+    _CallbackSpec(_adapter("framework_opt", "patch_llama4_static_eplb")),
 )
 
 

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -811,6 +811,9 @@ def apply_worker_patches(vllm_config: object | None = None) -> None:
                 parallel_config["_vllm_hcu_eplb_disable_rearrange"] = (
                     config.eplb_disable_rearrange
                 )
+                parallel_config["_vllm_hcu_eplb_static_dispatch_policy"] = (
+                    config.eplb_static_dispatch_policy
+                )
             elif parallel_config is not None:
                 setattr(
                     parallel_config,
@@ -831,6 +834,11 @@ def apply_worker_patches(vllm_config: object | None = None) -> None:
                     parallel_config,
                     "_vllm_hcu_eplb_disable_rearrange",
                     config.eplb_disable_rearrange,
+                )
+                setattr(
+                    parallel_config,
+                    "_vllm_hcu_eplb_static_dispatch_policy",
+                    config.eplb_static_dispatch_policy,
                 )
             rebound = _bind_deserialized_hcu_config(vllm_config)
             if rebound != config:

--- a/vllm_hcu/patch/worker/framework_opt/__init__.py
+++ b/vllm_hcu/patch/worker/framework_opt/__init__.py
@@ -1,3 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
 """Runtime adapters for audited target vLLM worker framework behavior."""
+
+__all__ = ["patch_model_loader_static_eplb"]

--- a/vllm_hcu/patch/worker/framework_opt/__init__.py
+++ b/vllm_hcu/patch/worker/framework_opt/__init__.py
@@ -2,4 +2,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
 """Runtime adapters for audited target vLLM worker framework behavior."""
 
-__all__ = ["patch_model_loader_static_eplb"]
+__all__ = [
+    "patch_llama4_static_eplb",
+    "patch_model_loader_static_eplb",
+    "patch_model_loader_static_eplb_gate",
+]

--- a/vllm_hcu/patch/worker/framework_opt/patch_llama4_static_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_llama4_static_eplb.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Direct-load Llama4 all-expert tensors through the static EPLB row."""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+from ._common import (
+    PatchCompatibilityError,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_exact_signature,
+)
+
+
+TARGET_MODULE = "vllm.model_executor.models.llama4"
+PATCH_ID = "worker.framework_opt.model_loader.llama4_static_eplb_fused"
+TARGET = f"{TARGET_MODULE}.Llama4Model.load_moe_expert_weights"
+_MODULE_MARKER = "_vllm_hcu_llama4_static_eplb_fused_applied"
+_WRAPPER_MARKER = "_vllm_hcu_llama4_static_eplb_fused_wrapper"
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    """Wrap only the audited Llama4 all-expert checkpoint helper."""
+
+    llama4 = load_exact_module(TARGET_MODULE, module)
+    model_class = require_class(llama4, "Llama4Model", f"{TARGET_MODULE}.Llama4Model")
+    current = require_callable(model_class, "load_moe_expert_weights", TARGET)
+    if getattr(llama4, _MODULE_MARKER, False):
+        if not getattr(current, _WRAPPER_MARKER, False):
+            raise PatchCompatibilityError(
+                f"required HCU patch marker for {TARGET} is stale"
+            )
+        return False
+    require_exact_signature(
+        current,
+        TARGET,
+        positional=(
+            "self",
+            "name",
+            "loaded_weight",
+            "params_dict",
+            "loaded_params",
+            "expert_params_mapping",
+            "fused",
+        ),
+        defaults={"fused": True},
+    )
+    is_pp_missing_parameter = require_callable(
+        llama4,
+        "is_pp_missing_parameter",
+        f"{TARGET_MODULE}.is_pp_missing_parameter",
+    )
+    extract_layer_index = require_callable(
+        llama4,
+        "extract_layer_index",
+        f"{TARGET_MODULE}.extract_layer_index",
+    )
+    original = current
+
+    @functools.wraps(original)
+    def hcu_load_moe_expert_weights(
+        self,
+        name,
+        loaded_weight,
+        params_dict,
+        loaded_params,
+        expert_params_mapping,
+        fused=True,
+    ):
+        if not fused:
+            return original(
+                self,
+                name,
+                loaded_weight,
+                params_dict,
+                loaded_params,
+                expert_params_mapping,
+                fused=fused,
+            )
+
+        fused_checkpoint_names: list[str] = []
+        for _, weight_name, _, _ in expert_params_mapping:
+            try:
+                expert_prefix, _, projection, _ = weight_name.split(".")
+            except ValueError:
+                # Preserve the audited upstream error for an incompatible
+                # mapping whenever static EPLB is not known to be active.
+                return original(
+                    self,
+                    name,
+                    loaded_weight,
+                    params_dict,
+                    loaded_params,
+                    expert_params_mapping,
+                    fused=fused,
+                )
+            fused_checkpoint_names.append(f"{expert_prefix}.{projection}")
+        if not any(checkpoint_name in name for checkpoint_name in fused_checkpoint_names):
+            return original(
+                self,
+                name,
+                loaded_weight,
+                params_dict,
+                loaded_params,
+                expert_params_mapping,
+                fused=fused,
+            )
+
+        layer_idx = extract_layer_index(name)
+        try:
+            runner = self.layers[layer_idx].feed_forward.experts
+            routed_experts = runner.routed_experts
+        except (AttributeError, IndexError, TypeError):
+            return original(
+                self,
+                name,
+                loaded_weight,
+                params_dict,
+                loaded_params,
+                expert_params_mapping,
+                fused=fused,
+            )
+        row = getattr(routed_experts, "_vllm_hcu_static_eplb_row", None)
+        if row is None:
+            return original(
+                self,
+                name,
+                loaded_weight,
+                params_dict,
+                loaded_params,
+                expert_params_mapping,
+                fused=fused,
+            )
+
+        # Llama4's fused checkpoint stores all logical experts in dimension
+        # zero.  Preserve its audited transpose/split rules, then feed each
+        # logical tensor to the standard RoutedExperts loader.  The bound
+        # common loader fans that tensor out to the configured physical slots.
+        if getattr(loaded_weight, "ndim", None) == 3:
+            loaded_weight = loaded_weight.transpose(-1, -2)
+            if "experts.gate_up_proj" in name:
+                loaded_weight = loaded_weight.chunk(2, dim=-2)
+
+        expert_param_loaded = False
+        for param_name, weight_name, _expert_id, shard_id in expert_params_mapping:
+            new_loaded_weight = loaded_weight
+            try:
+                expert_prefix, _, projection, _ = weight_name.split(".")
+            except ValueError as exc:
+                raise PatchCompatibilityError(
+                    f"required HCU patch target {TARGET} received an "
+                    f"incompatible fused expert mapping {weight_name!r}"
+                ) from exc
+            checkpoint_name = f"{expert_prefix}.{projection}"
+            parameter_name = f"{param_name}weight"
+            if checkpoint_name not in name:
+                continue
+
+            full_param_name = name.replace(checkpoint_name, parameter_name)
+            if is_pp_missing_parameter(name, self):
+                continue
+            if (
+                name.endswith(".bias") or name.endswith("_bias")
+            ) and name not in params_dict:
+                continue
+
+            try:
+                param = params_dict[full_param_name]
+                weight_loader = param.weight_loader
+            except (AttributeError, KeyError) as exc:
+                raise PatchCompatibilityError(
+                    "Static EPLB Llama4 fused loading could not resolve "
+                    f"the audited parameter {full_param_name!r}."
+                ) from exc
+
+            if "w13" in full_param_name:
+                if shard_id not in ("w1", "w3"):
+                    raise PatchCompatibilityError(
+                        "Static EPLB Llama4 fused w13 loading received "
+                        f"invalid shard {shard_id!r}."
+                    )
+                if not isinstance(new_loaded_weight, tuple) or len(new_loaded_weight) != 2:
+                    raise ValueError(
+                        "Static EPLB Llama4 fused gate/up checkpoint must "
+                        "split into exactly two expert tensors."
+                    )
+                new_loaded_weight = new_loaded_weight[0 if shard_id == "w1" else 1]
+
+            num_logical_experts = max(row, default=-1) + 1
+            if (
+                isinstance(num_logical_experts, bool)
+                or not isinstance(num_logical_experts, int)
+                or num_logical_experts <= 0
+                or set(row) != set(range(num_logical_experts))
+            ):
+                raise ValueError(
+                    "Static EPLB Llama4 fused loading received an invalid "
+                    "bound logical-expert row."
+                )
+            if (
+                getattr(new_loaded_weight, "ndim", None) is None
+                or new_loaded_weight.ndim < 1
+                or new_loaded_weight.shape[0] != num_logical_experts
+            ):
+                raise ValueError(
+                    "Static EPLB Llama4 fused checkpoint has logical-expert "
+                    f"dimension {getattr(new_loaded_weight, 'shape', None)!r}; "
+                    f"expected {num_logical_experts} rows."
+                )
+
+            for logical_expert_id, logical_weight in enumerate(
+                new_loaded_weight.unbind(0)
+            ):
+                weight_loader(
+                    param=param,
+                    loaded_weight=logical_weight,
+                    weight_name=full_param_name,
+                    shard_id=shard_id,
+                    expert_id=logical_expert_id,
+                    return_success=True,
+                )
+            loaded_params.add(full_param_name)
+            expert_param_loaded = True
+
+        return expert_param_loaded
+
+    setattr(hcu_load_moe_expert_weights, _WRAPPER_MARKER, True)
+    setattr(llama4, "_vllm_hcu_original_load_moe_expert_weights", original)
+    setattr(model_class, "load_moe_expert_weights", hcu_load_moe_expert_weights)
+    setattr(llama4, _MODULE_MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET", "TARGET_MODULE", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/worker/framework_opt/patch_model_loader_static_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_model_loader_static_eplb.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import functools
 import sys
+from contextvars import ContextVar
 from types import ModuleType
 from typing import Any
 
@@ -17,6 +18,7 @@ from ._common import (
     PatchCompatibilityError,
     load_exact_module,
     require_callable,
+    require_class,
     require_exact_signature,
 )
 
@@ -24,13 +26,26 @@ from ._common import (
 TARGET_MODULE = "vllm.model_executor.model_loader.utils"
 PATCH_ID = "worker.framework_opt.model_loader.static_eplb_preload"
 TARGETS = (f"{TARGET_MODULE}.initialize_model",)
+ENTRYPOINT_TARGET_MODULE = "vllm.model_executor.model_loader"
+ENTRYPOINT_TARGETS = (f"{ENTRYPOINT_TARGET_MODULE}.get_model_loader",)
 
 _MARKER = "_vllm_hcu_static_eplb_model_loader_applied"
 _WRAPPER_MARKER = "_vllm_hcu_static_eplb_model_loader_wrapper"
+_ENTRYPOINT_MARKER = "_vllm_hcu_static_eplb_loader_gate_applied"
+_ENTRYPOINT_WRAPPER_MARKER = "_vllm_hcu_static_eplb_loader_gate_wrapper"
+_LOADER_WRAPPER_MARKER = "_vllm_hcu_static_eplb_load_model_gate_wrapper"
+_INITIALIZER_DEPTH = ContextVar(
+    "vllm_hcu_static_eplb_initializer_depth",
+    default=0,
+)
 _INITIALIZER_ALIASES = (
     "vllm.model_executor.model_loader.base_loader",
     "vllm.model_executor.model_loader.tensorizer_loader",
     "vllm.model_executor.models.mllama4",
+)
+_LOADER_FACTORY_ALIASES = (
+    "vllm.v1.worker.gpu_model_runner",
+    "vllm.v1.worker.gpu.model_runner",
 )
 
 
@@ -41,6 +56,13 @@ def _validate_loaded_aliases(original: object) -> tuple[ModuleType, ...]:
         if alias_module is None:
             continue
         alias = getattr(alias_module, "initialize_model", None)
+        module_spec = getattr(alias_module, "__spec__", None)
+        if alias is None and bool(getattr(module_spec, "_initializing", False)):
+            # A parent such as base_loader can be suspended inside
+            # ``from ...utils import initialize_model`` while the utils
+            # completion callback runs.  It will naturally receive this
+            # wrapper when the dependency import returns.
+            continue
         if alias is not original:
             raise PatchCompatibilityError(
                 "already-imported alias "
@@ -48,6 +70,166 @@ def _validate_loaded_aliases(original: object) -> tuple[ModuleType, ...]:
             )
         aliases.append(alias_module)
     return tuple(aliases)
+
+
+def _validate_loaded_loader_factory_aliases(
+    original: object,
+) -> tuple[ModuleType, ...]:
+    aliases: list[ModuleType] = []
+    for module_name in _LOADER_FACTORY_ALIASES:
+        alias_module = sys.modules.get(module_name)
+        if alias_module is None:
+            continue
+        alias = getattr(alias_module, "get_model_loader", None)
+        module_spec = getattr(alias_module, "__spec__", None)
+        if alias is None and bool(getattr(module_spec, "_initializing", False)):
+            continue
+        if alias is not original:
+            raise PatchCompatibilityError(
+                "already-imported alias "
+                f"{module_name}.get_model_loader does not match "
+                f"{ENTRYPOINT_TARGETS[0]}"
+            )
+        aliases.append(alias_module)
+    return tuple(aliases)
+
+
+def _is_vllm_tensorized_loader(loader: object) -> bool:
+    from vllm.model_executor.model_loader.tensorizer import is_vllm_tensorized
+
+    return bool(is_vllm_tensorized(loader.tensorizer_config))
+
+
+def _require_static_preload_binding() -> None:
+    initializer_module = load_exact_module(TARGET_MODULE, sys.modules.get(TARGET_MODULE))
+    initializer = require_callable(initializer_module, "initialize_model", TARGETS[0])
+    if not getattr(initializer, _WRAPPER_MARKER, False):
+        raise PatchCompatibilityError(
+            "Static EPLB loader preflight requires the audited initialize_model "
+            "binding patch before checkpoint loading."
+        )
+
+
+def apply_entrypoint_to_module(module: ModuleType) -> bool:
+    """Reject loaders that bypass the audited logical-expert load contract."""
+
+    model_loader = load_exact_module(ENTRYPOINT_TARGET_MODULE, module)
+    original_get_model_loader = require_callable(
+        model_loader,
+        "get_model_loader",
+        ENTRYPOINT_TARGETS[0],
+    )
+    if getattr(model_loader, _ENTRYPOINT_MARKER, False):
+        if not getattr(
+            original_get_model_loader,
+            _ENTRYPOINT_WRAPPER_MARKER,
+            False,
+        ):
+            raise PatchCompatibilityError(
+                f"required HCU patch marker for {ENTRYPOINT_TARGETS[0]} is stale"
+            )
+        return False
+    require_exact_signature(
+        original_get_model_loader,
+        ENTRYPOINT_TARGETS[0],
+        positional=("load_config",),
+    )
+    loader_registry = getattr(model_loader, "_LOAD_FORMAT_TO_MODEL_LOADER", None)
+    if not isinstance(loader_registry, dict):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {ENTRYPOINT_TARGET_MODULE}."
+            "_LOAD_FORMAT_TO_MODEL_LOADER is missing"
+        )
+
+    default_loader = require_class(
+        model_loader,
+        "DefaultModelLoader",
+        f"{ENTRYPOINT_TARGET_MODULE}.DefaultModelLoader",
+    )
+    bitsandbytes_loader = require_class(
+        model_loader,
+        "BitsAndBytesModelLoader",
+        f"{ENTRYPOINT_TARGET_MODULE}.BitsAndBytesModelLoader",
+    )
+    runai_loader = require_class(
+        model_loader,
+        "RunaiModelStreamerLoader",
+        f"{ENTRYPOINT_TARGET_MODULE}.RunaiModelStreamerLoader",
+    )
+    tensorizer_loader = require_class(
+        model_loader,
+        "TensorizerLoader",
+        f"{ENTRYPOINT_TARGET_MODULE}.TensorizerLoader",
+    )
+    audited_loader_types = (
+        default_loader,
+        bitsandbytes_loader,
+        runai_loader,
+        tensorizer_loader,
+    )
+    aliases = _validate_loaded_loader_factory_aliases(original_get_model_loader)
+
+    @functools.wraps(original_get_model_loader)
+    def hcu_get_model_loader(load_config: object) -> Any:
+        loader = original_get_model_loader(load_config)
+        original_load_model = require_callable(
+            loader,
+            "load_model",
+            f"{type(loader).__name__}.load_model",
+        )
+        if getattr(original_load_model, _LOADER_WRAPPER_MARKER, False):
+            return loader
+
+        load_format = getattr(load_config, "load_format", None)
+        loader_type = loader_registry.get(load_format)
+
+        @functools.wraps(original_load_model)
+        def hcu_load_model(*args: object, **kwargs: object) -> Any:
+            if args:
+                vllm_config = args[0]
+            else:
+                vllm_config = kwargs.get("vllm_config")
+            parallel_config = getattr(vllm_config, "parallel_config", None)
+            if not getattr(parallel_config, "_vllm_hcu_expert_map_path", None):
+                return original_load_model(*args, **kwargs)
+
+            if loader_type not in audited_loader_types or type(loader) is not loader_type:
+                loader_name = type(loader).__name__
+                raise PatchCompatibilityError(
+                    f"Model loader {loader_name} for load format {load_format!r} "
+                    "does not support static EPLB direct loading through the "
+                    "audited model/RoutedExperts contract."
+                )
+
+            _require_static_preload_binding()
+            if loader_type is tensorizer_loader and _is_vllm_tensorized_loader(loader):
+                raise PatchCompatibilityError(
+                    "The vLLM-tensorized Tensorizer load path bypasses model "
+                    "weight loaders and does not support static EPLB direct loading."
+                )
+            return original_load_model(*args, **kwargs)
+
+        setattr(hcu_load_model, _LOADER_WRAPPER_MARKER, True)
+        try:
+            setattr(loader, "load_model", hcu_load_model)
+        except (AttributeError, TypeError) as exc:
+            raise PatchCompatibilityError(
+                f"Model loader {type(loader).__name__} does not expose a "
+                "wrappable load_model boundary for static EPLB gating."
+            ) from exc
+        return loader
+
+    setattr(hcu_get_model_loader, _ENTRYPOINT_WRAPPER_MARKER, True)
+    setattr(
+        model_loader,
+        "_vllm_hcu_original_static_eplb_get_model_loader",
+        original_get_model_loader,
+    )
+    setattr(model_loader, "get_model_loader", hcu_get_model_loader)
+    for alias_module in aliases:
+        setattr(alias_module, "get_model_loader", hcu_get_model_loader)
+    setattr(model_loader, _ENTRYPOINT_MARKER, True)
+    return True
 
 
 def apply_to_module(module: ModuleType) -> bool:
@@ -78,13 +260,28 @@ def apply_to_module(module: ModuleType) -> bool:
         model_class: type | None = None,
         model_config: object | None = None,
     ) -> Any:
-        model = original(
-            vllm_config,
-            prefix=prefix,
-            model_class=model_class,
-            model_config=model_config,
-        )
-        bind_static_eplb_plan(vllm_config, model)
+        parallel_config = getattr(vllm_config, "parallel_config", None)
+        if not getattr(parallel_config, "_vllm_hcu_expert_map_path", None):
+            return original(
+                vllm_config,
+                prefix=prefix,
+                model_class=model_class,
+                model_config=model_config,
+            )
+
+        depth = _INITIALIZER_DEPTH.get()
+        token = _INITIALIZER_DEPTH.set(depth + 1)
+        try:
+            model = original(
+                vllm_config,
+                prefix=prefix,
+                model_class=model_class,
+                model_config=model_config,
+            )
+        finally:
+            _INITIALIZER_DEPTH.reset(token)
+        if depth == 0:
+            bind_static_eplb_plan(vllm_config, model)
         return model
 
     setattr(hcu_initialize_model, _WRAPPER_MARKER, True)
@@ -100,4 +297,12 @@ def apply(module: ModuleType | None = None) -> bool:
     return apply_to_module(load_exact_module(TARGET_MODULE, module))
 
 
-__all__ = ["PATCH_ID", "TARGET_MODULE", "apply", "apply_to_module"]
+__all__ = [
+    "ENTRYPOINT_TARGET_MODULE",
+    "ENTRYPOINT_TARGETS",
+    "PATCH_ID",
+    "TARGET_MODULE",
+    "apply",
+    "apply_entrypoint_to_module",
+    "apply_to_module",
+]

--- a/vllm_hcu/patch/worker/framework_opt/patch_model_loader_static_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_model_loader_static_eplb.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Bind static EPLB maps before any vLLM checkpoint loader can run."""
+
+from __future__ import annotations
+
+import functools
+import sys
+from types import ModuleType
+from typing import Any
+
+from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    bind_static_eplb_plan,
+)
+
+from ._common import (
+    PatchCompatibilityError,
+    load_exact_module,
+    require_callable,
+    require_exact_signature,
+)
+
+
+TARGET_MODULE = "vllm.model_executor.model_loader.utils"
+PATCH_ID = "worker.framework_opt.model_loader.static_eplb_preload"
+TARGETS = (f"{TARGET_MODULE}.initialize_model",)
+
+_MARKER = "_vllm_hcu_static_eplb_model_loader_applied"
+_WRAPPER_MARKER = "_vllm_hcu_static_eplb_model_loader_wrapper"
+_INITIALIZER_ALIASES = (
+    "vllm.model_executor.model_loader.base_loader",
+    "vllm.model_executor.model_loader.tensorizer_loader",
+    "vllm.model_executor.models.mllama4",
+)
+
+
+def _validate_loaded_aliases(original: object) -> tuple[ModuleType, ...]:
+    aliases: list[ModuleType] = []
+    for module_name in _INITIALIZER_ALIASES:
+        alias_module = sys.modules.get(module_name)
+        if alias_module is None:
+            continue
+        alias = getattr(alias_module, "initialize_model", None)
+        if alias is not original:
+            raise PatchCompatibilityError(
+                "already-imported alias "
+                f"{module_name}.initialize_model does not match {TARGETS[0]}"
+            )
+        aliases.append(alias_module)
+    return tuple(aliases)
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    """Wrap the common construction boundary with static-plan binding."""
+
+    model_loader_utils = load_exact_module(TARGET_MODULE, module)
+    original = require_callable(model_loader_utils, "initialize_model", TARGETS[0])
+    if getattr(model_loader_utils, _MARKER, False):
+        if not getattr(original, _WRAPPER_MARKER, False):
+            raise PatchCompatibilityError(
+                f"required HCU patch marker for {TARGETS[0]} is stale"
+            )
+        return False
+    require_exact_signature(
+        original,
+        TARGETS[0],
+        positional=("vllm_config",),
+        keyword_only=("prefix", "model_class", "model_config"),
+        defaults={"prefix": "", "model_class": None, "model_config": None},
+    )
+    aliases = _validate_loaded_aliases(original)
+
+    @functools.wraps(original)
+    def hcu_initialize_model(
+        vllm_config: object,
+        *,
+        prefix: str = "",
+        model_class: type | None = None,
+        model_config: object | None = None,
+    ) -> Any:
+        model = original(
+            vllm_config,
+            prefix=prefix,
+            model_class=model_class,
+            model_config=model_config,
+        )
+        bind_static_eplb_plan(vllm_config, model)
+        return model
+
+    setattr(hcu_initialize_model, _WRAPPER_MARKER, True)
+    setattr(model_loader_utils, "_vllm_hcu_original_initialize_model", original)
+    setattr(model_loader_utils, "initialize_model", hcu_initialize_model)
+    for alias_module in aliases:
+        setattr(alias_module, "initialize_model", hcu_initialize_model)
+    setattr(model_loader_utils, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/worker/framework_opt/patch_model_loader_static_eplb_gate.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_model_loader_static_eplb_gate.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Gate static EPLB at vLLM's common model-loader entry point."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+from .patch_model_loader_static_eplb import (
+    ENTRYPOINT_TARGET_MODULE as TARGET_MODULE,
+    ENTRYPOINT_TARGETS as TARGETS,
+    apply_entrypoint_to_module,
+)
+
+
+PATCH_ID = "worker.framework_opt.model_loader.static_eplb_capability"
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    return apply_entrypoint_to_module(module)
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    from ._common import load_exact_module
+
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/worker/framework_opt/patch_model_loader_static_eplb_gate.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_model_loader_static_eplb_gate.py
@@ -6,18 +6,18 @@ from __future__ import annotations
 
 from types import ModuleType
 
-from .patch_model_loader_static_eplb import (
-    ENTRYPOINT_TARGET_MODULE as TARGET_MODULE,
-    ENTRYPOINT_TARGETS as TARGETS,
-    apply_entrypoint_to_module,
-)
+from . import patch_model_loader_static_eplb as _static_eplb
+
+
+TARGET_MODULE = _static_eplb.ENTRYPOINT_TARGET_MODULE
+TARGETS = _static_eplb.ENTRYPOINT_TARGETS
 
 
 PATCH_ID = "worker.framework_opt.model_loader.static_eplb_capability"
 
 
 def apply_to_module(module: ModuleType) -> bool:
-    return apply_entrypoint_to_module(module)
+    return _static_eplb.apply_entrypoint_to_module(module)
 
 
 def apply(module: ModuleType | None = None) -> bool:

--- a/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
@@ -315,6 +315,12 @@ def apply_to_module(module: ModuleType) -> bool:
                 model_state,
                 new_physical_to_logical_map=target_map,
             )
+            should_record = getattr(self, "should_record_tensor", None)
+            if should_record is not None:
+                should_record.fill_(False)
+            # A loaded map is static: do not start the asynchronous EPLB
+            # worker or collect data for a later dynamic rearrangement.
+            self.is_async = False
 
         _record_model_state(eplb_module, model_state)
 
@@ -328,7 +334,7 @@ def apply_to_module(module: ModuleType) -> bool:
         log_stats: bool = False,
     ) -> Any:
         _, load_path = _parallel_offline_paths(self.parallel_config)
-        if is_profile and load_path:
+        if load_path:
             return None
         return original_step(
             self,

--- a/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
@@ -20,6 +20,7 @@ import torch
 from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
     StaticEplbPlan,
     load_static_eplb_plan,
+    resolve_offline_eplb_model_key,
 )
 
 from ._common import (
@@ -313,6 +314,35 @@ def apply_to_module(module: ModuleType) -> bool:
 
     @functools.wraps(original_add_model)
     def hcu_add_model(self, model, model_config) -> None:
+        record_path, load_path = _parallel_offline_paths(self.parallel_config)
+        model_key = (
+            resolve_offline_eplb_model_key(model, self.parallel_config)
+            if record_path or load_path
+            else model.__class__.__name__
+        )
+        direct_plan = _find_static_eplb_plan(model) if load_path else None
+        if load_path and direct_plan is None:
+            raise PatchCompatibilityError(
+                f"Static EPLB path {load_path!r} for model key {model_key!r} "
+                "requires a direct-load plan for expert counts "
+                f"logical={model.num_logical_experts}, "
+                f"physical={model.num_physical_experts}, "
+                f"redundant={model.num_redundant_experts}; "
+                "model._vllm_hcu_static_eplb_plan must be bound before "
+                "checkpoint loading."
+            )
+
+        if record_path or load_path:
+            local_num_moe_layers = len(tuple(model.moe_layers))
+            if local_num_moe_layers <= 0:
+                raise PatchCompatibilityError(
+                    f"Offline EPLB found no PP-local MoE layers for {model_key!r}."
+                )
+            # Upstream sizes every EPLB state tensor from this public count.
+            # DeepSeek V2 and GLM expose a global count while ``moe_layers`` is
+            # PP-local, so offline modes must align it before upstream allocates.
+            model.num_moe_layers = local_num_moe_layers
+
         original_add_model(self, model, model_config)
         model_hash = model_config.compute_hash()
         model_state = self.model_states.get(model_hash)
@@ -320,8 +350,6 @@ def apply_to_module(module: ModuleType) -> bool:
             raise PatchCompatibilityError(
                 "vLLM EPLB add_model did not publish the expected model state"
             )
-        record_path, load_path = _parallel_offline_paths(self.parallel_config)
-        model_key = model.__class__.__name__
         setattr(model_state, _MODEL_RECORD_PATH_ATTR, record_path)
         setattr(model_state, _MODEL_KEY_ATTR, model_key)
 
@@ -337,17 +365,7 @@ def apply_to_module(module: ModuleType) -> bool:
             )
 
         if load_path:
-            direct_plan = _find_static_eplb_plan(model)
-            if direct_plan is None:
-                raise PatchCompatibilityError(
-                    f"Static EPLB path {load_path!r} for model key {model_key!r} "
-                    "requires a direct-load plan for expert counts "
-                    f"logical={model.num_logical_experts}, "
-                    f"physical={model.num_physical_experts}, "
-                    f"redundant={model.num_redundant_experts}; "
-                    "model._vllm_hcu_static_eplb_plan must be bound before "
-                    "checkpoint loading."
-                )
+            assert direct_plan is not None
             _validate_direct_load_plan(
                 direct_plan,
                 load_path=load_path,

--- a/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
@@ -14,6 +14,7 @@ from typing import Any
 import torch
 
 from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    StaticEplbPlan,
     load_static_eplb_plan,
 )
 
@@ -161,6 +162,78 @@ def _wrapped_is_valid(owner: object, name: str) -> bool:
     return callable(function) and bool(getattr(function, _WRAPPER_MARKER, False))
 
 
+def _find_static_eplb_plan(model: object) -> StaticEplbPlan | None:
+    plan = getattr(model, "_vllm_hcu_static_eplb_plan", None)
+    if plan is None:
+        inner_model = getattr(model, "model", None)
+        plan = getattr(inner_model, "_vllm_hcu_static_eplb_plan", None)
+    if plan is not None and not isinstance(plan, StaticEplbPlan):
+        raise PatchCompatibilityError(
+            "HY V4 static EPLB model published an invalid direct-load plan."
+        )
+    return plan
+
+
+def _validate_direct_load_plan(
+    plan: StaticEplbPlan,
+    *,
+    load_path: str,
+    model_key: str,
+    model: object,
+    expected_shape: tuple[int, int],
+) -> None:
+    configured_path = str(Path(load_path).expanduser().resolve(strict=True))
+    if plan.source_path != configured_path:
+        raise PatchCompatibilityError(
+            "HY V4 static EPLB direct-load plan path does not match the runtime "
+            f"configuration: plan={plan.source_path!r}, configured={configured_path!r}."
+        )
+    if plan.model_key != model_key:
+        raise PatchCompatibilityError(
+            "HY V4 static EPLB direct-load model key mismatch: "
+            f"plan={plan.model_key!r}, runtime={model_key!r}."
+        )
+    observed = (
+        plan.num_logical_experts,
+        plan.num_physical_experts,
+        plan.num_redundant_experts,
+    )
+    expected = (
+        int(getattr(model, "num_logical_experts")),
+        int(getattr(model, "num_physical_experts")),
+        int(getattr(model, "num_redundant_experts")),
+    )
+    if observed != expected or tuple(plan.physical_to_logical_map.shape) != expected_shape:
+        raise PatchCompatibilityError(
+            "HY V4 static EPLB direct-load plan metadata does not match EPLB state: "
+            f"plan_counts={observed}, model_counts={expected}, "
+            f"plan_shape={tuple(plan.physical_to_logical_map.shape)}, "
+            f"state_shape={expected_shape}."
+        )
+
+
+def _verify_static_plan_across_ep_ranks(
+    module: ModuleType,
+    plan: StaticEplbPlan,
+) -> None:
+    ep_group = module.get_ep_group()
+    world_size = int(getattr(ep_group, "world_size", 1))
+    if world_size <= 1:
+        return
+    fingerprints: list[object] = [None] * world_size
+    torch.distributed.all_gather_object(
+        fingerprints,
+        plan.fingerprint(),
+        group=ep_group.cpu_group,
+    )
+    if any(fingerprint != fingerprints[0] for fingerprint in fingerprints[1:]):
+        raise RuntimeError(
+            "Static EPLB plan fingerprints differ across EP ranks: "
+            f"local_rank={getattr(ep_group, 'rank_in_group', 'unknown')}, "
+            f"fingerprints={fingerprints}."
+        )
+
+
 def apply_to_module(module: ModuleType) -> bool:
     """Patch vLLM EPLB state transitions with offline save/load behavior."""
 
@@ -213,35 +286,61 @@ def apply_to_module(module: ModuleType) -> bool:
         setattr(model_state, _MODEL_KEY_ATTR, model_key)
 
         if load_path:
-            target_map = load_offline_expert_map(
-                load_path,
-                model_key=model_key,
-                expected_shape=tuple(model_state.physical_to_logical_map.shape),
-                num_logical_experts=model.num_logical_experts,
-                dtype=model_state.physical_to_logical_map.dtype,
-                device=torch.device("cpu"),
-            )
-            eplb_module.logger.info(
-                "Loading offline EPLB expert map from %s for model %s "
-                "with key %s.",
-                load_path,
-                model_config.model,
-                model_key,
-            )
-            rearrange(
-                model_state.physical_to_logical_map,
-                target_map,
-                model_state.model.expert_weights,
-                model_state.expert_buffer,
-                eplb_module.get_ep_group().device_group,
-                model_state.communicator,
-                False,
-                None,
-            )
-            original_commit(
-                model_state,
-                new_physical_to_logical_map=target_map,
-            )
+            direct_plan = _find_static_eplb_plan(model)
+            if direct_plan is not None:
+                _validate_direct_load_plan(
+                    direct_plan,
+                    load_path=load_path,
+                    model_key=model_key,
+                    model=model,
+                    expected_shape=tuple(model_state.physical_to_logical_map.shape),
+                )
+                _verify_static_plan_across_ep_ranks(eplb_module, direct_plan)
+                target_map = direct_plan.physical_to_logical_map.to(
+                    dtype=model_state.physical_to_logical_map.dtype,
+                    device="cpu",
+                )
+                original_commit(
+                    model_state,
+                    new_physical_to_logical_map=target_map,
+                )
+                eplb_module.get_ep_group().barrier()
+                eplb_module.logger.info(
+                    "Static EPLB direct-loaded model %s with map SHA-256 %s; "
+                    "committed routing metadata with zero expert rearrangement.",
+                    model_key,
+                    direct_plan.source_sha256,
+                )
+            else:
+                target_map = load_offline_expert_map(
+                    load_path,
+                    model_key=model_key,
+                    expected_shape=tuple(model_state.physical_to_logical_map.shape),
+                    num_logical_experts=model.num_logical_experts,
+                    dtype=model_state.physical_to_logical_map.dtype,
+                    device=torch.device("cpu"),
+                )
+                eplb_module.logger.info(
+                    "Loading offline EPLB expert map from %s for model %s "
+                    "with key %s through the compatibility rearrangement path.",
+                    load_path,
+                    model_config.model,
+                    model_key,
+                )
+                rearrange(
+                    model_state.physical_to_logical_map,
+                    target_map,
+                    model_state.model.expert_weights,
+                    model_state.expert_buffer,
+                    eplb_module.get_ep_group().device_group,
+                    model_state.communicator,
+                    False,
+                    None,
+                )
+                original_commit(
+                    model_state,
+                    new_physical_to_logical_map=target_map,
+                )
             should_record = getattr(self, "should_record_tensor", None)
             if should_record is not None:
                 should_record.fill_(False)

--- a/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
@@ -460,9 +460,12 @@ def apply_to_module(module: ModuleType) -> bool:
             )
             should_record = getattr(self, "should_record_tensor", None)
             if should_record is not None:
-                should_record.fill_(False)
+                should_record.fill_(
+                    bool(self.parallel_config.eplb_config.log_balancedness)
+                )
             # A loaded map is static: do not start the asynchronous EPLB
-            # worker or collect data for a later dynamic rearrangement.
+            # worker. Load collection may remain active for balancedness
+            # logging, but the map must never be rearranged dynamically.
             self.is_async = False
 
         _record_model_state(eplb_module, model_state)
@@ -477,7 +480,11 @@ def apply_to_module(module: ModuleType) -> bool:
         log_stats: bool = False,
     ) -> Any:
         _, load_path = _parallel_offline_paths(self.parallel_config)
-        if load_path:
+        if load_path and is_profile:
+            for model_state in self.model_states.values():
+                model_state.expert_load_pass.zero_()
+            return None
+        if load_path and not log_stats:
             return None
 
         should_log = False
@@ -532,13 +539,19 @@ def apply_to_module(module: ModuleType) -> bool:
         is_profile: bool = False,
         rank_mapping: dict[int, int] | None = None,
     ) -> Any:
+        _, load_path = _parallel_offline_paths(self.parallel_config)
         if (
             not is_profile
-            and getattr(self.parallel_config, _DISABLE_REARRANGE_ATTR, False)
+            and (
+                load_path
+                or getattr(self.parallel_config, _DISABLE_REARRANGE_ATTR, False)
+            )
         ):
             eplb_module.logger.info(
-                "Skipping dynamic EPLB expert rearrangement because "
-                "disable_rearrange=true."
+                "Skipping dynamic EPLB expert rearrangement because %s.",
+                "a static expert map is loaded"
+                if load_path
+                else "disable_rearrange=true",
             )
             return None
 

--- a/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
@@ -46,6 +46,7 @@ _MARKER = "_vllm_hcu_offline_eplb_patch_applied"
 _WRAPPER_MARKER = "_vllm_hcu_offline_eplb_wrapper"
 _RECORD_PATH_ATTR = "_vllm_hcu_expert_map_record_path"
 _LOAD_PATH_ATTR = "_vllm_hcu_expert_map_path"
+_DISABLE_REARRANGE_ATTR = "_vllm_hcu_eplb_disable_rearrange"
 _MODEL_RECORD_PATH_ATTR = "_vllm_hcu_expert_map_record_path"
 _MODEL_KEY_ATTR = "_vllm_hcu_expert_map_key"
 _RECORD_ONLY_REARRANGE = ContextVar(
@@ -422,6 +423,16 @@ def apply_to_module(module: ModuleType) -> bool:
                 model_key,
             )
 
+        if getattr(self.parallel_config, _DISABLE_REARRANGE_ATTR, False):
+            # No rearrangement will publish work to the async worker. Avoid
+            # starting an idle background loop while retaining load recording.
+            self.is_async = False
+            eplb_module.logger.info(
+                "EPLB load logging remains enabled for model %s; dynamic "
+                "expert rearrangement is disabled.",
+                model_key,
+            )
+
         if load_path:
             assert direct_plan is not None
             _validate_direct_load_plan(
@@ -521,6 +532,16 @@ def apply_to_module(module: ModuleType) -> bool:
         is_profile: bool = False,
         rank_mapping: dict[int, int] | None = None,
     ) -> Any:
+        if (
+            not is_profile
+            and getattr(self.parallel_config, _DISABLE_REARRANGE_ATTR, False)
+        ):
+            eplb_module.logger.info(
+                "Skipping dynamic EPLB expert rearrangement because "
+                "disable_rearrange=true."
+            )
+            return None
+
         record_path, _ = _parallel_offline_paths(self.parallel_config)
         if not record_path or is_profile:
             return original_rearrange(

--- a/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
@@ -40,6 +40,7 @@ TARGETS = (
     f"{TARGET_MODULE}.EplbState.rearrange",
     f"{TARGET_MODULE}.rearrange_expert_weights_inplace",
     f"{TARGET_MODULE}._commit_eplb_maps",
+    f"{TARGET_MODULE}._commit_eplb_maps_for_layer",
     f"{TARGET_MODULE}._move_to_workspace",
 )
 _MARKER = "_vllm_hcu_offline_eplb_patch_applied"
@@ -47,8 +48,10 @@ _WRAPPER_MARKER = "_vllm_hcu_offline_eplb_wrapper"
 _RECORD_PATH_ATTR = "_vllm_hcu_expert_map_record_path"
 _LOAD_PATH_ATTR = "_vllm_hcu_expert_map_path"
 _DISABLE_REARRANGE_ATTR = "_vllm_hcu_eplb_disable_rearrange"
+_STATIC_DISPATCH_POLICY_ATTR = "_vllm_hcu_eplb_static_dispatch_policy"
 _MODEL_RECORD_PATH_ATTR = "_vllm_hcu_expert_map_record_path"
 _MODEL_KEY_ATTR = "_vllm_hcu_expert_map_key"
+_MODEL_STATIC_DISPATCH_POLICY_ATTR = "_vllm_hcu_eplb_static_dispatch_policy"
 _RECORD_ONLY_REARRANGE = ContextVar(
     "vllm_hcu_record_only_eplb_rearrange",
     default=False,
@@ -252,6 +255,58 @@ def _find_static_eplb_plan(model: object) -> StaticEplbPlan | None:
     return plan
 
 
+def _apply_locality_fair_replica_order(
+    module: ModuleType,
+    model_state: object,
+    *,
+    layer: int | None = None,
+) -> bool:
+    policy = getattr(model_state, _MODEL_STATIC_DISPATCH_POLICY_ATTR, "nearest")
+    if policy != "locality_fair":
+        return False
+
+    from vllm_hcu.model_executor.layers.fused_moe.eplb_dispatch import (
+        build_locality_fair_replica_order,
+    )
+    from vllm_hcu.platforms import envs as henvs
+
+    if not (
+        henvs.VLLM_HCU_USE_CUSTOM_OPS
+        and henvs.VLLM_HCU_USE_EPLB_LOCALITY_FAIR_DISPATCH
+    ):
+        return False
+
+    ep_group = module.get_ep_group().device_group
+    ep_rank = ep_group.rank()
+    ep_size = ep_group.size()
+    replica_counts = model_state.logical_replica_count
+    logical_map = model_state.logical_to_physical_map
+    if layer is not None:
+        replica_counts = replica_counts[layer : layer + 1]
+        logical_map = logical_map[layer : layer + 1]
+    max_replicas = int(replica_counts.max().item())
+    if max_replicas <= 1:
+        return False
+    logical_map_prefix = logical_map[..., :max_replicas]
+    ordered_map = build_locality_fair_replica_order(
+        logical_map_prefix,
+        ep_rank=ep_rank,
+        ep_size=ep_size,
+        num_nodes=module.get_node_count(),
+        num_physical_experts=model_state.physical_to_logical_map.shape[1],
+        layer_offset=0 if layer is None else layer,
+    )
+    logical_map_prefix.copy_(ordered_map)
+    if layer is None or layer == model_state.model.num_moe_layers - 1:
+        module.logger.info(
+            "Applied locality-fair EPLB replica ordering for model %s "
+            "on EP rank %d.",
+            model_state.model_name,
+            ep_rank,
+        )
+    return True
+
+
 def _validate_direct_load_plan(
     plan: StaticEplbPlan,
     *,
@@ -333,6 +388,7 @@ def apply_to_module(module: ModuleType) -> bool:
             (eplb_state_cls, "rearrange"),
             (eplb_module, "rearrange_expert_weights_inplace"),
             (eplb_module, "_commit_eplb_maps"),
+            (eplb_module, "_commit_eplb_maps_for_layer"),
             (eplb_module, "_move_to_workspace"),
         )
         if not all(_wrapped_is_valid(owner, name) for owner, name in wrapped):
@@ -369,7 +425,12 @@ def apply_to_module(module: ModuleType) -> bool:
         TARGETS[3],
     )
     original_commit = require_callable(eplb_module, "_commit_eplb_maps", TARGETS[4])
-    original_move = require_callable(eplb_module, "_move_to_workspace", TARGETS[5])
+    original_commit_layer = require_callable(
+        eplb_module,
+        "_commit_eplb_maps_for_layer",
+        TARGETS[5],
+    )
+    original_move = require_callable(eplb_module, "_move_to_workspace", TARGETS[6])
 
     @functools.wraps(original_add_model)
     def hcu_add_model(self, model, model_config) -> None:
@@ -411,6 +472,15 @@ def apply_to_module(module: ModuleType) -> bool:
             )
         setattr(model_state, _MODEL_RECORD_PATH_ATTR, record_path)
         setattr(model_state, _MODEL_KEY_ATTR, model_key)
+        setattr(
+            model_state,
+            _MODEL_STATIC_DISPATCH_POLICY_ATTR,
+            getattr(
+                self.parallel_config,
+                _STATIC_DISPATCH_POLICY_ATTR,
+                "nearest",
+            ),
+        )
 
         if record_path:
             # Recording is an offline planning operation. Running the async
@@ -451,6 +521,7 @@ def apply_to_module(module: ModuleType) -> bool:
                 model_state,
                 new_physical_to_logical_map=target_map,
             )
+            _apply_locality_fair_replica_order(eplb_module, model_state)
             eplb_module.get_ep_group().barrier()
             eplb_module.logger.info(
                 "Static EPLB direct-loaded model %s with map SHA-256 %s; "
@@ -467,6 +538,9 @@ def apply_to_module(module: ModuleType) -> bool:
             # worker. Load collection may remain active for balancedness
             # logging, but the map must never be rearranged dynamically.
             self.is_async = False
+
+        if not load_path:
+            _apply_locality_fair_replica_order(eplb_module, model_state)
 
         _record_model_state(eplb_module, model_state)
 
@@ -601,9 +675,31 @@ def apply_to_module(module: ModuleType) -> bool:
             model_state,
             new_physical_to_logical_map=new_physical_to_logical_map,
         )
+        _apply_locality_fair_replica_order(eplb_module, model_state)
         _record_model_state(eplb_module, model_state)
 
     setattr(hcu_commit, _WRAPPER_MARKER, True)
+
+    @functools.wraps(original_commit_layer)
+    def hcu_commit_layer(
+        model_state,
+        new_physical_to_logical_map,
+        layer,
+    ) -> None:
+        if _RECORD_ONLY_REARRANGE.get():
+            return
+        original_commit_layer(
+            model_state,
+            new_physical_to_logical_map=new_physical_to_logical_map,
+            layer=layer,
+        )
+        _apply_locality_fair_replica_order(
+            eplb_module,
+            model_state,
+            layer=layer,
+        )
+
+    setattr(hcu_commit_layer, _WRAPPER_MARKER, True)
 
     @functools.wraps(original_move)
     def hcu_move_to_workspace(model_state, ep_rank) -> None:
@@ -634,9 +730,15 @@ def apply_to_module(module: ModuleType) -> bool:
         original_rearrange_weights,
     )
     setattr(eplb_module, "_vllm_hcu_original_offline_commit", original_commit)
+    setattr(
+        eplb_module,
+        "_vllm_hcu_original_offline_commit_layer",
+        original_commit_layer,
+    )
     setattr(eplb_module, "_vllm_hcu_original_offline_move", original_move)
     setattr(eplb_module, "rearrange_expert_weights_inplace", hcu_rearrange_weights)
     setattr(eplb_module, "_commit_eplb_maps", hcu_commit)
+    setattr(eplb_module, "_commit_eplb_maps_for_layer", hcu_commit_layer)
     setattr(eplb_module, "_move_to_workspace", hcu_move_to_workspace)
     setattr(eplb_module, _MARKER, True)
     return True

--- a/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
@@ -4,9 +4,13 @@
 
 from __future__ import annotations
 
+import fcntl
 import functools
 import json
+import os
+import tempfile
 import threading
+from contextvars import ContextVar
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -32,6 +36,8 @@ PATCH_ID = "worker.framework_opt.eplb.offline_expert_map"
 TARGETS = (
     f"{TARGET_MODULE}.EplbState.add_model",
     f"{TARGET_MODULE}.EplbState.step",
+    f"{TARGET_MODULE}.EplbState.rearrange",
+    f"{TARGET_MODULE}.rearrange_expert_weights_inplace",
     f"{TARGET_MODULE}._commit_eplb_maps",
     f"{TARGET_MODULE}._move_to_workspace",
 )
@@ -41,6 +47,10 @@ _RECORD_PATH_ATTR = "_vllm_hcu_expert_map_record_path"
 _LOAD_PATH_ATTR = "_vllm_hcu_expert_map_path"
 _MODEL_RECORD_PATH_ATTR = "_vllm_hcu_expert_map_record_path"
 _MODEL_KEY_ATTR = "_vllm_hcu_expert_map_key"
+_RECORD_ONLY_REARRANGE = ContextVar(
+    "vllm_hcu_record_only_eplb_rearrange",
+    default=False,
+)
 
 
 def load_offline_expert_map(
@@ -101,7 +111,7 @@ def record_offline_expert_map(
     num_logical_experts: int,
     num_redundant_experts: int,
 ) -> None:
-    """Atomically merge one model's committed map into an offline JSON file."""
+    """Atomically merge one model's candidate map into an offline JSON file."""
 
     output_path = Path(path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -118,11 +128,24 @@ def record_offline_expert_map(
         "physical_to_logical_map": map_cpu.tolist(),
     }
     with _FILE_LOCK:
-        payload = _merge_record_payload(output_path, model_key, model_payload)
-        tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
-        with tmp_path.open("w", encoding="utf-8") as destination:
-            json.dump(payload, destination)
-        tmp_path.replace(output_path)
+        lock_path = output_path.with_suffix(output_path.suffix + ".lock")
+        with lock_path.open("a", encoding="utf-8") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            payload = _merge_record_payload(output_path, model_key, model_payload)
+            descriptor, temporary_name = tempfile.mkstemp(
+                prefix=f".{output_path.name}.",
+                suffix=".tmp",
+                dir=output_path.parent,
+            )
+            temporary_path = Path(temporary_name)
+            try:
+                with os.fdopen(descriptor, "w", encoding="utf-8") as destination:
+                    json.dump(payload, destination)
+                    destination.flush()
+                    os.fsync(destination.fileno())
+                temporary_path.replace(output_path)
+            finally:
+                temporary_path.unlink(missing_ok=True)
 
 
 def _parallel_offline_paths(parallel_config: object) -> tuple[str | None, str | None]:
@@ -135,7 +158,12 @@ def _parallel_offline_paths(parallel_config: object) -> tuple[str | None, str | 
     return record_path, load_path
 
 
-def _record_model_state(module: ModuleType, model_state: object) -> None:
+def _record_model_state(
+    module: ModuleType,
+    model_state: object,
+    *,
+    physical_to_logical_map: torch.Tensor | None = None,
+) -> None:
     path = getattr(model_state, _MODEL_RECORD_PATH_ATTR, None)
     if not path or module.get_ep_group().device_group.rank() != 0:
         return
@@ -146,7 +174,11 @@ def _record_model_state(module: ModuleType, model_state: object) -> None:
         model_key=model_key,
         model_name=model_state.model_name,
         model_class=model.__class__.__name__,
-        physical_to_logical_map=model_state.physical_to_logical_map,
+        physical_to_logical_map=(
+            model_state.physical_to_logical_map
+            if physical_to_logical_map is None
+            else physical_to_logical_map
+        ),
         num_logical_experts=model.num_logical_experts,
         num_redundant_experts=model.num_redundant_experts,
     )
@@ -252,6 +284,8 @@ def apply_to_module(module: ModuleType) -> bool:
         wrapped = (
             (eplb_state_cls, "add_model"),
             (eplb_state_cls, "step"),
+            (eplb_state_cls, "rearrange"),
+            (eplb_module, "rearrange_expert_weights_inplace"),
             (eplb_module, "_commit_eplb_maps"),
             (eplb_module, "_move_to_workspace"),
         )
@@ -263,13 +297,18 @@ def apply_to_module(module: ModuleType) -> bool:
 
     original_add_model = require_callable(eplb_state_cls, "add_model", TARGETS[0])
     original_step = require_callable(eplb_state_cls, "step", TARGETS[1])
-    original_commit = require_callable(eplb_module, "_commit_eplb_maps", TARGETS[2])
-    original_move = require_callable(eplb_module, "_move_to_workspace", TARGETS[3])
-    rearrange = require_callable(
+    original_rearrange = require_callable(
+        eplb_state_cls,
+        "rearrange",
+        TARGETS[2],
+    )
+    original_rearrange_weights = require_callable(
         eplb_module,
         "rearrange_expert_weights_inplace",
-        f"{TARGET_MODULE}.rearrange_expert_weights_inplace",
+        TARGETS[3],
     )
+    original_commit = require_callable(eplb_module, "_commit_eplb_maps", TARGETS[4])
+    original_move = require_callable(eplb_module, "_move_to_workspace", TARGETS[5])
 
     @functools.wraps(original_add_model)
     def hcu_add_model(self, model, model_config) -> None:
@@ -284,6 +323,17 @@ def apply_to_module(module: ModuleType) -> bool:
         model_key = model.__class__.__name__
         setattr(model_state, _MODEL_RECORD_PATH_ATTR, record_path)
         setattr(model_state, _MODEL_KEY_ATTR, model_key)
+
+        if record_path:
+            # Recording is an offline planning operation. Running the async
+            # worker would transfer expert weights and block later layer
+            # commits even though the candidate map must not become live.
+            self.is_async = False
+            eplb_module.logger.info(
+                "EPLB expert-map recording for model %s uses plan-only mode; "
+                "online expert rearrangement is disabled.",
+                model_key,
+            )
 
         if load_path:
             direct_plan = _find_static_eplb_plan(model)
@@ -327,7 +377,7 @@ def apply_to_module(module: ModuleType) -> bool:
                     model_config.model,
                     model_key,
                 )
-                rearrange(
+                original_rearrange_weights(
                     model_state.physical_to_logical_map,
                     target_map,
                     model_state.model.expert_weights,
@@ -371,8 +421,54 @@ def apply_to_module(module: ModuleType) -> bool:
 
     setattr(hcu_step, _WRAPPER_MARKER, True)
 
+    @functools.wraps(original_rearrange)
+    def hcu_rearrange(
+        self,
+        is_profile: bool = False,
+        rank_mapping: dict[int, int] | None = None,
+    ) -> Any:
+        record_path, _ = _parallel_offline_paths(self.parallel_config)
+        if not record_path or is_profile:
+            return original_rearrange(
+                self,
+                is_profile=is_profile,
+                rank_mapping=rank_mapping,
+            )
+
+        token = _RECORD_ONLY_REARRANGE.set(True)
+        try:
+            result = original_rearrange(
+                self,
+                is_profile=False,
+                rank_mapping=rank_mapping,
+            )
+        finally:
+            _RECORD_ONLY_REARRANGE.reset(token)
+        eplb_module.logger.info(
+            "Recorded candidate EPLB expert maps without transferring weights "
+            "or changing live routing metadata."
+        )
+        return result
+
+    setattr(hcu_rearrange, _WRAPPER_MARKER, True)
+
+    @functools.wraps(original_rearrange_weights)
+    def hcu_rearrange_weights(*args, **kwargs) -> None:
+        if _RECORD_ONLY_REARRANGE.get():
+            return None
+        return original_rearrange_weights(*args, **kwargs)
+
+    setattr(hcu_rearrange_weights, _WRAPPER_MARKER, True)
+
     @functools.wraps(original_commit)
     def hcu_commit(model_state, new_physical_to_logical_map) -> None:
+        if _RECORD_ONLY_REARRANGE.get():
+            _record_model_state(
+                eplb_module,
+                model_state,
+                physical_to_logical_map=new_physical_to_logical_map,
+            )
+            return
         original_commit(
             model_state,
             new_physical_to_logical_map=new_physical_to_logical_map,
@@ -396,10 +492,22 @@ def apply_to_module(module: ModuleType) -> bool:
 
     setattr(eplb_state_cls, "_vllm_hcu_original_offline_add_model", original_add_model)
     setattr(eplb_state_cls, "_vllm_hcu_original_offline_step", original_step)
+    setattr(
+        eplb_state_cls,
+        "_vllm_hcu_original_offline_rearrange",
+        original_rearrange,
+    )
     setattr(eplb_state_cls, "add_model", hcu_add_model)
     setattr(eplb_state_cls, "step", hcu_step)
+    setattr(eplb_state_cls, "rearrange", hcu_rearrange)
+    setattr(
+        eplb_module,
+        "_vllm_hcu_original_offline_rearrange_weights",
+        original_rearrange_weights,
+    )
     setattr(eplb_module, "_vllm_hcu_original_offline_commit", original_commit)
     setattr(eplb_module, "_vllm_hcu_original_offline_move", original_move)
+    setattr(eplb_module, "rearrange_expert_weights_inplace", hcu_rearrange_weights)
     setattr(eplb_module, "_commit_eplb_maps", hcu_commit)
     setattr(eplb_module, "_move_to_workspace", hcu_move_to_workspace)
     setattr(eplb_module, _MARKER, True)

--- a/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
@@ -54,6 +54,49 @@ _RECORD_ONLY_REARRANGE = ContextVar(
 )
 
 
+def _compute_eplb_load_stats(
+    num_tokens_per_rank: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Backport vLLM #51813's per-layer EP load reduction."""
+    avg_tokens = num_tokens_per_rank.mean(dim=1).sum()
+    max_tokens = num_tokens_per_rank.max(dim=1).values.sum()
+    return avg_tokens, max_tokens
+
+
+def _log_corrected_eplb_balancedness(eplb_module: ModuleType, state) -> None:
+    expert_load_pass_list = state._sync_load_pass()
+    ep_group = eplb_module.get_ep_group().device_group
+    for expert_load_pass, model_state in zip(
+        expert_load_pass_list,
+        state.model_states.values(),
+    ):
+        num_tokens_per_rank = (
+            expert_load_pass.reshape(
+                expert_load_pass.shape[0],
+                ep_group.size(),
+                -1,
+            )
+            .sum(dim=-1)
+            .float()
+        )
+        avg_tensor, max_tensor = _compute_eplb_load_stats(num_tokens_per_rank)
+        avg_tokens, max_tokens = torch.stack([avg_tensor, max_tensor]).tolist()
+        balancedness = avg_tokens / max_tokens if max_tokens > 0 else 0.0
+        if ep_group.rank() == 0:
+            eplb_module.logger.info(
+                "EPLB step: %d for model %s: avg_tokens=%.2f, "
+                "max_tokens=%d, balancedness=%.4f, "
+                "steps until the next rearrangement: %d",
+                state.expert_rearrangement_step,
+                model_state.model_name,
+                avg_tokens,
+                max_tokens,
+                balancedness,
+                state.expert_rearrangement_step_interval
+                - state.expert_rearrangement_step,
+            )
+
+
 def load_offline_expert_map(
     path: str | Path,
     *,
@@ -299,6 +342,21 @@ def apply_to_module(module: ModuleType) -> bool:
 
     original_add_model = require_callable(eplb_state_cls, "add_model", TARGETS[0])
     original_step = require_callable(eplb_state_cls, "step", TARGETS[1])
+    require_callable(
+        eplb_state_cls,
+        "_sync_load_pass",
+        f"{TARGET_MODULE}.EplbState._sync_load_pass",
+    )
+    require_callable(
+        eplb_state_cls,
+        "_should_record_current_step",
+        f"{TARGET_MODULE}.EplbState._should_record_current_step",
+    )
+    require_callable(
+        eplb_state_cls,
+        "_update_layer_should_record",
+        f"{TARGET_MODULE}.EplbState._update_layer_should_record",
+    )
     original_rearrange = require_callable(
         eplb_state_cls,
         "rearrange",
@@ -410,12 +468,50 @@ def apply_to_module(module: ModuleType) -> bool:
         _, load_path = _parallel_offline_paths(self.parallel_config)
         if load_path:
             return None
-        return original_step(
+
+        should_log = False
+        if log_stats and not is_profile:
+            log_interval = (
+                self.parallel_config.eplb_config.log_balancedness_interval
+            )
+            should_log = self.expert_rearrangement_step % log_interval == 0
+        if not should_log:
+            return original_step(
+                self,
+                is_dummy=is_dummy,
+                is_profile=is_profile,
+                log_stats=log_stats,
+            )
+
+        # vLLM before #51813 reduces the layer/rank axes in the wrong order,
+        # which reports 1.0 when every layer has the same hot EP rank. Log the
+        # corrected values here, then let upstream perform every state change.
+        if is_dummy:
+            for model_state in self.model_states.values():
+                model_state.expert_load_pass.zero_()
+        _log_corrected_eplb_balancedness(eplb_module, self)
+
+        # Calling upstream with log_stats=False suppresses only its incorrect
+        # log block. Preserve the load-window update that log_stats=True would
+        # have requested when rearrangement proximity would not request it.
+        if not is_dummy and not self._should_record_current_step(log_stats=False):
+            for model_state in self.model_states.values():
+                model_state.expert_load_window[self.expert_load_window_step].copy_(
+                    model_state.expert_load_pass
+                )
+                model_state.expert_load_pass.zero_()
+            self.expert_load_window_step += 1
+            if self.expert_load_window_step >= self.expert_load_window_size:
+                self.expert_load_window_step = 0
+
+        result = original_step(
             self,
             is_dummy=is_dummy,
             is_profile=is_profile,
-            log_stats=log_stats,
+            log_stats=False,
         )
+        self._update_layer_should_record(log_stats=True)
+        return result
 
     setattr(hcu_step, _WRAPPER_MARKER, True)
 

--- a/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
@@ -13,6 +13,10 @@ from typing import Any
 
 import torch
 
+from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+    load_static_eplb_plan,
+)
+
 from ._common import (
     PatchCompatibilityError,
     load_exact_module,
@@ -38,29 +42,6 @@ _MODEL_RECORD_PATH_ATTR = "_vllm_hcu_expert_map_record_path"
 _MODEL_KEY_ATTR = "_vllm_hcu_expert_map_key"
 
 
-def _select_model_payload(
-    path: Path,
-    payload: dict,
-    model_key: str,
-) -> dict:
-    model_maps = payload.get("model_maps")
-    if model_maps is None:
-        return payload
-    if not isinstance(model_maps, dict):
-        raise ValueError(f"Offline EPLB map {str(path)!r} has invalid model_maps.")
-    if model_key not in model_maps:
-        raise ValueError(
-            f"Offline EPLB map {str(path)!r} does not contain key "
-            f"{model_key!r}; available keys: {sorted(model_maps)}."
-        )
-    selected = model_maps[model_key]
-    if not isinstance(selected, dict):
-        raise ValueError(
-            f"Offline EPLB map {str(path)!r} key {model_key!r} is invalid."
-        )
-    return selected
-
-
 def load_offline_expert_map(
     path: str | Path,
     *,
@@ -72,68 +53,14 @@ def load_offline_expert_map(
 ) -> torch.Tensor:
     """Load and validate one model's physical-to-logical expert map."""
 
-    input_path = Path(path)
-    with input_path.open(encoding="utf-8") as source:
-        payload = json.load(source)
-    if not isinstance(payload, dict):
-        raise ValueError(f"Offline EPLB map {str(input_path)!r} must be an object.")
-    selected = _select_model_payload(input_path, payload, model_key)
-    raw_map = selected.get(
-        "physical_to_logical_map",
-        selected.get("expert_map"),
+    plan = load_static_eplb_plan(
+        path,
+        model_key=model_key,
+        expected_shape=expected_shape,
+        num_logical_experts=num_logical_experts,
+        num_redundant_experts=expected_shape[1] - num_logical_experts,
     )
-    if raw_map is None:
-        raise ValueError(
-            f"Offline EPLB map {str(input_path)!r} must contain "
-            "physical_to_logical_map."
-        )
-
-    loaded = torch.tensor(raw_map, device="cpu")
-    if (
-        loaded.dtype == torch.bool
-        or loaded.is_floating_point()
-        or loaded.is_complex()
-    ):
-        raise ValueError(
-            f"Offline EPLB map {str(input_path)!r} must contain integer expert ids."
-        )
-    loaded = loaded.to(dtype=dtype)
-    loaded_shape = tuple(loaded.shape)
-    if loaded_shape != expected_shape:
-        if (
-            loaded.ndim == 2
-            and loaded.shape[0] > expected_shape[0]
-            and loaded.shape[1] == expected_shape[1]
-        ):
-            loaded = loaded[-expected_shape[0] :]
-        else:
-            raise ValueError(
-                f"Offline EPLB map {str(input_path)!r} has shape "
-                f"{loaded_shape}, expected {expected_shape}."
-            )
-    if loaded.numel() == 0:
-        raise ValueError(f"Offline EPLB map {str(input_path)!r} is empty.")
-    if loaded.min().item() < 0:
-        raise ValueError(
-            f"Offline EPLB map {str(input_path)!r} contains negative expert ids."
-        )
-    if loaded.max().item() >= num_logical_experts:
-        raise ValueError(
-            f"Offline EPLB map {str(input_path)!r} contains logical expert id "
-            f">= {num_logical_experts}."
-        )
-    for layer_idx, layer_map in enumerate(loaded):
-        counts = torch.bincount(
-            layer_map.to(torch.long),
-            minlength=num_logical_experts,
-        )
-        missing = torch.nonzero(counts[:num_logical_experts] == 0).flatten()
-        if missing.numel() > 0:
-            raise ValueError(
-                f"Offline EPLB map {str(input_path)!r} layer {layer_idx} "
-                f"misses logical experts {missing.tolist()}."
-            )
-    return loaded.to(device=device)
+    return plan.physical_to_logical_map.to(dtype=dtype, device=device)
 
 
 def _merge_record_payload(

--- a/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
@@ -201,7 +201,8 @@ def _find_static_eplb_plan(model: object) -> StaticEplbPlan | None:
         plan = getattr(inner_model, "_vllm_hcu_static_eplb_plan", None)
     if plan is not None and not isinstance(plan, StaticEplbPlan):
         raise PatchCompatibilityError(
-            "HY V4 static EPLB model published an invalid direct-load plan."
+            "Static EPLB model published an invalid direct-load plan: "
+            f"model_key={model.__class__.__name__!r}."
         )
     return plan
 
@@ -217,12 +218,12 @@ def _validate_direct_load_plan(
     configured_path = str(Path(load_path).expanduser().resolve(strict=True))
     if plan.source_path != configured_path:
         raise PatchCompatibilityError(
-            "HY V4 static EPLB direct-load plan path does not match the runtime "
+            "Static EPLB direct-load plan path does not match the runtime "
             f"configuration: plan={plan.source_path!r}, configured={configured_path!r}."
         )
     if plan.model_key != model_key:
         raise PatchCompatibilityError(
-            "HY V4 static EPLB direct-load model key mismatch: "
+            "Static EPLB direct-load model key mismatch: "
             f"plan={plan.model_key!r}, runtime={model_key!r}."
         )
     observed = (
@@ -237,7 +238,7 @@ def _validate_direct_load_plan(
     )
     if observed != expected or tuple(plan.physical_to_logical_map.shape) != expected_shape:
         raise PatchCompatibilityError(
-            "HY V4 static EPLB direct-load plan metadata does not match EPLB state: "
+            "Static EPLB direct-load plan metadata does not match EPLB state: "
             f"plan_counts={observed}, model_counts={expected}, "
             f"plan_shape={tuple(plan.physical_to_logical_map.shape)}, "
             f"state_shape={expected_shape}."
@@ -337,60 +338,39 @@ def apply_to_module(module: ModuleType) -> bool:
 
         if load_path:
             direct_plan = _find_static_eplb_plan(model)
-            if direct_plan is not None:
-                _validate_direct_load_plan(
-                    direct_plan,
-                    load_path=load_path,
-                    model_key=model_key,
-                    model=model,
-                    expected_shape=tuple(model_state.physical_to_logical_map.shape),
+            if direct_plan is None:
+                raise PatchCompatibilityError(
+                    f"Static EPLB path {load_path!r} for model key {model_key!r} "
+                    "requires a direct-load plan for expert counts "
+                    f"logical={model.num_logical_experts}, "
+                    f"physical={model.num_physical_experts}, "
+                    f"redundant={model.num_redundant_experts}; "
+                    "model._vllm_hcu_static_eplb_plan must be bound before "
+                    "checkpoint loading."
                 )
-                _verify_static_plan_across_ep_ranks(eplb_module, direct_plan)
-                target_map = direct_plan.physical_to_logical_map.to(
-                    dtype=model_state.physical_to_logical_map.dtype,
-                    device="cpu",
-                )
-                original_commit(
-                    model_state,
-                    new_physical_to_logical_map=target_map,
-                )
-                eplb_module.get_ep_group().barrier()
-                eplb_module.logger.info(
-                    "Static EPLB direct-loaded model %s with map SHA-256 %s; "
-                    "committed routing metadata with zero expert rearrangement.",
-                    model_key,
-                    direct_plan.source_sha256,
-                )
-            else:
-                target_map = load_offline_expert_map(
-                    load_path,
-                    model_key=model_key,
-                    expected_shape=tuple(model_state.physical_to_logical_map.shape),
-                    num_logical_experts=model.num_logical_experts,
-                    dtype=model_state.physical_to_logical_map.dtype,
-                    device=torch.device("cpu"),
-                )
-                eplb_module.logger.info(
-                    "Loading offline EPLB expert map from %s for model %s "
-                    "with key %s through the compatibility rearrangement path.",
-                    load_path,
-                    model_config.model,
-                    model_key,
-                )
-                original_rearrange_weights(
-                    model_state.physical_to_logical_map,
-                    target_map,
-                    model_state.model.expert_weights,
-                    model_state.expert_buffer,
-                    eplb_module.get_ep_group().device_group,
-                    model_state.communicator,
-                    False,
-                    None,
-                )
-                original_commit(
-                    model_state,
-                    new_physical_to_logical_map=target_map,
-                )
+            _validate_direct_load_plan(
+                direct_plan,
+                load_path=load_path,
+                model_key=model_key,
+                model=model,
+                expected_shape=tuple(model_state.physical_to_logical_map.shape),
+            )
+            _verify_static_plan_across_ep_ranks(eplb_module, direct_plan)
+            target_map = direct_plan.physical_to_logical_map.to(
+                dtype=model_state.physical_to_logical_map.dtype,
+                device="cpu",
+            )
+            original_commit(
+                model_state,
+                new_physical_to_logical_map=target_map,
+            )
+            eplb_module.get_ep_group().barrier()
+            eplb_module.logger.info(
+                "Static EPLB direct-loaded model %s with map SHA-256 %s; "
+                "committed routing metadata with zero expert rearrangement.",
+                model_key,
+                direct_plan.source_sha256,
+            )
             should_record = getattr(self, "should_record_tensor", None)
             if should_record is not None:
                 should_record.fill_(False)

--- a/vllm_hcu/patch/worker/op_opt/moe/patch_layer.py
+++ b/vllm_hcu/patch/worker/op_opt/moe/patch_layer.py
@@ -23,6 +23,9 @@ TARGETS = (
     f"{TARGET_MODULE}.FusedMoE",
     f"{TARGET_MODULE}.RoutedExperts.get_expert_weights",
     f"{TARGET_MODULE}.RoutedExperts.load_weights",
+    f"{TARGET_MODULE}.RoutedExperts.weight_loader",
+    f"{TARGET_MODULE}.RoutedExperts.get_expert_mapping",
+    f"{TARGET_MODULE}.RoutedExperts.make_expert_params_mapping",
 )
 _MARKER = "_vllm_hcu_moe_layer_applied"
 
@@ -63,6 +66,15 @@ def apply_to_module(module: ModuleType) -> bool:
         routed_experts_cls, "get_expert_weights", TARGETS[1]
     )
     load_weights = require_callable(routed_experts_cls, "load_weights", TARGETS[2])
+    weight_loader = require_callable(
+        routed_experts_cls, "weight_loader", TARGETS[3]
+    )
+    get_expert_mapping = require_callable(
+        routed_experts_cls, "get_expert_mapping", TARGETS[4]
+    )
+    make_expert_params_mapping = require_callable(
+        routed_experts_cls, "make_expert_params_mapping", TARGETS[5]
+    )
     require_parameter_names(
         factory,
         TARGETS[0],
@@ -84,6 +96,144 @@ def apply_to_module(module: ModuleType) -> bool:
     )
     require_parameter_names(get_weights, TARGETS[1], ("self",))
     require_parameter_names(load_weights, TARGETS[2], ("self", "weights"))
+    require_parameter_names(
+        weight_loader,
+        TARGETS[3],
+        (
+            "self",
+            "param",
+            "loaded_weight",
+            "weight_name",
+            "shard_id",
+            "expert_id",
+            "return_success",
+        ),
+    )
+    require_parameter_names(
+        get_expert_mapping,
+        TARGETS[4],
+        (
+            "self",
+            "ckpt_gate_proj_name",
+            "ckpt_down_proj_name",
+            "ckpt_up_proj_name",
+            "include_fused",
+        ),
+    )
+    require_parameter_names(
+        make_expert_params_mapping,
+        TARGETS[5],
+        (
+            "model",
+            "ckpt_gate_proj_name",
+            "ckpt_down_proj_name",
+            "ckpt_up_proj_name",
+            "num_experts",
+            "num_redundant_experts",
+            "routed_experts_prefix",
+        ),
+    )
+
+    @functools.wraps(weight_loader)
+    def hcu_weight_loader(
+        self,
+        param,
+        loaded_weight,
+        weight_name,
+        shard_id,
+        expert_id,
+        return_success=False,
+    ):
+        if not hasattr(self, "_vllm_hcu_static_eplb_row"):
+            return weight_loader(
+                self,
+                param,
+                loaded_weight,
+                weight_name,
+                shard_id,
+                expert_id,
+                return_success=return_success,
+            )
+
+        from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
+            load_static_logical_expert,
+        )
+
+        return load_static_logical_expert(
+            self,
+            weight_loader,
+            param=param,
+            loaded_weight=loaded_weight,
+            weight_name=weight_name,
+            shard_id=shard_id,
+            logical_expert_id=expert_id,
+            return_success=return_success,
+        )
+
+    @functools.wraps(get_expert_mapping)
+    def hcu_get_expert_mapping(
+        self,
+        ckpt_gate_proj_name=None,
+        ckpt_down_proj_name=None,
+        ckpt_up_proj_name=None,
+        include_fused=False,
+    ):
+        if not hasattr(self, "_vllm_hcu_static_eplb_row"):
+            return get_expert_mapping(
+                self,
+                ckpt_gate_proj_name,
+                ckpt_down_proj_name,
+                ckpt_up_proj_name,
+                include_fused,
+            )
+
+        moe_config = self.moe_config
+        num_fused_shared_experts = (
+            self.expert_map_manager.num_fused_shared_experts
+        )
+        return self.build_expert_params_mapping(
+            ckpt_gate_proj_name or self.ckpt_gate_proj_name,
+            ckpt_down_proj_name or self.ckpt_down_proj_name,
+            ckpt_up_proj_name or self.ckpt_up_proj_name,
+            num_experts=(
+                moe_config.num_logical_experts + num_fused_shared_experts
+            ),
+            num_redundant_experts=0,
+            routed_experts_prefix="",
+            lora_base_layer_prefix=self.lora_base_layer_prefix,
+            include_fused=include_fused,
+        )
+
+    def _model_has_static_eplb_binding(model) -> bool:
+        if hasattr(model, "_vllm_hcu_static_eplb_plan"):
+            return True
+        modules = getattr(model, "modules", None)
+        return callable(modules) and any(
+            hasattr(module, "_vllm_hcu_static_eplb_row")
+            for module in modules()
+        )
+
+    @functools.wraps(make_expert_params_mapping)
+    def hcu_make_expert_params_mapping(
+        model,
+        ckpt_gate_proj_name,
+        ckpt_down_proj_name,
+        ckpt_up_proj_name,
+        num_experts,
+        num_redundant_experts=0,
+        routed_experts_prefix="routed_experts",
+    ):
+        if _model_has_static_eplb_binding(model):
+            num_redundant_experts = 0
+        return make_expert_params_mapping(
+            model,
+            ckpt_gate_proj_name,
+            ckpt_down_proj_name,
+            ckpt_up_proj_name,
+            num_experts,
+            num_redundant_experts,
+            routed_experts_prefix,
+        )
 
     @functools.wraps(factory)
     def hcu_factory(*args, **kwargs):
@@ -185,14 +335,26 @@ def apply_to_module(module: ModuleType) -> bool:
             else:
                 yield from loaded_names
 
-    target._vllm_hcu_original_fused_moe_factory = factory
-    target.FusedMoE = hcu_factory
-    layer_module._vllm_hcu_original_fused_moe_factory = factory
-    layer_module.FusedMoE = hcu_factory
+    routed_experts_cls._vllm_hcu_original_weight_loader = weight_loader
+    routed_experts_cls.weight_loader = hcu_weight_loader
+    routed_experts_cls._vllm_hcu_original_get_expert_mapping = get_expert_mapping
+    routed_experts_cls.get_expert_mapping = hcu_get_expert_mapping
+    routed_experts_cls._vllm_hcu_original_make_expert_params_mapping = (
+        make_expert_params_mapping
+    )
+    routed_experts_cls.make_expert_params_mapping = staticmethod(
+        hcu_make_expert_params_mapping
+    )
     routed_experts_cls._vllm_hcu_original_get_expert_weights = get_weights
     routed_experts_cls.get_expert_weights = hcu_get_expert_weights
     routed_experts_cls._vllm_hcu_original_load_weights = load_weights
     routed_experts_cls.load_weights = hcu_load_weights
+    # Install RoutedExperts wrappers before exposing the factory: quantization
+    # create_weights captures a bound weight_loader while instances are built.
+    target._vllm_hcu_original_fused_moe_factory = factory
+    target.FusedMoE = hcu_factory
+    layer_module._vllm_hcu_original_fused_moe_factory = factory
+    layer_module.FusedMoE = hcu_factory
     setattr(target, _MARKER, True)
     return True
 

--- a/vllm_hcu/patch/worker/op_opt/moe/patch_layer.py
+++ b/vllm_hcu/patch/worker/op_opt/moe/patch_layer.py
@@ -155,6 +155,33 @@ def apply_to_module(module: ModuleType) -> bool:
                 return_success=return_success,
             )
 
+        row = self._vllm_hcu_static_eplb_row
+        num_logical_experts = self.moe_config.num_logical_experts
+        num_fused_shared_experts = (
+            self.expert_map_manager.num_fused_shared_experts
+        )
+        if (
+            not isinstance(expert_id, bool)
+            and isinstance(expert_id, int)
+            and num_logical_experts
+            <= expert_id
+            < num_logical_experts + num_fused_shared_experts
+        ):
+            # Shared experts are appended after all routed physical slots and
+            # remain fixed while EPLB remaps only routed logical experts.
+            shared_physical_expert_id = len(row) + (
+                expert_id - num_logical_experts
+            )
+            return weight_loader(
+                self,
+                param,
+                loaded_weight,
+                weight_name,
+                shard_id,
+                shared_physical_expert_id,
+                return_success=return_success,
+            )
+
         from vllm_hcu.model_executor.layers.fused_moe.static_eplb import (
             load_static_logical_expert,
         )

--- a/vllm_hcu/patch/worker/op_opt/moe/patch_routing_simulator.py
+++ b/vllm_hcu/patch/worker/op_opt/moe/patch_routing_simulator.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Register deterministic rank-balanced EPLB routing simulation."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+from ._common import (
+    PatchCompatibilityError,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_parameter_names,
+)
+
+TARGET_MODULE = (
+    "vllm.model_executor.layers.fused_moe.router.routing_simulator_router"
+)
+PATCH_ID = "worker.op_opt.moe.router.routing_simulator"
+TARGETS = (
+    f"{TARGET_MODULE}.RoutingStrategy",
+    f"{TARGET_MODULE}.RoutingSimulator.register_strategy",
+)
+STRATEGY_NAME = "hcu_eplb_balancedness"
+_MARKER = "_vllm_hcu_eplb_balancedness_strategy_registered"
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    target = load_exact_module(TARGET_MODULE, module)
+    simulator = require_class(target, "RoutingSimulator", TARGETS[1])
+    available = require_callable(
+        simulator,
+        "get_available_strategies",
+        f"{TARGET_MODULE}.RoutingSimulator.get_available_strategies",
+    )
+    if getattr(target, _MARKER, False):
+        if STRATEGY_NAME not in available():
+            raise PatchCompatibilityError(
+                f"stale HCU routing simulator marker for {TARGET_MODULE}; "
+                "restart process"
+            )
+        return False
+
+    base = require_class(target, "RoutingStrategy", TARGETS[0])
+    register = require_callable(simulator, "register_strategy", TARGETS[1])
+    require_parameter_names(register, TARGETS[1], ("name", "strategy"))
+
+    from vllm_hcu.model_executor.layers.fused_moe.router_runtime import (
+        make_hcu_eplb_balancedness_strategy,
+    )
+
+    strategy_type = make_hcu_eplb_balancedness_strategy(base)
+    register(STRATEGY_NAME, strategy_type())
+    setattr(target, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = [
+    "PATCH_ID",
+    "STRATEGY_NAME",
+    "TARGET_MODULE",
+    "TARGETS",
+    "apply",
+    "apply_to_module",
+]

--- a/vllm_hcu/platforms/envs.py
+++ b/vllm_hcu/platforms/envs.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     VLLM_HCU_USE_PD_SPLIT: bool = False
     VLLM_HCU_USE_AITER_W4A16_MOE: bool = False
     VLLM_HCU_USE_TORCH_EPLB_MAP_RECORD: bool = False
+    VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS: float = 1.0
     VLLM_HCU_USE_AITER_W16A16_MOE_SHUFFLE: bool = True
     VLLM_HCU_USE_AITER_MOE_CONFIG: bool = True
     VLLM_HCU_MOONCAKE_TTFT_TRACE: bool = False
@@ -347,6 +348,12 @@ hcu_vllm_environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_HCU_USE_TORCH_EPLB_MAP_RECORD":
         lambda: (os.environ.get("VLLM_HCU_USE_TORCH_EPLB_MAP_RECORD", "False").lower() in
                     ("true", "1")),
+
+    # Target mean/max EP-rank load ratio for the HCU EPLB routing simulator.
+    "VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS":
+        lambda: float(os.environ.get(
+            "VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS", "1.0"
+        )),
 
     # If use shuffle for AITER W16A16 MoE, please set True (default True)
     "VLLM_HCU_USE_AITER_W16A16_MOE_SHUFFLE":

--- a/vllm_hcu/platforms/envs.py
+++ b/vllm_hcu/platforms/envs.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     VLLM_HCU_USE_PD_SPLIT: bool = False
     VLLM_HCU_USE_AITER_W4A16_MOE: bool = False
     VLLM_HCU_USE_TORCH_EPLB_MAP_RECORD: bool = False
+    VLLM_HCU_USE_EPLB_LOCALITY_FAIR_DISPATCH: bool = True
     VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS: float = 1.0
     VLLM_HCU_USE_AITER_W16A16_MOE_SHUFFLE: bool = True
     VLLM_HCU_USE_AITER_MOE_CONFIG: bool = True
@@ -348,6 +349,13 @@ hcu_vllm_environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_HCU_USE_TORCH_EPLB_MAP_RECORD":
         lambda: (os.environ.get("VLLM_HCU_USE_TORCH_EPLB_MAP_RECORD", "False").lower() in
                     ("true", "1")),
+
+    # Enable rank-local replica ordering when locality_fair is selected in
+    # --eplb-config. The policy remains opt-in; this switch is its rollback.
+    "VLLM_HCU_USE_EPLB_LOCALITY_FAIR_DISPATCH":
+        lambda: (os.environ.get(
+            "VLLM_HCU_USE_EPLB_LOCALITY_FAIR_DISPATCH", "True"
+        ).lower() in ("true", "1")),
 
     # Target mean/max EP-rank load ratio for the HCU EPLB routing simulator.
     "VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS":


### PR DESCRIPTION
## Summary

- move offline static-EPLB checkpoint placement into the common MoE loading path so supported models share logical-expert-to-physical-slot fan-out instead of relying on HY V4 startup redistribution
- bind and validate the static plan before checkpoint tensors are consumed, then commit the fixed routing metadata without a startup expert rearrangement
- keep model-specific hooks only for checkpoint layouts that need them: HY V4 MTP compatibility and the Llama 4 fused all-expert tensor layout
- fail closed before loading for direct-copy or unaudited loaders (including sharded-state and vLLM-tensorized Tensorizer) that could otherwise leave weights inconsistent with routing
- make offline maps pipeline-stage safe with stage-qualified keys, local MoE-layer sizing, locked merge, and atomic replacement
- preserve the original interface: `expert_map_record_path` and `expert_map_path` remain inside `--eplb-config`; no migration to `--additional-config` is required
- keep static maps fixed after startup; when `log_balancedness=true`, continue collecting and logging EP-rank load without permitting later dynamic rearrangement, while `log_balancedness=false` retains the no-collection fast path
- backport vLLM #51813 balancedness reduction so EPLB logs reduce EP ranks per layer before summing layers; preserve the existing window state machine with no extra collective
- add `disable_rearrange` to the original `--eplb-config` interface so EPLB can keep collecting and logging rank-load balancedness without moving experts at runtime

## Record command (original `--eplb-config` syntax)

For real-routing recording, ensure `VLLM_MOE_ROUTING_SIMULATION_STRATEGY` and `VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS` are unset; those variables are only for synthetic performance simulation and do not produce an accuracy-valid routing map.

```bash
PYTHONPATH=/path/to/vllm-plugin-das \
vllm serve /models/Hy4-preview-Channel-FP8-w8a8-v2 \
  --served-model-name hy4-eplb-record \
  --data-parallel-size 8 \
  --enable-expert-parallel \
  --all2all-backend deepep_low_latency \
  --enable-eplb \
  --eplb-config '{"window_size":2,"step_interval":100,"num_redundant_experts":0,"log_balancedness":true,"log_balancedness_interval":100,"use_async":false,"policy":"default","expert_map_record_path":"/tmp/hy4-eplb-map.json"}' \
  --enforce-eager \
  --moe-backend deep_gemm \
  --gpu-memory-utilization 0.85 \
  --kv-cache-memory-bytes 67108864 \
  --kv-cache-dtype fp8_e4m3 \
  --max-model-len 256 \
  --max-num-batched-tokens 16 \
  --max-num-seqs 1 \
  --default-chat-template-kwargs '{"reasoning_effort":"no_think"}' \
  --reasoning-parser hy_v4 \
  --enable-auto-tool-choice \
  --tool-call-parser hy_v4 \
  --disable-log-stats \
  --port 10187
```

## Direct-load command (original `--eplb-config` syntax)

```bash
PYTHONPATH=/path/to/vllm-plugin-das \
vllm serve /models/Hy4-preview-Channel-FP8-w8a8-v2 \
  --served-model-name hy4-eplb-static \
  --data-parallel-size 8 \
  --enable-expert-parallel \
  --all2all-backend deepep_low_latency \
  --enable-eplb \
  --eplb-config '{"window_size":2,"step_interval":100,"num_redundant_experts":0,"log_balancedness":true,"log_balancedness_interval":100,"use_async":false,"policy":"default","expert_map_path":"/tmp/hy4-eplb-map.json"}' \
  --enforce-eager \
  --moe-backend deep_gemm \
  --gpu-memory-utilization 0.85 \
  --kv-cache-memory-bytes 67108864 \
  --kv-cache-dtype fp8_e4m3 \
  --max-model-len 256 \
  --max-num-batched-tokens 16 \
  --max-num-seqs 1 \
  --default-chat-template-kwargs '{"reasoning_effort":"no_think"}' \
  --reasoning-parser hy_v4 \
  --enable-auto-tool-choice \
  --tool-call-parser hy_v4 \
  --disable-log-stats \
  --port 10187
```

The 64 MiB KV cache and short context/batch limits are smoke-test settings; production deployments should size them for their workload.

## Validation

- current commit: `0e5d88fbc5416538de51b4917bc10992e8ce1929`
- full contract suite: `1289 passed, 64 deselected, 15 warnings`; inventory suite: `85 passed`; focused offline-EPLB suite: `24 passed`
- independent final re-review: all two Critical, four Important, and the included alias-isolation finding are addressed; no new Critical/Important breakage found
- real model: `/models/Hy4-preview-Channel-FP8-w8a8-v2`, TP1 / DP8 / EP8, `deepep_low_latency`, eager, DeepGEMM, `fp8_e4m3` KV cache
- real-routing record smoke (simulation variables explicitly unset) started all eight DP8/EP8 ranks; 64/64 live requests returned HTTP 200 (960 prompt tokens and 2048 completion tokens), and an all-nonzero 8-step router window wrote a keyed map
- direct-load smoke loaded the real-routing map on all eight ranks with identical SHA-256 `256d6efa7ff01a153e7bf9e83465f2e2f214b6f981dd0fb718e8bce020e54363`; every rank logged `zero expert rearrangement`, `/health` returned HTTP 200, and a deterministic completion returned HTTP 200
- unsupported loader, real Llama 4 fused tensor, nested mllama4 record-to-load, exact keyed-v2 shape, and two-stage PP record/load paths have dedicated regressions
- `python -m compileall -q vllm_hcu`, `git diff --check`, and base-relative `git diff --check` pass

### Runtime observation outside the direct-load correctness fix

During long Hy4 eager startup/warmup, `shm_broadcast.py` still emits the informational `No available shared memory broadcast block found in 60 seconds` message before the service becomes ready. Static direct loading itself completes and commits zero-rearrangement routing before that warmup. A forced 140-token smoke request also exceeded the 600-second client timeout in this shared test environment, while short record/static requests returned HTTP 200. This PR therefore does not claim to eliminate the separate warmup/performance timeout observation.

Dual-node acceptance remains to be run in the target two-node network environment.

## Safety and compatibility

- record and static-map paths remain mutually exclusive
- keyed-v2 maps require exact shapes; legacy suffix handling is limited to the explicit unkeyed HY V4 MTP compatibility case
- single-stage map keys remain unchanged; PP stage suffixes are introduced only when pipeline parallelism is greater than one
- ordinary online EPLB, elastic-EP guards, profile mode, and configurations without offline paths retain their existing behavior
- the branch remains based on `feat/hy-v4-mtp-blockwise-v0251` and excludes the removed `ead153255` change


## Configurable EPLB routing simulation

This PR also registers the plugin-owned `hcu_eplb_balancedness` strategy through vLLM's public `RoutingSimulator.register_strategy` interface. It is opt-in and does not alter ordinary routing:

```bash
export VLLM_MOE_ROUTING_SIMULATION_STRATEGY=hcu_eplb_balancedness
export VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS=0.6
```

`VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS` defaults to `1.0` and means `mean(EP-rank load) / max(EP-rank load)`. Requested levels `1.0`, `0.8`, `0.6`, `0.4`, and `0.2` are supported when they are at least `1 / EP_SIZE` (`0.2` therefore requires EP >= 5; EP8 was validated). For small token counts the strategy deterministically selects the nearest representable integer load ratio. Each token receives distinct experts; unsupported `top_k > min experts per EP rank` configurations fail explicitly.

The strategy is deterministic across fake-prefill and fixed-MTP shapes and is intended only for EPLB/performance simulation. As with vLLM's built-in routing simulators, generated model text is not valid for accuracy evaluation.

## HY4 simulation startup command

```bash
export PYTHONPATH=/path/to/vllm-plugin-das
export VLLM_USE_V2_MODEL_RUNNER=1
export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
export VLLM_ENGINE_ITERATION_TIMEOUT_S=1800
export VLLM_MOE_ROUTING_SIMULATION_STRATEGY=hcu_eplb_balancedness
export VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS=0.6
export VLLM_RANDOMIZE_DP_DUMMY_INPUTS=1

vllm serve /models/Hy4-preview-Channel-FP8-w8a8-v2 \
  --served-model-name hy4-eplb-log-06-ep8 \
  --data-parallel-size 8 \
  --enable-expert-parallel \
  --all2all-backend deepep_low_latency \
  --enable-eplb \
  --eplb-config '{"window_size":32,"step_interval":1000,"num_redundant_experts":0,"log_balancedness":true,"log_balancedness_interval":1,"use_async":false,"policy":"default","disable_rearrange":true}' \
  --moe-backend deep_gemm \
  --gpu-memory-utilization 0.85 \
  --kv-cache-memory-bytes 67108864 \
  --kv-cache-dtype fp8_e4m3 \
  --max-model-len 128 \
  --max-num-batched-tokens 32 \
  --max-num-seqs 1 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":1}' \
  --enable-auto-tool-choice \
  --tool-call-parser hy_v4 \
  --reasoning-parser hy_v4 \
  --default-chat-template-kwargs '{"reasoning_effort":"no_think"}' \
  --compilation-config '{"cudagraph_capture_sizes":[1,32]}' \
  --port 10189
```

The zero-redundant-expert setting is required by the currently installed DeepEP low-latency kernel for the 256-expert/EP8 layout; `264 / 8 = 33` was rejected as an unsupported low-latency expert layout.

## Routing-simulation validation

- exact generated EP8 rank-load ratios for 4096 tokens / top-k 2: `1.0`, `0.8`, `0.59988`, `0.4`, `0.2`
- HCU graph capture/replay at target `0.6`: deterministic IDs and measured ratio `0.59813`
- real target-`1.0` EP8 minimum-divisible validation: the HY4 service selected `hcu_eplb_balancedness`, captured 1/32-token graphs, accepted an exactly 32-token prompt (`prompt_tokens=32`) and returned HTTP 200; direct execution of the same route on an HCU produced rank loads `[32,32,32,32,32,32,32,32]` and all 256 expert loads exactly `1`
- real HY4 DP8/EP8 service with DeepEP low latency, FP8 KV cache, MTP=1, and graph capture: startup succeeded; three complete requests returned HTTP 200; repeated synchronous EPLB rearrangements completed in about 21-23 seconds without the 60-second shared-memory broadcast timeout
- focused regression suite: `174 passed`
- full contract suite: `1280 passed, 64 deselected`
- patch coverage, production import boundary (280 files), compileall, and diff checks passed
- independent re-review: no remaining Critical or Important findings

The vLLM #51813 reduction fix is backported by the runtime patch. On the real HY4 DP8/EP8 service above, an exact 32-token prompt at target `0.6` returned HTTP 200 and logged `avg_tokens=32.00, max_tokens=53, balancedness=0.6038` for the main model (the nearest integer-representable EP8 ratio), rather than the former misleading `1.0000`. The MTP model logged the same `0.6038` ratio. The fix reuses the original logging all-reduce and adds no collective; its additional control/scalar update work occurs only at configured log points.


## Logging-only EPLB mode

Set `"disable_rearrange":true` in the existing `--eplb-config` JSON, as shown in the HY4 simulation command above. The default is `false`, so existing online EPLB behavior is unchanged.

In logging-only mode, vLLM still records expert loads, advances/resets EPLB windows, performs the existing balancedness reduction, and emits `EPLB balancedness` logs. Non-profile dynamic `rearrange()` calls are skipped, while profile rearrangement remains available. The plugin also disables the otherwise-idle async EPLB worker.

Safety checks reject `disable_rearrange` together with `expert_map_record_path` or elastic EP. Static `expert_map_path` follows the same logging-only rule when `log_balancedness=true`: statistics are collected and emitted, but non-profile dynamic rearrangement remains disabled. With `log_balancedness=false`, the static-load step path returns without collecting load statistics.

Validation for commit `713f97a7448669f839bb1cd6a85562303b8a8488`:

- focused configuration/CLI/worker/EPLB/routing suite: `154 passed, 14 warnings`
- full patch contract suite: `1288 passed, 64 deselected`
- production-boundary, patch-coverage, compileall, and diff checks passed
- an independent code review found no Critical, Important, or Minor issues
- the exact DP8/EP8 command above accepted `disable_rearrange` through the original `--eplb-config` syntax and initialized all eight EP ranks; this shared host could not complete the new run because pre-existing HCU0 memory use left 123959 MiB available and HY4 construction exhausted the device after allocating 117.53 GiB, before EPLB model registration. Earlier DP8/EP8 runs on the same branch with clear devices reached HTTP 200 and logged `balancedness=0.6038`.

## Real-routing offline EPLB acceptance (DP8/EP8)

Validated at commit `713f97a7448669f839bb1cd6a85562303b8a8488` with both routing-simulation variables explicitly unset.

- record topology: Hy4 FP8, DP8 / EP8, DeepEP low latency, DeepGEMM, `fp8_e4m3` KV cache
- real workload: 64/64 concurrent requests returned HTTP 200; 960 prompt tokens and 2048 generated tokens
- captured record window: all eight steps contained real routed tokens (`avg_tokens=462` per layer); observed balancedness was `0.4561` to `0.4899`
- recorded map: SHA-256 `256d6efa7ff01a153e7bf9e83465f2e2f214b6f981dd0fb718e8bce020e54363`, shape `77 x 256`, all 77 rows valid permutations and non-linear, 15,311 physical slots differ from linear placement
- record mode logged that it wrote candidate maps without transferring weights or changing live routing metadata
- direct-load mode loaded that exact SHA on all eight ranks and logged `committed routing metadata with zero expert rearrangement`
- direct-load service: `/health` HTTP 200; deterministic completion HTTP 200 with 5 prompt tokens and 8 completion tokens
- neither run emitted `No available shared memory broadcast block found in 60 seconds`, `ERROR`, or `Traceback`

The record and direct-load commands above use the original `--eplb-config` interface. For real-routing acceptance, do not export either routing-simulation variable. Recording intentionally does not mutate live weights; the physical weight placement changes on the next direct-load startup, where checkpoint tensors are loaded directly into the recorded mapped slots.


## Static-map balancedness logging acceptance (DP8/EP8)

The direct-load command above is the supported startup interface. Keep `expert_map_path`, `log_balancedness`, and `log_balancedness_interval` inside the original `--eplb-config` JSON. No routing-simulation variables are required for real load statistics.

Validated at commit `0e5d88fbc5416538de51b4917bc10992e8ce1929` with `/models/Hy4-preview-Channel-FP8-w8a8-v2`, DP8 / EP8, DeepEP low latency, DeepGEMM, eager mode, and `fp8_e4m3` KV cache:

- all eight ranks direct-loaded map SHA-256 `256d6efa7ff01a153e7bf9e83465f2e2f214b6f981dd0fb718e8bce020e54363` with zero startup expert rearrangement
- a deterministic completion returned HTTP 200; real-request logs included balancedness values `0.4917`, `0.3949`, `0.3738`, `0.3793`, `0.3889`, `0.3850`, and `0.3969`
- forced rearrangement boundaries were reached 136 times across the eight ranks; every call logged the static-map skip guard, no `Rearranged experts` message was emitted, and the map file SHA remained unchanged
- no `ERROR`, traceback, or 60-second shared-memory timeout appeared in the validation log
- validation used `step_interval=2` and `log_balancedness_interval=1` only to exercise boundaries quickly; production values should be sized for the desired statistics cadence because enabled balancedness logging retains load-recording and synchronization overhead


## Locality-fair redundant-expert dispatch

Adapted from SGLang-DAS commit 1cc92e0d3706bd874e7b2b7957b3ec099420746c. Set static_dispatch_policy inside the original --eplb-config JSON; the default remains nearest, so existing deployments are unchanged.

The vLLM router hashes token positions across replica columns. The adaptation therefore creates a deterministic rank-local cyclic replica ordering: same-GPU first, then fairly selected same-node replicas, then a global fair fallback. Every hash column stays balanced, while the first decode position no longer sends all source ranks to the first same-node replica. The ordering is applied after initial state creation, static direct load, synchronous full-map commit, and asynchronous per-layer commit. Configurations with no redundant experts are a no-op.

### HY4 EP8 startup example

    unset VLLM_MOE_ROUTING_SIMULATION_STRATEGY
    unset VLLM_HCU_MOE_ROUTING_SIMULATION_BALANCEDNESS
    export PYTHONPATH=/path/to/vllm-plugin-das
    vllm serve /models/Hy4-preview-Channel-FP8-w8a8-v2 \
      --served-model-name hy4-eplb-locality-fair \
      --data-parallel-size 8 \
      --enable-expert-parallel \
      --all2all-backend allgather_reducescatter \
      --enable-eplb \
      --eplb-config "{\"window_size\":32,\"step_interval\":1000,\"num_redundant_experts\":8,\"log_balancedness\":true,\"log_balancedness_interval\":100,\"use_async\":false,\"policy\":\"default\",\"static_dispatch_policy\":\"locality_fair\"}" \
      --moe-backend deep_gemm \
      --gpu-memory-utilization 0.85 \
      --kv-cache-dtype fp8_e4m3 \
      --max-model-len 4096 \
      --port 10187

DeepEP low latency is intentionally not used in this redundant-expert example: the installed kernel rejects the 264 / EP8 = 33 local-expert layout. Use a backend that supports that layout. To roll back only this adaptation, omit static_dispatch_policy or set it to nearest. The emergency leaf switch is VLLM_HCU_USE_EPLB_LOCALITY_FAIR_DISPATCH=0.

### Validation for f4d69dc

- full v0.25.1 patch contract: 1315 passed, 64 deselected, 15 warnings
- patch inventory: 86 passed; patch coverage reports no missing contracts or untested modules; production boundary is clean across 281 Python files
- focused offline/locality-fair EPLB suite after commit: 43 passed; combined affected suite: 227 passed
- real HY4 recorded-map dimensions exercised on CPU with 77 layers, 256 logical experts, 264 simulated physical slots, and EP8: all 616 redundant rows selected replicas 4:4 across source ranks; all hash columns remained balanced; candidate sets were preserved; non-redundant rows were unchanged
- compileall and diff checks passed

A new live HY4 service run is not claimed for this commit: all eight HCUs currently have about 137 GiB of 147 GiB allocated by another workload. Existing allocations were left untouched.