### PR TITLE
feat: remove HY4 DEEPEP-LL bubbles

### DIFF
--- a/tests/runtime_patch/test_worker_framework_opt.py
+++ b/tests/runtime_patch/test_worker_framework_opt.py
@@ -27,9 +27,11 @@ from vllm_hcu.patch.worker.framework_opt import (
     patch_base_device_communicator,
     patch_cuda_communicator,
     patch_dp_utils,
+    patch_draft_speculator_inputs,
     patch_eagle_utils,
     patch_eplb_communicator,
     patch_forward_context,
+    patch_gpu_dp_utils,
     patch_gpu_ubatch_wrapper,
     patch_llm_base_proposer,
     patch_pynccl,
@@ -1258,6 +1260,78 @@ def test_dp_coordination_deepep_low_latency_and_feature_off_delegation():
     assert calls == [(4, normal)]
 
 
+def test_gpu_dp_cg_padding_sync_skip_for_deepep_low_latency():
+    calls: list[object] = []
+
+    def sync_cudagraph_and_dp_padding(
+        cudagraph_manager,
+        desired_batch_desc,
+        num_tokens,
+        num_reqs,
+        uniform_token_count,
+        dp_size,
+        dp_rank,
+        num_active_loras=0,
+    ):
+        calls.append(desired_batch_desc)
+        return "synced", "tokens"
+
+    module = _module(
+        patch_gpu_dp_utils.TARGET_MODULE,
+        sync_cudagraph_and_dp_padding=sync_cudagraph_and_dp_padding,
+    )
+    patch_gpu_dp_utils.bind_skip_cross_dp_cg_sync(enabled=True)
+    try:
+        assert patch_gpu_dp_utils.apply_to_module(module) is True
+        assert patch_gpu_dp_utils.apply_to_module(module) is False
+        assert module.sync_cudagraph_and_dp_padding(
+            None, "local_desc", 4, 2, None, 32, 0
+        ) == ("local_desc", None)
+        assert calls == []
+        patch_gpu_dp_utils.bind_skip_cross_dp_cg_sync(enabled=False)
+        assert module.sync_cudagraph_and_dp_padding(
+            None, "local_desc", 4, 2, None, 32, 0
+        ) == ("synced", "tokens")
+        assert calls == ["local_desc"]
+    finally:
+        patch_gpu_dp_utils.bind_skip_cross_dp_cg_sync(enabled=False)
+
+
+def test_draft_speculator_temperature_seeds_zero_copy():
+    class _IdxMapping:
+        def __getitem__(self, key):
+            return self
+
+        def copy_(self, other):
+            self.copied = other
+
+        def fill_(self, value):
+            self.filled = value
+
+    class DraftModelSpeculator:
+        def __init__(self):
+            self.temperature = SimpleNamespace(name="buf_t")
+            self.seeds = SimpleNamespace(name="buf_s")
+            self.idx_mapping = _IdxMapping()
+            self.draft_logits = None
+
+        def _copy_request_inputs(self, num_reqs, idx_mapping, temperature, seeds):
+            raise AssertionError("original should be wrapped")
+
+    module = _module(patch_draft_speculator_inputs.TARGET_MODULE)
+    module.DraftModelSpeculator = DraftModelSpeculator
+    assert patch_draft_speculator_inputs.apply_to_module(module) is True
+    assert patch_draft_speculator_inputs.apply_to_module(module) is False
+    obj = DraftModelSpeculator()
+    temperature = SimpleNamespace(name="caller_t")
+    seeds = SimpleNamespace(name="caller_s")
+    idx = object()
+    obj._copy_request_inputs(2, idx, temperature, seeds)
+    assert obj.temperature is temperature
+    assert obj.seeds is seeds
+    assert obj.idx_mapping.copied is idx
+
+
 class _Buffer:
     def __init__(self, size, **kwargs):
         self.size = size
@@ -1899,14 +1973,16 @@ assert target_file.is_relative_to(target_root), (
 print('VLLM_SOURCE', vllm.__file__)
 from vllm_hcu.patch.worker.framework_opt import (
     patch_all2all, patch_base_device_communicator, patch_cuda_communicator,
-    patch_dp_utils, patch_eagle_utils, patch_eplb_communicator,
-    patch_forward_context,
+    patch_dp_utils, patch_draft_speculator_inputs, patch_eagle_utils,
+    patch_eplb_communicator,
+    patch_forward_context, patch_gpu_dp_utils,
     patch_gpu_ubatch_wrapper, patch_llm_base_proposer, patch_pynccl,
     patch_pynccl_wrapper, patch_ubatch_utils,
 )
 adapters = (
     patch_all2all, patch_base_device_communicator, patch_forward_context,
-    patch_llm_base_proposer, patch_dp_utils, patch_eagle_utils,
+    patch_llm_base_proposer, patch_dp_utils, patch_gpu_dp_utils,
+    patch_draft_speculator_inputs, patch_eagle_utils,
     patch_eplb_communicator,
     patch_gpu_ubatch_wrapper, patch_ubatch_utils,
 )

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -323,6 +323,10 @@ _FRAMEWORK_CALLBACKS: tuple[_CallbackSpec, ...] = (
         feature="deepep_low_latency",
     ),
     _CallbackSpec(
+        _adapter("framework_opt", "patch_gpu_dp_utils"),
+        feature="deepep_low_latency",
+    ),
+    _CallbackSpec(
         _adapter("framework_opt", "patch_forward_context"),
         feature="forward_context",
     ),
@@ -347,6 +351,9 @@ _FRAMEWORK_CALLBACKS: tuple[_CallbackSpec, ...] = (
     _CallbackSpec(
         _adapter("framework_opt", "patch_eagle_utils"),
         feature="multi_layers_mtp",
+    ),
+    _CallbackSpec(
+        _adapter("framework_opt", "patch_draft_speculator_inputs"),
     ),
     _CallbackSpec(_adapter("framework_opt", "patch_gpu_ubatch_wrapper")),
     _CallbackSpec(_adapter("framework_opt", "patch_ubatch_utils")),
@@ -810,6 +817,14 @@ def apply_worker_patches(vllm_config: object | None = None) -> None:
         states = _feature_states(vllm_config, config)
         for patch_id, feature in _patch_features().items():
             IMPORT_COORDINATOR.set_feature_enabled(patch_id, states[feature])
+        from vllm_hcu.patch.worker.framework_opt import patch_gpu_dp_utils
+
+        patch_gpu_dp_utils.bind_skip_cross_dp_cg_sync(
+            enabled=(
+                _parallel_backend(vllm_config) == "deepep_low_latency"
+                and not config.deepep_auto
+            )
+        )
         _raise_latched_or_required_failures(IMPORT_COORDINATOR)
 
 

--- a/vllm_hcu/patch/worker/framework_opt/patch_draft_speculator_inputs.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_draft_speculator_inputs.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Avoid per-step H2D by reusing caller temperature/seeds buffers."""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+from ._common import (
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_exact_signature,
+)
+
+TARGET_MODULE = "vllm.v1.worker.gpu.spec_decode.speculator"
+PATCH_ID = "worker.framework_opt.spec_decode.draft_input_zero_copy"
+TARGETS = (f"{TARGET_MODULE}.DraftModelSpeculator._copy_request_inputs",)
+_MARKER = "_vllm_hcu_draft_input_zero_copy_applied"
+_WRAPPER = "_vllm_hcu_draft_input_zero_copy_wrapper"
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    spec = load_exact_module(TARGET_MODULE, module)
+    cls = require_class(
+        spec, "DraftModelSpeculator", f"{TARGET_MODULE}.DraftModelSpeculator"
+    )
+    wrapped = ((cls, "_copy_request_inputs", TARGETS[0], _WRAPPER),)
+    if already_applied(spec, _MARKER, wrapped):
+        return False
+    original = require_callable(cls, "_copy_request_inputs", TARGETS[0])
+    require_exact_signature(
+        original,
+        TARGETS[0],
+        positional=("self", "num_reqs", "idx_mapping", "temperature", "seeds"),
+    )
+
+    @functools.wraps(original)
+    def hcu_copy_request_inputs(self, num_reqs, idx_mapping, temperature, seeds):
+        # Alias caller buffers (often UVA views) instead of H2D copy_.
+        # idx_mapping still copied into the fixed CG-padded buffer.
+        self.temperature = temperature
+        self.seeds = seeds
+        self.idx_mapping[:num_reqs].copy_(idx_mapping)
+        if self.draft_logits is not None:
+            self.idx_mapping[num_reqs:].fill_(-1)
+
+    setattr(hcu_copy_request_inputs, _WRAPPER, True)
+    setattr(cls, "_vllm_hcu_original_copy_request_inputs", original)
+    setattr(cls, "_copy_request_inputs", hcu_copy_request_inputs)
+    setattr(spec, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/worker/framework_opt/patch_gpu_dp_utils.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_gpu_dp_utils.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Skip MRV2 cross-DP CG padding gloo allreduce for DeepEP-LL."""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+from ._common import already_applied, load_exact_module, require_callable, require_exact_signature
+
+TARGET_MODULE = "vllm.v1.worker.gpu.dp_utils"
+PATCH_ID = "worker.framework_opt.dp.gpu_deepep_low_latency"
+TARGETS = (f"{TARGET_MODULE}.sync_cudagraph_and_dp_padding",)
+_MARKER = "_vllm_hcu_gpu_dp_low_latency_applied"
+_WRAPPER = "_vllm_hcu_gpu_dp_low_latency_wrapper"
+
+# Set by apply_worker_patches (explicit deepep_low_latency, not deepep_auto).
+_SKIP = False
+
+
+def bind_skip_cross_dp_cg_sync(*, enabled: bool) -> None:
+    global _SKIP
+    _SKIP = bool(enabled)
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    dp = load_exact_module(TARGET_MODULE, module)
+    wrapped = ((dp, "sync_cudagraph_and_dp_padding", TARGETS[0], _WRAPPER),)
+    if already_applied(dp, _MARKER, wrapped):
+        return False
+    original = require_callable(dp, "sync_cudagraph_and_dp_padding", TARGETS[0])
+    require_exact_signature(
+        original,
+        TARGETS[0],
+        positional=(
+            "cudagraph_manager",
+            "desired_batch_desc",
+            "num_tokens",
+            "num_reqs",
+            "uniform_token_count",
+            "dp_size",
+            "dp_rank",
+            "num_active_loras",
+        ),
+        defaults={"num_active_loras": 0},
+    )
+
+    @functools.wraps(original)
+    def hcu_sync(
+        cudagraph_manager,
+        desired_batch_desc,
+        num_tokens,
+        num_reqs,
+        uniform_token_count,
+        dp_size,
+        dp_rank,
+        num_active_loras=0,
+    ):
+        if _SKIP:
+            return desired_batch_desc, None
+        return original(
+            cudagraph_manager,
+            desired_batch_desc,
+            num_tokens,
+            num_reqs,
+            uniform_token_count,
+            dp_size,
+            dp_rank,
+            num_active_loras=num_active_loras,
+        )
+
+    setattr(hcu_sync, _WRAPPER, True)
+    setattr(dp, "_vllm_hcu_original_sync_cudagraph_and_dp_padding", original)
+    setattr(dp, "sync_cudagraph_and_dp_padding", hcu_sync)
+    setattr(dp, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = [
+    "PATCH_ID",
+    "TARGET_MODULE",
+    "TARGETS",
+    "apply",
+    "apply_to_module",
+    "bind_skip_cross_dp_cg_sync",
+]


### PR DESCRIPTION
# 1 介绍
- 通过删除dp间的cudagraph padding的gloo:all_reduce通信，消除hy4 ep ll的空泡，
# 2 命令
```bash

rm -rf ~/.cache
rm -rf ~/.triton


export VLLM_HOST_IP=10.243.2.5
export VLLM_TORCH_PROFILER_DIR=/volume/vllm_profile
export ALLREDUCE_STREAM_WITH_COMPUTE=1
export NCCL_MIN_NCHANNELS=16
export NCCL_MAX_NCHANNELS=16
export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
export ROCSHMEM_IPC_MNVL=1
export VLLM_DEEPEP_BUFFER_SIZE_MB=0
export ROCSHMEM_HEAP_SIZE=9000000000

VLLM_USE_V2_MODEL_RUNNER=1 \
vllm serve /model_copy/Hy4-preview-Channel-FP8-w8a8-v2 \
    --tensor-parallel-size 1 \
    --data-parallel-size 32 \
    --enable-expert-parallel \
    --all2all-backend deepep_low_latency \
    --moe-backend deep_gemm \
    --no-enable-prefix-caching \
    --data-parallel-size-local 16 \
    --data-parallel-address 10.243.1.5 \
    --data-parallel-rpc-port 1127 \
    --data-parallel-start-rank 0 \
    --speculative-config '{"method":"mtp","num_speculative_tokens":3,"rejection_sample_method":"standard"}' \
    --gpu-memory-utilization 0.90 \
    --max-model-len 65536 \
    --max-num-seqs 700 \
    --max-num-batched-tokens 700 \
    --default-chat-template-kwargs '{"reasoning_effort":"no_think"}' \
    --api-server-count 1 \
    --reasoning-parser hy_v4 \
    --enable-auto-tool-choice \
    --tool-call-parser hy_v4 \
    --compilation-config.max_cudagraph_capture_size 16 \
    --compilation_config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
    --profiler-config '{"profiler": "torch", "torch_profiler_dir": "/volume/vllm_profile","torch_profiler_with_memory":false,"torch_profiler_with_stack":true}' \
    2>&1 | tee /volume/hy4_project/logs/tmp-Hy4-preview-Channel-FP8-w8a8-v2-dp32ep32-rank0.log

```


# 3 精度
<img width="1240" height="547" alt="image" src="https://github.com/user-attachments/assets/79fb76fa-7166-4038-abef-178a5863d540" />
