### PR TITLE
fix(eplb): preserve static maps and reject offline pipeline parallelism

### DIFF
--- a/tests/runtime_patch/test_offline_eplb.py
+++ b/tests/runtime_patch/test_offline_eplb.py
@@ -198,6 +198,7 @@ def _make_eplb_module(
             self.device = torch.device("cpu")
             self.model_states: dict[str, EplbModelState] = {}
             self.official_profile_steps = 0
+            self.official_rearrangements = 0
 
         def add_model(self, model, model_config) -> None:
             state = EplbModelState()
@@ -217,7 +218,12 @@ def _make_eplb_module(
             del is_dummy, log_stats
             if is_profile:
                 self.official_profile_steps += 1
+            self.rearrange(is_profile=is_profile)
             return "official-step"
+
+        def rearrange(self, is_profile=False, rank_mapping=None):
+            self.official_rearrangements += 1
+            return "official-rearrange"
 
     def rearrange_expert_weights_inplace(
         source_map,
@@ -305,3 +311,49 @@ def test_runtime_patch_loads_map_and_skips_profile_rearrangement(
     assert state.step(is_profile=True) is None
     assert state.official_profile_steps == 0
     assert state.step(is_profile=False) == "official-step"
+    assert state.step(is_dummy=True) == "official-step"
+    assert state.step(log_stats=True) == "official-step"
+    assert state.official_rearrangements == 0
+    assert len(rearrangements) == 1
+    assert not apply_to_module(module)
+    assert state.rearrange(rank_mapping={0: 0}) == "official-rearrange"
+    assert state.official_rearrangements == 1
+
+
+@pytest.mark.parametrize("record", [False, True])
+def test_non_static_eplb_still_rearranges(tmp_path: Path, record: bool) -> None:
+    module, _ = _make_eplb_module(
+        record_path=tmp_path / "record.json" if record else None,
+    )
+    apply_to_module(module)
+    state = module.EplbState()
+    assert state.step() == "official-step"
+    assert state.official_rearrangements == 1
+
+
+@pytest.mark.parametrize("mode", ["record_path", "load_path"])
+def test_offline_eplb_rejects_pp_before_registering_model(
+    tmp_path: Path,
+    mode: str,
+) -> None:
+    path = tmp_path / "map.json"
+    module, rearrangements = _make_eplb_module(**{mode: path})
+    apply_to_module(module)
+    state = module.EplbState()
+    state.parallel_config.pipeline_parallel_size = 2
+
+    with pytest.raises(ValueError, match="pipeline_parallel_size=1"):
+        state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+
+    assert not state.model_states
+    assert not rearrangements
+    assert not path.exists()
+
+
+def test_online_eplb_allows_pp() -> None:
+    module, _ = _make_eplb_module()
+    apply_to_module(module)
+    state = module.EplbState()
+    state.parallel_config.pipeline_parallel_size = 2
+    state.add_model(HYV4ForCausalLM(), _FakeModelConfig())
+    assert state.model_states

--- a/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_offline_eplb.py
@@ -29,6 +29,7 @@ TARGETS = (
     f"{TARGET_MODULE}.EplbState.step",
     f"{TARGET_MODULE}._commit_eplb_maps",
     f"{TARGET_MODULE}._move_to_workspace",
+    f"{TARGET_MODULE}.EplbState.rearrange",
 )
 _MARKER = "_vllm_hcu_offline_eplb_patch_applied"
 _WRAPPER_MARKER = "_vllm_hcu_offline_eplb_wrapper"
@@ -204,6 +205,10 @@ def _parallel_offline_paths(parallel_config: object) -> tuple[str | None, str | 
         raise ValueError(
             "expert_map_record_path and expert_map_path are mutually exclusive"
         )
+    if (record_path or load_path) and getattr(
+        parallel_config, "pipeline_parallel_size", 1
+    ) > 1:
+        raise ValueError("Offline EPLB requires pipeline_parallel_size=1")
     return record_path, load_path
 
 
@@ -254,6 +259,7 @@ def apply_to_module(module: ModuleType) -> bool:
             (eplb_state_cls, "step"),
             (eplb_module, "_commit_eplb_maps"),
             (eplb_module, "_move_to_workspace"),
+            (eplb_state_cls, "rearrange"),
         )
         if not all(_wrapped_is_valid(owner, name) for owner, name in wrapped):
             raise PatchCompatibilityError(
@@ -265,6 +271,7 @@ def apply_to_module(module: ModuleType) -> bool:
     original_step = require_callable(eplb_state_cls, "step", TARGETS[1])
     original_commit = require_callable(eplb_module, "_commit_eplb_maps", TARGETS[2])
     original_move = require_callable(eplb_module, "_move_to_workspace", TARGETS[3])
+    original_rearrange = require_callable(eplb_state_cls, "rearrange", TARGETS[4])
     rearrange = require_callable(
         eplb_module,
         "rearrange_expert_weights_inplace",
@@ -273,6 +280,7 @@ def apply_to_module(module: ModuleType) -> bool:
 
     @functools.wraps(original_add_model)
     def hcu_add_model(self, model, model_config) -> None:
+        record_path, load_path = _parallel_offline_paths(self.parallel_config)
         original_add_model(self, model, model_config)
         model_hash = model_config.compute_hash()
         model_state = self.model_states.get(model_hash)
@@ -280,7 +288,6 @@ def apply_to_module(module: ModuleType) -> bool:
             raise PatchCompatibilityError(
                 "vLLM EPLB add_model did not publish the expected model state"
             )
-        record_path, load_path = _parallel_offline_paths(self.parallel_config)
         model_key = model.__class__.__name__
         setattr(model_state, _MODEL_RECORD_PATH_ATTR, record_path)
         setattr(model_state, _MODEL_KEY_ATTR, model_key)
@@ -339,6 +346,18 @@ def apply_to_module(module: ModuleType) -> bool:
 
     setattr(hcu_step, _WRAPPER_MARKER, True)
 
+    @functools.wraps(original_rearrange)
+    def hcu_rearrange(self, is_profile=False, rank_mapping=None):
+        _, load_path = _parallel_offline_paths(self.parallel_config)
+        # Keep step statistics and explicit elastic-EP remapping intact.
+        if load_path and rank_mapping is None:
+            return None
+        return original_rearrange(
+            self, is_profile=is_profile, rank_mapping=rank_mapping
+        )
+
+    setattr(hcu_rearrange, _WRAPPER_MARKER, True)
+
     @functools.wraps(original_commit)
     def hcu_commit(model_state, new_physical_to_logical_map) -> None:
         original_commit(
@@ -366,6 +385,7 @@ def apply_to_module(module: ModuleType) -> bool:
     setattr(eplb_state_cls, "_vllm_hcu_original_offline_step", original_step)
     setattr(eplb_state_cls, "add_model", hcu_add_model)
     setattr(eplb_state_cls, "step", hcu_step)
+    eplb_state_cls.rearrange = hcu_rearrange
     setattr(eplb_module, "_vllm_hcu_original_offline_commit", original_commit)
     setattr(eplb_module, "_vllm_hcu_original_offline_move", original_move)
     setattr(eplb_module, "_commit_eplb_maps", hcu_commit)


### PR DESCRIPTION
Loading an offline expert map still allowed periodic EPLB to replace it. Recording with pipeline parallelism also let separate EP rank-zero workers overwrite the same model entry and temporary file.

This change suppresses scheduled rearrangement when `expert_map_path` is set, while retaining step statistics and explicit elastic-EP remapping. It rejects offline recording/loading with `pipeline_parallel_size > 1` before model registration or file writes. Online EPLB is unchanged. Regression coverage checks static, recording, online, and pipeline-parallel paths.

Targets `integrate/pr61-into-hy4-pcp-ep` to keep the diff limited to these two fixes (22 production lines changed, plus tests).

Validation:
- `.venv/bin/python -m pytest tests/runtime_patch/test_offline_eplb.py -q`: 16 passed.
- An isolated CPU check executed the local vLLM v0.25.1 `EplbState.step` implementation at a rearrangement interval boundary: online mode rearranged once; static mode did not rearrange.
- `VLLM_V0251_SOURCE_ROOT=/data/users/xiaojie.yuan/vllm .venv/bin/python -m pytest tests/runtime_patch/test_offline_eplb.py tests/patch/test_worker_dispatcher.py -q`: 23 passed, 10 failed during vLLM imports because NumPy was missing from the CPU test environment.
- `git diff --check`: passed.
- Ruff check and format check report existing issues in these files. Comparing Ruff diagnostics against the unmodified base found no new lint diagnostics. No HCU/multi-rank runtime validation was performed.

Duplicate-work check: inspected #61 and the open PR searches for `61 in:body`, `eplb`, `static`, and `offline`, including #34 and #62. Those PRs provide the underlying HY V4/EPLB integration; none addresses these static-map lifecycle fixes. This PR adds only the fixes on top of #62's branch.

AI assistance: Codex assisted with implementation, review, testing, and PR preparation. Human review and relevant hardware validation remain necessary before merge.
