### PR TITLE
feat(hcu): port v0.21 GDN and FLA kernel routes to v0.25.1

### DIFF
--- a/.github/workflows/configs/hcu-test-map.yaml
+++ b/.github/workflows/configs/hcu-test-map.yaml
@@ -224,7 +224,7 @@
       "suite": "model",
       "pytest_args": [
         "-k",
-        "qwen35_35b_a3b_tp_ep_smoke"
+        "qwen35_35b_a3b_tp_ep_smoke or qwen35_35b_a3b_tp2_ep2_mtp3_full_decode_graph_aiter_auto_shuffle"
       ],
       "timeout_minutes": 240,
       "requirements": [
@@ -554,6 +554,14 @@
         "qwen35-graph"
       ]
     },
+    "qwen35-mtp3-graph": {
+      "patterns": [
+        "tests/integration/graph/test_qwen35_35b_a3b_mtp3_graph_parity.py"
+      ],
+      "jobs": [
+        "qwen35-tp-ep"
+      ]
+    },
     "engine-features": {
       "patterns": [
         "vllm_hcu/**cache*",
@@ -660,6 +668,7 @@
       ],
       "jobs": [
         "qwen35-smoke",
+        "qwen35-tp-ep",
         "qwen25-models",
         "qwen3-pooling",
         "mamba-smoke",

--- a/docs/superpowers/plans/2026-09-06-port-v021-kernel-mrs-to-v0251.md
+++ b/docs/superpowers/plans/2026-09-06-port-v021-kernel-mrs-to-v0251.md
@@ -1176,6 +1176,38 @@ newest Qwen log under `/tmp/vllm-hcu-integration/logs/` and fail the task if it
 contains a patch compatibility error, optional-import traceback, or kernel
 launch exception.
 
+- [ ] **Step 4a: Run the targeted Qwen3.5 TP2/EP2 MTP3 graph parity case**
+
+Run the single targeted test with all five routing switches and the master
+custom-op switch unset so their default-enabled contract is exercised. The
+test itself clears these six variables before launching the child, so direct
+pytest invocations also exercise defaults regardless of the caller environment:
+
+```bash
+env -u VLLM_HCU_USE_CUSTOM_OPS \
+    -u VLLM_HCU_USE_CUSTOM_AITER_FLA \
+    -u VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE \
+    -u VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP \
+    -u VLLM_HCU_USE_CHUNK_FWD_KERNEL_O \
+    -u VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D \
+    VLLM_HCU_QWEN35_35B_A3B_MODEL=/models/Qwen3.5-35B-A3B \
+    pytest -q -s \
+      tests/integration/graph/test_qwen35_35b_a3b_mtp3_graph_parity.py
+```
+
+Expected: eager+MTP3 and graph+MTP3 each complete two identical 16-token
+greedy generations. Acceptance requires exact token-ID parity plus present,
+finite cumulative logprobs and logprobs for all 16 output positions. It does
+not require numerical logprob parity: eager and graph execution may differ
+in floating-point reduction rounding without changing greedy token choices.
+Both workers report the master switch and all five routing switches resolved to
+`True` through `vllm_hcu.platforms.envs`, and MTP with three speculative tokens;
+the graph workers resolve `decode_mode=FULL`, retain non-empty capture sizes,
+and report a positive capture count. Generation logs must contain positive
+MTP draft counts and positive FULL runtime counts. This proves FULL decode
+replay for the model path; it does not claim that the FLA prefill-only chunk
+H/O kernels are captured by `FULL_DECODE_ONLY`.
+
 - [ ] **Step 5: Review the requirement-to-evidence mapping**
 
 Check each spec section against the committed diff and record:

--- a/docs/superpowers/plans/2026-09-06-port-v021-kernel-mrs-to-v0251.md
+++ b/docs/superpowers/plans/2026-09-06-port-v021-kernel-mrs-to-v0251.md
@@ -1,0 +1,1293 @@
+# Port v0.21 Kernel MRs to v0.25.1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the four v0.21 HCU kernel-routing MRs to the v0.25.1 sidecar plugin with default-on selectors, deterministic fallbacks, real-model validation, and a reviewed pull request.
+
+**Architecture:** Extend the existing exact post-import adapters instead of copying v0.21 source-replacement patches. Each wrapper remains scoped to its audited vLLM 0.25.1 module, selects optional HCU kernels in a fixed priority order, and calls the original target function when a selector, dependency, or supported-call contract does not apply.
+
+**Tech Stack:** Python 3.10, PyTorch/HIP, vLLM 0.25.1, vLLM-HCU callback adapters, AITER HIP/Triton kernels, `causal_conv1d`, pytest, GitHub CLI/API.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-port-v021-kernel-mrs-to-v0251-design.md`
+
+## Global Constraints
+
+- Base every code commit on `origin/v0.25.1` commit `88f8a07` or its reviewed descendants already present on this branch.
+- Change only `HYGON-AI/vllm-plugin-das`; do not modify either vLLM source checkout, AITER, `causal_conv1d`, or model files.
+- Preserve exact vLLM 0.25.1 signature checks, callback idempotence, Qwen-local GDN ownership, and canonical-module isolation.
+- Default every new Boolean selector to enabled; explicit `0` and `false` disable it.
+- Catch optional-import failure only. Once a kernel is selected, propagate its runtime, shape, dtype, and launch errors.
+- Run portable tests with `VLLM_V0251_SOURCE_ROOT=/models/vllm_0251` and `VLLM_PLUGINS=__disabled__`.
+- Validate `/models/Qwen3.5-35B-A3B` with all new selectors absent from the environment.
+- Use commit author `alexanderbin123 <1414695739@qq.com>` and never store access tokens in files, remotes, commits, test output, or PR text.
+
+---
+
+### Task 1: Add default-on environment contracts
+
+**Files:**
+
+- Modify: `tests/accuracy/test_environment_routing.py`
+- Modify: `vllm_hcu/platforms/envs.py:11-68`
+- Modify: `vllm_hcu/platforms/envs.py:224-236`
+
+**Interfaces:**
+
+- Consumes: lazy module-level resolution through `vllm_hcu.platforms.envs.__getattr__(name)`.
+- Produces: Boolean attributes `VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE`, `VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP`, and `VLLM_HCU_USE_CHUNK_FWD_KERNEL_O`.
+
+- [ ] **Step 1: Write failing default and opt-out tests**
+
+Add these tests after `test_boolean_environment_values_are_lazily_parsed`:
+
+```python
+MIGRATED_KERNEL_FLAGS = (
+    "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE",
+    "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP",
+    "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O",
+)
+
+
+@pytest.mark.parametrize("name", MIGRATED_KERNEL_FLAGS)
+def test_migrated_kernel_flags_default_on(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+) -> None:
+    monkeypatch.delenv(name, raising=False)
+    assert getattr(hcu_envs, name) is True
+    assert hcu_envs.is_set(name) is False
+
+
+@pytest.mark.parametrize("name", MIGRATED_KERNEL_FLAGS)
+@pytest.mark.parametrize("value", ["0", "false", "FALSE"])
+def test_migrated_kernel_flags_allow_explicit_opt_out(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    value: str,
+) -> None:
+    monkeypatch.setenv(name, value)
+    assert getattr(hcu_envs, name) is False
+    assert hcu_envs.is_set(name) is True
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+PYTHONPATH=/models/vllm_0251:$PWD \
+VLLM_PLUGINS=__disabled__ \
+pytest -q tests/accuracy/test_environment_routing.py \
+  -k migrated_kernel_flags
+```
+
+Expected: collection succeeds and each case fails with `AttributeError` because
+the new environment names are not registered.
+
+- [ ] **Step 3: Register the three lazy environment variables**
+
+Add `bool = True` annotations inside `TYPE_CHECKING`, then add these entries
+beside the existing FLA and causal-convolution switches:
+
+```python
+    "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP":
+    lambda: _environment_flag(os.environ.get(
+        "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP", "True"
+    )),
+    "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O":
+    lambda: _environment_flag(os.environ.get(
+        "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", "True"
+    )),
+    "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE":
+    lambda: _environment_flag(os.environ.get(
+        "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE", "True"
+    )),
+```
+
+- [ ] **Step 4: Run the environment tests and verify GREEN**
+
+Run the command from Step 2, then run:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+PYTHONPATH=/models/vllm_0251:$PWD \
+VLLM_PLUGINS=__disabled__ \
+pytest -q tests/accuracy/test_environment_routing.py
+```
+
+Expected: all environment-routing tests pass.
+
+- [ ] **Step 5: Commit the environment contract**
+
+```bash
+git add vllm_hcu/platforms/envs.py tests/accuracy/test_environment_routing.py
+git diff --cached --check
+git commit -m "feat(hcu): add default-on kernel routing flags"
+```
+
+---
+
+### Task 2: Add HIP-first `chunk_delta_h` routing
+
+**Files:**
+
+- Modify: `tests/runtime_patch/test_attention_mla_fla_mamba.py:940-980`
+- Modify: `vllm_hcu/patch/worker/op_opt/patch_fla_chunk_delta_h.py:19-89`
+
+**Interfaces:**
+
+- Consumes: the Task 1 flag `VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP`, existing `VLLM_HCU_USE_CUSTOM_AITER_FLA`, and existing `VLLM_HCU_USE_CUSTOM_OPS`.
+- Produces: wrapper `hcu_chunk_delta_h(k, w, u, g=None, gk=None, initial_state=None, output_final_state=False, chunk_size=FLA_CHUNK_SIZE, save_new_value=True, cu_seqlens=None, chunk_indices=None, chunk_offsets=None, use_exp2=False)` with HIP → AITER Triton → original routing.
+
+- [ ] **Step 1: Replace the obsolete missing-import assertion with routing tests**
+
+Use `_install_fake_module` to install both optional modules. Record calls from
+the following fake HIP function and assert it receives the caller's values:
+
+```python
+def hip(k, w, u, g=None, gk=None, initial_state=None,
+        initial_state_indices=None, output_final_state=True,
+        chunk_size=64, save_new_value=True, cu_seqlens=None,
+        chunk_indices=None, chunk_offsets=None, use_exp2=False,
+        transpose_state_layout=True, kernel_cfg=None):
+    calls.append(("hip", chunk_size, output_final_state, save_new_value,
+                  cu_seqlens, chunk_indices, chunk_offsets,
+                  transpose_state_layout, kernel_cfg))
+    return "hip-h", "hip-v", "hip-final"
+```
+
+Cover the three tiers with this helper and tests:
+
+```python
+def _chunk_delta_module(adapter, original):
+    return _module(
+        adapter.TARGET_MODULE,
+        FLA_CHUNK_SIZE=64,
+        chunk_gated_delta_rule_fwd_h=original,
+        prepare_chunk_indices=lambda seq, size: torch.tensor([[0, 0]]),
+        prepare_chunk_offsets=lambda seq, size: torch.tensor([0]),
+        triton=SimpleNamespace(cdiv=lambda value, divisor: (value + divisor - 1) // divisor),
+        torch=torch,
+    )
+
+
+def _chunk_delta_original(k, w, u, g=None, gk=None, initial_state=None,
+                          output_final_state=False, chunk_size=64,
+                          save_new_value=True, cu_seqlens=None,
+                          chunk_indices=None, chunk_offsets=None,
+                          use_exp2=False):
+    return "original-h", "original-v", "original-final"
+
+
+def test_fla_chunk_delta_h_prefers_hip_and_preserves_metadata(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_delta_h")
+    calls = []
+
+    def hip(k, w, u, g=None, gk=None, initial_state=None,
+            initial_state_indices=None, output_final_state=True,
+            chunk_size=64, save_new_value=True, cu_seqlens=None,
+            chunk_indices=None, chunk_offsets=None, use_exp2=False,
+            transpose_state_layout=True, kernel_cfg=None):
+        calls.append((chunk_size, output_final_state, save_new_value,
+                      cu_seqlens, chunk_indices, chunk_offsets,
+                      use_exp2, transpose_state_layout, kernel_cfg))
+        return "hip-h", "hip-v", "hip-final"
+
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.fla",
+        chunk_gated_delta_rule_fwd_vllm_hip_blockdim64=hip,
+    )
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.vllm.chunk_delta_h",
+        launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64=lambda **kwargs: pytest.fail(
+            "HIP must have priority"
+        ),
+    )
+    module = _chunk_delta_module(adapter, _chunk_delta_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(
+        henvs, "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP", True
+    )
+    cu_seqlens = torch.tensor([0, 2])
+    result = module.chunk_gated_delta_rule_fwd_h(
+        torch.zeros(1, 2, 1, 4),
+        torch.zeros(1, 2, 1, 4),
+        torch.zeros(1, 2, 1, 4),
+        output_final_state=True,
+        chunk_size=32,
+        save_new_value=False,
+        cu_seqlens=cu_seqlens,
+        use_exp2=True,
+    )
+    assert result == ("hip-h", "hip-v", "hip-final")
+    assert calls[0][0:3] == (32, True, False)
+    assert calls[0][3] is cu_seqlens
+    assert calls[0][6:] == (True, True, None)
+
+
+def test_fla_chunk_delta_h_uses_aiter_triton_when_hip_is_unavailable(
+    monkeypatch,
+):
+    adapter = _adapter("patch_fla_chunk_delta_h")
+    calls = []
+    _install_fake_module(monkeypatch, "aiter.ops.fla")
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.vllm.chunk_delta_h",
+        launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64=(
+            lambda **kwargs: calls.append(kwargs)
+        ),
+    )
+    module = _chunk_delta_module(adapter, _chunk_delta_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(
+        henvs, "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP", True
+    )
+    module.chunk_gated_delta_rule_fwd_h(
+        torch.zeros(1, 2, 1, 4),
+        torch.zeros(1, 2, 1, 4),
+        torch.zeros(1, 2, 1, 4),
+        chunk_size=32,
+        use_exp2=True,
+    )
+    assert calls[0]["BT"] == 32
+    assert calls[0]["use_exp2"] is True
+    assert calls[0]["transpose_state_layout"] is True
+
+
+def test_fla_chunk_delta_h_uses_original_when_optional_aiter_is_unavailable(
+    monkeypatch,
+):
+    adapter = _adapter("patch_fla_chunk_delta_h")
+    _install_fake_module(monkeypatch, "aiter.ops.fla")
+    _install_fake_module(monkeypatch, "aiter.ops.triton.fla.vllm.chunk_delta_h")
+    module = _chunk_delta_module(adapter, _chunk_delta_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(
+        henvs, "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP", True
+    )
+    assert module.chunk_gated_delta_rule_fwd_h(
+        torch.zeros(1, 2, 1, 4),
+        torch.zeros(1, 2, 1, 4),
+        torch.zeros(1, 2, 1, 4),
+    ) == ("original-h", "original-v", "original-final")
+
+
+def test_fla_chunk_delta_h_propagates_selected_hip_runtime_error(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_delta_h")
+
+    def failing_hip(*args, **kwargs):
+        raise RuntimeError("hip delta launch failed")
+
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.fla",
+        chunk_gated_delta_rule_fwd_vllm_hip_blockdim64=failing_hip,
+    )
+    module = _chunk_delta_module(adapter, _chunk_delta_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(
+        henvs, "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP", True
+    )
+    with pytest.raises(RuntimeError, match="hip delta launch failed"):
+        module.chunk_gated_delta_rule_fwd_h(
+            torch.zeros(1, 2, 1, 4),
+            torch.zeros(1, 2, 1, 4),
+            torch.zeros(1, 2, 1, 4),
+        )
+```
+
+- [ ] **Step 2: Run the four tests and verify RED**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+PYTHONPATH=/models/vllm_0251:$PWD \
+VLLM_PLUGINS=__disabled__ \
+pytest -q tests/runtime_patch/test_attention_mla_fla_mamba.py \
+  -k 'fla_chunk_delta_h'
+```
+
+Expected: HIP-priority and original-fallback assertions fail; the current
+adapter knows only the AITER Triton route and raises when it is absent.
+
+- [ ] **Step 3: Implement deterministic three-tier routing**
+
+Keep the exact target-signature check. Inside the wrapper, prepare sequence
+indices and offsets once, then select the HIP callable only when all three
+flags are true:
+
+```python
+def _hip_enabled() -> bool:
+    from vllm_hcu.platforms import envs as henvs
+    return bool(
+        henvs.VLLM_HCU_USE_CUSTOM_OPS
+        and henvs.VLLM_HCU_USE_CUSTOM_AITER_FLA
+        and henvs.VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP
+    )
+```
+
+Resolve optional imports with independent `try/except ImportError` blocks.
+When the HIP callable exists, call it with:
+
+```python
+return hip_kernel(
+    k, w, u, g=g, gk=gk, initial_state=initial_state,
+    initial_state_indices=None, output_final_state=output_final_state,
+    chunk_size=chunk_size, save_new_value=save_new_value,
+    cu_seqlens=cu_seqlens, chunk_indices=chunk_indices,
+    chunk_offsets=chunk_offsets, use_exp2=use_exp2,
+    transpose_state_layout=True, kernel_cfg=None,
+)
+```
+
+If HIP is unavailable, retain the current AITER Triton allocation and launch
+when `_enabled()` is true. If that import is absent, invoke `original` with
+all thirteen original arguments instead of raising a synthetic error.
+
+- [ ] **Step 4: Run focused and shared FLA tests and verify GREEN**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+PYTHONPATH=/models/vllm_0251:$PWD \
+VLLM_PLUGINS=__disabled__ \
+pytest -q tests/runtime_patch/test_attention_mla_fla_mamba.py \
+  -k 'fla_chunk_delta_h or fla_chunk_o'
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit the state-update router**
+
+```bash
+git add vllm_hcu/patch/worker/op_opt/patch_fla_chunk_delta_h.py \
+  tests/runtime_patch/test_attention_mla_fla_mamba.py
+git diff --cached --check
+git commit -m "feat(hcu): prefer HIP gated-delta state kernel"
+```
+
+---
+
+### Task 3: Add HIP-first `chunk_o` routing
+
+**Files:**
+
+- Modify: `tests/runtime_patch/test_attention_mla_fla_mamba.py:910-940`
+- Modify: `vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py:19-68`
+
+**Interfaces:**
+
+- Consumes: the Task 1 flag `VLLM_HCU_USE_CHUNK_FWD_KERNEL_O`, existing `VLLM_HCU_USE_CUSTOM_AITER_FLA`, and existing `VLLM_HCU_USE_CUSTOM_OPS`.
+- Produces: wrapper `hcu_chunk_o(q, k, v, h, g=None, scale=None, cu_seqlens=None, chunk_indices=None, chunk_size=FLA_CHUNK_SIZE, core_attn_out=None)` with HIP → AITER Triton → original routing and output-buffer preservation.
+
+- [ ] **Step 1: Add HIP priority, fallback, and output-buffer tests**
+
+Add this helper and the five tests; the output-buffer assertion uses real CPU
+tensors:
+
+```python
+def _chunk_o_module(adapter, original):
+    return _module(
+        adapter.TARGET_MODULE,
+        FLA_CHUNK_SIZE=64,
+        chunk_fwd_o=original,
+        prepare_chunk_indices=lambda seq, size: torch.tensor([[0, 0]]),
+        triton=SimpleNamespace(cdiv=lambda value, divisor: (value + divisor - 1) // divisor),
+        torch=torch,
+    )
+
+
+def _chunk_o_original(q, k, v, h, g=None, scale=None, cu_seqlens=None,
+                      chunk_indices=None, chunk_size=64,
+                      core_attn_out=None):
+    return "original-output"
+
+
+def test_fla_chunk_o_prefers_hip_and_preserves_call_contract(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_o")
+    calls = []
+
+    def hip(**kwargs):
+        calls.append(kwargs)
+        return torch.ones_like(kwargs["v"])
+
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.fla",
+        chunk_fwd_o_vllm_hip_blockdim64=hip,
+    )
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.vllm.chunk_o",
+        launch_chunk_fwd_kernel_o=lambda **kwargs: pytest.fail(
+            "HIP must have priority"
+        ),
+    )
+    module = _chunk_o_module(adapter, _chunk_o_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", True)
+    cu_seqlens = torch.tensor([0, 2])
+    indices = torch.tensor([[0, 0]])
+    tensor = torch.zeros(1, 2, 1, 4)
+    module.chunk_fwd_o(
+        tensor, tensor, tensor, tensor, scale=0.25,
+        cu_seqlens=cu_seqlens, chunk_indices=indices, chunk_size=32,
+    )
+    assert calls[0]["scale"] == 0.25
+    assert calls[0]["cu_seqlens"] is cu_seqlens
+    assert calls[0]["chunk_indices"] is indices
+    assert calls[0]["chunk_size"] == 32
+    assert calls[0]["transpose_state_layout"] is True
+
+
+def test_fla_chunk_o_copies_hip_result_into_core_output(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_o")
+    hip_result = torch.arange(8, dtype=torch.float32).reshape(1, 2, 1, 4)
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.fla",
+        chunk_fwd_o_vllm_hip_blockdim64=lambda **kwargs: hip_result,
+    )
+    module = _chunk_o_module(adapter, _chunk_o_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", True)
+    core = torch.full((16,), -1.0)
+    tensor = torch.zeros(1, 2, 1, 4)
+    result = module.chunk_fwd_o(
+        tensor, tensor, tensor, tensor, core_attn_out=core
+    )
+    assert result.data_ptr() == core.data_ptr()
+    torch.testing.assert_close(result, hip_result)
+
+
+def test_fla_chunk_o_uses_aiter_triton_when_hip_is_unavailable(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_o")
+    calls = []
+    _install_fake_module(monkeypatch, "aiter.ops.fla")
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.vllm.chunk_o",
+        launch_chunk_fwd_kernel_o=lambda **kwargs: calls.append(kwargs),
+    )
+    module = _chunk_o_module(adapter, _chunk_o_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", True)
+    tensor = torch.zeros(1, 2, 1, 4)
+    module.chunk_fwd_o(tensor, tensor, tensor, tensor, chunk_size=32)
+    assert calls[0]["BT"] == 32
+    assert calls[0]["transpose_state_layout"] is True
+
+
+def test_fla_chunk_o_uses_original_when_optional_aiter_is_unavailable(
+    monkeypatch,
+):
+    adapter = _adapter("patch_fla_chunk_o")
+    _install_fake_module(monkeypatch, "aiter.ops.fla")
+    _install_fake_module(monkeypatch, "aiter.ops.triton.fla.vllm.chunk_o")
+    module = _chunk_o_module(adapter, _chunk_o_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", True)
+    tensor = torch.zeros(1, 2, 1, 4)
+    assert module.chunk_fwd_o(tensor, tensor, tensor, tensor) == (
+        "original-output"
+    )
+
+
+def test_fla_chunk_o_propagates_selected_hip_runtime_error(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_o")
+
+    def failing_hip(**kwargs):
+        raise RuntimeError("hip output launch failed")
+
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.fla",
+        chunk_fwd_o_vllm_hip_blockdim64=failing_hip,
+    )
+    module = _chunk_o_module(adapter, _chunk_o_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", True)
+    tensor = torch.zeros(1, 2, 1, 4)
+    with pytest.raises(RuntimeError, match="hip output launch failed"):
+        module.chunk_fwd_o(tensor, tensor, tensor, tensor)
+```
+
+Keep the existing feature-off numeric test and explicitly disable both the
+HIP selector and `VLLM_HCU_USE_CUSTOM_AITER_FLA` in it.
+
+- [ ] **Step 2: Run the `chunk_o` tests and verify RED**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+PYTHONPATH=/models/vllm_0251:$PWD \
+VLLM_PLUGINS=__disabled__ \
+pytest -q tests/runtime_patch/test_attention_mla_fla_mamba.py \
+  -k 'fla_chunk_o'
+```
+
+Expected: HIP route and import-fallback tests fail against the current
+Triton-only implementation.
+
+- [ ] **Step 3: Implement output routing and buffer preservation**
+
+Add a HIP selector independent of the AITER-Triton selector:
+
+```python
+def _hip_enabled() -> bool:
+    from vllm_hcu.platforms import envs as henvs
+    return bool(
+        henvs.VLLM_HCU_USE_CUSTOM_OPS
+        and henvs.VLLM_HCU_USE_CHUNK_FWD_KERNEL_O
+    )
+```
+
+Import `chunk_fwd_o_vllm_hip_blockdim64` and
+`launch_chunk_fwd_kernel_o` independently. Call HIP with the exact caller
+metadata and `transpose_state_layout=True`. Preserve the buffer contract with:
+
+```python
+hip_output = hip_kernel(
+    q=q, k=k, v=v, h=h, g=g, g_gamma=None, scale=scale,
+    cu_seqlens=cu_seqlens, chunk_size=chunk_size,
+    chunk_indices=chunk_indices, use_exp2=False,
+    transpose_state_layout=True, kernel_cfg=None,
+)
+if core_attn_out is None:
+    return hip_output
+out.copy_(hip_output)
+return out
+```
+
+Retain the existing AITER Triton launch as tier two. If neither optional
+callable is selected, call the original target function with all ten original
+arguments.
+
+- [ ] **Step 4: Run all FLA adapter tests and verify GREEN**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+PYTHONPATH=/models/vllm_0251:$PWD \
+VLLM_PLUGINS=__disabled__ \
+pytest -q tests/runtime_patch/test_attention_mla_fla_mamba.py \
+  -k 'fla_chunk_o or fla_chunk_delta_h'
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit the output router**
+
+```bash
+git add vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py \
+  tests/runtime_patch/test_attention_mla_fla_mamba.py
+git diff --cached --check
+git commit -m "feat(hcu): prefer HIP gated-delta output kernel"
+```
+
+---
+
+### Task 4: Route compatible Qwen GDN convolution updates
+
+**Files:**
+
+- Modify: `tests/runtime_patch/test_gdn_v0251_ownership.py:280-380`
+- Modify: `tests/runtime_patch/test_attention_mla_fla_mamba.py:1120-1280`
+- Modify: `vllm_hcu/patch/worker/op_opt/patch_gdn_causal_conv1d.py:87-111`
+
+**Interfaces:**
+
+- Consumes: existing `VLLM_HCU_USE_CUSTOM_OPS`, `VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D`, `use_nn_layout()`, and the audited v0.25.1 `causal_conv1d_update` signature.
+- Produces: Qwen-local compatible-call router to `causal_conv1d.causal_conv1d_interface.causal_conv1d_update`; unsupported v0.25.1 calls and missing imports return through the original function.
+
+- [ ] **Step 1: Add external-route and unsupported-call tests**
+
+Install a fake external module using `_install_fake_module`. Its callable must
+expose the real seven-argument contract and record every value:
+
+```python
+def custom_update(x, conv_state, weight, bias=None, activation=None,
+                  cache_seqlens=None, conv_state_indices=None):
+    calls["custom"] = {
+        "x": x,
+        "conv_state": conv_state,
+        "weight": weight,
+        "bias": bias,
+        "activation": activation,
+        "cache_seqlens": cache_seqlens,
+        "conv_state_indices": conv_state_indices,
+    }
+    return "custom-update"
+```
+
+Add these tests. Existing ownership tests continue to prove that canonical
+and non-Qwen consumers are unchanged:
+
+```python
+def _causal_route_module(adapter, original_update):
+    original_update.__signature__ = inspect.signature(  # type: ignore[attr-defined]
+        _gdn_causal_conv1d_update
+    )
+    return _module(
+        adapter.TARGET_MODULE,
+        causal_conv1d_fn=_gdn_causal_conv1d_fn,
+        causal_conv1d_update=original_update,
+    )
+
+
+def test_qwen_causal_update_routes_compatible_decode_to_external(monkeypatch):
+    adapter = _adapter("patch_gdn_causal_conv1d")
+    calls = {}
+
+    def original(*args, **kwargs):
+        calls["original"] = (args, kwargs)
+        return "original-update"
+
+    def custom_update(x, conv_state, weight, bias=None, activation=None,
+                      cache_seqlens=None, conv_state_indices=None):
+        calls["custom"] = {
+            "x": x,
+            "conv_state": conv_state,
+            "weight": weight,
+            "bias": bias,
+            "activation": activation,
+            "cache_seqlens": cache_seqlens,
+            "conv_state_indices": conv_state_indices,
+        }
+        return "custom-update"
+
+    _install_fake_module(
+        monkeypatch,
+        "causal_conv1d.causal_conv1d_interface",
+        causal_conv1d_update=custom_update,
+    )
+    module = _causal_route_module(adapter, original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_USE_NN", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D", True)
+    x = torch.empty(2, 8)
+    state = torch.empty(1, 8, 3)
+    physical_weight = torch.arange(32, dtype=torch.float32).reshape(4, 8)
+    indices = torch.tensor([0, 1])
+    assert module.causal_conv1d_update(
+        x, state, physical_weight, activation="silu",
+        conv_state_indices=indices, validate_data=True,
+    ) == "custom-update"
+    assert "original" not in calls
+    torch.testing.assert_close(
+        calls["custom"]["weight"], physical_weight.T.contiguous()
+    )
+    assert calls["custom"]["conv_state_indices"] is indices
+
+
+def test_qwen_causal_update_falls_back_for_spec_metadata(monkeypatch):
+    adapter = _adapter("patch_gdn_causal_conv1d")
+    calls = []
+
+    def original(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "original-update"
+
+    _install_fake_module(
+        monkeypatch,
+        "causal_conv1d.causal_conv1d_interface",
+        causal_conv1d_update=lambda *args, **kwargs: pytest.fail(
+            "spec metadata is unsupported by the external kernel"
+        ),
+    )
+    module = _causal_route_module(adapter, original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_USE_NN", False)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D", True)
+    accepted = torch.tensor([1])
+    query_start = torch.tensor([0, 1])
+    result = module.causal_conv1d_update(
+        torch.empty(1, 8), torch.empty(1, 8, 3), torch.empty(8, 4),
+        num_accepted_tokens=accepted, query_start_loc=query_start,
+        max_query_len=1,
+    )
+    assert result == "original-update"
+    assert calls[0][1]["num_accepted_tokens"] is accepted
+    assert calls[0][1]["query_start_loc"] is query_start
+
+
+def test_qwen_causal_update_falls_back_when_external_module_is_missing(
+    monkeypatch,
+):
+    adapter = _adapter("patch_gdn_causal_conv1d")
+    calls = []
+
+    def original(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "original-update"
+
+    _install_fake_module(monkeypatch, "causal_conv1d.causal_conv1d_interface")
+    module = _causal_route_module(adapter, original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_USE_NN", False)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D", True)
+    assert module.causal_conv1d_update(
+        torch.empty(1, 8), torch.empty(1, 8, 3), torch.empty(8, 4)
+    ) == "original-update"
+    assert len(calls) == 1
+
+
+def test_qwen_causal_update_propagates_selected_kernel_error(monkeypatch):
+    adapter = _adapter("patch_gdn_causal_conv1d")
+
+    def original(*args, **kwargs):
+        return "original-update"
+
+    def failing_custom(*args, **kwargs):
+        raise RuntimeError("causal update launch failed")
+
+    _install_fake_module(
+        monkeypatch,
+        "causal_conv1d.causal_conv1d_interface",
+        causal_conv1d_update=failing_custom,
+    )
+    module = _causal_route_module(adapter, original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_USE_NN", False)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D", True)
+    with pytest.raises(RuntimeError, match="causal update launch failed"):
+        module.causal_conv1d_update(
+            torch.empty(1, 8), torch.empty(1, 8, 3), torch.empty(8, 4)
+        )
+```
+
+- [ ] **Step 2: Run the GDN causal tests and verify RED**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+PYTHONPATH=/models/vllm_0251:$PWD \
+VLLM_PLUGINS=__disabled__ \
+pytest -q tests/runtime_patch/test_gdn_v0251_ownership.py \
+  tests/runtime_patch/test_attention_mla_fla_mamba.py \
+  -k 'gdn and causal'
+```
+
+Expected: the compatible call returns the original sentinel because no
+external routing exists yet.
+
+- [ ] **Step 3: Implement contract-aware routing after layout normalization**
+
+Bind and apply defaults once per call. Normalize `weight` when NN layout is
+enabled, then decide whether the external API can preserve semantics:
+
+```python
+def _supports_external_update(arguments: dict[str, object]) -> bool:
+    return (
+        arguments["num_accepted_tokens"] is None
+        and arguments["query_start_loc"] is None
+        and arguments["max_query_len"] == -1
+        and arguments["null_block_id"] == 0
+        and arguments["block_idx_last_scheduled_token"] is None
+        and arguments["initial_state_idx"] is None
+    )
+```
+
+When both selectors are enabled and the call is supported, import the external
+callable. On `ImportError`, use the bound original call. Otherwise call:
+
+```python
+return custom_update(
+    bound.arguments["x"],
+    bound.arguments["conv_state"],
+    bound.arguments["weight"],
+    bound.arguments["bias"],
+    bound.arguments["activation"],
+    conv_state_indices=bound.arguments["conv_state_indices"],
+)
+```
+
+Never pass `validate_data` to the external API. Use `causal_update(*bound.args,
+**bound.kwargs)` for every fallback so NN-layout normalization remains active.
+
+- [ ] **Step 4: Run the full Qwen GDN ownership suites and verify GREEN**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+PYTHONPATH=/models/vllm_0251:$PWD \
+VLLM_PLUGINS=__disabled__ \
+pytest -q tests/runtime_patch/test_gdn_v0251_ownership.py \
+  tests/runtime_patch/test_attention_mla_fla_mamba.py -k gdn
+```
+
+Expected: all selected tests pass, including idempotence, signature rejection,
+and real v0.25.1 cold-import ownership.
+
+- [ ] **Step 5: Commit the causal-convolution router**
+
+```bash
+git add vllm_hcu/patch/worker/op_opt/patch_gdn_causal_conv1d.py \
+  tests/runtime_patch/test_gdn_v0251_ownership.py \
+  tests/runtime_patch/test_attention_mla_fla_mamba.py
+git diff --cached --check
+git commit -m "feat(hcu): route compatible Qwen GDN causal updates"
+```
+
+---
+
+### Task 5: Route Qwen GDN sigmoid-gating updates
+
+**Files:**
+
+- Modify: `tests/runtime_patch/test_gdn_v0251_ownership.py:280-470`
+- Modify: `tests/runtime_patch/test_attention_mla_fla_mamba.py:1270-1330`
+- Modify: `vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py:24-118`
+
+**Interfaces:**
+
+- Consumes: Task 1 flag `VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE`, existing `VLLM_HCU_USE_CUSTOM_OPS`, Qwen's module-local official sigmoid function, optional `aiter.vllm_fused_sigmoid_gating_delta_rule_update`, and optional AITER Triton sigmoid function.
+- Produces: Qwen-local sigmoid wrapper with compatible AITER HIP → AITER Triton → official routing while preserving the existing native fused-convolution NN-layout wrapper.
+
+- [ ] **Step 1: Replace retired-path assertions with selector tests**
+
+Retain the assertion that `fused_recurrent_gated_delta_rule_packed_decode`
+stays target-owned. Add these helpers and independent tests using CPU tensors:
+
+```python
+def _gdn_sigmoid_update(A_log, a, b, dt_bias, q, k, v, beta=1.0,
+                        threshold=20.0, scale=None, initial_state=None,
+                        inplace_final_state=True, cu_seqlens=None,
+                        ssm_state_indices=None, num_accepted_tokens=None,
+                        use_qk_l2norm_in_kernel=False, is_kda=False):
+    return "official-sigmoid"
+
+
+def _sigmoid_module(adapter, official=_gdn_sigmoid_update):
+    return _module(
+        adapter.TARGET_MODULE,
+        GDN_AITER_TRITON_AVAILABLE=False,
+        fused_recurrent_gated_delta_rule_packed_decode=(
+            lambda *args, **kwargs: "official-recurrent"
+        ),
+        fused_sigmoid_gating_delta_rule_update=official,
+    )
+
+
+def _sigmoid_arguments(dtype):
+    return {
+        "A_log": torch.zeros(1, dtype=torch.float32),
+        "a": torch.zeros(1, dtype=dtype),
+        "b": torch.zeros(1, dtype=dtype),
+        "dt_bias": torch.zeros(1, dtype=torch.float32),
+        "q": torch.zeros(1, dtype=dtype),
+        "k": torch.zeros(1, dtype=dtype),
+        "v": torch.zeros(1, dtype=dtype),
+    }
+
+
+def test_qwen_sigmoid_prefers_aiter_hip_for_matching_dtype(monkeypatch):
+    adapter = _adapter("patch_gdn_linear_attention")
+    _install_fake_module(
+        monkeypatch,
+        "aiter",
+        vllm_fused_sigmoid_gating_delta_rule_update=(
+            lambda *args, **kwargs: "hip-sigmoid"
+        ),
+    )
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.fused_sigmoid_gating",
+        fused_sigmoid_gating_delta_rule_update=lambda *args, **kwargs: pytest.fail(
+            "matching dtype must prefer HIP"
+        ),
+    )
+    module = _sigmoid_module(adapter)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE",
+        True,
+    )
+    assert module.fused_sigmoid_gating_delta_rule_update(
+        **_sigmoid_arguments(torch.float32)
+    ) == "hip-sigmoid"
+
+
+def test_qwen_sigmoid_uses_aiter_triton_for_mixed_a_log_dtype(monkeypatch):
+    adapter = _adapter("patch_gdn_linear_attention")
+    _install_fake_module(
+        monkeypatch,
+        "aiter",
+        vllm_fused_sigmoid_gating_delta_rule_update=lambda *args, **kwargs: pytest.fail(
+            "mixed A_log dtype must skip HIP"
+        ),
+    )
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.fused_sigmoid_gating",
+        fused_sigmoid_gating_delta_rule_update=(
+            lambda *args, **kwargs: "triton-sigmoid"
+        ),
+    )
+    module = _sigmoid_module(adapter)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE",
+        True,
+    )
+    assert module.fused_sigmoid_gating_delta_rule_update(
+        **_sigmoid_arguments(torch.bfloat16)
+    ) == "triton-sigmoid"
+
+
+@pytest.mark.parametrize("mode", ["disabled", "missing"])
+def test_qwen_sigmoid_uses_official_when_disabled_or_aiter_missing(
+    monkeypatch,
+    mode,
+):
+    adapter = _adapter("patch_gdn_linear_attention")
+    if mode == "disabled":
+        _install_fake_module(
+            monkeypatch,
+            "aiter",
+            vllm_fused_sigmoid_gating_delta_rule_update=(
+                lambda *args, **kwargs: pytest.fail("selector is disabled")
+            ),
+        )
+        _install_fake_module(
+            monkeypatch,
+            "aiter.ops.triton.fla.fused_sigmoid_gating",
+            fused_sigmoid_gating_delta_rule_update=(
+                lambda *args, **kwargs: pytest.fail("selector is disabled")
+            ),
+        )
+    else:
+        _install_fake_module(monkeypatch, "aiter")
+        _install_fake_module(
+            monkeypatch, "aiter.ops.triton.fla.fused_sigmoid_gating"
+        )
+    module = _sigmoid_module(adapter)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE",
+        mode != "disabled",
+    )
+    assert module.fused_sigmoid_gating_delta_rule_update(
+        **_sigmoid_arguments(torch.bfloat16)
+    ) == "official-sigmoid"
+
+
+def test_qwen_sigmoid_wrapper_is_qwen_local_and_idempotent(monkeypatch):
+    adapter = _adapter("patch_gdn_linear_attention")
+    canonical = _gdn_sigmoid_update
+    module = _sigmoid_module(adapter, canonical)
+    recurrent = module.fused_recurrent_gated_delta_rule_packed_decode
+    assert adapter.apply_to_module(module) is True
+    assert adapter.apply_to_module(module) is False
+    assert module.fused_sigmoid_gating_delta_rule_update is not canonical
+    assert module._vllm_hcu_original_fused_sigmoid is canonical
+    assert module.fused_recurrent_gated_delta_rule_packed_decode is recurrent
+
+
+def test_qwen_sigmoid_propagates_selected_kernel_error(monkeypatch):
+    adapter = _adapter("patch_gdn_linear_attention")
+
+    def failing_hip(*args, **kwargs):
+        raise RuntimeError("sigmoid update launch failed")
+
+    _install_fake_module(
+        monkeypatch,
+        "aiter",
+        vllm_fused_sigmoid_gating_delta_rule_update=failing_hip,
+    )
+    module = _sigmoid_module(adapter)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE",
+        True,
+    )
+    with pytest.raises(RuntimeError, match="sigmoid update launch failed"):
+        module.fused_sigmoid_gating_delta_rule_update(
+            **_sigmoid_arguments(torch.float32)
+        )
+```
+
+Update the cold-import test to assert Qwen's sigmoid is wrapped,
+`_vllm_hcu_original_fused_sigmoid` is the canonical FLA function, and the
+canonical FLA export is unchanged.
+
+- [ ] **Step 2: Run the sigmoid tests and verify RED**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+PYTHONPATH=/models/vllm_0251:$PWD \
+VLLM_PLUGINS=__disabled__ \
+pytest -q tests/runtime_patch/test_gdn_v0251_ownership.py \
+  tests/runtime_patch/test_attention_mla_fla_mamba.py \
+  -k 'gdn and sigmoid'
+```
+
+Expected: routing assertions fail because the current adapter deliberately
+leaves the sigmoid function target-owned.
+
+- [ ] **Step 3: Compose the sigmoid wrapper with the existing native wrapper**
+
+Keep the native AITER update target at `TARGETS[0]` for compatibility and add
+the Qwen sigmoid target as `TARGETS[1]`. Always validate and wrap the local
+sigmoid symbol, even when `GDN_AITER_TRITON_AVAILABLE` is false. Import the HIP
+and Triton callables independently at invocation time.
+
+Select HIP only when `A_log.dtype == q.dtype`; otherwise select AITER Triton.
+Use the exact original call signature by declaring the wrapper as `*args,
+**kwargs`, binding through `inspect.signature(official_sigmoid)`, applying
+defaults, and forwarding `*bound.args, **bound.kwargs` to the selected
+callable. If both optional imports fail or either selector is off, call the
+official function with the same bound arguments.
+
+Mark the wrapper with `_vllm_hcu_qwen_gdn_sigmoid_wrapper`, store the original
+as `_vllm_hcu_original_fused_sigmoid`, include it in the `already_applied`
+contract, and leave the recurrent symbol untouched.
+
+- [ ] **Step 4: Run all GDN and focused baseline tests and verify GREEN**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+PYTHONPATH=/models/vllm_0251:$PWD \
+VLLM_PLUGINS=__disabled__ \
+pytest -q tests/runtime_patch/test_gdn_v0251_ownership.py \
+  tests/runtime_patch/test_attention_mla_fla_mamba.py \
+  tests/accuracy/test_environment_routing.py
+```
+
+Expected: the focused baseline and all newly added tests pass.
+
+- [ ] **Step 5: Commit the sigmoid router**
+
+```bash
+git add vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py \
+  tests/runtime_patch/test_gdn_v0251_ownership.py \
+  tests/runtime_patch/test_attention_mla_fla_mamba.py
+git diff --cached --check
+git commit -m "feat(hcu): route Qwen GDN sigmoid updates through AITER"
+```
+
+---
+
+### Task 6: Verify the complete migration on tests and hardware
+
+**Files:**
+
+- Inspect: `docs/superpowers/specs/2026-09-06-port-v021-kernel-mrs-to-v0251-design.md`
+- Inspect: all files changed since `origin/v0.25.1`
+- Runtime artifact: `/tmp/vllm-hcu-integration/logs/`
+
+**Interfaces:**
+
+- Consumes: all adapters and environment contracts from Tasks 1-5.
+- Produces: fresh test, static-check, and real-model evidence suitable for the pull-request description.
+
+- [ ] **Step 1: Run whitespace, syntax, and patch inventory checks**
+
+```bash
+git diff --check origin/v0.25.1...HEAD
+python -m compileall -q vllm_hcu tests
+VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+python tools/run_patch_tests.py --suite inventory --vllm-source /models/vllm_0251
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 2: Run the full portable contract suite**
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+python tools/run_patch_tests.py --suite contract --vllm-source /models/vllm_0251
+```
+
+Expected: zero failed tests. Record passed/skipped counts exactly.
+
+- [ ] **Step 3: Verify default selectors in a fresh interpreter**
+
+```bash
+env -u VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE \
+    -u VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP \
+    -u VLLM_HCU_USE_CHUNK_FWD_KERNEL_O \
+    PYTHONPATH=/models/vllm_0251:$PWD \
+    VLLM_PLUGINS=__disabled__ \
+    python -c 'from vllm_hcu.platforms import envs; names=("VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE","VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP","VLLM_HCU_USE_CHUNK_FWD_KERNEL_O"); print({name: getattr(envs, name) for name in names})'
+```
+
+Expected: all three printed values are `True`.
+
+- [ ] **Step 4: Run one real Qwen3.5 TP2/EP2 smoke case with defaults**
+
+```bash
+env -u VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE \
+    -u VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP \
+    -u VLLM_HCU_USE_CHUNK_FWD_KERNEL_O \
+    VLLM_HCU_QWEN35_35B_A3B_MODEL=/models/Qwen3.5-35B-A3B \
+    VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+    python tools/run_patch_tests.py --suite model \
+      --vllm-source /models/vllm_0251 \
+      --target 'tests/integration/parallel/test_tp_ep_models.py::test_qwen35_35b_a3b_tp_ep_smoke[aiter-auto-shuffle-tp2-ep2]'
+```
+
+Expected: the model loads on two gfx938 HCU devices, generates two non-empty
+responses of one to four tokens, and exits with zero failures. Inspect the
+newest Qwen log under `/tmp/vllm-hcu-integration/logs/` and fail the task if it
+contains a patch compatibility error, optional-import traceback, or kernel
+launch exception.
+
+- [ ] **Step 5: Review the requirement-to-evidence mapping**
+
+Check each spec section against the committed diff and record:
+
+```bash
+git log --oneline origin/v0.25.1..HEAD
+git diff --stat origin/v0.25.1...HEAD
+git diff origin/v0.25.1...HEAD -- \
+  vllm_hcu/platforms/envs.py \
+  vllm_hcu/patch/worker/op_opt/patch_fla_chunk_delta_h.py \
+  vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py \
+  vllm_hcu/patch/worker/op_opt/patch_gdn_causal_conv1d.py \
+  vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py
+```
+
+Expected: the diff contains only scoped production code, tests, the approved
+spec, and this plan; all four source MR behaviors map to a tested target
+adapter.
+
+---
+
+### Task 7: Independent review, remediation, and pull-request delivery
+
+**Files:**
+
+- Inspect: complete diff `origin/v0.25.1...HEAD`
+- Modify only if review identifies a concrete defect in a changed file.
+
+**Interfaces:**
+
+- Consumes: verified Task 6 commits and exact source-MR mapping.
+- Produces: reviewed remote branch and one GitHub pull request targeting `v0.25.1`.
+
+- [ ] **Step 1: Request an independent code review**
+
+Set the review range:
+
+```bash
+BASE_SHA=$(git rev-parse origin/v0.25.1)
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+Ask the reviewer to compare `$BASE_SHA..$HEAD_SHA` against the approved spec,
+with special attention to optional-import semantics, v0.25.1 argument
+preservation, output-buffer aliasing, dtype routing, module ownership,
+idempotence, and default-enabled switches.
+
+- [ ] **Step 2: Resolve every critical or important review finding**
+
+For each valid finding, first add a failing regression test and run its exact
+node id to observe RED. Apply the smallest production fix, rerun the node to
+observe GREEN, then rerun all focused files:
+
+```bash
+VLLM_V0251_SOURCE_ROOT=/models/vllm_0251 \
+PYTHONPATH=/models/vllm_0251:$PWD \
+VLLM_PLUGINS=__disabled__ \
+pytest -q tests/accuracy/test_environment_routing.py \
+  tests/runtime_patch/test_attention_mla_fla_mamba.py \
+  tests/runtime_patch/test_gdn_v0251_ownership.py
+```
+
+Commit reviewed corrections with:
+
+```bash
+git add -u
+git diff --cached --check
+git commit -m "fix(hcu): address kernel migration review"
+```
+
+If there are no critical or important findings, do not create an empty commit.
+
+- [ ] **Step 3: Re-run completion verification after review**
+
+Repeat Task 6 Steps 1-4 against the final `HEAD`. Completion claims and PR
+creation are blocked unless the fresh commands exit zero.
+
+- [ ] **Step 4: Push the reviewed branch without persisting credentials**
+
+```bash
+git status --short --branch
+git push --set-upstream origin feat/port-021-kernel-mrs-v0251
+```
+
+Expected: the remote branch is created and the configured remote remains
+`https://github.com/HYGON-AI/vllm-plugin-das.git` without embedded credentials.
+
+- [ ] **Step 5: Create one pull request targeting `v0.25.1`**
+
+Use title:
+
+```text
+feat(hcu): port v0.21 GDN and FLA kernel routes to v0.25.1
+```
+
+The body must include the five source commit hashes, explain why target-native
+adapters replace v0.21 text patches, list all three default-on environment
+variables, report exact portable/model test commands and counts, summarize
+the independent review outcome, and state that AI assistance was used and the
+human submitter must review every changed line.
+
+Create it with:
+
+```bash
+gh pr create \
+  --repo HYGON-AI/vllm-plugin-das \
+  --base v0.25.1 \
+  --head feat/port-021-kernel-mrs-v0251 \
+  --title 'feat(hcu): port v0.21 GDN and FLA kernel routes to v0.25.1' \
+  --body-file /tmp/vllm-hcu-port-pr-body.md
+```
+
+The temporary body file must contain no credentials and may be removed after
+the command returns. Confirm the returned PR URL and query its changed-file
+list before reporting completion.

--- a/docs/superpowers/specs/2026-09-06-port-v021-kernel-mrs-to-v0251-design.md
+++ b/docs/superpowers/specs/2026-09-06-port-v021-kernel-mrs-to-v0251-design.md
@@ -1,0 +1,186 @@
+# Port v0.21 Kernel MRs to v0.25.1 Design
+
+## Goal
+
+Port the behavior introduced by vLLM-HCU merge requests 270, 271, 272,
+and 273 from the v0.21 plugin to the `v0.25.1` branch of
+`HYGON-AI/vllm-plugin-das`. The result must preserve the v0.25.1 sidecar
+architecture, default every newly introduced optimization switch to enabled,
+and keep a working upstream fallback for each optional HCU dependency.
+
+## Source Changes
+
+The source behavior is defined by these v0.21 commits:
+
+| MR | Commit | Behavior to port |
+| --- | --- | --- |
+| 270 | `c1b95f70bf179a954d7205922fb575cf2cfdacc4` | Route Qwen GDN sigmoid-gating recurrent updates through AITER when available. |
+| 271 | `14a680b5b3c4ce83dce3adae7e61aa2b772996ab` | Route supported Qwen GDN decode convolution updates through `causal_conv1d`. |
+| 272 | `a4c14b2f67d75003e3db9cd043b989aa9673f86a` | Prefer AITER HIP for `chunk_gated_delta_rule_fwd_h`, with lower-tier fallbacks. |
+| 273 | `f82655b0c6c6fd2c8988c26308d9fefa6c0d1fb6` and `85d01aebf9620db36db28cc83dba616204f4be47` | Prefer AITER HIP for `chunk_fwd_o` and remove unrelated environment variables. |
+
+The v0.21 text-replacement patches will not be copied. v0.25.1 uses exact
+post-import callbacks, so each behavior will be implemented in the existing
+target-native adapters.
+
+## Scope
+
+The implementation will change only the v0.25.1 plugin repository. It will
+not modify the vLLM source checkout, AITER, `causal_conv1d`, model files, or
+system Python installation.
+
+Expected production files are:
+
+- `vllm_hcu/platforms/envs.py`
+- `vllm_hcu/patch/worker/op_opt/patch_fla_chunk_delta_h.py`
+- `vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py`
+- `vllm_hcu/patch/worker/op_opt/patch_gdn_causal_conv1d.py`
+- `vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py`
+
+Tests will extend the existing environment-routing, FLA/Mamba adapter, and
+real-v0.25.1 ownership suites. No unrelated refactor is in scope.
+
+## Environment Contract
+
+The three existing parent switches remain unchanged:
+
+- `VLLM_HCU_USE_CUSTOM_OPS`, default enabled.
+- `VLLM_HCU_USE_CUSTOM_AITER_FLA`, default enabled.
+- `VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D`, default enabled.
+
+The port introduces the following switches, all defaulting to enabled (`1` or
+`True` semantics) and accepting the repository's existing `1`/`true` Boolean
+forms:
+
+| Variable | Purpose | Parent gate |
+| --- | --- | --- |
+| `VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE` | Select the AITER sigmoid-gating update for compatible Qwen GDN calls. | `VLLM_HCU_USE_CUSTOM_OPS` |
+| `VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP` | Prefer the AITER HIP state-update kernel. | `VLLM_HCU_USE_CUSTOM_OPS` and `VLLM_HCU_USE_CUSTOM_AITER_FLA` |
+| `VLLM_HCU_USE_CHUNK_FWD_KERNEL_O` | Prefer the AITER HIP output kernel. | `VLLM_HCU_USE_CUSTOM_OPS` |
+
+`VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP` does not control `chunk_o`,
+matching the cleanup in MR 273. Explicitly setting any selector to `0` or
+`false` disables only that route and preserves lower-tier behavior.
+
+## Runtime Design
+
+### Qwen GDN sigmoid gating
+
+`patch_gdn_linear_attention` will continue to own only symbols local to
+`vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn`. It will wrap the
+module-local `fused_sigmoid_gating_delta_rule_update` while leaving the
+canonical FLA export and all non-Qwen consumers untouched.
+
+When both the global custom-op switch and the new sigmoid switch are enabled,
+the wrapper selects AITER's top-level HIP
+`vllm_fused_sigmoid_gating_delta_rule_update` when it imports and `A_log` has
+the same dtype as `q`, as required by that kernel. A dtype-incompatible HIP
+call falls through to AITER's Triton
+`fused_sigmoid_gating_delta_rule_update`, which supports v0.25.1's FP32
+`A_log` with BF16 activations. If no compatible AITER callable imports, the
+wrapper calls the original vLLM function. Import availability is resolved
+without mutating the canonical module. Once an AITER callable is selected,
+runtime errors from it are propagated rather than silently hiding kernel
+failures.
+
+The existing v0.25.1 fused decode path and NN-layout wrapper remain intact.
+The new wrapper composes with those behaviors instead of replacing the class
+or copying `_forward_core`.
+
+### Qwen GDN causal convolution
+
+`patch_gdn_causal_conv1d` will preserve its current NN-layout normalization
+and add a local routing layer around `causal_conv1d_update`. The external HCU
+call accepts `x`, state, weight, bias, activation, and state indices. Calls
+using only that compatible decode contract route to the external kernel when
+both existing causal-convolution gates are enabled. Calls carrying v0.25.1
+features unsupported by the external API—such as accepted-token or query
+location metadata—remain on the original vLLM implementation.
+
+This keeps speculative or future call semantics correct while accelerating
+the two decode forms represented by MR 271. `causal_conv1d_fn` remains scoped
+to its current NN-layout adaptation. The canonical causal-convolution module,
+Kimi, Olmo, MambaMixer, MambaMixer2, and ShortConv remain unmodified.
+
+### FLA state-update routing
+
+`patch_fla_chunk_delta_h` will use this priority order when custom ops are
+enabled:
+
+1. AITER HIP `chunk_gated_delta_rule_fwd_vllm_hip_blockdim64` when its new
+   selector and `VLLM_HCU_USE_CUSTOM_AITER_FLA` are enabled and the callable
+   imports successfully.
+2. Existing AITER Triton launch helper when
+   `VLLM_HCU_USE_CUSTOM_AITER_FLA` is enabled and the callable imports.
+3. The original vLLM 0.25.1 function.
+
+The adapter will reuse vLLM-prepared sequence indices and offsets and preserve
+the caller's chunk size, final-state request, new-value request, and state
+layout. Missing optional imports select the next tier. Shape, dtype, or launch
+errors raised after selection are not caught.
+
+### FLA output routing
+
+`patch_fla_chunk_o` will use this priority order when custom ops are enabled:
+
+1. AITER HIP `chunk_fwd_o_vllm_hip_blockdim64` when its selector is enabled
+   and the callable imports successfully.
+2. Existing AITER Triton launch helper when
+   `VLLM_HCU_USE_CUSTOM_AITER_FLA` is enabled and the callable imports.
+3. The original vLLM 0.25.1 function.
+
+The HIP call will receive the caller's `chunk_size`, scale, sequence metadata,
+and state-layout contract. The Triton route will retain support for the
+caller's preallocated `core_attn_out`. If the HIP route is selected while a
+preallocated output exists, its returned tensor will be copied into that
+buffer when needed so the v0.25.1 output-buffer contract remains observable.
+Missing imports fall through; selected-kernel runtime errors propagate.
+
+## Error Handling and Compatibility
+
+- Exact v0.25.1 target signatures remain checked before adapters are armed.
+- Applying any adapter twice remains idempotent.
+- Optional dependency absence causes deterministic fallback, not startup
+  failure.
+- An incompatible target vLLM signature raises the existing
+  `PatchCompatibilityError` during patch application.
+- Environment access remains lazy through `vllm_hcu.platforms.envs`.
+- The change does not monkey-patch shared canonical modules.
+
+## Test Strategy
+
+Implementation follows red-green-refactor. Before production changes, tests
+will demonstrate failures for:
+
+- all three new switches being enabled by default and disabled by `0`;
+- HIP-first, AITER-Triton-second, and vLLM fallback routing for both FLA
+  functions;
+- preservation of keyword arguments, return tuples, and preallocated output;
+- Qwen-local sigmoid selection and safe fallback without changing canonical
+  FLA exports;
+- Qwen-local compatible causal-convolution routing, unsupported-call fallback,
+  NN-layout normalization, and non-Qwen ownership boundaries;
+- idempotent adapter application and clear target-signature rejection.
+
+Verification will include:
+
+1. Focused environment, FLA/Mamba, and GDN ownership tests against the local
+   vLLM 0.25.1 source checkout.
+2. The repository contract suite via `tools/run_patch_tests.py`.
+3. Static formatting and compilation checks used by the repository.
+4. A real HCU smoke inference using `/models/Qwen3.5-35B-A3B`, with new
+   switches left unset to prove their default-enabled behavior. The test must
+   load the model, generate non-empty deterministic output, and show no kernel
+   or patch compatibility exception in its log.
+
+The pre-change focused baseline is 105 passed tests with zero failures when
+`VLLM_V0251_SOURCE_ROOT=/models/vllm_0251` is supplied.
+
+## Delivery and Review
+
+Work will be committed on `feat/port-021-kernel-mrs-v0251` with author
+`alexanderbin123 <1414695739@qq.com>`. The branch will be pushed to
+`HYGON-AI/vllm-plugin-das` and opened as one pull request targeting
+`v0.25.1`, with source MR/commit mapping and exact verification evidence in
+the description. An independent code review will inspect the complete diff;
+all critical and important findings will be resolved before final handoff.

--- a/docs/superpowers/specs/2026-09-06-port-v021-kernel-mrs-to-v0251-design.md
+++ b/docs/superpowers/specs/2026-09-06-port-v021-kernel-mrs-to-v0251-design.md
@@ -172,6 +172,26 @@ Verification will include:
    switches left unset to prove their default-enabled behavior. The test must
    load the model, generate non-empty deterministic output, and show no kernel
    or patch compatibility exception in its log.
+5. One targeted Qwen3.5-35B-A3B TP2/EP2 graph acceptance case. It runs
+   eager+MTP3 and graph+MTP3 sequentially with identical greedy requests,
+   repeats each request, and requires exact token parity plus present, finite
+   cumulative logprobs and logprobs for all 16 output positions. Numerical
+   logprob equality is not required because eager and graph execution can
+   round floating-point reductions differently without changing token choices.
+   The test clears inherited overrides for the master custom-op switch and
+   five routing switches (including the existing `VLLM_HCU_USE_CUSTOM_AITER_FLA`
+   gate), and verifies all six resolve to `True` on each
+   worker through `vllm_hcu.platforms.envs`. The graph engine
+   must resolve to FULL decode mode on both workers, capture the bounded
+   MTP3 buckets, report positive FULL runtime counts during generation, and
+   report positive speculative draft activity. This complements rather than
+   replaces the non-MTP eager smoke: MTP metadata deliberately keeps the
+   causal-convolution adapter on the upstream-compatible fallback path.
+
+The graph acceptance claim is deliberately scoped to graph-enabled model
+execution and FULL decode replay. The FLA chunk H/O adapters execute during
+prefill, which is outside `FULL_DECODE_ONLY`; this case does not claim those
+prefill kernels were themselves captured in a graph.
 
 The pre-change focused baseline is 105 passed tests with zero failures when
 `VLLM_V0251_SOURCE_ROOT=/models/vllm_0251` is supplied.

--- a/tests/accuracy/test_environment_routing.py
+++ b/tests/accuracy/test_environment_routing.py
@@ -87,6 +87,35 @@ def test_boolean_environment_values_are_lazily_parsed(
     assert hcu_envs.is_set("VLLM_HCU_USE_CUSTOM_OPS") is True
 
 
+MIGRATED_KERNEL_FLAGS = (
+    "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE",
+    "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP",
+    "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O",
+)
+
+
+@pytest.mark.parametrize("name", MIGRATED_KERNEL_FLAGS)
+def test_migrated_kernel_flags_default_on(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+) -> None:
+    monkeypatch.delenv(name, raising=False)
+    assert getattr(hcu_envs, name) is True
+    assert hcu_envs.is_set(name) is False
+
+
+@pytest.mark.parametrize("name", MIGRATED_KERNEL_FLAGS)
+@pytest.mark.parametrize("value", ["0", "false", "FALSE"])
+def test_migrated_kernel_flags_allow_explicit_opt_out(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    value: str,
+) -> None:
+    monkeypatch.setenv(name, value)
+    assert getattr(hcu_envs, name) is False
+    assert hcu_envs.is_set(name) is True
+
+
 def test_lightop_per_token_fp8_route_is_enabled_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/hcu_ci_registry.py
+++ b/tests/hcu_ci_registry.py
@@ -179,6 +179,14 @@ register_hcu_ci(
     est_time=7200,
 )
 register_hcu_ci(
+    job="qwen35-tp-ep",
+    target=(
+        "tests/integration/graph/test_qwen35_35b_a3b_mtp3_graph_parity.py::"
+        "test_qwen35_35b_a3b_tp2_ep2_mtp3_full_decode_graph_aiter_auto_shuffle"
+    ),
+    est_time=1200,
+)
+register_hcu_ci(
     job="deepseek-tp-ep",
     target=(
         "tests/integration/parallel/test_tp_ep_models.py::"

--- a/tests/integration/graph/test_qwen35_35b_a3b_mtp3_graph_parity.py
+++ b/tests/integration/graph/test_qwen35_35b_a3b_mtp3_graph_parity.py
@@ -43,6 +43,9 @@ def _assert_mtp3_graph_parity(result: dict[str, Any], log: str) -> None:
             assert worker["speculative_config"] == {
                 "method": "mtp", "num_speculative_tokens": 3,
             }, worker
+            assert worker["cache_config"] == {
+                "mamba_cache_dtype": "float32",
+            }, worker
             compilation = worker["compilation_config"]
             if label == "graph":
                 # This is the target enum's decode_mode(), not a substring

--- a/tests/integration/graph/test_qwen35_35b_a3b_mtp3_graph_parity.py
+++ b/tests/integration/graph/test_qwen35_35b_a3b_mtp3_graph_parity.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""One targeted Qwen3.5 TP2/EP2 + MTP3 FULL decode graph nightly case."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import math
+import re
+from typing import Any
+
+import pytest
+
+from tests.fixtures.resources import TestResources as HcuTestResources
+from tests.integration.model_runtime import (
+    QWEN35_MTP3_SELECTOR_NAMES,
+    require_gfx_arch,
+    require_model_runtime,
+    run_vllm_case,
+)
+from tests.integration.parallel.test_tp_ep_models import (
+    QWEN35_35B_A3B,
+    _qwen35_gpu_memory_utilization,
+)
+
+
+def _assert_mtp3_graph_parity(result: dict[str, Any], log: str) -> None:
+    baseline = None
+    for label in ("eager", "graph"):
+        entry = result[label]
+        assert len(entry["workers"]) == 2, (label, entry["workers"])
+        for worker in entry["workers"]:
+            assert worker["enforce_eager"] is (label == "eager"), worker
+            assert all(
+                worker["hcu_selectors"][name] is True
+                for name in QWEN35_MTP3_SELECTOR_NAMES
+            ), worker
+            assert worker["parallel_config"] == {
+                "tensor_parallel_size": 2,
+                "data_parallel_size": 1,
+                "enable_expert_parallel": True,
+            }, worker
+            assert worker["speculative_config"] == {
+                "method": "mtp", "num_speculative_tokens": 3,
+            }, worker
+            compilation = worker["compilation_config"]
+            if label == "graph":
+                # This is the target enum's decode_mode(), not a substring
+                # match against the requested mode or the driver's config.
+                assert compilation["decode_mode"] == "FULL", worker
+                assert compilation["cudagraph_capture_sizes"], worker
+                assert compilation["num_cudagraph_captured"] > 0, worker
+            else:
+                assert compilation["decode_mode"] == "NONE", worker
+
+        assert len(entry["rounds"]) == 2, (label, entry["rounds"])
+        for round_index, output in enumerate(entry["rounds"]):
+            tokens = [record["token_ids"] for record in output]
+            assert tokens and all(len(ids) >= 16 for ids in tokens), (label, tokens)
+            for record in output:
+                # Eager/graph reductions can differ in floating-point rounding.
+                # Logprobs require presence, finiteness, and per-token coverage;
+                # exact parity below applies only to generated token IDs.
+                assert record["cumulative_logprob"] is not None, (label, record)
+                assert math.isfinite(record["cumulative_logprob"]), (label, record)
+                assert record["sample_logprob_count"] == 16, (label, record)
+            if baseline is None:
+                baseline = tokens
+            assert tokens == baseline, (label, round_index, tokens, baseline)
+
+            # Bound evidence to generation, excluding startup/capture logs.
+            begin = f"VLLM_HCU_GENERATE_BEGIN={label}:{round_index}"
+            end = f"VLLM_HCU_GENERATE_END={label}:{round_index}"
+            assert begin in log and end in log, (label, round_index)
+            segment = log.split(begin, 1)[1].split(end, 1)[0]
+            drafts = re.findall(
+                r"SpecDecoding metrics:[^\n]*Drafted: (\d+) tokens", segment
+            )
+            assert any(int(count) > 0 for count in drafts), (
+                label, round_index, segment,
+            )
+            if label == "graph":
+                full_counts = re.findall(
+                    r"\|\s*\d+\s*\|\s*\d+\s*\|\s*\d+\s*\|\s*FULL\s*\|\s*(\d+)\s*\|",
+                    segment,
+                )
+                assert any(int(count) > 0 for count in full_counts), (
+                    round_index, segment,
+                )
+
+
+@pytest.mark.hcu
+@pytest.mark.model
+@pytest.mark.multi_hcu
+@pytest.mark.hcu_count(2)
+@pytest.mark.slow
+@pytest.mark.nightly
+def test_qwen35_35b_a3b_tp2_ep2_mtp3_full_decode_graph_aiter_auto_shuffle(
+    hcu_test_resources: HcuTestResources,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Exercise default-enabled selectors even if the invoking shell disables
+    # them; pytest restores the caller environment after this targeted test.
+    for name in QWEN35_MTP3_SELECTOR_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    label = "Qwen3.5-35B-A3B TP2/EP2 MTP3 FULL decode graph"
+    require_gfx_arch("gfx938", label)
+    model_path = require_model_runtime(
+        hcu_test_resources,
+        env_name="VLLM_HCU_QWEN35_35B_A3B_MODEL",
+        relative_path=QWEN35_35B_A3B,
+        label=label,
+        hcu_count=2,
+    )
+    result = run_vllm_case(
+        "qwen35-mtp3-graph-parity",
+        model_path,
+        timeout_s=5400,
+        extra_args=[
+            "--gpu-memory-utilization", str(_qwen35_gpu_memory_utilization(2)),
+        ],
+        extra_env={
+            "VLLM_HCU_USE_AITER_MOE_SHUFFLE": "1",
+            "VLLM_LOG_STATS_INTERVAL": "0.1",
+            # The trusted local worker-config callback needs callable RPC.
+            "VLLM_ALLOW_INSECURE_SERIALIZATION": "1",
+        },
+        log_label="qwen35-tp2-ep2-mtp3-full-decode-graph-aiter-auto-shuffle",
+    )
+    log = Path(result["_log_path"]).read_text(encoding="utf-8", errors="replace")
+    _assert_mtp3_graph_parity(result, log)

--- a/tests/integration/model_runtime.py
+++ b/tests/integration/model_runtime.py
@@ -1321,6 +1321,9 @@ def _mtp3_worker_config_summary(worker: Any) -> dict[str, Any]:
             "method": speculative.method,
             "num_speculative_tokens": speculative.num_speculative_tokens,
         },
+        "cache_config": {
+            "mamba_cache_dtype": config.cache_config.mamba_cache_dtype,
+        },
         "compilation_config": {
             "mode": compilation.mode.name,
             "cudagraph_mode": compilation.cudagraph_mode.name,
@@ -1361,6 +1364,7 @@ def _case_qwen35_mtp3_graph_parity(
             max_num_seqs=2,
             gpu_memory_utilization=gpu_memory_utilization,
             speculative_config={"method": "mtp", "num_speculative_tokens": 3},
+            mamba_cache_dtype="float32",
             cudagraph_metrics=True,
             disable_log_stats=False,
             **graph_kwargs,

--- a/tests/integration/model_runtime.py
+++ b/tests/integration/model_runtime.py
@@ -39,6 +39,14 @@ DEFAULT_MODEL_ROOT = Path("/models/llm-models")
 DEFAULT_LOG_DIR = Path("/tmp/vllm-hcu-integration/logs")
 RESULT_PREFIX = "VLLM_HCU_RESULT="
 UNIFIED_ATTENTION_HEAD_DIMS = {128, 192, 256, 512}
+QWEN35_MTP3_SELECTOR_NAMES = (
+    "VLLM_HCU_USE_CUSTOM_OPS",
+    "VLLM_HCU_USE_CUSTOM_AITER_FLA",
+    "VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D",
+    "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE",
+    "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP",
+    "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O",
+)
 DEEPSEEK_V4_DSPARK_SPECULATIVE_CONFIG = {
     "method": "dspark",
     "num_speculative_tokens": 7,
@@ -1290,6 +1298,97 @@ def _case_deepseek_v4_dspark_rank(
     }
 
 
+def _mtp3_worker_config_summary(worker: Any) -> dict[str, Any]:
+    """Read post-initialization config in each worker, where graph mode resolves."""
+    from vllm.compilation.counter import compilation_counter
+    from vllm_hcu.platforms import envs as henvs
+
+    config = worker.vllm_config
+    parallel = config.parallel_config
+    speculative = config.speculative_config
+    compilation = config.compilation_config
+    return {
+        "enforce_eager": config.model_config.enforce_eager,
+        "hcu_selectors": {
+            name: getattr(henvs, name) for name in QWEN35_MTP3_SELECTOR_NAMES
+        },
+        "parallel_config": {
+            "tensor_parallel_size": parallel.tensor_parallel_size,
+            "data_parallel_size": parallel.data_parallel_size,
+            "enable_expert_parallel": parallel.enable_expert_parallel,
+        },
+        "speculative_config": {
+            "method": speculative.method,
+            "num_speculative_tokens": speculative.num_speculative_tokens,
+        },
+        "compilation_config": {
+            "mode": compilation.mode.name,
+            "cudagraph_mode": compilation.cudagraph_mode.name,
+            "decode_mode": compilation.cudagraph_mode.decode_mode().name,
+            "cudagraph_capture_sizes": list(compilation.cudagraph_capture_sizes or []),
+            "num_cudagraph_captured": compilation_counter.num_cudagraph_captured,
+        },
+    }
+
+
+def _case_qwen35_mtp3_graph_parity(
+    model_path: Path, *, gpu_memory_utilization: float,
+) -> dict[str, Any]:
+    """Targeted TP2/EP2 MTP3 parity; separate from the eager-only TP/EP smoke."""
+    from vllm import LLM
+    from vllm.sampling_params import SamplingParams
+
+    prompts = [
+        "Explain why deterministic parallel inference is useful in three sentences.",
+        "Describe how a compiler translates a program in three sentences.",
+    ]
+    result = {}
+    for label, enforce_eager in (("eager", True), ("graph", False)):
+        graph_kwargs = {} if enforce_eager else {
+            "compilation_config": {
+                # v0.25.1 decode_mode() returns FULL for this mode. Two
+                # requests with MTP3 verify up to 2 * (1 + 3) tokens per step.
+                "cudagraph_mode": "FULL_DECODE_ONLY",
+                "cudagraph_capture_sizes": [4, 8],
+            },
+        }
+        llm = LLM(**_llm_kwargs(
+            model_path,
+            enforce_eager=enforce_eager,
+            tensor_parallel_size=2,
+            enable_expert_parallel=True,
+            moe_backend="aiter",
+            max_num_seqs=2,
+            gpu_memory_utilization=gpu_memory_utilization,
+            speculative_config={"method": "mtp", "num_speculative_tokens": 3},
+            cudagraph_metrics=True,
+            disable_log_stats=False,
+            **graph_kwargs,
+        ))
+        try:
+            rounds = []
+            for round_index in range(2):
+                print(f"VLLM_HCU_GENERATE_BEGIN={label}:{round_index}", flush=True)
+                outputs = llm.generate(
+                    prompts,
+                    SamplingParams(
+                        temperature=0.0, seed=0, min_tokens=16, max_tokens=16,
+                        ignore_eos=True, logprobs=1,
+                    ),
+                    use_tqdm=False,
+                )
+                rounds.append([_single_completion(record) for record in outputs])
+                llm.llm_engine.do_log_stats()
+                print(f"VLLM_HCU_GENERATE_END={label}:{round_index}", flush=True)
+            result[label] = {
+                "rounds": rounds,
+                "workers": llm.collective_rpc(_mtp3_worker_config_summary, timeout=30),
+            }
+        finally:
+            _shutdown_llm(llm)
+    return result
+
+
 def _case_tp_ep_smoke(
     model_path: Path,
     *,
@@ -1599,6 +1698,7 @@ def _main(argv: list[str] | None = None) -> int:
             "reranker-smoke",
             "vl-image-smoke",
             "tp-ep-smoke",
+            "qwen35-mtp3-graph-parity",
             "deepseek-v4-dspark-smoke",
         ),
     )
@@ -1652,6 +1752,11 @@ def _main(argv: list[str] | None = None) -> int:
         payload = _case_reranker_smoke(args.model)
     elif args.case == "vl-image-smoke":
         payload = _case_vl_image_smoke(args.model)
+    elif args.case == "qwen35-mtp3-graph-parity":
+        payload = _case_qwen35_mtp3_graph_parity(
+            args.model,
+            gpu_memory_utilization=args.gpu_memory_utilization,
+        )
     elif args.case == "tp-ep-smoke":
         payload = _case_tp_ep_smoke(
             args.model,

--- a/tests/integration/test_model_runtime_cli.py
+++ b/tests/integration/test_model_runtime_cli.py
@@ -3,6 +3,8 @@
 """CPU-safe CLI coverage for the model runtime subprocess harness."""
 
 from pathlib import Path
+import copy
+import json
 import signal
 import sys
 from types import SimpleNamespace
@@ -13,6 +15,331 @@ from tests.integration import model_runtime
 
 
 DEEPSEEK_V4_MODEL = Path("/models/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8")
+MTP3_SELECTOR_NAMES = (
+    "VLLM_HCU_USE_CUSTOM_OPS",
+    "VLLM_HCU_USE_CUSTOM_AITER_FLA",
+    "VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D",
+    "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE",
+    "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP",
+    "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O",
+)
+
+
+@pytest.mark.parametrize("resolved_mode", ["FULL", "FULL_DECODE_ONLY"])
+def test_mtp3_graph_cli_uses_worker_config_and_repeats_sequential_engines(
+    monkeypatch, capsys, resolved_mode,
+):
+    events = []
+    engines = []
+    counter = SimpleNamespace(num_cudagraph_captured=0)
+    for name in MTP3_SELECTOR_NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+    class FakeLLM:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.label = "eager" if kwargs["enforce_eager"] else "graph"
+            self.round = 0
+            engines.append(self)
+            events.append((self.label, "start"))
+            # Deliberately differs from the resolved worker config.
+            self.llm_engine = SimpleNamespace(
+                vllm_config=None,
+                do_log_stats=lambda: events.append((self.label, "flush")),
+            )
+
+        def generate(self, prompts, sampling_params, *, use_tqdm):
+            assert use_tqdm is False
+            self.round += 1
+            events.append((self.label, "generate"))
+            self.prompts = list(prompts)
+            self.sampling = sampling_params
+            wants_logprobs = getattr(sampling_params, "logprobs", None) == 1
+            return [SimpleNamespace(
+                prompt_token_ids=[5, 6],
+                outputs=[SimpleNamespace(
+                    token_ids=list(range(16)), text="sixteen tokens",
+                    finish_reason="length",
+                    cumulative_logprob=-0.5 if wants_logprobs else None,
+                    logprobs=[{i: -0.1} for i in range(16)] if wants_logprobs else None,
+                )],
+            ) for _ in prompts]
+
+        def collective_rpc(self, method, *, timeout):
+            assert timeout == 30
+            mode = "NONE" if self.label == "eager" else resolved_mode
+            counter.num_cudagraph_captured = 0 if self.label == "eager" else 2
+            worker = SimpleNamespace(vllm_config=SimpleNamespace(
+                model_config=SimpleNamespace(enforce_eager=self.label == "eager"),
+                parallel_config=SimpleNamespace(
+                    tensor_parallel_size=2, data_parallel_size=1,
+                    enable_expert_parallel=True,
+                ),
+                speculative_config=SimpleNamespace(
+                    method="mtp", num_speculative_tokens=3,
+                ),
+                compilation_config=SimpleNamespace(
+                    mode=SimpleNamespace(
+                        name="NONE" if self.label == "eager" else "VLLM_COMPILE"
+                    ),
+                    cudagraph_mode=SimpleNamespace(
+                        name=mode,
+                        decode_mode=lambda: SimpleNamespace(
+                            name="NONE" if self.label == "eager" else "FULL"
+                        ),
+                    ),
+                    cudagraph_capture_sizes=[] if self.label == "eager" else [4, 8],
+                ),
+            ))
+            return [method(worker), method(worker)]
+
+    monkeypatch.setitem(sys.modules, "vllm", SimpleNamespace(LLM=FakeLLM))
+    monkeypatch.setitem(
+        sys.modules, "vllm.sampling_params",
+        SimpleNamespace(SamplingParams=SimpleNamespace),
+    )
+    monkeypatch.setitem(
+        sys.modules, "vllm.compilation.counter",
+        SimpleNamespace(compilation_counter=counter),
+    )
+    monkeypatch.setattr(
+        model_runtime, "_shutdown_llm",
+        lambda llm: events.append((llm.label, "stop")),
+    )
+    assert model_runtime._main([
+        "qwen35-mtp3-graph-parity", "--model", "/models/fake",
+        "--gpu-memory-utilization", "0.4",
+    ]) == 0
+    log = capsys.readouterr().out
+    result = json.loads(next(
+        line.removeprefix(model_runtime.RESULT_PREFIX)
+        for line in log.splitlines() if line.startswith(model_runtime.RESULT_PREFIX)
+    ))
+    assert events == [
+        (label, event) for label in ("eager", "graph")
+        for event in ("start", "generate", "flush", "generate", "flush", "stop")
+    ]
+    for engine in engines:
+        assert engine.kwargs["speculative_config"] == {
+            "method": "mtp", "num_speculative_tokens": 3,
+        }
+        assert engine.kwargs["tensor_parallel_size"] == 2
+        assert engine.kwargs["enable_expert_parallel"] is True
+        assert engine.kwargs["moe_backend"] == "aiter"
+        assert engine.kwargs["gpu_memory_utilization"] == 0.4
+        assert engine.kwargs["cudagraph_metrics"] is True
+        assert engine.kwargs["disable_log_stats"] is False
+        assert engine.sampling.temperature == 0.0
+        assert engine.sampling.seed == 0
+        assert engine.sampling.max_tokens == 16
+        assert engine.sampling.min_tokens == 16
+        assert engine.sampling.ignore_eos is True
+        assert getattr(engine.sampling, "logprobs", None) == 1
+        workers = result[engine.label]["workers"]
+        assert len(workers) == 2
+        assert all(
+            worker.get("hcu_selectors") == {
+                name: True for name in MTP3_SELECTOR_NAMES
+            }
+            for worker in workers
+        )
+        assert all(
+            w["speculative_config"] == {"method": "mtp", "num_speculative_tokens": 3}
+            for w in workers
+        )
+        assert len(result[engine.label]["rounds"]) == 2
+        for output in result[engine.label]["rounds"]:
+            assert all(record["cumulative_logprob"] == -0.5 for record in output)
+            assert all(record["sample_logprob_count"] == 16 for record in output)
+    assert engines[0].prompts == engines[1].prompts
+    assert engines[0].kwargs.get("compilation_config") is None
+    assert engines[1].kwargs["compilation_config"] == {
+        "cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 8],
+    }
+    assert result["graph"]["workers"][0]["compilation_config"] == {
+        "mode": "VLLM_COMPILE", "cudagraph_mode": resolved_mode,
+        "decode_mode": "FULL", "cudagraph_capture_sizes": [4, 8],
+        "num_cudagraph_captured": 2,
+    }
+    for label in ("eager", "graph"):
+        for round_index in range(2):
+            assert f"VLLM_HCU_GENERATE_BEGIN={label}:{round_index}" in log
+            assert f"VLLM_HCU_GENERATE_END={label}:{round_index}" in log
+
+
+def _mtp3_parity_payload():
+    worker = {
+        "enforce_eager": False,
+        "hcu_selectors": {name: True for name in MTP3_SELECTOR_NAMES},
+        "parallel_config": {
+            "tensor_parallel_size": 2, "data_parallel_size": 1,
+            "enable_expert_parallel": True,
+        },
+        "speculative_config": {"method": "mtp", "num_speculative_tokens": 3},
+        "compilation_config": {
+            "mode": "VLLM_COMPILE", "cudagraph_mode": "FULL_DECODE_ONLY",
+            "decode_mode": "FULL", "cudagraph_capture_sizes": [4, 8],
+            "num_cudagraph_captured": 2,
+        },
+    }
+    result = {
+        label: {"workers": [copy.deepcopy(worker), copy.deepcopy(worker)],
+                "rounds": [[{
+                    "token_ids": list(range(16)), "cumulative_logprob": -0.5,
+                    "sample_logprob_count": 16,
+                }] for _ in range(2)]}
+        for label in ("eager", "graph")
+    }
+    for entry in result["eager"]["workers"]:
+        entry["enforce_eager"] = True
+        entry["compilation_config"].update(
+            mode="NONE", cudagraph_mode="NONE", decode_mode="NONE",
+            num_cudagraph_captured=0,
+        )
+    return result
+
+
+def _mtp3_parity_log():
+    return "\n".join(
+        f"VLLM_HCU_GENERATE_BEGIN={label}:{i}\n"
+        "SpecDecoding metrics: Accepted: 8 tokens, Drafted: 12 tokens,\n"
+        f"| 8 | 8 | 0 | {'FULL' if label == 'graph' else 'NONE'} | 4 |\n"
+        f"VLLM_HCU_GENERATE_END={label}:{i}"
+        for label in ("eager", "graph") for i in range(2)
+    )
+
+
+def test_mtp3_graph_callable_rpc_opt_in_is_local_and_logged(monkeypatch, tmp_path):
+    from tests.integration.graph import test_qwen35_35b_a3b_mtp3_graph_parity as case
+
+    launched = []
+    opt_in = "VLLM_ALLOW_INSECURE_SERIALIZATION"
+    monkeypatch.delenv(opt_in, raising=False)
+    for name in MTP3_SELECTOR_NAMES:
+        monkeypatch.setenv(name, "0")
+    monkeypatch.setenv("VLLM_HCU_INTEGRATION_LOG_DIR", str(tmp_path))
+    monkeypatch.setattr(case, "require_gfx_arch", lambda *args: None)
+    monkeypatch.setattr(
+        case, "require_model_runtime", lambda *args, **kwargs: Path("/models/fake")
+    )
+
+    def fake_popen(command, *, env, stdout, **kwargs):
+        launched.append((dict(env), Path(stdout.name)))
+        stdout.write(_mtp3_parity_log() + "\n")
+        stdout.write(
+            model_runtime.RESULT_PREFIX + json.dumps(_mtp3_parity_payload()) + "\n"
+        )
+        stdout.flush()
+        return SimpleNamespace(wait=lambda timeout: 0)
+
+    monkeypatch.setattr(model_runtime.subprocess, "Popen", fake_popen)
+    with monkeypatch.context() as case_env:
+        case.test_qwen35_35b_a3b_tp2_ep2_mtp3_full_decode_graph_aiter_auto_shuffle(
+            None, case_env,
+        )
+    model_runtime.run_vllm_case("tp-ep-smoke", Path("/models/fake"))
+
+    targeted_env, targeted_log = launched[0]
+    smoke_env, smoke_log = launched[1]
+    targeted_opt_in = targeted_env.get(opt_in)
+    assert targeted_opt_in == "1"
+    environment_header = next(
+        line for line in targeted_log.read_text().splitlines()
+        if line.startswith("environment: ")
+    )
+    assert f"{opt_in}=1" in environment_header
+    assert opt_in not in smoke_env
+    assert opt_in not in smoke_log.read_text()
+    assert opt_in not in model_runtime.os.environ
+    inherited_selectors = set(MTP3_SELECTOR_NAMES) & targeted_env.keys()
+    assert not inherited_selectors
+    assert all(smoke_env[name] == "0" for name in MTP3_SELECTOR_NAMES)
+    assert all(model_runtime.os.environ[name] == "0" for name in MTP3_SELECTOR_NAMES)
+
+
+@pytest.mark.parametrize("selector", MTP3_SELECTOR_NAMES)
+def test_mtp3_graph_rejects_disabled_worker_selector(selector):
+    from tests.integration.graph.test_qwen35_35b_a3b_mtp3_graph_parity import (
+        _assert_mtp3_graph_parity,
+    )
+
+    result = _mtp3_parity_payload()
+    result["graph"]["workers"][1]["hcu_selectors"][selector] = False
+    with pytest.raises(AssertionError):
+        _assert_mtp3_graph_parity(result, _mtp3_parity_log())
+
+
+@pytest.mark.parametrize("graph_logprob", [-0.75, float("nan"), float("inf")])
+def test_mtp3_graph_logprobs_require_finiteness_not_numerical_parity(graph_logprob):
+    from tests.integration.graph.test_qwen35_35b_a3b_mtp3_graph_parity import (
+        _assert_mtp3_graph_parity,
+    )
+
+    result = _mtp3_parity_payload()
+    for output in result["graph"]["rounds"]:
+        output[0]["cumulative_logprob"] = graph_logprob
+    if graph_logprob == -0.75:
+        # The eager cumulative value is -0.5 with the same exact token IDs.
+        _assert_mtp3_graph_parity(result, _mtp3_parity_log())
+    else:
+        with pytest.raises(AssertionError):
+            _assert_mtp3_graph_parity(result, _mtp3_parity_log())
+
+
+@pytest.mark.parametrize("fault", [
+    None, "downgraded", "uncaptured", "empty_capture_sizes", "wrong_mtp",
+    "wrong_draft_count", "wrong_tp", "missing_worker", "empty_round",
+    "short_output", "token_mismatch", "second_round_mismatch", "missing_full_metric",
+    "zero_full_metric", "missing_drafts", "zero_drafts",
+    "missing_logprobs", "short_logprobs",
+])
+def test_mtp3_graph_assertions_reject_false_parity(fault):
+    from tests.integration.graph.test_qwen35_35b_a3b_mtp3_graph_parity import (
+        _assert_mtp3_graph_parity,
+    )
+    result = _mtp3_parity_payload()
+    log = _mtp3_parity_log()
+    worker = result["graph"]["workers"][1]
+    if fault == "downgraded":
+        worker["compilation_config"]["decode_mode"] = "PIECEWISE"
+    elif fault == "uncaptured":
+        worker["compilation_config"]["num_cudagraph_captured"] = 0
+    elif fault == "empty_capture_sizes":
+        worker["compilation_config"]["cudagraph_capture_sizes"] = []
+    elif fault == "wrong_mtp":
+        worker["speculative_config"]["method"] = "eagle"
+    elif fault == "wrong_draft_count":
+        worker["speculative_config"]["num_speculative_tokens"] = 1
+    elif fault == "wrong_tp":
+        worker["parallel_config"]["tensor_parallel_size"] = 1
+    elif fault == "missing_worker":
+        result["graph"]["workers"].pop()
+    elif fault == "empty_round":
+        result["graph"]["rounds"][1] = []
+    elif fault == "short_output":
+        result["graph"]["rounds"][1][0]["token_ids"] = [1]
+    elif fault == "token_mismatch":
+        result["graph"]["rounds"][0][0]["token_ids"][0] = 99
+    elif fault == "second_round_mismatch":
+        for label in ("eager", "graph"):
+            result[label]["rounds"][1][0]["token_ids"][0] = 99
+    elif fault == "missing_full_metric":
+        log = log.replace("| FULL |", "| NONE |")
+    elif fault == "zero_full_metric":
+        log = log.replace("| FULL | 4 |", "| FULL | 0 |")
+    elif fault == "missing_drafts":
+        log = log.replace("SpecDecoding metrics:", "unrelated:")
+    elif fault == "zero_drafts":
+        log = log.replace("Drafted: 12", "Drafted: 0")
+    elif fault == "missing_logprobs":
+        result["graph"]["rounds"][1][0]["cumulative_logprob"] = None
+    elif fault == "short_logprobs":
+        result["graph"]["rounds"][1][0]["sample_logprob_count"] = 15
+    if fault is None:
+        _assert_mtp3_graph_parity(result, log)
+    else:
+        with pytest.raises(AssertionError):
+            _assert_mtp3_graph_parity(result, log)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_model_runtime_cli.py
+++ b/tests/integration/test_model_runtime_cli.py
@@ -78,6 +78,7 @@ def test_mtp3_graph_cli_uses_worker_config_and_repeats_sequential_engines(
                 speculative_config=SimpleNamespace(
                     method="mtp", num_speculative_tokens=3,
                 ),
+                cache_config=SimpleNamespace(mamba_cache_dtype="float32"),
                 compilation_config=SimpleNamespace(
                     mode=SimpleNamespace(
                         name="NONE" if self.label == "eager" else "VLLM_COMPILE"
@@ -123,6 +124,7 @@ def test_mtp3_graph_cli_uses_worker_config_and_repeats_sequential_engines(
         assert engine.kwargs["speculative_config"] == {
             "method": "mtp", "num_speculative_tokens": 3,
         }
+        assert engine.kwargs["mamba_cache_dtype"] == "float32"
         assert engine.kwargs["tensor_parallel_size"] == 2
         assert engine.kwargs["enable_expert_parallel"] is True
         assert engine.kwargs["moe_backend"] == "aiter"
@@ -176,6 +178,7 @@ def _mtp3_parity_payload():
             "enable_expert_parallel": True,
         },
         "speculative_config": {"method": "mtp", "num_speculative_tokens": 3},
+        "cache_config": {"mamba_cache_dtype": "float32"},
         "compilation_config": {
             "mode": "VLLM_COMPILE", "cudagraph_mode": "FULL_DECODE_ONLY",
             "decode_mode": "FULL", "cudagraph_capture_sizes": [4, 8],

--- a/tests/patch/test_hcu_ci_selector.py
+++ b/tests/patch/test_hcu_ci_selector.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 import datetime as dt
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -192,6 +193,58 @@ def test_every_hcu_marked_test_file_is_registered() -> None:
     }
     registered_files = {registration.test_file for registration in parse_registry()}
     assert hcu_test_files <= registered_files
+
+
+def test_qwen35_mtp3_graph_has_exact_registration_on_multicard_job() -> None:
+    target = (
+        "tests/integration/graph/test_qwen35_35b_a3b_mtp3_graph_parity.py::"
+        "test_qwen35_35b_a3b_tp2_ep2_mtp3_full_decode_graph_aiter_auto_shuffle"
+    )
+    registrations = [
+        item for item in parse_registry()
+        if item.target == target and item.disabled is None
+    ]
+    assert {item.job for item in registrations} == {"qwen35-tp-ep"}
+    jobs = validate_config(_config())
+    assert jobs["qwen35-tp-ep"]["cards"] >= 2
+    assert jobs["qwen35-tp-ep"]["arch"] == "gfx938"
+
+
+def test_qwen35_mtp3_graph_routes_to_multicard_job_without_widening_other_graphs():
+    assert "qwen35-tp-ep" in _selected_job_ids(
+        "tests/integration/graph/test_qwen35_35b_a3b_mtp3_graph_parity.py"
+    )
+    assert "qwen35-tp-ep" not in _selected_job_ids(
+        "tests/integration/graph/test_qwen35_9b_graph_parity.py"
+    )
+
+
+def test_qwen35_mtp3_graph_job_filter_collects_graph_and_existing_smoke() -> None:
+    job = validate_config(_config())["qwen35-tp-ep"]
+    graph_target = (
+        "tests/integration/graph/test_qwen35_35b_a3b_mtp3_graph_parity.py::"
+        "test_qwen35_35b_a3b_tp2_ep2_mtp3_full_decode_graph_aiter_auto_shuffle"
+    )
+    smoke_target = (
+        "tests/integration/parallel/test_tp_ep_models.py::"
+        "test_qwen35_35b_a3b_tp_ep_smoke"
+    )
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "pytest", "--collect-only", "-q",
+            graph_target, smoke_target, *job["pytest_args"],
+        ],
+        cwd=REPOSITORY,
+        env={**os.environ, "VLLM_PLUGINS": "__disabled__"},
+        text=True,
+        capture_output=True,
+        timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    collected = result.stdout.splitlines()
+    assert graph_target in collected, result.stdout
+    assert sum(line.startswith(smoke_target + "[") for line in collected) == 6
 
 
 def test_due_quarantine_builds_a_fail_closed_retest_job(tmp_path: Path) -> None:
@@ -695,7 +748,7 @@ def test_deepseek_runtime_change_selects_deepseek_jobs() -> None:
     assert fallback is False
 
 
-def test_model_runtime_change_selects_text_vl_and_pooling_models() -> None:
+def test_model_runtime_change_selects_text_vl_pooling_and_tp_ep_models() -> None:
     jobs, groups, fallback = select_jobs(
         _config(),
         ["tests/integration/model_runtime.py"],
@@ -705,6 +758,7 @@ def test_model_runtime_change_selects_text_vl_and_pooling_models() -> None:
             "qwen35-smoke",
             "qwen25-models",
             "qwen3-pooling",
+            "qwen35-tp-ep",
         }
     )
     assert "model-runtime-helper" in groups

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -935,36 +935,155 @@ def test_fla_chunk_o_feature_off_is_numerically_identical(monkeypatch):
     torch.testing.assert_close(module.chunk_fwd_o(x, x, x, x), original(x, x, x, x))
 
 
-def test_fla_chunk_delta_h_enabled_missing_aiter_fails_clearly(monkeypatch):
-    adapter = _adapter("patch_fla_chunk_delta_h")
-
-    def original(k, w, u, g=None, gk=None, initial_state=None,
-                 output_final_state=False, chunk_size=64, save_new_value=True,
-                 cu_seqlens=None, chunk_indices=None, chunk_offsets=None,
-                 use_exp2=False):
-        return k, u, None
-
-    module = _module(
+def _chunk_delta_module(adapter, original):
+    return _module(
         adapter.TARGET_MODULE,
         FLA_CHUNK_SIZE=64,
         chunk_gated_delta_rule_fwd_h=original,
+        prepare_chunk_indices=lambda seq, size: torch.tensor([[0, 0]]),
+        prepare_chunk_offsets=lambda seq, size: torch.tensor([0]),
+        triton=SimpleNamespace(cdiv=lambda value, divisor: (value + divisor - 1) // divisor),
         torch=torch,
     )
+
+
+def _chunk_delta_original(k, w, u, g=None, gk=None, initial_state=None,
+                          output_final_state=False, chunk_size=64,
+                          save_new_value=True, cu_seqlens=None,
+                          chunk_indices=None, chunk_offsets=None,
+                          use_exp2=False):
+    return "original-h", "original-v", "original-final"
+
+
+def test_fla_chunk_delta_h_prefers_hip_and_preserves_metadata(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_delta_h")
+    calls = []
+
+    def hip(k, w, u, g=None, gk=None, initial_state=None,
+            initial_state_indices=None, output_final_state=True,
+            chunk_size=64, save_new_value=True, cu_seqlens=None,
+            chunk_indices=None, chunk_offsets=None, use_exp2=False,
+            transpose_state_layout=True, kernel_cfg=None):
+        calls.append((chunk_size, output_final_state, save_new_value,
+                      cu_seqlens, chunk_indices, chunk_offsets,
+                      use_exp2, transpose_state_layout, kernel_cfg))
+        return "hip-h", "hip-v", "hip-final"
+
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.fla",
+        chunk_gated_delta_rule_fwd_vllm_hip_blockdim64=hip,
+    )
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.vllm.chunk_delta_h",
+        launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64=lambda **kwargs: pytest.fail(
+            "HIP must have priority"
+        ),
+    )
+    module = _chunk_delta_module(adapter, _chunk_delta_original)
     adapter.apply_to_module(module)
     from vllm_hcu.platforms import envs as henvs
-
-    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
     monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
-    monkeypatch.setitem(
-        sys.modules,
-        "aiter.ops.triton.fla.vllm.chunk_delta_h",
-        ModuleType("aiter.ops.triton.fla.vllm.chunk_delta_h"),
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(
+        henvs, "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP", True
     )
-    with pytest.raises(RuntimeError, match="enabled but unavailable"):
+    cu_seqlens = torch.tensor([0, 2])
+    result = module.chunk_gated_delta_rule_fwd_h(
+        torch.zeros(1, 2, 1, 4),
+        torch.zeros(1, 2, 1, 4),
+        torch.zeros(1, 2, 1, 4),
+        output_final_state=True,
+        chunk_size=32,
+        save_new_value=False,
+        cu_seqlens=cu_seqlens,
+        use_exp2=True,
+    )
+    assert result == ("hip-h", "hip-v", "hip-final")
+    assert calls[0][0:3] == (32, True, False)
+    assert calls[0][3] is cu_seqlens
+    assert calls[0][6:] == (True, True, None)
+
+
+def test_fla_chunk_delta_h_uses_aiter_triton_when_hip_is_unavailable(
+    monkeypatch,
+):
+    adapter = _adapter("patch_fla_chunk_delta_h")
+    calls = []
+    _install_fake_module(monkeypatch, "aiter.ops.fla")
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.vllm.chunk_delta_h",
+        launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64=(
+            lambda **kwargs: calls.append(kwargs)
+        ),
+    )
+    module = _chunk_delta_module(adapter, _chunk_delta_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(
+        henvs, "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP", True
+    )
+    module.chunk_gated_delta_rule_fwd_h(
+        torch.zeros(1, 2, 1, 4),
+        torch.zeros(1, 2, 1, 4),
+        torch.zeros(1, 2, 1, 4),
+        chunk_size=32,
+        use_exp2=True,
+    )
+    assert calls[0]["BT"] == 32
+    assert calls[0]["use_exp2"] is True
+    assert calls[0]["transpose_state_layout"] is True
+
+
+def test_fla_chunk_delta_h_uses_original_when_optional_aiter_is_unavailable(
+    monkeypatch,
+):
+    adapter = _adapter("patch_fla_chunk_delta_h")
+    _install_fake_module(monkeypatch, "aiter.ops.fla")
+    _install_fake_module(monkeypatch, "aiter.ops.triton.fla.vllm.chunk_delta_h")
+    module = _chunk_delta_module(adapter, _chunk_delta_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(
+        henvs, "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP", True
+    )
+    assert module.chunk_gated_delta_rule_fwd_h(
+        torch.zeros(1, 2, 1, 4),
+        torch.zeros(1, 2, 1, 4),
+        torch.zeros(1, 2, 1, 4),
+    ) == ("original-h", "original-v", "original-final")
+
+
+def test_fla_chunk_delta_h_propagates_selected_hip_runtime_error(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_delta_h")
+
+    def failing_hip(*args, **kwargs):
+        raise RuntimeError("hip delta launch failed")
+
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.fla",
+        chunk_gated_delta_rule_fwd_vllm_hip_blockdim64=failing_hip,
+    )
+    module = _chunk_delta_module(adapter, _chunk_delta_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(
+        henvs, "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP", True
+    )
+    with pytest.raises(RuntimeError, match="hip delta launch failed"):
         module.chunk_gated_delta_rule_fwd_h(
-            torch.empty(1, 1, 1, 1),
-            torch.empty(1),
-            torch.empty(1, 1, 1, 1),
+            torch.zeros(1, 2, 1, 4),
+            torch.zeros(1, 2, 1, 4),
+            torch.zeros(1, 2, 1, 4),
         )
 
 

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -993,6 +993,58 @@ def test_fla_chunk_o_prefers_hip_and_preserves_call_contract(monkeypatch):
     assert calls[0]["transpose_state_layout"] is True
 
 
+def test_fla_chunk_o_normalizes_varlen_inputs_before_hip(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_o")
+    calls = {}
+    prepared_indices = torch.tensor([[0, 0], [0, 1]], dtype=torch.int32)
+
+    def prepare_chunk_indices(cu_seqlens, chunk_size):
+        calls["prepare"] = (cu_seqlens, chunk_size)
+        return prepared_indices
+
+    def reference(q, k, v, h, g=None, scale=None, cu_seqlens=None,
+                  chunk_indices=None, chunk_size=64, core_attn_out=None):
+        if chunk_indices is None and cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+        if scale is None:
+            scale = k.shape[-1] ** -0.5
+        return v + scale
+
+    def hip(**kwargs):
+        calls["hip"] = kwargs
+        return kwargs["v"] + kwargs["scale"]
+
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.fla",
+        chunk_fwd_o_vllm_hip_blockdim64=hip,
+    )
+    module = _chunk_o_module(adapter, reference)
+    module.prepare_chunk_indices = prepare_chunk_indices
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", True)
+    cu_seqlens = torch.tensor([0, 2], dtype=torch.int32)
+    tensor = torch.zeros(1, 2, 1, 4)
+    expected = reference(
+        tensor, tensor, tensor, tensor,
+        cu_seqlens=cu_seqlens, chunk_size=32,
+    )
+    calls.pop("prepare")
+
+    result = module.chunk_fwd_o(
+        tensor, tensor, tensor, tensor,
+        cu_seqlens=cu_seqlens, chunk_size=32,
+    )
+
+    assert calls["prepare"] == (cu_seqlens, 32)
+    assert calls["hip"]["chunk_indices"] is prepared_indices
+    assert calls["hip"]["scale"] == tensor.shape[-1] ** -0.5
+    torch.testing.assert_close(result, expected)
+
+
 def test_fla_chunk_o_copies_hip_result_into_core_output(monkeypatch):
     adapter = _adapter("patch_fla_chunk_o")
     hip_result = torch.arange(8, dtype=torch.float32).reshape(1, 2, 1, 4)

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -1485,7 +1485,7 @@ def test_gdn_nn_layout_normalizes_all_conv_weight_consumers(monkeypatch):
         GDN_AITER_TRITON_AVAILABLE=True,
         gdn_aiter_fused_reshape_causal_conv1d_update_single_token=aiter_update,
         fused_recurrent_gated_delta_rule_packed_decode=lambda *a, **k: "official-recurrent",
-        fused_sigmoid_gating_delta_rule_update=lambda *a, **k: "official-sigmoid",
+        fused_sigmoid_gating_delta_rule_update=_gdn_sigmoid_update,
         GatedDeltaNetAttention=GatedDeltaNetAttention,
         MambaStateDtypeCalculator=SimpleNamespace(
             gated_delta_net_state_dtype=lambda *a: "calculator"

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -931,8 +931,148 @@ def test_fla_chunk_o_feature_off_is_numerically_identical(monkeypatch):
     from vllm_hcu.platforms import envs as henvs
 
     monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", False)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", False)
     x = torch.arange(4, dtype=torch.float32)
     torch.testing.assert_close(module.chunk_fwd_o(x, x, x, x), original(x, x, x, x))
+
+
+def _chunk_o_module(adapter, original):
+    return _module(
+        adapter.TARGET_MODULE,
+        FLA_CHUNK_SIZE=64,
+        chunk_fwd_o=original,
+        prepare_chunk_indices=lambda seq, size: torch.tensor([[0, 0]]),
+        triton=SimpleNamespace(cdiv=lambda value, divisor: (value + divisor - 1) // divisor),
+        torch=torch,
+    )
+
+
+def _chunk_o_original(q, k, v, h, g=None, scale=None, cu_seqlens=None,
+                      chunk_indices=None, chunk_size=64,
+                      core_attn_out=None):
+    return "original-output"
+
+
+def test_fla_chunk_o_prefers_hip_and_preserves_call_contract(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_o")
+    calls = []
+
+    def hip(**kwargs):
+        calls.append(kwargs)
+        return torch.ones_like(kwargs["v"])
+
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.fla",
+        chunk_fwd_o_vllm_hip_blockdim64=hip,
+    )
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.vllm.chunk_o",
+        launch_chunk_fwd_kernel_o=lambda **kwargs: pytest.fail(
+            "HIP must have priority"
+        ),
+    )
+    module = _chunk_o_module(adapter, _chunk_o_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", True)
+    cu_seqlens = torch.tensor([0, 2])
+    indices = torch.tensor([[0, 0]])
+    tensor = torch.zeros(1, 2, 1, 4)
+    module.chunk_fwd_o(
+        tensor, tensor, tensor, tensor, scale=0.25,
+        cu_seqlens=cu_seqlens, chunk_indices=indices, chunk_size=32,
+    )
+    assert calls[0]["scale"] == 0.25
+    assert calls[0]["cu_seqlens"] is cu_seqlens
+    assert calls[0]["chunk_indices"] is indices
+    assert calls[0]["chunk_size"] == 32
+    assert calls[0]["transpose_state_layout"] is True
+
+
+def test_fla_chunk_o_copies_hip_result_into_core_output(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_o")
+    hip_result = torch.arange(8, dtype=torch.float32).reshape(1, 2, 1, 4)
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.fla",
+        chunk_fwd_o_vllm_hip_blockdim64=lambda **kwargs: hip_result,
+    )
+    module = _chunk_o_module(adapter, _chunk_o_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", True)
+    core = torch.full((16,), -1.0)
+    tensor = torch.zeros(1, 2, 1, 4)
+    result = module.chunk_fwd_o(
+        tensor, tensor, tensor, tensor, core_attn_out=core
+    )
+    assert result.data_ptr() == core.data_ptr()
+    torch.testing.assert_close(result, hip_result)
+
+
+def test_fla_chunk_o_uses_aiter_triton_when_hip_is_unavailable(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_o")
+    calls = []
+    _install_fake_module(monkeypatch, "aiter.ops.fla")
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.vllm.chunk_o",
+        launch_chunk_fwd_kernel_o=lambda **kwargs: calls.append(kwargs),
+    )
+    module = _chunk_o_module(adapter, _chunk_o_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", True)
+    tensor = torch.zeros(1, 2, 1, 4)
+    module.chunk_fwd_o(tensor, tensor, tensor, tensor, chunk_size=32)
+    assert calls[0]["BT"] == 32
+    assert calls[0]["transpose_state_layout"] is True
+
+
+def test_fla_chunk_o_uses_original_when_optional_aiter_is_unavailable(
+    monkeypatch,
+):
+    adapter = _adapter("patch_fla_chunk_o")
+    _install_fake_module(monkeypatch, "aiter.ops.fla")
+    _install_fake_module(monkeypatch, "aiter.ops.triton.fla.vllm.chunk_o")
+    module = _chunk_o_module(adapter, _chunk_o_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", True)
+    tensor = torch.zeros(1, 2, 1, 4)
+    assert module.chunk_fwd_o(tensor, tensor, tensor, tensor) == (
+        "original-output"
+    )
+
+
+def test_fla_chunk_o_propagates_selected_hip_runtime_error(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_o")
+
+    def failing_hip(**kwargs):
+        raise RuntimeError("hip output launch failed")
+
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.fla",
+        chunk_fwd_o_vllm_hip_blockdim64=failing_hip,
+    )
+    module = _chunk_o_module(adapter, _chunk_o_original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", True)
+    tensor = torch.zeros(1, 2, 1, 4)
+    with pytest.raises(RuntimeError, match="hip output launch failed"):
+        module.chunk_fwd_o(tensor, tensor, tensor, tensor)
 
 
 def _chunk_delta_module(adapter, original):

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -1542,7 +1542,71 @@ def test_gdn_nn_layout_normalizes_all_conv_weight_consumers(monkeypatch):
     )
 
 
-def test_gdn_recurrent_and_sigmoid_remain_target_owned(monkeypatch):
+def _gdn_sigmoid_update(
+    A_log,
+    a,
+    b,
+    dt_bias,
+    q,
+    k,
+    v,
+    beta=1.0,
+    threshold=20.0,
+    scale=None,
+    initial_state=None,
+    inplace_final_state=True,
+    cu_seqlens=None,
+    ssm_state_indices=None,
+    num_accepted_tokens=None,
+    use_qk_l2norm_in_kernel=False,
+    is_kda=False,
+):
+    del (
+        A_log,
+        a,
+        b,
+        dt_bias,
+        q,
+        k,
+        v,
+        beta,
+        threshold,
+        scale,
+        initial_state,
+        inplace_final_state,
+        cu_seqlens,
+        ssm_state_indices,
+        num_accepted_tokens,
+        use_qk_l2norm_in_kernel,
+        is_kda,
+    )
+    return "official-sigmoid"
+
+
+def _sigmoid_module(adapter, official=_gdn_sigmoid_update):
+    return _module(
+        adapter.TARGET_MODULE,
+        GDN_AITER_TRITON_AVAILABLE=False,
+        fused_recurrent_gated_delta_rule_packed_decode=(
+            lambda *args, **kwargs: "official-recurrent"
+        ),
+        fused_sigmoid_gating_delta_rule_update=official,
+    )
+
+
+def _sigmoid_arguments(dtype):
+    return {
+        "A_log": torch.zeros(1, dtype=torch.float32),
+        "a": torch.zeros(1, dtype=dtype),
+        "b": torch.zeros(1, dtype=dtype),
+        "dt_bias": torch.zeros(1, dtype=torch.float32),
+        "q": torch.zeros(1, dtype=dtype),
+        "k": torch.zeros(1, dtype=dtype),
+        "v": torch.zeros(1, dtype=dtype),
+    }
+
+
+def test_qwen_recurrent_remains_target_owned(monkeypatch):
     adapter = _adapter("patch_gdn_linear_attention")
 
     _install_fake_module(
@@ -1552,36 +1616,165 @@ def test_gdn_recurrent_and_sigmoid_remain_target_owned(monkeypatch):
             "retired HCU recurrent path must not be imported"
         ),
     )
-    _install_fake_module(
-        monkeypatch,
-        "aiter.ops.triton.fla.fused_sigmoid_gating",
-        fused_sigmoid_gating_delta_rule_update=lambda *a, **k: pytest.fail(
-            "retired HCU sigmoid path must not be imported"
-        ),
-    )
 
     def recurrent(*args, **kwargs):
         del args, kwargs
         return "official-recurrent"
 
-    def sigmoid(*args, **kwargs):
-        del args, kwargs
-        return "official-sigmoid"
-
     module = _module(
         adapter.TARGET_MODULE,
         GDN_AITER_TRITON_AVAILABLE=False,
         fused_recurrent_gated_delta_rule_packed_decode=recurrent,
-        fused_sigmoid_gating_delta_rule_update=sigmoid,
+        fused_sigmoid_gating_delta_rule_update=_gdn_sigmoid_update,
     )
     adapter.apply_to_module(module)
     from vllm_hcu.platforms import envs as henvs
 
     monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
     assert module.fused_recurrent_gated_delta_rule_packed_decode is recurrent
-    assert module.fused_sigmoid_gating_delta_rule_update is sigmoid
     assert module.fused_recurrent_gated_delta_rule_packed_decode() == "official-recurrent"
-    assert module.fused_sigmoid_gating_delta_rule_update() == "official-sigmoid"
+
+
+def test_gdn_qwen_sigmoid_prefers_aiter_hip_for_matching_dtype(monkeypatch):
+    adapter = _adapter("patch_gdn_linear_attention")
+    _install_fake_module(
+        monkeypatch,
+        "aiter",
+        vllm_fused_sigmoid_gating_delta_rule_update=(
+            lambda *args, **kwargs: "hip-sigmoid"
+        ),
+    )
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.fused_sigmoid_gating",
+        fused_sigmoid_gating_delta_rule_update=lambda *args, **kwargs: pytest.fail(
+            "matching dtype must prefer HIP"
+        ),
+    )
+    module = _sigmoid_module(adapter)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE",
+        True,
+    )
+    assert module.fused_sigmoid_gating_delta_rule_update(
+        **_sigmoid_arguments(torch.float32)
+    ) == "hip-sigmoid"
+
+
+def test_gdn_qwen_sigmoid_uses_aiter_triton_for_mixed_a_log_dtype(monkeypatch):
+    adapter = _adapter("patch_gdn_linear_attention")
+    _install_fake_module(
+        monkeypatch,
+        "aiter",
+        vllm_fused_sigmoid_gating_delta_rule_update=lambda *args, **kwargs: pytest.fail(
+            "mixed A_log dtype must skip HIP"
+        ),
+    )
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.fused_sigmoid_gating",
+        fused_sigmoid_gating_delta_rule_update=(
+            lambda *args, **kwargs: "triton-sigmoid"
+        ),
+    )
+    module = _sigmoid_module(adapter)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE",
+        True,
+    )
+    assert module.fused_sigmoid_gating_delta_rule_update(
+        **_sigmoid_arguments(torch.bfloat16)
+    ) == "triton-sigmoid"
+
+
+@pytest.mark.parametrize("mode", ["disabled", "missing"])
+def test_gdn_qwen_sigmoid_uses_official_when_disabled_or_aiter_missing(
+    monkeypatch,
+    mode,
+):
+    adapter = _adapter("patch_gdn_linear_attention")
+    if mode == "disabled":
+        _install_fake_module(
+            monkeypatch,
+            "aiter",
+            vllm_fused_sigmoid_gating_delta_rule_update=(
+                lambda *args, **kwargs: pytest.fail("selector is disabled")
+            ),
+        )
+        _install_fake_module(
+            monkeypatch,
+            "aiter.ops.triton.fla.fused_sigmoid_gating",
+            fused_sigmoid_gating_delta_rule_update=(
+                lambda *args, **kwargs: pytest.fail("selector is disabled")
+            ),
+        )
+    else:
+        _install_fake_module(monkeypatch, "aiter")
+        _install_fake_module(
+            monkeypatch, "aiter.ops.triton.fla.fused_sigmoid_gating"
+        )
+    module = _sigmoid_module(adapter)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE",
+        mode != "disabled",
+    )
+    assert module.fused_sigmoid_gating_delta_rule_update(
+        **_sigmoid_arguments(torch.bfloat16)
+    ) == "official-sigmoid"
+
+
+def test_gdn_qwen_sigmoid_wrapper_is_qwen_local_and_idempotent(monkeypatch):
+    adapter = _adapter("patch_gdn_linear_attention")
+    canonical = _gdn_sigmoid_update
+    module = _sigmoid_module(adapter, canonical)
+    recurrent = module.fused_recurrent_gated_delta_rule_packed_decode
+    assert adapter.apply_to_module(module) is True
+    assert adapter.apply_to_module(module) is False
+    assert module.fused_sigmoid_gating_delta_rule_update is not canonical
+    assert module._vllm_hcu_original_fused_sigmoid is canonical
+    assert module.fused_recurrent_gated_delta_rule_packed_decode is recurrent
+
+
+def test_gdn_qwen_sigmoid_propagates_selected_kernel_error(monkeypatch):
+    adapter = _adapter("patch_gdn_linear_attention")
+
+    def failing_hip(*args, **kwargs):
+        raise RuntimeError("sigmoid update launch failed")
+
+    _install_fake_module(
+        monkeypatch,
+        "aiter",
+        vllm_fused_sigmoid_gating_delta_rule_update=failing_hip,
+    )
+    module = _sigmoid_module(adapter)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(
+        henvs,
+        "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE",
+        True,
+    )
+    with pytest.raises(RuntimeError, match="sigmoid update launch failed"):
+        module.fused_sigmoid_gating_delta_rule_update(
+            **_sigmoid_arguments(torch.float32)
+        )
 
 
 def test_gdn_state_dtype_feature_on_uses_auto_ssm_dtype(monkeypatch):

--- a/tests/runtime_patch/test_gdn_v0251_ownership.py
+++ b/tests/runtime_patch/test_gdn_v0251_ownership.py
@@ -609,7 +609,10 @@ def test_native_aiter_signature_and_keyword_calls_fail_closed(
             unexpected=torch.empty(1),
         )
 
-    bad_module, _, _, _, _ = _fake_qwen(aiter_available=True)
+    bad_module, _, _, _, original_sigmoid = _fake_qwen(aiter_available=True)
+    native_update = (
+        bad_module.gdn_aiter_fused_reshape_causal_conv1d_update_single_token
+    )
 
     def incompatible(x, weight):
         return x, weight
@@ -619,6 +622,17 @@ def test_native_aiter_signature_and_keyword_calls_fail_closed(
     )
     with pytest.raises(PatchCompatibilityError, match="incompatible parameters"):
         adapter.apply_to_module(bad_module)
+    assert bad_module.fused_sigmoid_gating_delta_rule_update is original_sigmoid
+    assert not hasattr(bad_module, "_vllm_hcu_original_fused_sigmoid")
+    assert not getattr(bad_module, "_vllm_hcu_qwen_gdn_aiter_layout_applied", False)
+
+    bad_module.gdn_aiter_fused_reshape_causal_conv1d_update_single_token = (
+        native_update
+    )
+    assert adapter.apply_to_module(bad_module) is True
+    assert adapter.apply_to_module(bad_module) is False
+    assert bad_module.fused_sigmoid_gating_delta_rule_update is not original_sigmoid
+    assert bad_module._vllm_hcu_original_fused_sigmoid is original_sigmoid
 
 
 def test_real_v0251_cold_import_scopes_gdn_deltas_to_qwen():

--- a/tests/runtime_patch/test_gdn_v0251_ownership.py
+++ b/tests/runtime_patch/test_gdn_v0251_ownership.py
@@ -498,9 +498,9 @@ def test_qwen_local_weight_deltas_and_target_fla_ownership(
     assert module.causal_conv1d_fn is not canonical.causal_conv1d_fn
     assert module.causal_conv1d_update is not canonical.causal_conv1d_update
     assert module.fused_recurrent_gated_delta_rule_packed_decode is recurrent
-    assert module.fused_sigmoid_gating_delta_rule_update is sigmoid
+    assert module.fused_sigmoid_gating_delta_rule_update is not sigmoid
     assert not hasattr(module, "_vllm_hcu_original_fused_recurrent")
-    assert not hasattr(module, "_vllm_hcu_original_fused_sigmoid")
+    assert module._vllm_hcu_original_fused_sigmoid is sigmoid
 
     conv_state = torch.empty(1, 8, 3)
     x_fn = torch.empty(8, 2)
@@ -586,7 +586,8 @@ def test_native_aiter_unavailable_is_idempotent_and_does_not_require_symbol():
     assert adapter.apply_to_module(module) is True
     assert adapter.apply_to_module(module) is False
     assert module.fused_recurrent_gated_delta_rule_packed_decode is recurrent
-    assert module.fused_sigmoid_gating_delta_rule_update is sigmoid
+    assert module.fused_sigmoid_gating_delta_rule_update is not sigmoid
+    assert module._vllm_hcu_original_fused_sigmoid is sigmoid
     assert not hasattr(
         module,
         "gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
@@ -691,10 +692,13 @@ assert (
 )
 assert (
     qwen.fused_sigmoid_gating_delta_rule_update
-    is fla.fused_sigmoid_gating_delta_rule_update
+    is not fla.fused_sigmoid_gating_delta_rule_update
 )
 assert not hasattr(qwen, "_vllm_hcu_original_fused_recurrent")
-assert not hasattr(qwen, "_vllm_hcu_original_fused_sigmoid")
+assert (
+    qwen._vllm_hcu_original_fused_sigmoid
+    is fla.fused_sigmoid_gating_delta_rule_update
+)
 assert not bool(qwen.GDN_AITER_TRITON_AVAILABLE)
 assert getattr(qwen, "_vllm_hcu_qwen_gdn_aiter_layout_applied", False)
 

--- a/tests/runtime_patch/test_gdn_v0251_ownership.py
+++ b/tests/runtime_patch/test_gdn_v0251_ownership.py
@@ -274,6 +274,12 @@ def _install_module(monkeypatch: pytest.MonkeyPatch, name: str, **values):
     return module
 
 
+def _install_fake_module(
+    monkeypatch: pytest.MonkeyPatch, name: str, **values
+):
+    return _install_module(monkeypatch, name, **values)
+
+
 def _call_aiter(module, conv_state, weight):
     return module.gdn_aiter_fused_reshape_causal_conv1d_update_single_token(
         x=torch.empty(1),
@@ -292,6 +298,153 @@ def _call_aiter(module, conv_state, weight):
         conv_state_indices=None,
         validate_data=True,
     )
+
+
+def _causal_route_module(adapter, original_update):
+    original_update.__signature__ = inspect.signature(  # type: ignore[attr-defined]
+        _causal_update_contract
+    )
+    module = ModuleType(adapter.TARGET_MODULE)
+    module.causal_conv1d_fn = _causal_contract
+    module.causal_conv1d_update = original_update
+    return module
+
+
+def test_qwen_causal_update_routes_compatible_decode_to_external(monkeypatch):
+    adapter = _adapter("patch_gdn_causal_conv1d")
+    calls = {}
+
+    def original(*args, **kwargs):
+        calls["original"] = (args, kwargs)
+        return "original-update"
+
+    def custom_update(x, conv_state, weight, bias=None, activation=None,
+                      cache_seqlens=None, conv_state_indices=None):
+        calls["custom"] = {
+            "x": x,
+            "conv_state": conv_state,
+            "weight": weight,
+            "bias": bias,
+            "activation": activation,
+            "cache_seqlens": cache_seqlens,
+            "conv_state_indices": conv_state_indices,
+        }
+        return "custom-update"
+
+    _install_fake_module(
+        monkeypatch,
+        "causal_conv1d.causal_conv1d_interface",
+        causal_conv1d_update=custom_update,
+    )
+    module = _causal_route_module(adapter, original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_USE_NN", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D", True)
+    x = torch.empty(2, 8)
+    state = torch.empty(1, 8, 3)
+    physical_weight = torch.arange(32, dtype=torch.float32).reshape(4, 8)
+    indices = torch.tensor([0, 1])
+    assert module.causal_conv1d_update(
+        x, state, physical_weight, activation="silu",
+        conv_state_indices=indices, validate_data=True,
+    ) == "custom-update"
+    assert "original" not in calls
+    torch.testing.assert_close(
+        calls["custom"]["weight"], physical_weight.T.contiguous()
+    )
+    assert calls["custom"]["conv_state_indices"] is indices
+
+
+def test_qwen_causal_update_falls_back_for_spec_metadata(monkeypatch):
+    adapter = _adapter("patch_gdn_causal_conv1d")
+    calls = []
+
+    def original(*args, **kwargs):
+        calls.append(
+            inspect.signature(_causal_update_contract).bind(*args, **kwargs)
+        )
+        return "original-update"
+
+    _install_fake_module(
+        monkeypatch,
+        "causal_conv1d.causal_conv1d_interface",
+        causal_conv1d_update=lambda *args, **kwargs: pytest.fail(
+            "spec metadata is unsupported by the external kernel"
+        ),
+    )
+    module = _causal_route_module(adapter, original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_USE_NN", False)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D", True)
+    accepted = torch.tensor([1])
+    query_start = torch.tensor([0, 1])
+    result = module.causal_conv1d_update(
+        torch.empty(1, 8), torch.empty(1, 8, 3), torch.empty(8, 4),
+        num_accepted_tokens=accepted, query_start_loc=query_start,
+        max_query_len=1,
+    )
+    assert result == "original-update"
+    assert calls[0].arguments["num_accepted_tokens"] is accepted
+    assert calls[0].arguments["query_start_loc"] is query_start
+
+
+def test_qwen_causal_update_falls_back_when_external_module_is_missing(
+    monkeypatch,
+):
+    adapter = _adapter("patch_gdn_causal_conv1d")
+    calls = []
+
+    def original(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "original-update"
+
+    _install_fake_module(
+        monkeypatch, "causal_conv1d.causal_conv1d_interface"
+    )
+    module = _causal_route_module(adapter, original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_USE_NN", False)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D", True)
+    assert module.causal_conv1d_update(
+        torch.empty(1, 8), torch.empty(1, 8, 3), torch.empty(8, 4)
+    ) == "original-update"
+    assert len(calls) == 1
+
+
+def test_qwen_causal_update_propagates_selected_kernel_error(monkeypatch):
+    adapter = _adapter("patch_gdn_causal_conv1d")
+
+    def original(*args, **kwargs):
+        return "original-update"
+
+    def failing_custom(*args, **kwargs):
+        raise RuntimeError("causal update launch failed")
+
+    _install_fake_module(
+        monkeypatch,
+        "causal_conv1d.causal_conv1d_interface",
+        causal_conv1d_update=failing_custom,
+    )
+    module = _causal_route_module(adapter, original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_USE_NN", False)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D", True)
+    with pytest.raises(RuntimeError, match="causal update launch failed"):
+        module.causal_conv1d_update(
+            torch.empty(1, 8), torch.empty(1, 8, 3), torch.empty(8, 4)
+        )
 
 
 def test_dispatcher_scopes_all_gdn_callbacks_to_qwen():
@@ -333,6 +486,8 @@ def test_qwen_local_weight_deltas_and_target_fla_ownership(
     from vllm_hcu.platforms import envs as henvs
 
     monkeypatch.setattr(henvs, "VLLM_USE_NN", use_nn)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", False)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D", False)
     assert causal_adapter.apply_to_module(module) is True
     assert aiter_adapter.apply_to_module(module) is True
     assert causal_adapter.apply_to_module(module) is False

--- a/tests/runtime_patch/test_gdn_v0251_ownership.py
+++ b/tests/runtime_patch/test_gdn_v0251_ownership.py
@@ -348,7 +348,7 @@ def test_qwen_causal_update_routes_compatible_decode_to_external(
             "cache_seqlens": cache_seqlens,
             "conv_state_indices": conv_state_indices,
         }
-        return "custom-update"
+        return torch.full_like(x, 7)
 
     _install_fake_module(
         monkeypatch,
@@ -366,10 +366,11 @@ def test_qwen_causal_update_routes_compatible_decode_to_external(
     state = torch.empty(1, 8, 3)
     physical_weight = torch.arange(32, dtype=torch.float32).reshape(4, 8)
     indices = torch.tensor([0, 1])
-    assert module.causal_conv1d_update(
+    result = module.causal_conv1d_update(
         x, state, physical_weight, activation=activation,
         conv_state_indices=indices, validate_data=True,
-    ) == "custom-update"
+    )
+    torch.testing.assert_close(result, torch.full_like(x, 7))
     assert "original" not in calls
     torch.testing.assert_close(
         calls["custom"]["weight"], physical_weight.T.contiguous()
@@ -377,6 +378,49 @@ def test_qwen_causal_update_routes_compatible_decode_to_external(
     assert calls["custom"]["conv_state_indices"] is indices
     assert calls["custom"]["activation"] == expected_activation
     assert calls["custom"]["cache_seqlens"] is None
+
+
+def test_qwen_causal_update_preserves_vllm_mixed_cache_dtype_contract(
+    monkeypatch,
+):
+    adapter = _adapter("patch_gdn_causal_conv1d")
+    calls = {}
+
+    def original(*args, **kwargs):
+        pytest.fail("compatible decode must use the selected external kernel")
+
+    def custom_update(x, conv_state, weight, bias=None, activation=None,
+                      cache_seqlens=None, conv_state_indices=None):
+        assert x.dtype == conv_state.dtype
+        calls["x_dtype"] = x.dtype
+        calls["indices"] = conv_state_indices
+        return x + 1
+
+    _install_fake_module(
+        monkeypatch,
+        "causal_conv1d.causal_conv1d_interface",
+        causal_conv1d_update=custom_update,
+    )
+    module = _causal_route_module(adapter, original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_USE_NN", False)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D", True)
+    x = torch.zeros(2, 8, dtype=torch.bfloat16)
+    state = torch.zeros(2, 8, 3, dtype=torch.float32)
+    weight = torch.zeros(8, 4, dtype=torch.float32)
+    indices = torch.tensor([0, 1], dtype=torch.int32)
+
+    result = module.causal_conv1d_update(
+        x, state, weight, conv_state_indices=indices
+    )
+
+    assert calls["x_dtype"] == state.dtype
+    assert calls["indices"] is indices
+    assert result.dtype == x.dtype
+    torch.testing.assert_close(result, torch.ones_like(x))
 
 
 def test_qwen_causal_update_falls_back_for_spec_metadata(monkeypatch):

--- a/tests/runtime_patch/test_gdn_v0251_ownership.py
+++ b/tests/runtime_patch/test_gdn_v0251_ownership.py
@@ -213,6 +213,15 @@ def _recording_callable(contract, name: str, calls: dict[str, object]):
     return target
 
 
+def _sigmoid_contract(
+    A_log, a, b, dt_bias, q, k, v, beta=1.0, threshold=20.0, scale=None,
+    initial_state=None, inplace_final_state=True, cu_seqlens=None,
+    ssm_state_indices=None, num_accepted_tokens=None,
+    use_qk_l2norm_in_kernel=False, is_kda=False,
+):
+    return "target-sigmoid"
+
+
 def _fake_qwen(*, aiter_available: bool = True):
     calls: dict[str, object] = {}
     causal = _recording_callable(_causal_contract, "causal", calls)
@@ -240,6 +249,8 @@ def _fake_qwen(*, aiter_available: bool = True):
     def sigmoid(*args, **kwargs):
         del args, kwargs
         return "target-sigmoid"
+
+    sigmoid.__signature__ = inspect.signature(_sigmoid_contract)
 
     values = {
         "GDN_AITER_TRITON_AVAILABLE": aiter_available,
@@ -310,7 +321,13 @@ def _causal_route_module(adapter, original_update):
     return module
 
 
-def test_qwen_causal_update_routes_compatible_decode_to_external(monkeypatch):
+@pytest.mark.parametrize(
+    ("activation", "expected_activation"),
+    [(True, "silu"), (False, None), ("silu", "silu"), ("swish", "swish"), (None, None)],
+)
+def test_qwen_causal_update_routes_compatible_decode_to_external(
+    monkeypatch, activation, expected_activation,
+):
     adapter = _adapter("patch_gdn_causal_conv1d")
     calls = {}
 
@@ -320,6 +337,8 @@ def test_qwen_causal_update_routes_compatible_decode_to_external(monkeypatch):
 
     def custom_update(x, conv_state, weight, bias=None, activation=None,
                       cache_seqlens=None, conv_state_indices=None):
+        if activation not in [None, "silu", "swish"]:
+            raise NotImplementedError("Only silu activation is supported")
         calls["custom"] = {
             "x": x,
             "conv_state": conv_state,
@@ -348,7 +367,7 @@ def test_qwen_causal_update_routes_compatible_decode_to_external(monkeypatch):
     physical_weight = torch.arange(32, dtype=torch.float32).reshape(4, 8)
     indices = torch.tensor([0, 1])
     assert module.causal_conv1d_update(
-        x, state, physical_weight, activation="silu",
+        x, state, physical_weight, activation=activation,
         conv_state_indices=indices, validate_data=True,
     ) == "custom-update"
     assert "original" not in calls
@@ -356,6 +375,8 @@ def test_qwen_causal_update_routes_compatible_decode_to_external(monkeypatch):
         calls["custom"]["weight"], physical_weight.T.contiguous()
     )
     assert calls["custom"]["conv_state_indices"] is indices
+    assert calls["custom"]["activation"] == expected_activation
+    assert calls["custom"]["cache_seqlens"] is None
 
 
 def test_qwen_causal_update_falls_back_for_spec_metadata(monkeypatch):
@@ -592,6 +613,68 @@ def test_native_aiter_unavailable_is_idempotent_and_does_not_require_symbol():
         module,
         "gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
     )
+
+
+@pytest.mark.parametrize("aiter_available", [False, True])
+@pytest.mark.parametrize("saved_state", [False, True])
+@pytest.mark.parametrize(
+    "incompatibility",
+    [
+        "missing", "reordered", "keyword_only", "variadic",
+        "beta", "threshold", "scale", "initial_state", "inplace_final_state",
+        "cu_seqlens", "ssm_state_indices", "num_accepted_tokens",
+        "use_qk_l2norm_in_kernel", "is_kda",
+    ],
+)
+def test_sigmoid_incompatible_signature_leaves_module_unchanged_and_retryable(
+    aiter_available, saved_state, incompatibility,
+):
+    adapter = _adapter("patch_gdn_linear_attention")
+    module, _, _, _, official_sigmoid = _fake_qwen(
+        aiter_available=aiter_available
+    )
+    parameters = list(inspect.signature(_sigmoid_contract).parameters.values())
+    if incompatibility == "missing":
+        signature = inspect.signature(lambda x: x)
+    elif incompatibility == "variadic":
+        signature = inspect.signature(lambda *args, **kwargs: None)
+    else:
+        if incompatibility == "reordered":
+            parameters[0], parameters[1] = parameters[1], parameters[0]
+        elif incompatibility == "keyword_only":
+            parameters[-1] = parameters[-1].replace(
+                kind=inspect.Parameter.KEYWORD_ONLY
+            )
+        else:
+            index = next(
+                i for i, parameter in enumerate(parameters)
+                if parameter.name == incompatibility
+            )
+            parameters[index] = parameters[index].replace(default="incompatible")
+        signature = inspect.Signature(parameters)
+
+    def incompatible(*args, **kwargs):
+        pytest.fail("incompatible sigmoid must never be invoked")
+
+    incompatible.__signature__ = signature
+    module.fused_sigmoid_gating_delta_rule_update = incompatible
+    if saved_state:
+        module._vllm_hcu_original_fused_sigmoid = object()
+        module._vllm_hcu_original_gdn_aiter_update = object()
+        module._vllm_hcu_qwen_gdn_aiter_layout_applied = False
+    before = dict(vars(module))
+    with pytest.raises(PatchCompatibilityError, match="incompatible signature"):
+        adapter.apply_to_module(module)
+    assert vars(module) == before
+
+    module.fused_sigmoid_gating_delta_rule_update = official_sigmoid
+    assert adapter.apply_to_module(module) is True
+    assert adapter.apply_to_module(module) is False
+    assert module._vllm_hcu_original_fused_sigmoid is official_sigmoid
+    if aiter_available:
+        assert module._vllm_hcu_original_gdn_aiter_update is before[
+            "gdn_aiter_fused_reshape_causal_conv1d_update_single_token"
+        ]
 
 
 def test_native_aiter_signature_and_keyword_calls_fail_closed(

--- a/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_delta_h.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_delta_h.py
@@ -22,6 +22,16 @@ def _enabled() -> bool:
     return bool(henvs.VLLM_HCU_USE_CUSTOM_AITER_FLA and henvs.VLLM_HCU_USE_CUSTOM_OPS)
 
 
+def _hip_enabled() -> bool:
+    from vllm_hcu.platforms import envs as henvs
+
+    return bool(
+        henvs.VLLM_HCU_USE_CUSTOM_OPS
+        and henvs.VLLM_HCU_USE_CUSTOM_AITER_FLA
+        and henvs.VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP
+    )
+
+
 def apply_to_module(module: ModuleType) -> bool:
     chunk = load_exact_module(TARGET_MODULE, module)
     if already_applied(chunk, _MARKER, ((chunk, "chunk_gated_delta_rule_fwd_h", TARGETS[0], _WRAPPER),)):
@@ -54,13 +64,8 @@ def apply_to_module(module: ModuleType) -> bool:
             return original(k, w, u, g, gk, initial_state, output_final_state,
                             chunk_size, save_new_value, cu_seqlens, chunk_indices,
                             chunk_offsets, use_exp2)
-        try:
-            from aiter.ops.triton.fla.vllm.chunk_delta_h import (
-                launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64,
-            )
-        except ImportError as exc:
-            raise RuntimeError("HCU AITER FLA chunk_delta_h is enabled but unavailable") from exc
-
+        original_chunk_indices = chunk_indices
+        original_chunk_offsets = chunk_offsets
         B, T, Hg, K, V = *k.shape, u.shape[-1]
         H, BT = u.shape[-2], chunk_size
         if chunk_indices is None and cu_seqlens is not None:
@@ -71,6 +76,32 @@ def apply_to_module(module: ModuleType) -> bool:
             N, NT = len(cu_seqlens) - 1, len(chunk_indices)
             if chunk_offsets is None:
                 chunk_offsets = chunk.prepare_chunk_offsets(cu_seqlens, BT)
+        if _hip_enabled():
+            try:
+                from aiter.ops.fla import (
+                    chunk_gated_delta_rule_fwd_vllm_hip_blockdim64 as hip_kernel,
+                )
+            except ImportError:
+                hip_kernel = None
+            if hip_kernel is not None:
+                return hip_kernel(
+                    k, w, u, g=g, gk=gk, initial_state=initial_state,
+                    initial_state_indices=None, output_final_state=output_final_state,
+                    chunk_size=chunk_size, save_new_value=save_new_value,
+                    cu_seqlens=cu_seqlens, chunk_indices=chunk_indices,
+                    chunk_offsets=chunk_offsets, use_exp2=use_exp2,
+                    transpose_state_layout=True, kernel_cfg=None,
+                )
+        try:
+            from aiter.ops.triton.fla.vllm.chunk_delta_h import (
+                launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64,
+            )
+        except ImportError:
+            return original(
+                k, w, u, g, gk, initial_state, output_final_state, chunk_size,
+                save_new_value, cu_seqlens, original_chunk_indices,
+                original_chunk_offsets, use_exp2,
+            )
         if K > 256:
             raise ValueError("HCU AITER FLA does not support head dimension > 256")
         h = k.new_empty(B, NT, H, V, K)

--- a/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py
@@ -31,6 +31,15 @@ def _hip_enabled() -> bool:
     )
 
 
+def _normalize_kernel_inputs(chunk, k, cu_seqlens, chunk_indices,
+                             chunk_size, scale):
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = chunk.prepare_chunk_indices(cu_seqlens, chunk_size)
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    return chunk_indices, scale
+
+
 def apply_to_module(module: ModuleType) -> bool:
     chunk = load_exact_module(TARGET_MODULE, module)
     if already_applied(chunk, _MARKER, ((chunk, "chunk_fwd_o", TARGETS[0], _WRAPPER),)):
@@ -56,10 +65,14 @@ def apply_to_module(module: ModuleType) -> bool:
             except ImportError:
                 hip_kernel = None
             if hip_kernel is not None:
+                kernel_chunk_indices, kernel_scale = _normalize_kernel_inputs(
+                    chunk, k, cu_seqlens, chunk_indices, chunk_size, scale
+                )
                 hip_output = hip_kernel(
-                    q=q, k=k, v=v, h=h, g=g, g_gamma=None, scale=scale,
+                    q=q, k=k, v=v, h=h, g=g, g_gamma=None,
+                    scale=kernel_scale,
                     cu_seqlens=cu_seqlens, chunk_size=chunk_size,
-                    chunk_indices=chunk_indices, use_exp2=False,
+                    chunk_indices=kernel_chunk_indices, use_exp2=False,
                     transpose_state_layout=True, kernel_cfg=None,
                 )
                 if core_attn_out is None:
@@ -80,11 +93,10 @@ def apply_to_module(module: ModuleType) -> bool:
                             chunk_size, core_attn_out)
         B, T, Hg, K, V = *q.shape, v.shape[-1]
         H, BT = v.shape[-2], chunk_size
-        if chunk_indices is None and cu_seqlens is not None:
-            chunk_indices = chunk.prepare_chunk_indices(cu_seqlens, BT)
+        chunk_indices, scale = _normalize_kernel_inputs(
+            chunk, k, cu_seqlens, chunk_indices, BT, scale
+        )
         NT = chunk.triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
-        if scale is None:
-            scale = k.shape[-1] ** -0.5
         if core_attn_out is not None:
             if core_attn_out.numel() < v.numel():
                 raise ValueError("core_attn_out is too small for HCU FLA chunk_o")

--- a/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py
@@ -22,6 +22,15 @@ def _enabled() -> bool:
     return bool(henvs.VLLM_HCU_USE_CUSTOM_AITER_FLA and henvs.VLLM_HCU_USE_CUSTOM_OPS)
 
 
+def _hip_enabled() -> bool:
+    from vllm_hcu.platforms import envs as henvs
+
+    return bool(
+        henvs.VLLM_HCU_USE_CUSTOM_OPS
+        and henvs.VLLM_HCU_USE_CHUNK_FWD_KERNEL_O
+    )
+
+
 def apply_to_module(module: ModuleType) -> bool:
     chunk = load_exact_module(TARGET_MODULE, module)
     if already_applied(chunk, _MARKER, ((chunk, "chunk_fwd_o", TARGETS[0], _WRAPPER),)):
@@ -39,13 +48,36 @@ def apply_to_module(module: ModuleType) -> bool:
     def hcu_chunk_o(q, k, v, h, g=None, scale=None, cu_seqlens=None,
                     chunk_indices=None, chunk_size=chunk.FLA_CHUNK_SIZE,
                     core_attn_out=None):
+        if _hip_enabled():
+            try:
+                from aiter.ops.fla import (
+                    chunk_fwd_o_vllm_hip_blockdim64 as hip_kernel,
+                )
+            except ImportError:
+                hip_kernel = None
+            if hip_kernel is not None:
+                hip_output = hip_kernel(
+                    q=q, k=k, v=v, h=h, g=g, g_gamma=None, scale=scale,
+                    cu_seqlens=cu_seqlens, chunk_size=chunk_size,
+                    chunk_indices=chunk_indices, use_exp2=False,
+                    transpose_state_layout=True, kernel_cfg=None,
+                )
+                if core_attn_out is None:
+                    return hip_output
+                if core_attn_out.numel() < v.numel():
+                    raise ValueError("core_attn_out is too small for HCU FLA chunk_o")
+                out = core_attn_out[:v.numel()].view(*v.shape)
+                out.copy_(hip_output)
+                return out
+
         if not _enabled():
             return original(q, k, v, h, g, scale, cu_seqlens, chunk_indices,
                             chunk_size, core_attn_out)
         try:
             from aiter.ops.triton.fla.vllm.chunk_o import launch_chunk_fwd_kernel_o
-        except ImportError as exc:
-            raise RuntimeError("HCU AITER FLA chunk_o is enabled but unavailable") from exc
+        except ImportError:
+            return original(q, k, v, h, g, scale, cu_seqlens, chunk_indices,
+                            chunk_size, core_attn_out)
         B, T, Hg, K, V = *q.shape, v.shape[-1]
         H, BT = v.shape[-2], chunk_size
         if chunk_indices is None and cu_seqlens is not None:

--- a/vllm_hcu/patch/worker/op_opt/patch_gdn_causal_conv1d.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_gdn_causal_conv1d.py
@@ -133,12 +133,15 @@ def apply_to_module(module: ModuleType) -> bool:
             )
         except ImportError:
             return causal_update(*bound.args, **bound.kwargs)
+        activation = bound.arguments["activation"]
+        if isinstance(activation, bool):
+            activation = "silu" if activation else None
         return custom_update(
             bound.arguments["x"],
             bound.arguments["conv_state"],
             bound.arguments["weight"],
             bound.arguments["bias"],
-            bound.arguments["activation"],
+            activation,
             conv_state_indices=bound.arguments["conv_state_indices"],
         )
 

--- a/vllm_hcu/patch/worker/op_opt/patch_gdn_causal_conv1d.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_gdn_causal_conv1d.py
@@ -26,6 +26,17 @@ _MARKER = "_vllm_hcu_gdn_causal_conv1d_applied"
 _WRAPPER = "_vllm_hcu_gdn_causal_conv1d_wrapper"
 
 
+def _supports_external_update(arguments: dict[str, object]) -> bool:
+    return (
+        arguments["num_accepted_tokens"] is None
+        and arguments["query_start_loc"] is None
+        and arguments["max_query_len"] == -1
+        and arguments["null_block_id"] == 0
+        and arguments["block_idx_last_scheduled_token"] is None
+        and arguments["initial_state_idx"] is None
+    )
+
+
 def apply_to_module(module: ModuleType) -> bool:
     qwen = load_exact_module(TARGET_MODULE, module)
     wrapped = (
@@ -99,16 +110,37 @@ def apply_to_module(module: ModuleType) -> bool:
 
     @functools.wraps(causal_update)
     def hcu_causal_update(*args, **kwargs):
-        if not use_nn_layout():
-            return causal_update(*args, **kwargs)
         bound = causal_update_signature.bind(*args, **kwargs)
-        x = bound.arguments["x"]
-        conv_state = bound.arguments["conv_state"]
-        expected_dim = shape_dim(conv_state, -2) or shape_dim(x, 1)
-        bound.arguments["weight"] = normalize_nn_conv_weight(
-            bound.arguments["weight"], expected_dim, TARGETS[1]
+        bound.apply_defaults()
+        if use_nn_layout():
+            x = bound.arguments["x"]
+            conv_state = bound.arguments["conv_state"]
+            expected_dim = shape_dim(conv_state, -2) or shape_dim(x, 1)
+            bound.arguments["weight"] = normalize_nn_conv_weight(
+                bound.arguments["weight"], expected_dim, TARGETS[1]
+            )
+        from vllm_hcu.platforms import envs as henvs
+
+        if not (
+            henvs.VLLM_HCU_USE_CUSTOM_OPS
+            and henvs.VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D
+            and _supports_external_update(bound.arguments)
+        ):
+            return causal_update(*bound.args, **bound.kwargs)
+        try:
+            from causal_conv1d.causal_conv1d_interface import (
+                causal_conv1d_update as custom_update,
+            )
+        except ImportError:
+            return causal_update(*bound.args, **bound.kwargs)
+        return custom_update(
+            bound.arguments["x"],
+            bound.arguments["conv_state"],
+            bound.arguments["weight"],
+            bound.arguments["bias"],
+            bound.arguments["activation"],
+            conv_state_indices=bound.arguments["conv_state_indices"],
         )
-        return causal_update(*bound.args, **bound.kwargs)
 
     for function in (hcu_causal_conv, hcu_causal_update):
         setattr(function, _WRAPPER, True)

--- a/vllm_hcu/patch/worker/op_opt/patch_gdn_causal_conv1d.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_gdn_causal_conv1d.py
@@ -136,14 +136,18 @@ def apply_to_module(module: ModuleType) -> bool:
         activation = bound.arguments["activation"]
         if isinstance(activation, bool):
             activation = "silu" if activation else None
-        return custom_update(
-            bound.arguments["x"],
+        x = bound.arguments["x"]
+        original_x_dtype = x.dtype
+        x_for_kernel = x.to(bound.arguments["conv_state"].dtype)
+        out = custom_update(
+            x_for_kernel,
             bound.arguments["conv_state"],
             bound.arguments["weight"],
             bound.arguments["bias"],
             activation,
             conv_state_indices=bound.arguments["conv_state_indices"],
         )
+        return out.to(original_x_dtype)
 
     for function in (hcu_causal_conv, hcu_causal_update):
         setattr(function, _WRAPPER, True)

--- a/vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py
@@ -112,10 +112,6 @@ def apply_to_module(module: ModuleType) -> bool:
                 return triton_kernel(*bound.args, **bound.kwargs)
         return official_sigmoid(*bound.args, **bound.kwargs)
 
-    setattr(hcu_sigmoid_update, _SIGMOID_WRAPPER, True)
-    setattr(qwen, "_vllm_hcu_original_fused_sigmoid", official_sigmoid)
-    setattr(qwen, "fused_sigmoid_gating_delta_rule_update", hcu_sigmoid_update)
-
     if aiter_available:
         aiter_update = require_callable(
             qwen,
@@ -151,6 +147,10 @@ def apply_to_module(module: ModuleType) -> bool:
             )
             return aiter_update(*bound.args, **bound.kwargs)
 
+    setattr(hcu_sigmoid_update, _SIGMOID_WRAPPER, True)
+    setattr(qwen, "_vllm_hcu_original_fused_sigmoid", official_sigmoid)
+    setattr(qwen, "fused_sigmoid_gating_delta_rule_update", hcu_sigmoid_update)
+    if aiter_available:
         setattr(hcu_aiter_update, _WRAPPER, True)
         setattr(qwen, "_vllm_hcu_original_gdn_aiter_update", aiter_update)
         setattr(

--- a/vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py
@@ -27,9 +27,11 @@ TARGET_MODULE = (
 PATCH_ID = "worker.op_opt.mamba.gdn.qwen_kernel_bindings"
 TARGETS = (
     f"{TARGET_MODULE}.gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
+    f"{TARGET_MODULE}.fused_sigmoid_gating_delta_rule_update",
 )
 _MARKER = "_vllm_hcu_qwen_gdn_aiter_layout_applied"
 _WRAPPER = "_vllm_hcu_qwen_gdn_aiter_layout_wrapper"
+_SIGMOID_WRAPPER = "_vllm_hcu_qwen_gdn_sigmoid_wrapper"
 
 # This is the audited vLLM v0.25.1 AITER launcher contract.  Binding by name is
 # intentional: the old HCU adapter rewrote args[10], which could silently
@@ -63,59 +65,110 @@ _AITER_UPDATE_PARAMETERS = (
 def apply_to_module(module: ModuleType) -> bool:
     qwen = load_exact_module(TARGET_MODULE, module)
     aiter_available = bool(getattr(qwen, "GDN_AITER_TRITON_AVAILABLE", False))
-    wrapped = (
-        (qwen, TARGETS[0].rsplit(".", 1)[-1], TARGETS[0], _WRAPPER),
-    ) if aiter_available else ()
+    wrapped = [
+        (
+            qwen,
+            TARGETS[1].rsplit(".", 1)[-1],
+            TARGETS[1],
+            _SIGMOID_WRAPPER,
+        ),
+    ]
+    if aiter_available:
+        wrapped.insert(
+            0,
+            (qwen, TARGETS[0].rsplit(".", 1)[-1], TARGETS[0], _WRAPPER),
+        )
     if already_applied(qwen, _MARKER, wrapped):
         return False
 
-    if not aiter_available:
-        setattr(qwen, _MARKER, True)
-        return True
-
-    aiter_update = require_callable(
+    official_sigmoid = require_callable(
         qwen,
-        "gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
-        TARGETS[0],
+        "fused_sigmoid_gating_delta_rule_update",
+        TARGETS[1],
     )
-    require_parameter_names(
-        aiter_update,
-        TARGETS[0],
-        _AITER_UPDATE_PARAMETERS,
-    )
-    aiter_signature = inspect.signature(aiter_update)
+    sigmoid_signature = inspect.signature(official_sigmoid)
 
-    @functools.wraps(aiter_update)
-    def hcu_aiter_update(*args, **kwargs):
-        if not use_nn_layout():
-            return aiter_update(*args, **kwargs)
-        try:
-            bound = aiter_signature.bind(*args, **kwargs)
-        except TypeError as exc:
-            raise PatchCompatibilityError(
-                f"required HCU call for {TARGETS[0]} does not match the "
-                f"audited vLLM v0.25.1 AITER contract {aiter_signature}"
-            ) from exc
-        conv_state = bound.arguments.get("conv_state")
-        if conv_state is None or "weight" not in bound.arguments:
-            raise PatchCompatibilityError(
-                f"required HCU call for {TARGETS[0]} is missing conv_state or weight"
-            )
-        expected_dim = shape_dim(conv_state, -2)
-        bound.arguments["weight"] = normalize_nn_conv_weight(
-            bound.arguments["weight"], expected_dim, TARGETS[0]
+    @functools.wraps(official_sigmoid)
+    def hcu_sigmoid_update(*args, **kwargs):
+        bound = sigmoid_signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        if _sigmoid_enabled():
+            if bound.arguments["A_log"].dtype == bound.arguments["q"].dtype:
+                try:
+                    from aiter import (
+                        vllm_fused_sigmoid_gating_delta_rule_update as hip_kernel,
+                    )
+                except ImportError:
+                    pass
+                else:
+                    return hip_kernel(*bound.args, **bound.kwargs)
+            try:
+                from aiter.ops.triton.fla.fused_sigmoid_gating import (
+                    fused_sigmoid_gating_delta_rule_update as triton_kernel,
+                )
+            except ImportError:
+                pass
+            else:
+                return triton_kernel(*bound.args, **bound.kwargs)
+        return official_sigmoid(*bound.args, **bound.kwargs)
+
+    setattr(hcu_sigmoid_update, _SIGMOID_WRAPPER, True)
+    setattr(qwen, "_vllm_hcu_original_fused_sigmoid", official_sigmoid)
+    setattr(qwen, "fused_sigmoid_gating_delta_rule_update", hcu_sigmoid_update)
+
+    if aiter_available:
+        aiter_update = require_callable(
+            qwen,
+            "gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
+            TARGETS[0],
         )
-        return aiter_update(*bound.args, **bound.kwargs)
+        require_parameter_names(
+            aiter_update,
+            TARGETS[0],
+            _AITER_UPDATE_PARAMETERS,
+        )
+        aiter_signature = inspect.signature(aiter_update)
 
-    setattr(hcu_aiter_update, _WRAPPER, True)
-    setattr(qwen, "_vllm_hcu_original_gdn_aiter_update", aiter_update)
-    setattr(
-        qwen,
-        "gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
-        hcu_aiter_update,
-    )
+        @functools.wraps(aiter_update)
+        def hcu_aiter_update(*args, **kwargs):
+            if not use_nn_layout():
+                return aiter_update(*args, **kwargs)
+            try:
+                bound = aiter_signature.bind(*args, **kwargs)
+            except TypeError as exc:
+                raise PatchCompatibilityError(
+                    f"required HCU call for {TARGETS[0]} does not match the "
+                    f"audited vLLM v0.25.1 AITER contract {aiter_signature}"
+                ) from exc
+            conv_state = bound.arguments.get("conv_state")
+            if conv_state is None or "weight" not in bound.arguments:
+                raise PatchCompatibilityError(
+                    f"required HCU call for {TARGETS[0]} is missing conv_state or weight"
+                )
+            expected_dim = shape_dim(conv_state, -2)
+            bound.arguments["weight"] = normalize_nn_conv_weight(
+                bound.arguments["weight"], expected_dim, TARGETS[0]
+            )
+            return aiter_update(*bound.args, **bound.kwargs)
+
+        setattr(hcu_aiter_update, _WRAPPER, True)
+        setattr(qwen, "_vllm_hcu_original_gdn_aiter_update", aiter_update)
+        setattr(
+            qwen,
+            "gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
+            hcu_aiter_update,
+        )
     setattr(qwen, _MARKER, True)
     return True
+
+
+def _sigmoid_enabled() -> bool:
+    from vllm_hcu.platforms import envs as henvs
+
+    return bool(
+        henvs.VLLM_HCU_USE_CUSTOM_OPS
+        and henvs.VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE
+    )
 
 
 def apply(module: ModuleType | None = None) -> bool:

--- a/vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py
@@ -13,6 +13,7 @@ from ._common import (
     already_applied,
     load_exact_module,
     require_callable,
+    require_exact_signature,
 )
 from ._gdn_common import (
     normalize_nn_conv_weight,
@@ -85,6 +86,28 @@ def apply_to_module(module: ModuleType) -> bool:
         qwen,
         "fused_sigmoid_gating_delta_rule_update",
         TARGETS[1],
+    )
+    require_exact_signature(
+        official_sigmoid,
+        TARGETS[1],
+        positional=(
+            "A_log", "a", "b", "dt_bias", "q", "k", "v", "beta", "threshold",
+            "scale", "initial_state", "inplace_final_state", "cu_seqlens",
+            "ssm_state_indices", "num_accepted_tokens", "use_qk_l2norm_in_kernel",
+            "is_kda",
+        ),
+        defaults={
+            "beta": 1.0,
+            "threshold": 20.0,
+            "scale": None,
+            "initial_state": None,
+            "inplace_final_state": True,
+            "cu_seqlens": None,
+            "ssm_state_indices": None,
+            "num_accepted_tokens": None,
+            "use_qk_l2norm_in_kernel": False,
+            "is_kda": False,
+        },
     )
     sigmoid_signature = inspect.signature(official_sigmoid)
 

--- a/vllm_hcu/platforms/envs.py
+++ b/vllm_hcu/platforms/envs.py
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
     VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER : bool = False
     VLLM_HCU_USE_CUSTOM_RMS_NORM : bool = False
     VLLM_HCU_USE_CUSTOM_AITER_FLA : bool = False
+    VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE: bool = True
+    VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP: bool = True
+    VLLM_HCU_USE_CHUNK_FWD_KERNEL_O: bool = True
     VLLM_HCU_PP_LAYER_PARTITION_D : Optional[str] = None
     VLLM_HCU_USE_FUSE_MOE_GATE : bool = False
     VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D : bool = False
@@ -234,6 +237,18 @@ hcu_vllm_environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D":
     lambda: (os.environ.get("VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D", "True").lower() in
              ("true", "1")),
+    "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP":
+    lambda: _environment_flag(os.environ.get(
+        "VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP", "True"
+    )),
+    "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O":
+    lambda: _environment_flag(os.environ.get(
+        "VLLM_HCU_USE_CHUNK_FWD_KERNEL_O", "True"
+    )),
+    "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE":
+    lambda: _environment_flag(os.environ.get(
+        "VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE", "True"
+    )),
     # vllm use dp connector
     "VLLM_HCU_USE_DP_CONNECTOR":
     lambda: (os.environ.get("VLLM_HCU_USE_DP_CONNECTOR", "False").lower() in


### PR DESCRIPTION
## Summary

Port the vLLM-HCU v0.21 GDN/FLA kernel routes from the following source changes into the v0.25.1 sidecar-plugin architecture:

- MR 270: `c1b95f70bf179a954d7205922fb575cf2cfdacc4`
- MR 271: `14a680b5b3c4ce83dce3adae7e61aa2b772996ab`
- MR 272: `a4c14b2f67d75003e3db9cd043b989aa9673f86a`
- MR 273: `f82655b0c6c6fd2c8988c26308d9fefa6c0d1fb6`
- MR 273 cleanup: `85d01aebf9620db36db28cc83dba616204f4be47`

The v0.21 text-replacement patches are intentionally not copied. v0.25.1 uses exact post-import callbacks, so this PR extends the existing target-native adapters with deterministic optional-kernel fallbacks, exact signature guards, idempotent/atomic installation, and Qwen-local ownership.

## Routing

- `chunk_delta_h`: AITER HIP -> AITER Triton -> original vLLM.
- `chunk_o`: AITER HIP -> AITER Triton -> original vLLM, preserving preallocated output buffers.
- Qwen GDN causal update: compatible seven-argument calls use external `causal_conv1d`; unsupported v0.25.1/MTP metadata uses the original implementation. Boolean activation is normalized to the external API contract.
- Qwen GDN sigmoid update: matching-dtype AITER HIP -> mixed-dtype-capable AITER Triton -> official Qwen callable.
- Setting only `VLLM_HCU_USE_CUSTOM_OPS=0` disables all four custom routes while child selectors remain default-enabled.

New default-on selectors:

- `VLLM_HCU_USE_AITER_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE`
- `VLLM_HCU_USE_AITER_CHUNK_GATED_DELTA_RULE_HIP`
- `VLLM_HCU_USE_CHUNK_FWD_KERNEL_O`

Explicit `0` or `false` disables each selector.

## Verification

Final reviewed commit: `f8f27d02cd167a9c975979de6f609c0c7a818ce9`.

- `git diff --check`: passed.
- `python -m compileall -q vllm_hcu tests`: passed.
- Patch coverage: `files=96 adapters=95 helpers=1 untested=0 invalid_contracts=0`.
- Production boundary: clean across 252 Python files.
- Final non-HCU suite against the target vLLM source: `1592 passed, 12 skipped, 163 deselected, 15 warnings`.
- Affected GDN/FLA runtime files: `125 passed, 14 warnings`.
- `tests/runtime_patch/test_attention_mla_fla_mamba.py` in the target HCU environment: `52 passed, 14 warnings`.
- gfx938 external causal-conv1d comparison with bf16 input and fp32 convolution state: exact output/state parity with official vLLM for valid cache indices, and the returned dtype remained bf16.
- gfx938 AITER HIP `chunk_o` varlen comparison with `cu_seqlens` present, `chunk_indices=None`, and `scale=None`: output matched official Triton with maximum absolute difference `3.0517578125e-05`.
- `/models/Qwen3.5-35B-A3B` TP2/EP2 + MTP3 parity with explicit `mamba_cache_dtype=float32`: `1 passed in 631.36s`. It ran two eager and two FULL-decode-graph greedy generations of 16 tokens each; token IDs matched, logprobs were present/finite, and every round drafted tokens.
- Both graph workers resolved `method=mtp`, `num_speculative_tokens=3`, `mamba_cache_dtype=float32`, `cudagraph_mode=FULL_DECODE_ONLY`, `decode_mode=FULL`, capture sizes `[4, 8]`, and a positive graph-capture count. FULL graph dispatch was observed during generation.
- The test clears inherited selector overrides and verifies on every worker that `VLLM_HCU_USE_CUSTOM_OPS`, `VLLM_HCU_USE_CUSTOM_AITER_FLA`, `VLLM_HCU_USE_CUSTOM_CAUSAL_CONV1D`, and all three new selectors resolve to `True` by default.

Hardware verification used isolated Hygon vLLM commit `7a636ba6ca800776c7737a45e17c99fb0c32c317`, which contains the official v0.25.1 merge `752a3a504485790a2e8491cacbb35c137339ad34`, on gfx938. The plugin Python sources were loaded directly from this PR's `f8f27d0` worktree ahead of the target vLLM source.

The graph acceptance claim is scoped to graph-enabled model execution and FULL decode replay. FLA chunk H/O execute during prefill, outside `FULL_DECODE_ONLY`, so this result does not claim those prefill kernels were themselves captured.

## Review

The original whole-branch review found two Important issues: missing audited sigmoid signature validation and Boolean causal-activation incompatibility. Commit `c596331` fixed both with RED->GREEN regressions.

A subsequent review found two additional contract issues: external causal-conv1d did not preserve vLLM's mixed cache dtype behavior, and the HIP `chunk_o` path did not prepare missing varlen indices/default scale. Commit `f8f27d0` fixes both with RED->GREEN regressions and real gfx938 comparisons. The Qwen MTP3 graph case now also forces and worker-verifies `mamba_cache_dtype=float32`.

An independent read-only review of `8153fca..f8f27d0` reported no Critical, Important, or Minor findings and assessed the change ready to merge.

## AI assistance

AI assistance was used to analyze, implement, test, and review this change. The human submitter must understand the design, review every changed line, and independently validate the evidence before merge.
