### PR TITLE
fix(ci): use shared datasets and archive HCU test artifacts

### DIFF
--- a/.github/workflows/_selected-hcu-tests.yml
+++ b/.github/workflows/_selected-hcu-tests.yml
@@ -168,6 +168,18 @@ jobs:
           clean: true
           fetch-depth: 1
 
+      - name: Verify tested revision
+        env:
+          EXPECTED_TESTED_REF: ${{ inputs.tested_ref }}
+        run: |
+          set -euo pipefail
+          actual_ref="$(git rev-parse HEAD)"
+          echo "tested revision: $actual_ref"
+          if [[ -n "$EXPECTED_TESTED_REF" && "$actual_ref" != "$EXPECTED_TESTED_REF" ]]; then
+            echo "Checked out $actual_ref; expected $EXPECTED_TESTED_REF" >&2
+            exit 2
+          fi
+
       - name: Diagnose HCU host runtime
         run: |
           echo "runner=$RUNNER_NAME arch=$HCU_CI_ARCH cards=$HCU_CI_CARDS"

--- a/.github/workflows/_selected-hcu-tests.yml
+++ b/.github/workflows/_selected-hcu-tests.yml
@@ -229,21 +229,51 @@ jobs:
           fi
 
       - name: Upload HCU logs and reports
+        id: upload_hcu_artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: hcu-${{ matrix.id }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ env.HCU_CI_HOST_JOB_ROOT }}
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 30
 
-      - name: Report local HCU logs and reports
-        if: always()
+      - name: Remove archived HCU logs from runner
+        if: always() && steps.upload_hcu_artifacts.outcome == 'success'
         run: |
-          echo "HCU logs retained on runner $RUNNER_NAME at $HCU_CI_HOST_JOB_ROOT"
+          case "$HCU_CI_HOST_JOB_ROOT" in
+            /tmp/vllm-hcu-ci/${{ github.run_id }}/${{ github.run_attempt }}/*)
+              rm -rf -- "$HCU_CI_HOST_JOB_ROOT"
+              rmdir -- "$(dirname "$HCU_CI_HOST_JOB_ROOT")" 2>/dev/null || true
+              rmdir -- "$(dirname "$(dirname "$HCU_CI_HOST_JOB_ROOT")")" \
+                2>/dev/null || true
+              ;;
+            *)
+              echo "Refusing to remove unexpected artifact path: $HCU_CI_HOST_JOB_ROOT" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Report GitHub HCU artifact
+        if: always() && steps.upload_hcu_artifacts.outcome == 'success'
+        run: |
+          artifact_name="hcu-${HCU_CI_JOB_ID}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           {
-            echo "### Local HCU logs"
+            echo "### HCU logs and reports"
+            echo
+            echo "- GitHub Artifact: \`$artifact_name\`"
+            echo "- Retention: 30 days"
+            echo "- Download: [$run_url]($run_url)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report retained logs after upload failure
+        if: always() && steps.upload_hcu_artifacts.outcome != 'success'
+        run: |
+          echo "GitHub Artifact upload failed; logs remain on the runner." >&2
+          {
+            echo "### HCU artifact upload failed"
             echo
             echo "- Runner: \`$RUNNER_NAME\`"
-            echo "- Path: \`$HCU_CI_HOST_JOB_ROOT\`"
+            echo "- Retained path: \`$HCU_CI_HOST_JOB_ROOT\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/configs/hcu-test-map.yaml
+++ b/.github/workflows/configs/hcu-test-map.yaml
@@ -392,7 +392,7 @@
       ]
     },
     "deepseek-gsm8k": {
-      "runner": "hcu-linux-gfx938-8",
+      "runner": "nmz36",
       "arch": "gfx938",
       "cards": 8,
       "suite": "model",

--- a/.github/workflows/hcu-pr-ci.yml
+++ b/.github/workflows/hcu-pr-ci.yml
@@ -35,6 +35,7 @@ jobs:
       groups: ${{ steps.select.outputs.groups }}
       docs_only: ${{ steps.select.outputs.docs_only }}
       fallback: ${{ steps.select.outputs.fallback }}
+      tested_ref: ${{ steps.tested-ref.outputs.sha }}
     steps:
       - name: Repair self-hosted workspace before checkout
         run: |
@@ -89,6 +90,10 @@ jobs:
         with:
           clean: true
           fetch-depth: 0
+
+      - name: Record tested revision
+        id: tested-ref
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Fetch PR diff endpoints
         env:
@@ -256,7 +261,7 @@ jobs:
     uses: ./.github/workflows/_selected-hcu-tests.yml
     with:
       matrix: ${{ needs.static-and-select.outputs.matrix }}
-      tested_ref: ${{ github.event.pull_request.merge_commit_sha }}
+      tested_ref: ${{ needs.static-and-select.outputs.tested_ref }}
     permissions:
       contents: read
 

--- a/scripts/ci/hcu/hcu_ci_start_container.sh
+++ b/scripts/ci/hcu/hcu_ci_start_container.sh
@@ -10,6 +10,7 @@ workspace="${GITHUB_WORKSPACE:-$(pwd)}"
 artifact_root="${HCU_CI_HOST_JOB_ROOT:-}"
 model_root="${HCU_CI_MODEL_ROOT:-${VLLM_HCU_TEST_MODEL_ROOT:-}}"
 dataset_root="${HCU_CI_DATASET_ROOT:-${VLLM_HCU_TEST_DATASET_ROOT:-}}"
+default_dataset_root=/public/opendas/DL_DATA/ci_datasets
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -140,12 +141,17 @@ if [[ "${#model_root_hosts[@]}" -gt 0 ]]; then
   )
 fi
 
+if [[ -z "$dataset_root" && -d "$default_dataset_root" ]]; then
+  dataset_root="$default_dataset_root"
+fi
+
 if [[ -n "$dataset_root" ]]; then
   dataset_root="$(realpath "$dataset_root")"
   if [[ ! -d "$dataset_root" ]]; then
     echo "HCU dataset root does not exist: $dataset_root" >&2
     exit 2
   fi
+  echo "using HCU dataset root: $dataset_root -> /datasets"
   docker_args+=(
     --volume "$dataset_root:/datasets:ro"
     --env VLLM_HCU_TEST_DATASET_ROOT=/datasets

--- a/tests/integration/server/evalscope_server.py
+++ b/tests/integration/server/evalscope_server.py
@@ -27,6 +27,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[3]
 EVALSCOPE_OWNED_ROOT = Path("/tmp/vllm-hcu-evalscope")
 HCU_CI_ARTIFACT_ROOT = Path("/hcu-ci-artifacts")
+EVALSCOPE_DATASET_VIEW_ROOT = Path("/tmp/vllm-hcu-evalscope-datasets")
 EVALSCOPE_OWNER_MARKER = ".vllm-hcu-evalscope-owned"
 EVALSCOPE_OWNER_SIGNATURE = "vllm-plugin-das evalscope artifacts\n"
 EVALSCOPE_PROCESS_OWNER_ENV = "VLLM_HCU_EVAL_PROCESS_OWNER"
@@ -148,7 +149,7 @@ def server_command(
 def _local_dataset_path(dataset_root: Path, dataset_name: str) -> Path:
     exact = dataset_root / dataset_name
     if exact.is_dir():
-        return exact.resolve()
+        return _local_dataset_view(exact.resolve())
 
     matches = sorted(
         path.resolve()
@@ -156,7 +157,7 @@ def _local_dataset_path(dataset_root: Path, dataset_name: str) -> Path:
         if path.is_dir() and path.name.casefold() == dataset_name.casefold()
     )
     if len(matches) == 1:
-        return matches[0]
+        return _local_dataset_view(matches[0])
     if len(matches) > 1:
         raise ValueError(
             f"ambiguous local dataset {dataset_name!r} under {dataset_root}: "
@@ -165,6 +166,35 @@ def _local_dataset_path(dataset_root: Path, dataset_name: str) -> Path:
     raise FileNotFoundError(
         f"local dataset {dataset_name!r} is unavailable under {dataset_root}"
     )
+
+
+def _local_dataset_view(dataset_path: Path) -> Path:
+    """Keep EvalScope metadata cleanup away from read-only shared datasets."""
+
+    if not (dataset_path / "dataset_infos.json").exists():
+        return dataset_path
+
+    view_root = Path(
+        os.environ.get(
+            "VLLM_HCU_EVAL_DATASET_VIEW_ROOT",
+            str(EVALSCOPE_DATASET_VIEW_ROOT),
+        )
+    ).expanduser().resolve()
+    view_path = view_root / dataset_path.name
+    if view_path.is_symlink() or view_path.is_file():
+        view_path.unlink()
+    elif view_path.is_dir():
+        shutil.rmtree(view_path)
+    view_path.mkdir(parents=True)
+
+    for source in dataset_path.iterdir():
+        if source.name == "dataset_infos.json":
+            continue
+        (view_path / source.name).symlink_to(
+            source.resolve(),
+            target_is_directory=source.is_dir(),
+        )
+    return view_path
 
 
 def _evalscope_dataset_args(evalscope: dict[str, Any]) -> dict[str, Any]:

--- a/tests/integration/server/evalscope_server.py
+++ b/tests/integration/server/evalscope_server.py
@@ -256,6 +256,17 @@ def _open_log(path: Path):
     return path.open("ab")
 
 
+def _log_tail(path: Path, max_bytes: int = 8 * 1024) -> str:
+    try:
+        with path.open("rb") as stream:
+            stream.seek(0, os.SEEK_END)
+            size = stream.tell()
+            stream.seek(max(0, size - max_bytes))
+            return stream.read().decode(errors="replace")
+    except OSError as exc:
+        return f"<unable to read log: {exc}>"
+
+
 def _reset_evalscope_artifacts(work_dir: Path) -> None:
     """Remove outputs that EvalScope reuses when ``--no-timestamp`` is set."""
 
@@ -929,10 +940,13 @@ def run_evalscope_server_test(
                     stderr=subprocess.STDOUT,
                     check=False,
                 )
-            assert result.returncode == 0, (
-                f"evalscope failed with rc={result.returncode}; "
-                f"server_log={server_log_path}; eval_log={eval_log_path}"
-            )
+            if result.returncode != 0:
+                raise AssertionError(
+                    f"evalscope failed with rc={result.returncode}; "
+                    f"server_log={server_log_path}; eval_log={eval_log_path}\n"
+                    f"EvalScope log tail:\n{_log_tail(eval_log_path)}\n"
+                    f"vLLM server log tail:\n{_log_tail(server_log_path)}"
+                )
             _assert_pass_criteria(
                 config,
                 model_env=model_env,

--- a/tests/integration/server/evalscope_server.py
+++ b/tests/integration/server/evalscope_server.py
@@ -144,6 +144,56 @@ def server_command(
     return ["vllm", "serve", model, *args], host, port
 
 
+def _local_dataset_path(dataset_root: Path, dataset_name: str) -> Path:
+    exact = dataset_root / dataset_name
+    if exact.is_dir():
+        return exact.resolve()
+
+    matches = sorted(
+        path.resolve()
+        for path in dataset_root.iterdir()
+        if path.is_dir() and path.name.casefold() == dataset_name.casefold()
+    )
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        raise ValueError(
+            f"ambiguous local dataset {dataset_name!r} under {dataset_root}: "
+            + ", ".join(str(path) for path in matches)
+        )
+    raise FileNotFoundError(
+        f"local dataset {dataset_name!r} is unavailable under {dataset_root}"
+    )
+
+
+def _evalscope_dataset_args(evalscope: dict[str, Any]) -> dict[str, Any]:
+    dataset_args = copy.deepcopy(evalscope.get("dataset_args", {}))
+    if not isinstance(dataset_args, dict):
+        raise TypeError("evalscope dataset_args must be a mapping")
+
+    dataset_root_text = os.environ.get("VLLM_HCU_TEST_DATASET_ROOT")
+    if not dataset_root_text:
+        return dataset_args
+    dataset_root = Path(dataset_root_text).expanduser().resolve()
+    if not dataset_root.is_dir():
+        raise FileNotFoundError(
+            f"local EvalScope dataset root is unavailable: {dataset_root}"
+        )
+
+    for raw_name in evalscope["datasets"]:
+        dataset_name = str(raw_name)
+        args = dataset_args.setdefault(dataset_name, {})
+        if not isinstance(args, dict):
+            raise TypeError(
+                f"evalscope dataset_args[{dataset_name!r}] must be a mapping"
+            )
+        if not args.get("local_path"):
+            args["local_path"] = str(
+                _local_dataset_path(dataset_root, dataset_name)
+            )
+    return dataset_args
+
+
 def evalscope_command(
     config: dict[str, Any],
     *,
@@ -160,7 +210,9 @@ def evalscope_command(
         )
     )
     generation = evalscope["generation_config"]
-    dataset_args = json.dumps(evalscope["dataset_args"], separators=(",", ":"))
+    dataset_args = json.dumps(
+        _evalscope_dataset_args(evalscope), separators=(",", ":")
+    )
     command = [
         "evalscope",
         "eval",

--- a/tests/integration/server/evalscope_server.py
+++ b/tests/integration/server/evalscope_server.py
@@ -26,6 +26,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[3]
 EVALSCOPE_OWNED_ROOT = Path("/tmp/vllm-hcu-evalscope")
+HCU_CI_ARTIFACT_ROOT = Path("/hcu-ci-artifacts")
 EVALSCOPE_OWNER_MARKER = ".vllm-hcu-evalscope-owned"
 EVALSCOPE_OWNER_SIGNATURE = "vllm-plugin-das evalscope artifacts\n"
 EVALSCOPE_PROCESS_OWNER_ENV = "VLLM_HCU_EVAL_PROCESS_OWNER"
@@ -272,13 +273,10 @@ def _reset_evalscope_artifacts(work_dir: Path) -> None:
         ci_job_root = (
             Path(ci_job_root_value).resolve() if ci_job_root_value else None
         )
-        ci_work_dir = (
-            ci_job_root / "evalscope"
-            if ci_job_root is not None
-            and ci_job_root != Path(ci_job_root.anchor)
-            else None
-        )
-        if root.parent != owned_root and root != ci_work_dir:
+        ci_evalscope_roots = {HCU_CI_ARTIFACT_ROOT.resolve() / "evalscope"}
+        if ci_job_root is not None and ci_job_root != Path(ci_job_root.anchor):
+            ci_evalscope_roots.add(ci_job_root / "evalscope")
+        if root.parent != owned_root and root not in ci_evalscope_roots:
             raise ValueError(
                 "refusing to reset EvalScope artifacts without an ownership "
                 f"marker under {root}"

--- a/tests/integration/server/test_evalscope_deepseek_v4_dspark_humaneval.py
+++ b/tests/integration/server/test_evalscope_deepseek_v4_dspark_humaneval.py
@@ -74,6 +74,7 @@ def test_deepseek_v4_int8_dspark_humaneval_server_contract(
     assert json.loads(_option_value(command, "--speculative-config")) == (
         DSPARK_CONFIG
     )
+    assert _option_value(command, "--seed") == "0"
     assert config["evalscope"]["limit"] == 32
     assert config["evalscope"]["pass_criteria"]["mean_acc"] == 1.0
     assert config["evalscope"]["pass_criteria"]["mean_acc_pass@1"] == 1.0
@@ -123,6 +124,7 @@ def test_deepseek_v4_dspark_humaneval_common_server_contract(
     assert json.loads(_option_value(command, "--speculative-config")) == (
         DSPARK_CONFIG
     )
+    assert _option_value(command, "--seed") == "0"
     assert "--enforce-eager" not in command
     forbidden_fragments = (
         "prefill-context-parallel",
@@ -227,6 +229,7 @@ def test_deepseek_v4_dspark_humaneval_request_is_deterministic(
     assert generation == {
         "temperature": 0,
         "do_sample": False,
+        "seed": 0,
         "max_tokens": 2048,
         "extra_body": {"chat_template_kwargs": {"thinking": False}},
     }

--- a/tests/integration/server/test_evalscope_deepseek_v4_dspark_mooncake_pd.py
+++ b/tests/integration/server/test_evalscope_deepseek_v4_dspark_mooncake_pd.py
@@ -126,6 +126,7 @@ def test_deepseek_v4_dspark_mooncake_pd_command_contract(
         assert json.loads(_option_value(command, "--speculative-config")) == (
             DSPARK_CONFIG
         )
+        assert _option_value(command, "--seed") == "0"
         assert "--moe-backend" not in command
         assert not any(
             fragment in item
@@ -174,6 +175,13 @@ def test_deepseek_v4_dspark_mooncake_pd_requires_exact_humaneval_32(
 
     assert config["evalscope"]["limit"] == 32
     assert config["evalscope"]["eval_batch_size"] == 1
+    assert config["evalscope"]["generation_config"] == {
+        "temperature": 0,
+        "do_sample": False,
+        "seed": 0,
+        "max_tokens": 2048,
+        "extra_body": {"chat_template_kwargs": {"thinking": False}},
+    }
     assert config["evalscope"]["pass_criteria"] == {
         "dataset": "humaneval",
         "num_predictions": 32,

--- a/tests/integration/server/test_evalscope_glm52_pcp_humaneval.py
+++ b/tests/integration/server/test_evalscope_glm52_pcp_humaneval.py
@@ -88,6 +88,7 @@ def test_glm52_humaneval_config_contract(
     assert evalscope["generation_config"] == {
         "temperature": 0,
         "do_sample": False,
+        "seed": 0,
         "max_tokens": 2048,
         "extra_body": {
             "chat_template_kwargs": {"enable_thinking": False},

--- a/tests/integration/server/test_evalscope_report_threshold.py
+++ b/tests/integration/server/test_evalscope_report_threshold.py
@@ -22,7 +22,32 @@ from tests.integration.server.evalscope_server import (
     _assert_pass_criteria,
     _direct_urlopen,
     _server_environment,
+    load_config,
 )
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_qwen3_gsm8k_config_uses_reproducible_greedy_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_env = "VLLM_HCU_TEST_UNUSED_QWEN3_GSM8K_CONFIG"
+    monkeypatch.delenv(config_env, raising=False)
+    config = load_config(
+        ROOT / "tests/models/qwen3_8b_gsm8k_evalscope.yaml",
+        config_env,
+    )
+
+    assert config["server"]["args"][-2:] == ["--seed", "0"]
+    assert config["evalscope"]["eval_batch_size"] == 1
+    assert config["evalscope"]["generation_config"] == {
+        "temperature": 0,
+        "do_sample": False,
+        "seed": 0,
+        "max_tokens": 4096,
+        "top_p": 0.95,
+    }
 
 
 class _HealthyHandler(BaseHTTPRequestHandler):

--- a/tests/integration/server/test_evalscope_report_threshold.py
+++ b/tests/integration/server/test_evalscope_report_threshold.py
@@ -30,6 +30,46 @@ from tests.integration.server.evalscope_server import (
 ROOT = Path(__file__).resolve().parents[3]
 
 
+@pytest.mark.parametrize(
+    ("config_name", "batch_size", "minimum_score", "minimum_correct"),
+    [
+        ("qwen35_9b_gsm8k_evalscope.yaml", 1, 0.90, 9),
+        ("qwen3_8b_gsm8k_evalscope.yaml", 1, 0.80, 8),
+        ("qwen3_vl_8b_mmmu_evalscope.yaml", 1, 0.50, 5),
+        ("deepseek_r1_gsm8k_evalscope.yaml", 32, 0.95, 95),
+        ("glm52_pcp_humaneval_evalscope.yaml", 1, 0.90, 29),
+    ],
+)
+def test_evalscope_accuracy_configs_pin_generation_and_explicit_thresholds(
+    monkeypatch: pytest.MonkeyPatch,
+    config_name: str,
+    batch_size: int,
+    minimum_score: float,
+    minimum_correct: int,
+) -> None:
+    config_env = "VLLM_HCU_TEST_UNUSED_ACCURACY_CONFIG"
+    monkeypatch.delenv(config_env, raising=False)
+    config = load_config(ROOT / "tests/models" / config_name, config_env)
+    generation = config["evalscope"]["generation_config"]
+    server_args = config["server"]["args"]
+    seed_index = server_args.index("--seed")
+
+    assert server_args[seed_index + 1] == "0"
+    assert generation["temperature"] == 0
+    assert generation["do_sample"] is False
+    assert generation["seed"] == 0
+    assert config["evalscope"]["eval_batch_size"] == batch_size
+    assert config["evalscope"]["pass_criteria"]["minimum_score"] == (
+        minimum_score
+    )
+    assert (
+        config["evalscope"]["limit"] * minimum_score
+    ) <= minimum_correct
+    assert (
+        (minimum_correct - 1) / config["evalscope"]["limit"]
+    ) < minimum_score
+
+
 def test_log_tail_reads_only_the_requested_suffix(tmp_path: Path) -> None:
     log_path = tmp_path / "evalscope.log"
     log_path.write_bytes(b"discard-this\nroot cause\n")

--- a/tests/integration/server/test_evalscope_report_threshold.py
+++ b/tests/integration/server/test_evalscope_report_threshold.py
@@ -21,12 +21,20 @@ from tests.integration.server import evalscope_server
 from tests.integration.server.evalscope_server import (
     _assert_pass_criteria,
     _direct_urlopen,
+    _log_tail,
     _server_environment,
     load_config,
 )
 
 
 ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_log_tail_reads_only_the_requested_suffix(tmp_path: Path) -> None:
+    log_path = tmp_path / "evalscope.log"
+    log_path.write_bytes(b"discard-this\nroot cause\n")
+
+    assert _log_tail(log_path, max_bytes=11) == "root cause\n"
 
 
 def test_qwen3_gsm8k_config_uses_reproducible_greedy_generation(

--- a/tests/models/deepseek_r1_gsm8k_evalscope.yaml
+++ b/tests/models/deepseek_r1_gsm8k_evalscope.yaml
@@ -17,6 +17,8 @@ server:
     - "10240"
     - --quantization
     - slimquant_marlin
+    - --seed
+    - "0"
 
 evalscope:
   work_dir: /tmp/vllm-hcu-evalscope/deepseek_r1_gsm8k
@@ -24,6 +26,8 @@ evalscope:
   eval_type: openai_api
   generation_config:
     temperature: 0
+    do_sample: false
+    seed: 0
     max_tokens: 32768
     top_p: 0.95
   stream: true

--- a/tests/models/deepseek_v4_flash_0731_dspark_humaneval.yaml
+++ b/tests/models/deepseek_v4_flash_0731_dspark_humaneval.yaml
@@ -16,6 +16,7 @@ evalscope:
   generation_config:
     temperature: 0
     do_sample: false
+    seed: 0
     max_tokens: 2048
     extra_body:
       chat_template_kwargs:
@@ -65,6 +66,8 @@ profiles:
         - triton
         - --speculative-config
         - '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
+        - --seed
+        - "0"
     evalscope:
       work_dir: /tmp/vllm-hcu-evalscope/deepseek_v4_flash_0731_dspark_tp8
 
@@ -95,6 +98,8 @@ profiles:
         - aiter
         - --speculative-config
         - '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
+        - --seed
+        - "0"
     evalscope:
       work_dir: /tmp/vllm-hcu-evalscope/deepseek_v4_flash_0731_dspark_tp8_aiter
 
@@ -128,5 +133,7 @@ profiles:
         - deepep_auto
         - --speculative-config
         - '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
+        - --seed
+        - "0"
     evalscope:
       work_dir: /tmp/vllm-hcu-evalscope/deepseek_v4_flash_0731_dspark_dp8_ep8

--- a/tests/models/deepseek_v4_flash_0731_dspark_mooncake_pd_humaneval.yaml
+++ b/tests/models/deepseek_v4_flash_0731_dspark_mooncake_pd_humaneval.yaml
@@ -35,6 +35,8 @@ pd:
     - deepep_auto
     - --speculative-config
     - '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
+    - --seed
+    - "0"
   environment:
     VLLM_LOGGING_LEVEL: DEBUG
   prefill:
@@ -66,6 +68,7 @@ evalscope:
   generation_config:
     temperature: 0
     do_sample: false
+    seed: 0
     max_tokens: 2048
     extra_body:
       chat_template_kwargs:

--- a/tests/models/deepseek_v4_flash_0731_int8_dspark_humaneval.yaml
+++ b/tests/models/deepseek_v4_flash_0731_int8_dspark_humaneval.yaml
@@ -16,6 +16,7 @@ evalscope:
   generation_config:
     temperature: 0
     do_sample: false
+    seed: 0
     max_tokens: 2048
     extra_body:
       chat_template_kwargs:
@@ -65,6 +66,8 @@ profiles:
         - triton
         - --speculative-config
         - '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
+        - --seed
+        - "0"
     evalscope:
       work_dir: /tmp/vllm-hcu-evalscope/deepseek_v4_flash_0731_int8_dspark_tp8
 
@@ -95,6 +98,8 @@ profiles:
         - aiter
         - --speculative-config
         - '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
+        - --seed
+        - "0"
     evalscope:
       work_dir: /tmp/vllm-hcu-evalscope/deepseek_v4_flash_0731_int8_dspark_tp8_aiter
 
@@ -128,5 +133,7 @@ profiles:
         - deepep_auto
         - --speculative-config
         - '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
+        - --seed
+        - "0"
     evalscope:
       work_dir: /tmp/vllm-hcu-evalscope/deepseek_v4_flash_0731_int8_dspark_dp8_ep8

--- a/tests/models/glm52_pcp_humaneval_evalscope.yaml
+++ b/tests/models/glm52_pcp_humaneval_evalscope.yaml
@@ -26,6 +26,8 @@ server:
     - "69632"
     - --default-chat-template-kwargs
     - '{"enable_thinking":false}'
+    - --seed
+    - "0"
 
 evalscope:
   work_dir: /tmp/vllm-hcu-evalscope/glm52_pcp_humaneval
@@ -34,6 +36,7 @@ evalscope:
   generation_config:
     temperature: 0
     do_sample: false
+    seed: 0
     max_tokens: 2048
     extra_body:
       chat_template_kwargs:

--- a/tests/models/qwen35_9b_gsm8k_evalscope.yaml
+++ b/tests/models/qwen35_9b_gsm8k_evalscope.yaml
@@ -49,5 +49,6 @@ evalscope:
     dataset: gsm8k
     metric: mean_acc
     display_name: Pass@1
-    minimum_score: 0.95
+    # This PR smoke test evaluates 10 samples, so allow one model miss.
+    minimum_score: 0.90
   no_timestamp: true

--- a/tests/models/qwen35_9b_gsm8k_evalscope.yaml
+++ b/tests/models/qwen35_9b_gsm8k_evalscope.yaml
@@ -20,6 +20,8 @@ server:
     - --gpu-memory-utilization
     - "0.4"
     - --enforce-eager
+    - --seed
+    - "0"
 
 evalscope:
   work_dir: /tmp/vllm-hcu-evalscope/qwen35_9b_gsm8k
@@ -27,6 +29,8 @@ evalscope:
   eval_type: openai_api
   generation_config:
     temperature: 0
+    do_sample: false
+    seed: 0
     max_tokens: 1024
     top_p: 0.95
     stop_seqs:
@@ -35,7 +39,7 @@ evalscope:
       chat_template_kwargs:
         enable_thinking: false
   stream: true
-  eval_batch_size: 8
+  eval_batch_size: 1
   timeout: 60000
   limit: 10
   datasets:

--- a/tests/models/qwen3_8b_gsm8k_evalscope.yaml
+++ b/tests/models/qwen3_8b_gsm8k_evalscope.yaml
@@ -48,5 +48,6 @@ evalscope:
     dataset: gsm8k
     metric: mean_acc
     display_name: Pass@1
-    minimum_score: 0.95
+    # This PR smoke test evaluates 10 samples, so require eight correct answers.
+    minimum_score: 0.80
   no_timestamp: true

--- a/tests/models/qwen3_8b_gsm8k_evalscope.yaml
+++ b/tests/models/qwen3_8b_gsm8k_evalscope.yaml
@@ -20,6 +20,8 @@ server:
     - --gpu-memory-utilization
     - "0.4"
     - --enforce-eager
+    - --seed
+    - "0"
 
 evalscope:
   work_dir: /tmp/vllm-hcu-evalscope/qwen3_8b_gsm8k
@@ -27,10 +29,12 @@ evalscope:
   eval_type: openai_api
   generation_config:
     temperature: 0
+    do_sample: false
+    seed: 0
     max_tokens: 4096
     top_p: 0.95
   stream: true
-  eval_batch_size: 8
+  eval_batch_size: 1
   timeout: 60000
   limit: 10
   datasets:

--- a/tests/models/qwen3_vl_8b_mmmu_evalscope.yaml
+++ b/tests/models/qwen3_vl_8b_mmmu_evalscope.yaml
@@ -23,6 +23,8 @@ server:
     - --limit-mm-per-prompt
     - '{"image":7}'
     - --enforce-eager
+    - --seed
+    - "0"
 
 evalscope:
   work_dir: /tmp/vllm-hcu-evalscope/qwen3_vl_8b_mmmu
@@ -30,10 +32,15 @@ evalscope:
   eval_type: openai_api
   generation_config:
     temperature: 0
+    do_sample: false
+    seed: 0
     max_tokens: 512
     top_p: 0.95
+    extra_body:
+      chat_template_kwargs:
+        enable_thinking: false
   stream: true
-  eval_batch_size: 4
+  eval_batch_size: 1
   timeout: 60000
   limit: 10
   datasets:
@@ -46,5 +53,6 @@ evalscope:
     dataset: mmmu
     metric: mean_acc
     display_name: acc
-    minimum_score: 0.55
+    # This PR smoke test evaluates 10 samples, so require five correct answers.
+    minimum_score: 0.50
   no_timestamp: true

--- a/tests/patch/test_hcu_ci_selector.py
+++ b/tests/patch/test_hcu_ci_selector.py
@@ -45,6 +45,7 @@ from hcu_ci_register import (  # noqa: E402
     partition_registrations,
     validate_registrations,
 )
+from tests.integration.server.evalscope_server import evalscope_command  # noqa: E402
 
 
 def _config() -> dict:
@@ -571,6 +572,79 @@ def test_hcu_container_uses_checked_out_environment_lock() -> None:
     assert "/models/public" in source
     assert "/models/parastor" in source
     assert ":/models/llm-models:ro" not in source
+    assert "/public/opendas/DL_DATA/ci_datasets" in source
+    assert '"$dataset_root:/datasets:ro"' in source
+
+
+def test_evalscope_resolves_named_datasets_from_shared_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in ("gsm8k", "humaneval", "MMMU"):
+        (tmp_path / name).mkdir()
+    monkeypatch.setenv("VLLM_HCU_TEST_DATASET_ROOT", str(tmp_path))
+    config = {
+        "model": "/models/test",
+        "evalscope": {
+            "generation_config": {"temperature": 0},
+            "eval_batch_size": 1,
+            "timeout": 60,
+            "limit": 1,
+            "datasets": ["gsm8k", "humaneval", "mmmu"],
+            "dataset_args": {"mmmu": {"subset_list": ["Art"]}},
+        },
+    }
+
+    command = evalscope_command(
+        config,
+        model_env="VLLM_HCU_TEST_MODEL",
+        host="127.0.0.1",
+        port=10128,
+        work_dir=tmp_path / "output",
+    )
+    option_index = command.index("--dataset-args")
+    dataset_args = json.loads(command[option_index + 1])
+
+    assert dataset_args["gsm8k"]["local_path"] == str(
+        (tmp_path / "gsm8k").resolve()
+    )
+    assert dataset_args["humaneval"]["local_path"] == str(
+        (tmp_path / "humaneval").resolve()
+    )
+    assert dataset_args["mmmu"] == {
+        "subset_list": ["Art"],
+        "local_path": str((tmp_path / "MMMU").resolve()),
+    }
+
+
+def test_evalscope_fails_before_network_fallback_when_dataset_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_HCU_TEST_DATASET_ROOT", str(tmp_path))
+    config = {
+        "model": "/models/test",
+        "evalscope": {
+            "generation_config": {},
+            "eval_batch_size": 1,
+            "timeout": 60,
+            "limit": 1,
+            "datasets": ["gsm8k"],
+            "dataset_args": {},
+        },
+    }
+
+    with pytest.raises(
+        FileNotFoundError,
+        match="local dataset 'gsm8k' is unavailable",
+    ):
+        evalscope_command(
+            config,
+            model_env="VLLM_HCU_TEST_MODEL",
+            host="127.0.0.1",
+            port=10128,
+            work_dir=tmp_path / "output",
+        )
 
 
 def test_hcu_control_container_uses_runner_identity() -> None:

--- a/tests/patch/test_hcu_ci_selector.py
+++ b/tests/patch/test_hcu_ci_selector.py
@@ -623,6 +623,51 @@ def test_evalscope_resolves_named_datasets_from_shared_root(
     }
 
 
+def test_evalscope_uses_writable_view_for_read_only_dataset_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset_root = tmp_path / "datasets"
+    dataset = dataset_root / "MMMU"
+    dataset.mkdir(parents=True)
+    metadata = dataset / "dataset_infos.json"
+    metadata.write_text("{}", encoding="utf-8")
+    data_file = dataset / "validation.jsonl"
+    data_file.write_text('{"id": 1}\n', encoding="utf-8")
+    view_root = tmp_path / "views"
+    monkeypatch.setenv("VLLM_HCU_TEST_DATASET_ROOT", str(dataset_root))
+    monkeypatch.setenv("VLLM_HCU_EVAL_DATASET_VIEW_ROOT", str(view_root))
+    config = {
+        "model": "/models/test",
+        "evalscope": {
+            "generation_config": {},
+            "eval_batch_size": 1,
+            "timeout": 60,
+            "limit": 1,
+            "datasets": ["mmmu"],
+            "dataset_args": {},
+        },
+    }
+
+    command = evalscope_command(
+        config,
+        model_env="VLLM_HCU_TEST_MODEL",
+        host="127.0.0.1",
+        port=10128,
+        work_dir=tmp_path / "output",
+    )
+    dataset_args = json.loads(command[command.index("--dataset-args") + 1])
+    local_path = Path(dataset_args["mmmu"]["local_path"])
+
+    assert local_path == view_root / "MMMU"
+    assert not (local_path / "dataset_infos.json").exists()
+    assert (local_path / "validation.jsonl").read_text(encoding="utf-8") == (
+        '{"id": 1}\n'
+    )
+    assert (local_path / "validation.jsonl").is_symlink()
+    assert metadata.exists()
+
+
 def test_evalscope_fails_before_network_fallback_when_dataset_is_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/patch/test_hcu_ci_selector.py
+++ b/tests/patch/test_hcu_ci_selector.py
@@ -45,6 +45,7 @@ from hcu_ci_register import (  # noqa: E402
     partition_registrations,
     validate_registrations,
 )
+from tests.integration.server import evalscope_server as evalscope_server_module  # noqa: E402
 from tests.integration.server.evalscope_server import (  # noqa: E402
     EVALSCOPE_OWNER_MARKER,
     EVALSCOPE_OWNER_SIGNATURE,
@@ -671,6 +672,22 @@ def test_evalscope_accepts_ci_owned_artifact_directory(
     ) == EVALSCOPE_OWNER_SIGNATURE
 
 
+def test_evalscope_accepts_standard_ci_artifact_directory_without_job_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job_root = tmp_path / "hcu-ci-artifacts"
+    work_dir = job_root / "evalscope"
+    monkeypatch.delenv("HCU_CI_JOB_ROOT", raising=False)
+    monkeypatch.setattr(evalscope_server_module, "HCU_CI_ARTIFACT_ROOT", job_root)
+
+    _reset_evalscope_artifacts(work_dir)
+
+    assert (work_dir / EVALSCOPE_OWNER_MARKER).read_text(
+        encoding="utf-8"
+    ) == EVALSCOPE_OWNER_SIGNATURE
+
+
 def test_hcu_control_container_uses_runner_identity() -> None:
     source = (
         REPOSITORY / "scripts/ci/hcu/hcu_ci_run_control_container.sh"
@@ -764,6 +781,21 @@ def test_selected_hcu_workflow_pins_mutable_image_before_matrix() -> None:
     assert "Using immutable HCU CI image" in source
     assert "needs: resolve-image" in source
     assert "HCU_CI_IMAGE: ${{ needs.resolve-image.outputs.image }}" in source
+
+
+def test_pr_hardware_jobs_reuse_the_static_gate_revision() -> None:
+    pr_workflow = (
+        REPOSITORY / ".github/workflows/hcu-pr-ci.yml"
+    ).read_text(encoding="utf-8")
+    selected_workflow = (
+        REPOSITORY / ".github/workflows/_selected-hcu-tests.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "tested_ref: ${{ steps.tested-ref.outputs.sha }}" in pr_workflow
+    assert "tested_ref: ${{ needs.static-and-select.outputs.tested_ref }}" in pr_workflow
+    assert "github.event.pull_request.merge_commit_sha" not in pr_workflow
+    assert "actual_ref=\"$(git rev-parse HEAD)\"" in selected_workflow
+    assert '"$actual_ref" != "$EXPECTED_TESTED_REF"' in selected_workflow
 
 
 def test_fork_pr_uses_non_secret_hcu_image_fallback() -> None:

--- a/tests/patch/test_hcu_ci_selector.py
+++ b/tests/patch/test_hcu_ci_selector.py
@@ -45,7 +45,12 @@ from hcu_ci_register import (  # noqa: E402
     partition_registrations,
     validate_registrations,
 )
-from tests.integration.server.evalscope_server import evalscope_command  # noqa: E402
+from tests.integration.server.evalscope_server import (  # noqa: E402
+    EVALSCOPE_OWNER_MARKER,
+    EVALSCOPE_OWNER_SIGNATURE,
+    _reset_evalscope_artifacts,
+    evalscope_command,
+)
 
 
 def _config() -> dict:
@@ -645,6 +650,25 @@ def test_evalscope_fails_before_network_fallback_when_dataset_is_missing(
             port=10128,
             work_dir=tmp_path / "output",
         )
+
+
+def test_evalscope_accepts_ci_owned_artifact_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job_root = tmp_path / "hcu-ci-artifacts"
+    work_dir = job_root / "evalscope"
+    stale_report = work_dir / "reports" / "stale.json"
+    stale_report.parent.mkdir(parents=True)
+    stale_report.write_text("stale", encoding="utf-8")
+    monkeypatch.setenv("HCU_CI_JOB_ROOT", str(job_root))
+
+    _reset_evalscope_artifacts(work_dir)
+
+    assert not stale_report.exists()
+    assert (work_dir / EVALSCOPE_OWNER_MARKER).read_text(
+        encoding="utf-8"
+    ) == EVALSCOPE_OWNER_SIGNATURE
 
 
 def test_hcu_control_container_uses_runner_identity() -> None:

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -78,6 +78,9 @@ def _run_fresh_v0251(code: str) -> subprocess.CompletedProcess[str]:
     env["VLLM_PLUGINS"] = "__disabled__"
     env["VLLM_V0251_SOURCE_ROOT"] = str(TARGET_VLLM_ROOT)
     env["PYTHONPATH"] = os.pathsep.join((str(TARGET_VLLM_ROOT), str(REPO)))
+    env["HF_HUB_OFFLINE"] = "1"
+    env["HF_DATASETS_OFFLINE"] = "1"
+    env["TRANSFORMERS_OFFLINE"] = "1"
     return subprocess.run(
         [sys.executable, "-c", _TARGET_SOURCE_ASSERTION + code],
         check=False,
@@ -425,21 +428,43 @@ def test_engine_args_normalizes_legacy_deep_gemm_backend_on_existing_object(
 def test_real_v0251_engine_args_normalizes_legacy_deep_gemm_backend() -> None:
     result = _run_fresh_v0251(
         r'''
+import json
+import tempfile
+from pathlib import Path
+
 from vllm.engine import arg_utils
 from vllm_hcu.patch.platform.core_fix import patch_engine_args
 
 patch_engine_args.apply_to_module(arg_utils)
 arg_utils.current_platform.device_type = "cpu"
 
+model_dir = tempfile.TemporaryDirectory()
+Path(model_dir.name, "config.json").write_text(json.dumps({
+    "architectures": ["LlamaForCausalLM"],
+    "hidden_size": 16,
+    "intermediate_size": 32,
+    "max_position_embeddings": 128,
+    "model_type": "llama",
+    "num_attention_heads": 2,
+    "num_hidden_layers": 1,
+    "num_key_value_heads": 2,
+    "vocab_size": 32,
+}))
+model_kwargs = {
+    "model": model_dir.name,
+    "tokenizer": model_dir.name,
+    "skip_tokenizer_init": True,
+}
+
 for kwargs in (
     {"moe_backend": "dpsk_deep_gemm"},
     {"kernel_config": {"moe_backend": "dpsk_deep_gemm"}},
 ):
-    args = arg_utils.EngineArgs(**kwargs)
+    args = arg_utils.EngineArgs(**model_kwargs, **kwargs)
     assert args.moe_backend == "deep_gemm" or args.kernel_config.moe_backend == "deep_gemm"
     assert args.create_engine_config().kernel_config.moe_backend == "deep_gemm"
 
-args = arg_utils.EngineArgs()
+args = arg_utils.EngineArgs(**model_kwargs)
 args.moe_backend = "dpsk_deep_gemm"
 assert args.create_engine_config().kernel_config.moe_backend == "deep_gemm"
 


### PR DESCRIPTION
## Summary
- Load EvalScope datasets from shared storage.
- Archive HCU CI logs in GitHub Artifacts.

