### PR TITLE
feat(hy-v4): enable Mooncake heteroid P/D and producer-only PCP

### DIFF
--- a/tests/models/hy_v4/test_attention.py
+++ b/tests/models/hy_v4/test_attention.py
@@ -247,8 +247,10 @@ def test_pipeline_stage_must_start_with_a_local_full_indexer() -> None:
 
     require_local_indexer_producer(config, start_layer=0, end_layer=3)
     require_local_indexer_producer(config, start_layer=3, end_layer=6)
-    with pytest.raises(ValueError, match="pipeline stage starts at shared"):
-        require_local_indexer_producer(config, start_layer=2, end_layer=5)
+    # Shared-start stages are allowed once top-k is copied across PP.
+    assert require_local_indexer_producer(config, start_layer=2, end_layer=5) is None
+    with pytest.raises(ValueError, match="Invalid HY V4 pipeline layer range"):
+        require_local_indexer_producer(config, start_layer=0, end_layer=99)
 
 
 def test_sink_incapable_backend_fails_closed() -> None:
@@ -384,3 +386,61 @@ def test_fp8_decode_forwards_live_sink(monkeypatch) -> None:
     assert forwarded is not None
     assert forwarded.shape == (64,)
     assert torch.equal(forwarded[:4], sinks)
+
+
+def test_pp_topk_is_copied_through_intermediate_tensors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.models.hy_v4 import model as hy_model
+
+    class _NoLightlyCP:
+        enable_lightly_cp = False
+
+    monkeypatch.setattr(
+        "vllm.forward_context.get_forward_context",
+        lambda: _NoLightlyCP(),
+        raising=False,
+    )
+    live = torch.arange(8, dtype=torch.int32).reshape(2, 4)
+    producer = SimpleNamespace(topk_indices_buffer=live.clone())
+    outgoing = {"hidden_states": torch.zeros(2, 1)}
+    hy_model._hcu_hyv4_append_topk_to_pp(producer, outgoing)
+    restored = torch.zeros_like(live)
+    consumer = SimpleNamespace(topk_indices_buffer=restored)
+    hy_model._hcu_hyv4_sync_topk_from_pp(consumer, outgoing)
+    assert torch.equal(restored, live)
+
+
+def test_pp_topk_all_gather_errors_are_not_swallowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_hcu.models.hy_v4 import model as hy_model
+
+    class _LightlyCP:
+        enable_lightly_cp = True
+
+    class _TpGroup:
+        def all_gather(self, tensor, dim=0):
+            del tensor, dim
+            raise RuntimeError("all_gather failed")
+
+    monkeypatch.setattr(
+        "vllm.forward_context.get_forward_context",
+        lambda: _LightlyCP(),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "vllm.forward_context.is_forward_context_available",
+        lambda: True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "vllm.distributed.parallel_state.get_tp_group",
+        lambda: _TpGroup(),
+        raising=False,
+    )
+    live = torch.arange(4, dtype=torch.int32).reshape(1, 4)
+    producer = SimpleNamespace(topk_indices_buffer=live)
+    outgoing = {"hidden_states": torch.zeros(1, 1)}
+    with pytest.raises(RuntimeError, match="all_gather failed"):
+        hy_model._hcu_hyv4_append_topk_to_pp(producer, outgoing)

--- a/tests/runtime_patch/test_glm52_pcp_config.py
+++ b/tests/runtime_patch/test_glm52_pcp_config.py
@@ -36,6 +36,9 @@ def _make_pcp_config(**overrides: object) -> object:
     hybrid = overrides.pop("hybrid", False)
     kv_offload = overrides.pop("kv_offload", False)
     kv_transfer = overrides.pop("kv_transfer", False)
+    kv_connector = overrides.pop("kv_connector", "MooncakeConnector")
+    kv_role = overrides.pop("kv_role", None)
+    kv_connector_extra_config = overrides.pop("kv_connector_extra_config", None)
     enable_lightly_cp = overrides.pop("enable_lightly_cp", False)
     enable_multi_layers_mtp = overrides.pop("enable_multi_layers_mtp", False)
     attention_backend = overrides.pop(
@@ -73,7 +76,13 @@ def _make_pcp_config(**overrides: object) -> object:
         lora_config=(SimpleNamespace() if lora else None),
         cache_config=SimpleNamespace(kv_offloading_size=(1.0 if kv_offload else None)),
         kv_transfer_config=(
-            SimpleNamespace(kv_connector="MooncakeConnector") if kv_transfer else None
+            SimpleNamespace(
+                kv_connector=kv_connector,
+                kv_role=kv_role,
+                kv_connector_extra_config=kv_connector_extra_config or {},
+            )
+            if kv_transfer
+            else None
         ),
         additional_config={
             "hcu": HcuFeatureConfig(
@@ -116,6 +125,43 @@ def test_hy4_mrv2_mla_pcp2_eager_is_allowed(make_pcp_config) -> None:
     )
 
     assert patch_vllm_config._validate_hcu_pcp_scope(config) is True
+
+
+def test_hy4_pcp_allows_mooncake_producer_pd(make_pcp_config) -> None:
+    """Mooncake kv_producer is the only PCP P/D path with replica dedup."""
+
+    config = make_pcp_config(
+        architecture="HYV4ForCausalLM",
+        use_mla=True,
+        pcp=2,
+        tp=4,
+        enable_expert_parallel=True,
+        enforce_eager=True,
+        kv_transfer=True,
+        kv_connector="MooncakeConnector",
+        kv_role="kv_producer",
+    )
+
+    assert patch_vllm_config._validate_hcu_pcp_scope(config) is True
+
+
+def test_pcp_rejects_non_mooncake_producer_pd(make_pcp_config) -> None:
+    """Other connectors must stay rejected; they lack PCP rank0 send semantics."""
+
+    config = make_pcp_config(
+        architecture="HYV4ForCausalLM",
+        use_mla=True,
+        pcp=2,
+        tp=4,
+        enable_expert_parallel=True,
+        enforce_eager=True,
+        kv_transfer=True,
+        kv_connector="DuSwiftConnector",
+        kv_role="kv_producer",
+    )
+
+    with pytest.raises(ValueError, match="MooncakeConnector only"):
+        patch_vllm_config._validate_hcu_pcp_scope(config)
 
 
 def test_gqa_mrv2_flash_pcp_is_allowed(make_pcp_config) -> None:

--- a/tests/runtime_patch/test_hcu_mooncake_contract.py
+++ b/tests/runtime_patch/test_hcu_mooncake_contract.py
@@ -946,3 +946,28 @@ def test_hetero_pp_rejects_custom_layer_partition(mooncake, monkeypatch):
     monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "4,4")
     with pytest.raises(RuntimeError, match="VLLM_PP_LAYER_PARTITION"):
         worker._pp_overlap_layer_range(remote_pp_rank=0, remote_pp_size=2)
+
+
+def test_same_pp_rejects_custom_layer_partition(mooncake, monkeypatch):
+    """Same PP size still cannot guess the remote custom partition."""
+    worker = _worker(mooncake, blocks_first=True)
+    worker.pp_size = 2
+    worker.pp_rank = 0
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
+    with pytest.raises(RuntimeError, match="VLLM_PP_LAYER_PARTITION"):
+        worker._reject_custom_partition_for_hetero_pp(remote_pp_size=2)
+
+
+def test_receive_kv_same_pp_rejects_custom_partition(mooncake, monkeypatch):
+    """same_pp pairs by rank; reject custom partitions before the pull."""
+    worker = _worker(mooncake, blocks_first=True)
+    worker.pp_size = 2
+    worker.pp_rank = 0
+    worker._fail_pull_metas = lambda *args, **kwargs: None
+    worker._tp_size = {"engine": 1}
+    worker._remote_agents = {"engine": {0: {0: "tp0-pp0", 1: "tp0-pp1"}}}
+    worker.transfer_topo.handshake_target_ranks = lambda remote_tp_size: [0]
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
+    pull_metas = {"request": SimpleNamespace(pull_tasks_count=0)}
+    with pytest.raises(RuntimeError, match="VLLM_PP_LAYER_PARTITION"):
+        worker.receive_kv("engine", pull_metas)

--- a/tests/runtime_patch/test_hcu_mooncake_contract.py
+++ b/tests/runtime_patch/test_hcu_mooncake_contract.py
@@ -959,15 +959,29 @@ def test_same_pp_rejects_custom_layer_partition(mooncake, monkeypatch):
 
 
 def test_receive_kv_same_pp_rejects_custom_partition(mooncake, monkeypatch):
-    """same_pp pairs by rank; reject custom partitions before the pull."""
+    """Background receive must finish the pull instead of raising."""
     worker = _worker(mooncake, blocks_first=True)
     worker.pp_size = 2
     worker.pp_rank = 0
-    worker._fail_pull_metas = lambda *args, **kwargs: None
+    failures = []
+
+    def fail_pull(pull_metas, err_msg):
+        failures.append((pull_metas, err_msg))
+
+    worker._fail_pull_metas = fail_pull
     worker._tp_size = {"engine": 1}
     worker._remote_agents = {"engine": {0: {0: "tp0-pp0", 1: "tp0-pp1"}}}
     worker.transfer_topo.handshake_target_ranks = lambda remote_tp_size: [0]
     monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
     pull_metas = {"request": SimpleNamespace(pull_tasks_count=0)}
+    worker.receive_kv("engine", pull_metas)
+    assert len(failures) == 1
+    assert failures[0][0] is pull_metas
+    assert "VLLM_PP_LAYER_PARTITION" in failures[0][1]
+
+
+def test_mooncake_init_rejects_custom_pp_partition(mooncake, monkeypatch):
+    """Config-time reject so the background send/recv path never starts."""
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
     with pytest.raises(RuntimeError, match="VLLM_PP_LAYER_PARTITION"):
-        worker.receive_kv("engine", pull_metas)
+        mooncake._reject_custom_pp_partition()

--- a/tests/runtime_patch/test_hcu_mooncake_contract.py
+++ b/tests/runtime_patch/test_hcu_mooncake_contract.py
@@ -110,6 +110,7 @@ def test_target_metadata_schema_and_round_trip(mooncake):
         "model_layer_end",
         "xfer_head_rank",
         "remote_pp_size",
+        "pp_layer_partition",
     )
     metadata = _metadata(
         mooncake,
@@ -124,6 +125,12 @@ def test_target_metadata_schema_and_round_trip(mooncake):
     encoded = msgspec.msgpack.encode(metadata)
     decoded = msgspec.msgpack.decode(encoded, type=mooncake.MooncakeXferMetadata)
     assert decoded == metadata
+    custom = _metadata(mooncake, remote_pp_size=2, pp_layer_partition="3,5")
+    restored = msgspec.msgpack.decode(
+        msgspec.msgpack.encode(custom), type=mooncake.MooncakeXferMetadata
+    )
+    assert restored.remote_pp_size == 2
+    assert restored.pp_layer_partition == "3,5"
 
 
 def test_cutlass_mooncake_uses_target_hnd_layout(mooncake):
@@ -948,18 +955,33 @@ def test_hetero_pp_rejects_custom_layer_partition(mooncake, monkeypatch):
         worker._pp_overlap_layer_range(remote_pp_rank=0, remote_pp_size=2)
 
 
-def test_same_pp_rejects_custom_layer_partition(mooncake, monkeypatch):
-    """Same PP size still cannot guess the remote custom partition."""
+def test_same_pp_allows_matching_custom_layer_partition(mooncake, monkeypatch):
     worker = _worker(mooncake, blocks_first=True)
     worker.pp_size = 2
     worker.pp_rank = 0
     monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
-    with pytest.raises(RuntimeError, match="VLLM_PP_LAYER_PARTITION"):
-        worker._reject_custom_partition_for_hetero_pp(remote_pp_size=2)
+    worker._reject_custom_partition_for_hetero_pp(remote_pp_size=2)
+    worker._reject_custom_partition_for_hetero_pp(
+        remote_pp_size=2, remote_partition="3,5"
+    )
+    worker._reject_custom_partition_for_hetero_pp(
+        remote_pp_size=2, remote_partition="3, 5"
+    )
 
 
-def test_receive_kv_same_pp_rejects_custom_partition(mooncake, monkeypatch):
-    """Background receive must finish the pull instead of raising."""
+def test_same_pp_rejects_mismatched_custom_layer_partition(mooncake, monkeypatch):
+    worker = _worker(mooncake, blocks_first=True)
+    worker.pp_size = 2
+    worker.pp_rank = 0
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
+    with pytest.raises(RuntimeError, match="matching"):
+        worker._reject_custom_partition_for_hetero_pp(
+            remote_pp_size=2, remote_partition="4,4"
+        )
+
+
+def test_receive_kv_same_pp_keeps_custom_partition(mooncake, monkeypatch):
+    """Same-PP custom partition still rank-pairs instead of failing the pull."""
     worker = _worker(mooncake, blocks_first=True)
     worker.pp_size = 2
     worker.pp_rank = 0
@@ -973,6 +995,46 @@ def test_receive_kv_same_pp_rejects_custom_partition(mooncake, monkeypatch):
     worker._remote_agents = {"engine": {0: {0: "tp0-pp0", 1: "tp0-pp1"}}}
     worker.transfer_topo.handshake_target_ranks = lambda remote_tp_size: [0]
     monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
+    calls = []
+
+    async def receive(
+        worker_addr,
+        pull_metas,
+        *,
+        chunk_idx=None,
+        model_layer_start=-1,
+        model_layer_end=-1,
+    ):
+        calls.append((worker_addr, model_layer_start, model_layer_end))
+
+    worker.receive_kv_from_single_worker = receive
+    pull_metas = {"request": SimpleNamespace(pull_tasks_count=0)}
+
+    async def run():
+        worker.receive_kv("engine", pull_metas)
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    assert failures == []
+    assert calls == [("tp0-pp0", -1, -1)]
+
+
+def test_receive_kv_hetero_pp_rejects_custom_partition(mooncake, monkeypatch):
+    """Hetero PP + custom partition must finish the pull instead of raising."""
+    worker = _worker(mooncake, blocks_first=True)
+    worker.pp_size = 1
+    worker.pp_rank = 0
+    failures = []
+
+    def fail_pull(pull_metas, err_msg):
+        failures.append((pull_metas, err_msg))
+
+    worker._fail_pull_metas = fail_pull
+    worker._tp_size = {"engine": 1}
+    worker._remote_agents = {"engine": {0: {0: "tp0-pp0", 1: "tp0-pp1"}}}
+    worker.transfer_topo.handshake_target_ranks = lambda remote_tp_size: [0]
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "4,4")
     pull_metas = {"request": SimpleNamespace(pull_tasks_count=0)}
     worker.receive_kv("engine", pull_metas)
     assert len(failures) == 1
@@ -980,8 +1042,7 @@ def test_receive_kv_same_pp_rejects_custom_partition(mooncake, monkeypatch):
     assert "VLLM_PP_LAYER_PARTITION" in failures[0][1]
 
 
-def test_mooncake_init_rejects_custom_pp_partition(mooncake, monkeypatch):
-    """Config-time reject so the background send/recv path never starts."""
-    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
-    with pytest.raises(RuntimeError, match="VLLM_PP_LAYER_PARTITION"):
-        mooncake._reject_custom_pp_partition()
+def test_normalize_pp_layer_partition(mooncake):
+    assert mooncake._normalize_pp_layer_partition(None) == ""
+    assert mooncake._normalize_pp_layer_partition("3,5") == "3,5"
+    assert mooncake._normalize_pp_layer_partition(" 3, 5 ") == "3,5"

--- a/tests/runtime_patch/test_hcu_mooncake_contract.py
+++ b/tests/runtime_patch/test_hcu_mooncake_contract.py
@@ -851,13 +851,6 @@ def test_ttft_transfer_identity(mooncake):
     )
 
 
-def _even_pp_indices(num_hidden_layers, pp_rank, pp_size):
-    per = num_hidden_layers // pp_size
-    start = pp_rank * per
-    end = num_hidden_layers if pp_rank + 1 == pp_size else start + per
-    return start, end
-
-
 def test_noncanonical_pcp_skips_empty_alloc_send(mooncake):
     worker = object.__new__(mooncake.MooncakeConnectorWorker)
     worker.finished_sending_reqs = set()
@@ -919,7 +912,7 @@ def test_receive_kv_uses_layer_overlap_for_heterogeneous_pp(mooncake, monkeypatc
     worker._tp_size = {"engine": 1}
     worker._remote_agents = {"engine": {0: {0: "tp0-pp0", 1: "tp0-pp1"}}}
     worker.transfer_topo.handshake_target_ranks = lambda remote_tp_size: [0]
-    monkeypatch.setattr(mooncake, "get_pp_indices", _even_pp_indices)
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", None)
     calls = []
 
     async def receive(
@@ -946,13 +939,67 @@ def test_receive_kv_uses_layer_overlap_for_heterogeneous_pp(mooncake, monkeypatc
     assert pull_meta.pull_tasks_count == 2
 
 
-def test_hetero_pp_rejects_custom_layer_partition(mooncake, monkeypatch):
+def test_hetero_pp_pp1_allows_matching_custom_layer_partition(
+    mooncake, monkeypatch
+):
+    """pp1↔pp2 with the same custom partition uses those stage ranges."""
     worker = _worker(mooncake, blocks_first=True)
     worker.pp_size = 1
     worker.pp_rank = 0
-    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "4,4")
-    with pytest.raises(RuntimeError, match="VLLM_PP_LAYER_PARTITION"):
-        worker._pp_overlap_layer_range(remote_pp_rank=0, remote_pp_size=2)
+    worker.model_config = SimpleNamespace(get_total_num_hidden_layers=lambda: 8)
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
+    worker._reject_custom_partition_for_hetero_pp(
+        remote_pp_size=2, remote_partition="3,5"
+    )
+    assert worker._pp_overlap_layer_range(
+        remote_pp_rank=0, remote_pp_size=2
+    ) == (0, 3)
+    assert worker._pp_overlap_layer_range(
+        remote_pp_rank=1, remote_pp_size=2
+    ) == (3, 8)
+
+    worker.pp_size = 2
+    worker.pp_rank = 0
+    worker._reject_custom_partition_for_hetero_pp(
+        remote_pp_size=1, remote_partition="3,5"
+    )
+    assert worker._pp_overlap_layer_range(
+        remote_pp_rank=0, remote_pp_size=1
+    ) == (0, 3)
+
+
+def test_hetero_pp_pp1_rejects_mismatched_custom_partition(
+    mooncake, monkeypatch
+):
+    worker = _worker(mooncake, blocks_first=True)
+    worker.pp_size = 1
+    worker.pp_rank = 0
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
+    with pytest.raises(RuntimeError, match="matching"):
+        worker._reject_custom_partition_for_hetero_pp(
+            remote_pp_size=2, remote_partition="4,4"
+        )
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
+    with pytest.raises(RuntimeError, match="matching"):
+        worker._reject_custom_partition_for_hetero_pp(
+            remote_pp_size=2, remote_partition=""
+        )
+    worker.pp_size = 2
+    with pytest.raises(RuntimeError, match="matching"):
+        worker._reject_custom_partition_for_hetero_pp(
+            remote_pp_size=1, remote_partition=""
+        )
+
+
+def test_hetero_pp_both_gt1_rejects_custom_layer_partition(
+    mooncake, monkeypatch
+):
+    worker = _worker(mooncake, blocks_first=True)
+    worker.pp_size = 2
+    worker.pp_rank = 0
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
+    with pytest.raises(RuntimeError, match="both PP sizes are >1"):
+        worker._pp_overlap_layer_range(remote_pp_rank=0, remote_pp_size=4)
 
 
 def test_same_pp_allows_matching_custom_layer_partition(mooncake, monkeypatch):
@@ -1020,11 +1067,12 @@ def test_receive_kv_same_pp_keeps_custom_partition(mooncake, monkeypatch):
     assert calls == [("tp0-pp0", -1, -1)]
 
 
-def test_receive_kv_hetero_pp_rejects_custom_partition(mooncake, monkeypatch):
-    """Hetero PP + custom partition must finish the pull instead of raising."""
+def test_receive_kv_hetero_pp_uses_custom_partition(mooncake, monkeypatch):
+    """pp1 D pulls pp2 P by local custom stages, not even split."""
     worker = _worker(mooncake, blocks_first=True)
     worker.pp_size = 1
     worker.pp_rank = 0
+    worker.model_config = SimpleNamespace(get_total_num_hidden_layers=lambda: 8)
     failures = []
 
     def fail_pull(pull_metas, err_msg):
@@ -1034,15 +1082,116 @@ def test_receive_kv_hetero_pp_rejects_custom_partition(mooncake, monkeypatch):
     worker._tp_size = {"engine": 1}
     worker._remote_agents = {"engine": {0: {0: "tp0-pp0", 1: "tp0-pp1"}}}
     worker.transfer_topo.handshake_target_ranks = lambda remote_tp_size: [0]
-    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "4,4")
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
+    calls = []
+
+    async def receive(
+        worker_addr,
+        pull_metas,
+        *,
+        chunk_idx=None,
+        model_layer_start=-1,
+        model_layer_end=-1,
+    ):
+        calls.append((worker_addr, model_layer_start, model_layer_end))
+
+    worker.receive_kv_from_single_worker = receive
+    pull_meta = SimpleNamespace(pull_tasks_count=0)
+    pull_metas = {"request": pull_meta}
+
+    async def run():
+        worker.receive_kv("engine", pull_metas)
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    assert failures == []
+    assert calls == [("tp0-pp0", 0, 3), ("tp0-pp1", 3, 8)]
+    assert pull_meta.pull_tasks_count == 2
+
+
+def test_receive_kv_hetero_pp_d_pp2_uses_custom_partition(mooncake, monkeypatch):
+    """pp2 D slices its local stage from pp1 P without P's partition."""
+    worker = _worker(mooncake, blocks_first=True)
+    worker.pp_size = 2
+    worker.pp_rank = 0
+    worker.model_config = SimpleNamespace(get_total_num_hidden_layers=lambda: 8)
+    failures = []
+
+    def fail_pull(pull_metas, err_msg):
+        failures.append((pull_metas, err_msg))
+
+    worker._fail_pull_metas = fail_pull
+    worker._tp_size = {"engine": 1}
+    worker._remote_agents = {"engine": {0: {0: "tp0-pp0"}}}
+    worker.transfer_topo.handshake_target_ranks = lambda remote_tp_size: [0]
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
+    calls = []
+
+    async def receive(
+        worker_addr,
+        pull_metas,
+        *,
+        chunk_idx=None,
+        model_layer_start=-1,
+        model_layer_end=-1,
+    ):
+        calls.append((worker_addr, model_layer_start, model_layer_end))
+
+    worker.receive_kv_from_single_worker = receive
+    pull_meta = SimpleNamespace(pull_tasks_count=0)
+    pull_metas = {"request": pull_meta}
+
+    async def run():
+        worker.receive_kv("engine", pull_metas)
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    assert failures == []
+    assert calls == [("tp0-pp0", 0, 3)]
+    assert pull_meta.pull_tasks_count == 1
+
+
+def test_receive_kv_hetero_pp_both_gt1_custom_partition_fail_closed(
+    mooncake, monkeypatch
+):
+    """Both PP sizes >1 plus a custom partition must finish the pull."""
+    worker = _worker(mooncake, blocks_first=True)
+    worker.pp_size = 2
+    worker.pp_rank = 0
+    failures = []
+
+    def fail_pull(pull_metas, err_msg):
+        failures.append((pull_metas, err_msg))
+
+    worker._fail_pull_metas = fail_pull
+    worker._tp_size = {"engine": 1}
+    worker._remote_agents = {
+        "engine": {0: {0: "tp0-pp0", 1: "tp0-pp1", 2: "tp0-pp2", 3: "tp0-pp3"}}
+    }
+    worker.transfer_topo.handshake_target_ranks = lambda remote_tp_size: [0]
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "3,5")
     pull_metas = {"request": SimpleNamespace(pull_tasks_count=0)}
     worker.receive_kv("engine", pull_metas)
     assert len(failures) == 1
     assert failures[0][0] is pull_metas
-    assert "VLLM_PP_LAYER_PARTITION" in failures[0][1]
+    assert "both PP sizes are >1" in failures[0][1]
 
 
 def test_normalize_pp_layer_partition(mooncake):
     assert mooncake._normalize_pp_layer_partition(None) == ""
     assert mooncake._normalize_pp_layer_partition("3,5") == "3,5"
     assert mooncake._normalize_pp_layer_partition(" 3, 5 ") == "3,5"
+
+
+def test_pp_stage_range_matches_v21_pp1_and_custom(mooncake):
+    assert mooncake._pp_stage_range(8, 0, 1, "3,5") == (0, 8)
+    assert mooncake._pp_stage_range(8, 0, 2, "3,5") == (0, 3)
+    assert mooncake._pp_stage_range(8, 1, 2, "3,5") == (3, 8)
+    with pytest.raises(RuntimeError, match="does not match pp_size"):
+        mooncake._pp_stage_range(8, 0, 4, "3,5")
+    # Empty partition uses even split; 78/8 matches vLLM remainder.
+    assert mooncake._pp_partition_sizes(78, 8, None) == [9, 10, 10, 10, 10, 10, 10, 9]
+    assert mooncake._pp_stage_range(8, 0, 2, "") == (0, 4)
+    assert mooncake._pp_stage_range(8, 1, 2, None) == (4, 8)

--- a/tests/runtime_patch/test_hcu_mooncake_contract.py
+++ b/tests/runtime_patch/test_hcu_mooncake_contract.py
@@ -105,6 +105,11 @@ def test_target_metadata_schema_and_round_trip(mooncake):
         "registered_layer_names",
         "registered_layer_indices",
         "registered_group_indices",
+        "src_layer_offset",
+        "model_layer_start",
+        "model_layer_end",
+        "xfer_head_rank",
+        "remote_pp_size",
     )
     metadata = _metadata(
         mooncake,
@@ -785,8 +790,17 @@ def test_receive_kv_selects_matching_remote_pp_workers(mooncake):
     worker.transfer_topo.handshake_target_ranks = lambda remote_tp_size: [0, 1]
     calls = []
 
-    async def receive(worker_addr, pull_metas):
-        calls.append((worker_addr, pull_metas))
+    async def receive(
+        worker_addr,
+        pull_metas,
+        *,
+        chunk_idx=None,
+        model_layer_start=-1,
+        model_layer_end=-1,
+    ):
+        calls.append(
+            (worker_addr, pull_metas, chunk_idx, model_layer_start, model_layer_end)
+        )
 
     worker.receive_kv_from_single_worker = receive
     pull_meta = SimpleNamespace(pull_tasks_count=0)
@@ -798,9 +812,10 @@ def test_receive_kv_selects_matching_remote_pp_workers(mooncake):
 
     asyncio.run(run())
 
-    assert [address for address, _ in calls] == ["tp0-pp1", "tp1-pp1"]
-    assert all(metadata is pull_metas for _, metadata in calls)
+    assert [address for address, *_ in calls] == ["tp0-pp1", "tp1-pp1"]
+    assert all(metadata is pull_metas for _, metadata, *_ in calls)
     assert pull_meta.pull_tasks_count == 2
+    assert all(start == -1 and end == -1 for _, _, _, start, end in calls)
 
 
 def test_target_first_patch_contract_is_idempotent(
@@ -827,3 +842,107 @@ def test_ttft_transfer_identity(mooncake):
     assert mooncake.transfer_id_from_req(req_id, {"transfer_id": "explicit"}) == (
         "explicit"
     )
+
+
+def _even_pp_indices(num_hidden_layers, pp_rank, pp_size):
+    per = num_hidden_layers // pp_size
+    start = pp_rank * per
+    end = num_hidden_layers if pp_rank + 1 == pp_size else start + per
+    return start, end
+
+
+def test_noncanonical_pcp_skips_empty_alloc_send(mooncake):
+    worker = object.__new__(mooncake.MooncakeConnectorWorker)
+    worker.finished_sending_reqs = set()
+    worker.reqs_need_send = {}
+    metadata = mooncake.MooncakeConnectorMetadata()
+    metadata.reqs_to_send = {"req-1": ("xfer-1", [])}
+
+    asyncio.run(worker._complete_noncanonical_pcp_sends(metadata))
+
+    assert worker.finished_sending_reqs == set()
+
+
+def test_noncanonical_pcp_reports_complete_on_final_blocks(mooncake):
+    worker = object.__new__(mooncake.MooncakeConnectorWorker)
+    worker.finished_sending_reqs = set()
+    worker.reqs_need_send = {}
+    metadata = mooncake.MooncakeConnectorMetadata()
+    metadata.reqs_to_send = {"req-1": ("xfer-1", [[1, 2]])}
+
+    asyncio.run(worker._complete_noncanonical_pcp_sends(metadata))
+
+    assert worker.finished_sending_reqs == {"req-1"}
+
+
+def test_validate_mooncake_pcp_pd_rejects_consumer_and_dcp(mooncake):
+    consumer = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=2,
+            decode_context_parallel_size=1,
+        ),
+        kv_transfer_config=SimpleNamespace(
+            kv_role="kv_consumer",
+            kv_connector_extra_config={},
+        ),
+    )
+    with pytest.raises(NotImplementedError, match="kv_producer only"):
+        mooncake._validate_mooncake_pcp_pd(consumer)
+
+    dcp = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=2,
+            decode_context_parallel_size=2,
+        ),
+        kv_transfer_config=SimpleNamespace(
+            kv_role="kv_producer",
+            kv_connector_extra_config={},
+        ),
+    )
+    with pytest.raises(NotImplementedError, match="decode_context_parallel_size"):
+        mooncake._validate_mooncake_pcp_pd(dcp)
+
+
+def test_receive_kv_uses_layer_overlap_for_heterogeneous_pp(mooncake, monkeypatch):
+    worker = _worker(mooncake, blocks_first=True)
+    worker.pp_size = 1
+    worker.pp_rank = 0
+    worker.model_config = SimpleNamespace(get_total_num_hidden_layers=lambda: 8)
+    worker._fail_pull_metas = lambda *args, **kwargs: None
+    worker._tp_size = {"engine": 1}
+    worker._remote_agents = {"engine": {0: {0: "tp0-pp0", 1: "tp0-pp1"}}}
+    worker.transfer_topo.handshake_target_ranks = lambda remote_tp_size: [0]
+    monkeypatch.setattr(mooncake, "get_pp_indices", _even_pp_indices)
+    calls = []
+
+    async def receive(
+        worker_addr,
+        pull_metas,
+        *,
+        chunk_idx=None,
+        model_layer_start=-1,
+        model_layer_end=-1,
+    ):
+        calls.append((worker_addr, model_layer_start, model_layer_end))
+
+    worker.receive_kv_from_single_worker = receive
+    pull_meta = SimpleNamespace(pull_tasks_count=0)
+    pull_metas = {"request": pull_meta}
+
+    async def run():
+        worker.receive_kv("engine", pull_metas)
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    assert calls == [("tp0-pp0", 0, 4), ("tp0-pp1", 4, 8)]
+    assert pull_meta.pull_tasks_count == 2
+
+
+def test_hetero_pp_rejects_custom_layer_partition(mooncake, monkeypatch):
+    worker = _worker(mooncake, blocks_first=True)
+    worker.pp_size = 1
+    worker.pp_rank = 0
+    monkeypatch.setattr(mooncake.envs, "VLLM_PP_LAYER_PARTITION", "4,4")
+    with pytest.raises(RuntimeError, match="VLLM_PP_LAYER_PARTITION"):
+        worker._pp_overlap_layer_range(remote_pp_rank=0, remote_pp_size=2)

--- a/vllm_hcu/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm_hcu/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -43,10 +43,14 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.stats import (
     MooncakeKVConnectorStats,
 )
 from vllm.distributed.parallel_state import (
+    # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
+    get_pcp_group,
+    # === HCU_MOONCAKE_PCP_NIXL52779_END ===
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+from vllm.distributed.utils import get_pp_indices
 from vllm.forward_context import ForwardContext
 from vllm.logger import init_logger
 from vllm.model_executor.models.utils import extract_layer_index
@@ -143,11 +147,12 @@ class TransferRegion:
 
 
 def _get_tp_ratio(local_tp_size: int, remote_tp_size: int) -> int:
-    """Return the TP ratio used by heterogeneous TP transfer planning.
+    """TP ratio for heterogeneous KV transfer.
 
-    Positive values mean one local rank maps into a larger remote KV region.
-    Negative values mean one local rank must gather from multiple remote KV
-    regions.
+    Sign convention aligned with v0.21:
+    - ``1``: homogeneous TP
+    - ``> 1``: P_TP > D_TP
+    - ``< 0``: D_TP > P_TP
     """
     if local_tp_size >= remote_tp_size:
         assert local_tp_size % remote_tp_size == 0, (
@@ -161,6 +166,65 @@ def _get_tp_ratio(local_tp_size: int, remote_tp_size: int) -> int:
         f"by local tensor parallel size {local_tp_size}."
     )
     return -(remote_tp_size // local_tp_size)
+
+
+def _get_head_split_ratio(tp_ratio: int) -> int:
+    """Head-chunk count for heterogeneous TP (always positive)."""
+    if tp_ratio > 1:
+        return tp_ratio
+    if tp_ratio < 0:
+        return -tp_ratio
+    return 1
+
+
+def _cache_type_sort_key(layer_name: str) -> int:
+    """Indexer cache entries sort before MLA/FA in the same model layer."""
+    if layer_name.endswith(".indexer") or ".indexer." in layer_name:
+        return 0
+    return 1
+
+
+def _is_hcu_global_first_rank() -> bool:
+    """Internal LB launches bootstrap only on the global first rank."""
+    try:
+        from vllm.distributed.parallel_state import is_global_first_rank
+    except ImportError:
+        return True
+    try:
+        return bool(is_global_first_rank())
+    except Exception:
+        return True
+
+
+def _select_cache_entry_indices(
+    layer_names: list[str],
+    layer_indices: list[int],
+    *,
+    model_layer_start: int = -1,
+    model_layer_end: int = -1,
+    src_layer_offset: int = 0,
+) -> list[int]:
+    """Select cache rows by model-layer overlap, then indexer-first."""
+    if model_layer_start >= 0:
+        selected = [
+            index
+            for index, layer_idx in enumerate(layer_indices)
+            if model_layer_start <= layer_idx < model_layer_end
+        ]
+    else:
+        selected = list(range(src_layer_offset, len(layer_names)))
+    selected.sort(
+        key=lambda index: (
+            layer_indices[index],
+            _cache_type_sort_key(layer_names[index]),
+            index,
+        )
+    )
+    return selected
+
+
+def _take_cache_entries(values_list: list, indices: list[int]):
+    return [values_list[index] for index in indices]
 
 
 def _expand_transfer_regions(
@@ -584,6 +648,11 @@ class MooncakeXferMetadata(
     registered_layer_names: list[str] = msgspec.field(default_factory=list)
     registered_layer_indices: list[int] = msgspec.field(default_factory=list)
     registered_group_indices: list[int] = msgspec.field(default_factory=list)
+    src_layer_offset: int = 0
+    model_layer_start: int = -1
+    model_layer_end: int = -1
+    xfer_head_rank: int = -1
+    remote_pp_size: int = 1
 
 
 class MooncakeXferResponseStatus(IntEnum):
@@ -672,6 +741,9 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
         assert vllm_config.kv_transfer_config is not None
         assert vllm_config.kv_transfer_config.engine_id is not None
         self.engine_id: EngineId = vllm_config.kv_transfer_config.engine_id
+        # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
+        _validate_mooncake_pcp_pd(vllm_config)
+        # === HCU_MOONCAKE_PCP_NIXL52779_END ===
 
         if role == KVConnectorRole.SCHEDULER:
             assert kv_cache_config is not None, (
@@ -1160,6 +1232,20 @@ class MooncakeConnectorWorker:
         self.engine_id: EngineId = engine_id
         self.tp_rank = get_tensor_model_parallel_rank()
         self.tp_size = get_tensor_model_parallel_world_size()
+        # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
+        # PCP adds KV replicas, not extra shards.
+        self.pcp_size = int(
+            getattr(vllm_config.parallel_config, "prefill_context_parallel_size", 1)
+            or 1
+        )
+        self.dcp_size = int(
+            getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1)
+            or 1
+        )
+        self.pcp_rank = (
+            int(get_pcp_group().rank_in_group) if self.pcp_size > 1 else 0
+        )
+        # === HCU_MOONCAKE_PCP_NIXL52779_END ===
         self.block_len_per_layer: list[int] = []
         self.kv_block_len_per_layer: list[int] = []
         self.registered_layer_names: list[str] = []
@@ -1450,13 +1536,33 @@ class MooncakeConnectorWorker:
             if metadata_err is not None:
                 await reject_metadata(metadata_err)
                 return
+        local_base_addrs = self.kv_caches_base_addr
+        local_block_lens = self.block_len_per_layer
+        local_kv_block_lens = self.kv_block_len_per_layer
+        local_layer_names = self.registered_layer_names
+        local_layer_indices = self.registered_layer_indices
+        local_group_indices = self.registered_group_indices
+        if meta.model_layer_start >= 0 or meta.src_layer_offset:
+            local_keep = _select_cache_entry_indices(
+                local_layer_names,
+                local_layer_indices,
+                model_layer_start=meta.model_layer_start,
+                model_layer_end=meta.model_layer_end,
+                src_layer_offset=meta.src_layer_offset,
+            )
+            local_base_addrs = _take_cache_entries(local_base_addrs, local_keep)
+            local_block_lens = _take_cache_entries(local_block_lens, local_keep)
+            local_kv_block_lens = _take_cache_entries(local_kv_block_lens, local_keep)
+            local_layer_names = _take_cache_entries(local_layer_names, local_keep)
+            local_layer_indices = _take_cache_entries(local_layer_indices, local_keep)
+            local_group_indices = _take_cache_entries(local_group_indices, local_keep)
         local_regions = self._get_transfer_regions(
-            self.kv_caches_base_addr,
-            self.block_len_per_layer,
-            self.kv_block_len_per_layer,
-            self.registered_layer_names,
-            self.registered_layer_indices,
-            self.registered_group_indices,
+            local_base_addrs,
+            local_block_lens,
+            local_kv_block_lens,
+            local_layer_names,
+            local_layer_indices,
+            local_group_indices,
         )
         remote_regions = self._get_transfer_regions(
             meta.kv_caches_base_addr,
@@ -1542,7 +1648,11 @@ class MooncakeConnectorWorker:
                     # Mark it sending to avoid expiration.
                     send_meta.sending += 1
                     if not send_meta.need_send:
-                        self.resolve_need_send(send_meta, remote_tp_ranks)
+                        self.resolve_need_send(
+                            send_meta,
+                            remote_tp_ranks,
+                            remote_pp_size=meta.remote_pp_size,
+                        )
                     ready_reqs.append((d_req_id, send_meta))
                 else:
                     # Otherwise (expired, very unlikely), just forget it.
@@ -1628,18 +1738,41 @@ class MooncakeConnectorWorker:
             )
             await sock.send_multipart((identity, self._encoder.encode(response)))
 
+    def _count_overlapping_remote_pp_stages(self, remote_pp_size: int) -> int:
+        """How many consumer PP stages overlap this producer's layer range."""
+        remote_pp_size = max(int(remote_pp_size), 1)
+        if remote_pp_size == 1 or self.pp_size <= 0:
+            return remote_pp_size
+        total_model_layers = self.model_config.get_total_num_hidden_layers()
+        p_start, p_end = get_pp_indices(
+            total_model_layers, self.pp_rank, self.pp_size
+        )
+        overlap = 0
+        for d_pp_rank in range(remote_pp_size):
+            d_start, d_end = get_pp_indices(
+                total_model_layers, d_pp_rank, remote_pp_size
+            )
+            if d_start >= p_end or p_start >= d_end:
+                continue
+            overlap += 1
+        return max(overlap, 1)
+
     def resolve_need_send(
         self,
         send_meta: SendBlockMeta,
         remote_tp_ranks: list[int],
+        remote_pp_size: int = 1,
     ):
-        # Prepare for heterogeneous TP (one P pairs to multiple D)
-        send_meta.need_send = len(remote_tp_ranks)
+        pp_contacts = self._count_overlapping_remote_pp_stages(remote_pp_size)
+        send_meta.need_send = len(remote_tp_ranks) * pp_contacts
         logger.debug(
-            "Mooncake request %s will be served by %d consumer TP workers: TP ranks=%s",
+            "Mooncake request %s will be served by %d consumer contacts "
+            "(tp_ranks=%s pp_contacts=%d remote_pp_size=%d)",
             send_meta.transfer_id,
             send_meta.need_send,
             remote_tp_ranks,
+            pp_contacts,
+            remote_pp_size,
         )
 
     def _logical_to_kernel_block_ids(
@@ -1803,7 +1936,11 @@ class MooncakeConnectorWorker:
                 ) = self._get_sender_transfer_plan(
                     local_kv_block_len=local_region.kv_block_len,
                     remote_kv_block_len=remote_region.kv_block_len,
-                    remote_tp_rank=agent_meta.remote_tp_rank,
+                    remote_tp_rank=(
+                        agent_meta.xfer_head_rank
+                        if agent_meta.xfer_head_rank >= 0
+                        else agent_meta.remote_tp_rank
+                    ),
                     remote_tp_size=agent_meta.remote_tp_size,
                 )
                 if not should_transfer:
@@ -2043,6 +2180,29 @@ class MooncakeConnectorWorker:
                     kv_data_ptrs.append(storage_addr)
                     kv_data_lens.append(storage_len)
 
+        indexer_order = _select_cache_entry_indices(
+            self.registered_layer_names,
+            self.registered_layer_indices,
+        )
+        region_base_addresses = _take_cache_entries(
+            region_base_addresses, indexer_order
+        )
+        self.block_len_per_layer = _take_cache_entries(
+            self.block_len_per_layer, indexer_order
+        )
+        self.kv_block_len_per_layer = _take_cache_entries(
+            self.kv_block_len_per_layer, indexer_order
+        )
+        self.registered_layer_names = _take_cache_entries(
+            self.registered_layer_names, indexer_order
+        )
+        self.registered_layer_indices = _take_cache_entries(
+            self.registered_layer_indices, indexer_order
+        )
+        self.registered_group_indices = _take_cache_entries(
+            self.registered_group_indices, indexer_order
+        )
+
         self.kv_caches_base_addr = region_base_addresses
         self.seen_base_addresses = kv_data_ptrs
 
@@ -2063,6 +2223,17 @@ class MooncakeConnectorWorker:
         # No need to launch server for D node.
         if self.is_kv_consumer:
             return
+        # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
+        # Non-canonical PCP replicas do not listen or register.
+        if not self._is_canonical_pcp_kv_replica():
+            logger.info(
+                "Mooncake PCP replica skip listen/register: pcp_rank=%s "
+                "pcp_size=%s (rank0 sends the KV replica)",
+                self.pcp_rank,
+                self.pcp_size,
+            )
+            return
+        # === HCU_MOONCAKE_PCP_NIXL52779_END ===
 
         ready_event = threading.Event()
         asyncio.run_coroutine_threadsafe(
@@ -2147,8 +2318,31 @@ class MooncakeConnectorWorker:
         self,
         worker_addr: str,
         pull_metas: dict[ReqId, PullReqMeta],
+        *,
+        chunk_idx: int | None = None,
+        model_layer_start: int = -1,
+        model_layer_end: int = -1,
     ):
         req_ids = set(pull_metas)
+        base_addrs = self.kv_caches_base_addr
+        block_lens = self.block_len_per_layer
+        kv_block_lens = self.kv_block_len_per_layer
+        layer_names = self.registered_layer_names
+        layer_indices = self.registered_layer_indices
+        group_indices = self.registered_group_indices
+        if model_layer_start >= 0:
+            keep = _select_cache_entry_indices(
+                layer_names,
+                layer_indices,
+                model_layer_start=model_layer_start,
+                model_layer_end=model_layer_end,
+            )
+            base_addrs = _take_cache_entries(base_addrs, keep)
+            block_lens = _take_cache_entries(block_lens, keep)
+            kv_block_lens = _take_cache_entries(kv_block_lens, keep)
+            layer_names = _take_cache_entries(layer_names, keep)
+            layer_indices = _take_cache_entries(layer_indices, keep)
+            group_indices = _take_cache_entries(group_indices, keep)
         metadata = MooncakeXferMetadata(
             remote_hostname=self.hostname,
             remote_port=self.rpc_port,
@@ -2158,12 +2352,18 @@ class MooncakeConnectorWorker:
                 req_id: (pull_meta.transfer_id, pull_meta.local_block_ids)
                 for req_id, pull_meta in pull_metas.items()
             },
-            kv_caches_base_addr=self.kv_caches_base_addr,
-            block_lens=self.block_len_per_layer,
-            kv_block_lens=self.kv_block_len_per_layer,
-            registered_layer_names=self.registered_layer_names,
-            registered_layer_indices=self.registered_layer_indices,
-            registered_group_indices=self.registered_group_indices,
+            kv_caches_base_addr=base_addrs,
+            block_lens=block_lens,
+            kv_block_lens=kv_block_lens,
+            registered_layer_names=layer_names,
+            registered_layer_indices=layer_indices,
+            registered_group_indices=group_indices,
+            model_layer_start=model_layer_start,
+            model_layer_end=model_layer_end,
+            xfer_head_rank=(
+                chunk_idx if chunk_idx is not None else self.tp_rank
+            ),
+            remote_pp_size=self.pp_size,
         )
 
         encoded_data = self._encoder.encode(metadata)
@@ -2295,18 +2495,43 @@ class MooncakeConnectorWorker:
         remote_tp_ranks = self.transfer_topo.handshake_target_ranks(
             self._tp_size[remote_engine_id]
         )
-        worker_addrs: list[str] = []
+        worker_jobs: list[tuple[str, int | None, int, int]] = []
         selected_remote_pp: dict[int, list[int]] = {}
-        for remote_tp_rank in remote_tp_ranks:
+        needs_chunk_idx = len(remote_tp_ranks) > 1
+        for i, remote_tp_rank in enumerate(remote_tp_ranks):
             pp_to_addr = self._remote_agents[remote_engine_id][remote_tp_rank]
-            if self.pp_size == len(pp_to_addr) and self.pp_rank in pp_to_addr:
+            remote_pp_size = len(pp_to_addr)
+            same_pp = self.pp_size == remote_pp_size and self.pp_rank in pp_to_addr
+            if same_pp:
                 pp_ranks = [self.pp_rank]
             else:
-                pp_ranks = sorted(pp_to_addr)
+                pp_ranks = self._overlapping_remote_pp_ranks(
+                    remote_pp_size, sorted(pp_to_addr)
+                )
             selected_remote_pp[remote_tp_rank] = pp_ranks
-            worker_addrs.extend(pp_to_addr[pp_rank] for pp_rank in pp_ranks)
+            chunk_idx = i if needs_chunk_idx else None
+            for pp_rank in pp_ranks:
+                if same_pp:
+                    worker_jobs.append(
+                        (pp_to_addr[pp_rank], chunk_idx, -1, -1)
+                    )
+                    continue
+                overlap_start, overlap_end = self._pp_overlap_layer_range(
+                    remote_pp_rank=pp_rank,
+                    remote_pp_size=remote_pp_size,
+                )
+                if overlap_start >= overlap_end:
+                    continue
+                worker_jobs.append(
+                    (
+                        pp_to_addr[pp_rank],
+                        chunk_idx,
+                        overlap_start,
+                        overlap_end,
+                    )
+                )
 
-        count = len(worker_addrs)
+        count = len(worker_jobs)
         logger.debug(
             "Receiving Mooncake KV for engine %s from producer TP ranks %s "
             "and PP ranks %s",
@@ -2314,11 +2539,24 @@ class MooncakeConnectorWorker:
             remote_tp_ranks,
             selected_remote_pp,
         )
+        if count == 0:
+            self._fail_pull_metas(
+                pull_metas,
+                f"asymmetric PP has zero overlap tasks for engine "
+                f"{remote_engine_id}",
+            )
+            return
         for pull_meta in pull_metas.values():
             pull_meta.pull_tasks_count = count
-        for worker_addr in worker_addrs:
+        for worker_addr, chunk_idx, layer_start, layer_end in worker_jobs:
             asyncio.create_task(
-                self.receive_kv_from_single_worker(worker_addr, pull_metas)
+                self.receive_kv_from_single_worker(
+                    worker_addr,
+                    pull_metas,
+                    chunk_idx=chunk_idx,
+                    model_layer_start=layer_start,
+                    model_layer_end=layer_end,
+                )
             )
 
     async def handle_new_engine_id(
@@ -2387,6 +2625,27 @@ class MooncakeConnectorWorker:
             if send_meta is not None:
                 assert not send_meta.ready.is_set()
 
+    # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
+    def _is_canonical_pcp_kv_replica(self) -> bool:
+        """True if this rank owns the sendable PCP KV replica."""
+
+        return int(getattr(self, "pcp_size", 1) or 1) <= 1 or int(
+            getattr(self, "pcp_rank", 0)
+        ) == 0
+
+    async def _complete_noncanonical_pcp_sends(
+        self, metadata: MooncakeConnectorMetadata
+    ) -> None:
+        """Mark send complete without transferring KV on non-rank0 PCP."""
+
+        for p_req_id, (_transfer_id, _block_ids) in metadata.reqs_to_send.items():
+            self.finished_sending_reqs.add(p_req_id)
+        for transfer_id in metadata.reqs_not_processed:
+            send_meta = self.reqs_need_send.pop(transfer_id, None)
+            if send_meta is not None and send_meta.p_req_id:
+                self.finished_sending_reqs.add(send_meta.p_req_id)
+
+    # === HCU_MOONCAKE_PCP_NIXL52779_END ===
     def start_load_kv(self, metadata: MooncakeConnectorMetadata):
         if not self.is_kv_producer and metadata.reqs_to_recv:
             asyncio.run_coroutine_threadsafe(
@@ -2396,12 +2655,44 @@ class MooncakeConnectorWorker:
         if not self.is_kv_consumer and (
             metadata.reqs_to_send or metadata.reqs_not_processed
         ):
-            asyncio.run_coroutine_threadsafe(
-                self.record_send_reqs(metadata), self.sender_loop
+            # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
+            # Non-canonical PCP replicas only mark send complete.
+            send_coro = (
+                self.record_send_reqs(metadata)
+                if self._is_canonical_pcp_kv_replica()
+                else self._complete_noncanonical_pcp_sends(metadata)
             )
+            asyncio.run_coroutine_threadsafe(send_coro, self.sender_loop)
+            # === HCU_MOONCAKE_PCP_NIXL52779_END ===
 
     def _producer_cache_is_replicated(self) -> bool:
         return self.transfer_topo.local_replicates_kv_cache
+
+    def _pp_overlap_layer_range(
+        self, *, remote_pp_rank: int, remote_pp_size: int
+    ) -> tuple[int, int]:
+        total_model_layers = self.model_config.get_total_num_hidden_layers()
+        d_start, d_end = get_pp_indices(
+            total_model_layers, self.pp_rank, self.pp_size
+        )
+        p_start, p_end = get_pp_indices(
+            total_model_layers, remote_pp_rank, remote_pp_size
+        )
+        return max(d_start, p_start), min(d_end, p_end)
+
+    def _overlapping_remote_pp_ranks(
+        self, remote_pp_size: int, remote_pp_ranks: list[int]
+    ) -> list[int]:
+        selected: list[int] = []
+        for pp_rank in remote_pp_ranks:
+            start, end = self._pp_overlap_layer_range(
+                remote_pp_rank=pp_rank,
+                remote_pp_size=remote_pp_size,
+            )
+            if start >= end:
+                continue
+            selected.append(pp_rank)
+        return selected
 
     def _get_transfer_regions(
         self,
@@ -2503,8 +2794,51 @@ def _async_loop(loop: asyncio.AbstractEventLoop):
     loop.run_forever()
 
 
+# === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
+def _validate_mooncake_pcp_pd(vllm_config: VllmConfig) -> None:
+    """Reject PCP on consumers, kv_both, DCP>1, and bidirectional xfer."""
+
+    parallel_config = vllm_config.parallel_config
+    kv_transfer_config = vllm_config.kv_transfer_config
+    if parallel_config is None or kv_transfer_config is None:
+        return
+    pcp_size = int(
+        getattr(parallel_config, "prefill_context_parallel_size", 1) or 1
+    )
+    if pcp_size <= 1:
+        return
+    kv_role = getattr(kv_transfer_config, "kv_role", None)
+    dcp_size = int(
+        getattr(parallel_config, "decode_context_parallel_size", 1) or 1
+    )
+    extra = getattr(kv_transfer_config, "kv_connector_extra_config", None) or {}
+    if kv_role in ("kv_consumer", "kv_both"):
+        raise NotImplementedError(
+            "MooncakeConnector PCP currently supports kv_producer only. "
+            "Consumers and kv_both require prefill_context_parallel_size=1."
+        )
+    if dcp_size > 1:
+        raise NotImplementedError(
+            "MooncakeConnector PCP producers currently require "
+            "decode_context_parallel_size=1."
+        )
+    if extra.get("bidirectional_kv_xfer"):
+        raise NotImplementedError(
+            "MooncakeConnector PCP producers do not support bidirectional KV transfer."
+        )
+
+
+# === HCU_MOONCAKE_PCP_NIXL52779_END ===
 def should_launch_bootstrap_server(vllm_config: VllmConfig) -> bool:
     assert (parallel_config := vllm_config.parallel_config)
+    # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
+    # TP=1 shares tp_rank=0 across PCP ranks; skip non-rank0 replicas.
+    _pcp_size = int(
+        getattr(parallel_config, "prefill_context_parallel_size", 1) or 1
+    )
+    if _pcp_size > 1 and int(get_pcp_group().rank_in_group) != 0:
+        return False
+    # === HCU_MOONCAKE_PCP_NIXL52779_END ===
     # Only the TP=0, PP=0 worker of the designated engine should launch it.
     if get_tensor_model_parallel_rank() != 0:
         return False
@@ -2516,8 +2850,10 @@ def should_launch_bootstrap_server(vllm_config: VllmConfig) -> bool:
     if parallel_config.local_engines_only:
         return parallel_config.data_parallel_rank_local == 0
 
-    # In internal LB mode,
-    # only the first data-parallel engine should launch the bootstrap server.
+    # Hybrid/external LB: each local engine keeps its own bootstrap.
+    # Multi-node prefill (Ray/internal LB): only global rank 0 on dp index 0.
+    if not _is_hcu_global_first_rank():
+        return False
     return parallel_config.data_parallel_index == 0
 
 

--- a/vllm_hcu/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm_hcu/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -48,7 +48,6 @@ from vllm.distributed.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
-from vllm.distributed.utils import get_pp_indices
 from vllm.forward_context import ForwardContext
 from vllm.logger import init_logger
 from vllm.model_executor.models.utils import extract_layer_index
@@ -651,7 +650,7 @@ class MooncakeXferMetadata(
     model_layer_end: int = -1
     xfer_head_rank: int = -1
     remote_pp_size: int = 1
-    # Consumer's VLLM_PP_LAYER_PARTITION; empty means default even split.
+    # Consumer partition; empty means even split. pp1 must still echo pp>1.
     pp_layer_partition: str = ""
 
 
@@ -1492,6 +1491,7 @@ class MooncakeConnectorWorker:
             logger.error(message)
             response = MooncakeXferResponse(
                 status=MooncakeXferResponseStatus.ERROR,
+                err_reqs=list(meta.req_blocks) or None,
                 err_msg=message,
             )
             await sock.send_multipart((identity, self._encoder.encode(response)))
@@ -1659,6 +1659,10 @@ class MooncakeConnectorWorker:
                                 send_meta,
                                 remote_tp_ranks,
                                 remote_pp_size=meta.remote_pp_size,
+                                remote_partition=getattr(
+                                    meta, "pp_layer_partition", ""
+                                )
+                                or "",
                             )
                     except Exception as e:
                         send_meta.sending -= 1
@@ -1768,24 +1772,27 @@ class MooncakeConnectorWorker:
         remote_pp_size: int,
         remote_partition: str | None = None,
     ) -> None:
-        """Reject custom PP partitions that cannot be verified.
+        """Validate P/D PP partitions before layer-overlap transfer.
 
-        Same-PP P/D with a matching partition (including both unset) keeps
-        the rank-pair path. Heterogeneous PP cannot map remote stages from
-        the local env, so any custom partition is fail-closed.
+        Same PP: strings must match (both empty = even split); rank-pair.
+        Hetero ppN↔pp1: custom partitions allowed; handshake strings must match.
+        Hetero with both PP sizes >1: reject custom partitions.
         """
         local = _normalize_pp_layer_partition(
             getattr(envs, "VLLM_PP_LAYER_PARTITION", None)
         )
         remote_pp_size = max(int(remote_pp_size), 1)
-        same_pp = remote_pp_size == int(self.pp_size)
+        local_pp_size = int(self.pp_size)
+        same_pp = remote_pp_size == local_pp_size
+        # ppN↔pp1: both sides set the same partition string.
+        pp1_hetero = min(local_pp_size, remote_pp_size) == 1
         if remote_partition is None:
-            if same_pp or not local:
+            if same_pp or not local or pp1_hetero:
                 return
             raise RuntimeError(
                 "Mooncake heterogeneous PP does not support "
-                "VLLM_PP_LAYER_PARTITION; unset it so both sides use the "
-                "default even split."
+                "VLLM_PP_LAYER_PARTITION when both PP sizes are >1; "
+                "unset it so both sides use the default even split."
             )
         remote = _normalize_pp_layer_partition(remote_partition)
         if same_pp:
@@ -1796,26 +1803,46 @@ class MooncakeConnectorWorker:
                 "VLLM_PP_LAYER_PARTITION "
                 f"(local={local!r} remote={remote!r})."
             )
+        if pp1_hetero:
+            if local == remote:
+                return
+            raise RuntimeError(
+                "Mooncake heterogeneous PP (ppN↔pp1) requires matching "
+                "VLLM_PP_LAYER_PARTITION "
+                f"(local={local!r} remote={remote!r})."
+            )
         if local or remote:
             raise RuntimeError(
                 "Mooncake heterogeneous PP does not support "
-                "VLLM_PP_LAYER_PARTITION; unset it on both sides."
+                "VLLM_PP_LAYER_PARTITION when both PP sizes are >1; "
+                "unset it on both sides."
             )
 
-    def _count_overlapping_remote_pp_stages(self, remote_pp_size: int) -> int:
-        """How many consumer PP stages overlap this producer's layer range."""
+    def _count_overlapping_remote_pp_stages(
+        self,
+        remote_pp_size: int,
+        remote_partition: str | None = None,
+    ) -> int:
+        """How many remote PP stages overlap this producer's layer range."""
         remote_pp_size = max(int(remote_pp_size), 1)
-        self._reject_custom_partition_for_hetero_pp(remote_pp_size)
+        self._reject_custom_partition_for_hetero_pp(
+            remote_pp_size, remote_partition=remote_partition
+        )
         if remote_pp_size == 1 or self.pp_size <= 0:
             return remote_pp_size
         total_model_layers = self.model_config.get_total_num_hidden_layers()
-        p_start, p_end = get_pp_indices(
-            total_model_layers, self.pp_rank, self.pp_size
+        local_part = getattr(envs, "VLLM_PP_LAYER_PARTITION", None)
+        # Prefer the remote-reported partition after handshake.
+        remote_part = (
+            remote_partition if remote_partition is not None else local_part
+        )
+        p_start, p_end = _pp_stage_range(
+            total_model_layers, self.pp_rank, self.pp_size, local_part
         )
         overlap = 0
         for d_pp_rank in range(remote_pp_size):
-            d_start, d_end = get_pp_indices(
-                total_model_layers, d_pp_rank, remote_pp_size
+            d_start, d_end = _pp_stage_range(
+                total_model_layers, d_pp_rank, remote_pp_size, remote_part
             )
             if d_start >= p_end or p_start >= d_end:
                 continue
@@ -1827,8 +1854,11 @@ class MooncakeConnectorWorker:
         send_meta: SendBlockMeta,
         remote_tp_ranks: list[int],
         remote_pp_size: int = 1,
+        remote_partition: str | None = None,
     ):
-        pp_contacts = self._count_overlapping_remote_pp_stages(remote_pp_size)
+        pp_contacts = self._count_overlapping_remote_pp_stages(
+            remote_pp_size, remote_partition=remote_partition
+        )
         send_meta.need_send = len(remote_tp_ranks) * pp_contacts
         logger.debug(
             "Mooncake request %s will be served by %d consumer contacts "
@@ -2742,13 +2772,16 @@ class MooncakeConnectorWorker:
     def _pp_overlap_layer_range(
         self, *, remote_pp_rank: int, remote_pp_size: int
     ) -> tuple[int, int]:
+        """Layer overlap [start, end) with one remote PP stage."""
         self._reject_custom_partition_for_hetero_pp(remote_pp_size)
         total_model_layers = self.model_config.get_total_num_hidden_layers()
-        d_start, d_end = get_pp_indices(
-            total_model_layers, self.pp_rank, self.pp_size
+        # Local string describes both sides; pp=1 ignores it.
+        local_part = getattr(envs, "VLLM_PP_LAYER_PARTITION", None)
+        d_start, d_end = _pp_stage_range(
+            total_model_layers, self.pp_rank, self.pp_size, local_part
         )
-        p_start, p_end = get_pp_indices(
-            total_model_layers, remote_pp_rank, remote_pp_size
+        p_start, p_end = _pp_stage_range(
+            total_model_layers, remote_pp_rank, remote_pp_size, local_part
         )
         return max(d_start, p_start), min(d_end, p_end)
 
@@ -2867,10 +2900,64 @@ def _async_loop(loop: asyncio.AbstractEventLoop):
 
 
 def _normalize_pp_layer_partition(partition: str | None) -> str:
-    """Canonical comma-separated PP layer counts, or empty for even split."""
+    """Comma-separated layer counts, or empty for even split."""
     if not partition:
         return ""
     return ",".join(part.strip() for part in str(partition).split(",") if part.strip())
+
+
+def _pp_partition_sizes(
+    num_hidden_layers: int,
+    pp_size: int,
+    partition: str | None = None,
+) -> list[int]:
+    """Per-stage layer counts: custom string, else vLLM even split."""
+    normalized = _normalize_pp_layer_partition(partition)
+    if normalized:
+        try:
+            parts = [int(part) for part in normalized.split(",")]
+        except ValueError as err:
+            raise RuntimeError(
+                f"invalid VLLM_PP_LAYER_PARTITION {normalized!r}"
+            ) from err
+        if len(parts) != pp_size:
+            raise RuntimeError(
+                f"VLLM_PP_LAYER_PARTITION {normalized!r} length "
+                f"{len(parts)} does not match pp_size={pp_size}."
+            )
+        if sum(parts) != num_hidden_layers:
+            raise RuntimeError(
+                f"VLLM_PP_LAYER_PARTITION {normalized!r} sum "
+                f"{sum(parts)} does not match {num_hidden_layers} layers."
+            )
+        return parts
+    layers_per_partition = num_hidden_layers // pp_size
+    parts = [layers_per_partition] * pp_size
+    if remaining := num_hidden_layers % pp_size:
+        for i in range(2, remaining + 2):
+            parts[-i] += 1
+    return parts
+
+
+def _pp_stage_range(
+    num_hidden_layers: int,
+    pp_rank: int,
+    pp_size: int,
+    partition: str | None = None,
+) -> tuple[int, int]:
+    """PP stage [start, end). pp=1 covers all layers; uses `partition` only."""
+    pp_size = max(int(pp_size), 1)
+    pp_rank = int(pp_rank)
+    num_hidden_layers = int(num_hidden_layers)
+    if pp_size == 1:
+        return 0, num_hidden_layers
+    if not 0 <= pp_rank < pp_size:
+        raise RuntimeError(
+            f"pp_rank={pp_rank} is outside pp_size={pp_size}."
+        )
+    parts = _pp_partition_sizes(num_hidden_layers, pp_size, partition)
+    start = sum(parts[:pp_rank])
+    return start, start + parts[pp_rank]
 
 
 def _validate_mooncake_pcp_pd(vllm_config: VllmConfig) -> None:

--- a/vllm_hcu/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm_hcu/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -740,6 +740,7 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
         assert vllm_config.kv_transfer_config.engine_id is not None
         self.engine_id: EngineId = vllm_config.kv_transfer_config.engine_id
         _validate_mooncake_pcp_pd(vllm_config)
+        _reject_custom_pp_partition()
 
         if role == KVConnectorRole.SCHEDULER:
             assert kv_cache_config is not None, (
@@ -1634,6 +1635,8 @@ class MooncakeConnectorWorker:
                 else MooncakeXferResponseStatus.FINISH
             )
             ready_reqs: list[tuple[ReqId, SendBlockMeta]] = []
+            resolve_err_reqs: list[ReqId] = []
+            resolve_err_msg: str | None = None
             for task in done:
                 d_req_id, send_meta = task.result()
                 del pending_reqs[d_req_id]
@@ -1641,12 +1644,23 @@ class MooncakeConnectorWorker:
                 if send_meta.transfer_id in self.reqs_need_send:
                     # Mark it sending to avoid expiration.
                     send_meta.sending += 1
-                    if not send_meta.need_send:
-                        self.resolve_need_send(
-                            send_meta,
-                            remote_tp_ranks,
-                            remote_pp_size=meta.remote_pp_size,
+                    try:
+                        if not send_meta.need_send:
+                            self.resolve_need_send(
+                                send_meta,
+                                remote_tp_ranks,
+                                remote_pp_size=meta.remote_pp_size,
+                            )
+                    except Exception as e:
+                        send_meta.sending -= 1
+                        logger.error(
+                            "Mooncake resolve_need_send failed for %s: %s",
+                            d_req_id,
+                            e,
                         )
+                        resolve_err_reqs.append(d_req_id)
+                        resolve_err_msg = str(e)
+                        continue
                     ready_reqs.append((d_req_id, send_meta))
                 else:
                     # Otherwise (expired, very unlikely), just forget it.
@@ -1667,6 +1681,14 @@ class MooncakeConnectorWorker:
                 remote_regions,
             )
             err_req_set = set(err_reqs)
+            if resolve_err_reqs:
+                err_reqs = list(err_reqs) + resolve_err_reqs
+                err_req_set.update(resolve_err_reqs)
+                err_msg = (
+                    resolve_err_msg
+                    if err_msg is None
+                    else f"{err_msg}; {resolve_err_msg}"
+                )
             ok_ready_reqs = [
                 (d_req_id, send_meta)
                 for d_req_id, send_meta in ready_reqs
@@ -1742,13 +1764,7 @@ class MooncakeConnectorWorker:
         ``remote_pp_size`` is unused and kept for the call sites.
         """
         del remote_pp_size
-        partition = getattr(envs, "VLLM_PP_LAYER_PARTITION", None) or ""
-        if not partition:
-            return
-        raise RuntimeError(
-            "Mooncake P/D does not support VLLM_PP_LAYER_PARTITION; "
-            "unset it so both sides use the default even split."
-        )
+        _reject_custom_pp_partition()
 
     def _count_overlapping_remote_pp_stages(self, remote_pp_size: int) -> int:
         """How many consumer PP stages overlap this producer's layer range."""
@@ -2509,11 +2525,15 @@ class MooncakeConnectorWorker:
         worker_jobs: list[tuple[str, int | None, int, int]] = []
         selected_remote_pp: dict[int, list[int]] = {}
         needs_chunk_idx = len(remote_tp_ranks) > 1
+        try:
+            # Config errors on this background path must finish the pull.
+            self._reject_custom_partition_for_hetero_pp(self.pp_size)
+        except RuntimeError as e:
+            self._fail_pull_metas(pull_metas, str(e))
+            return
         for i, remote_tp_rank in enumerate(remote_tp_ranks):
             pp_to_addr = self._remote_agents[remote_engine_id][remote_tp_rank]
             remote_pp_size = len(pp_to_addr)
-            # Same-PP still cannot infer the remote custom partition.
-            self._reject_custom_partition_for_hetero_pp(remote_pp_size)
             same_pp = self.pp_size == remote_pp_size and self.pp_rank in pp_to_addr
             if same_pp:
                 pp_ranks = [self.pp_rank]
@@ -2805,6 +2825,17 @@ def get_mooncake_side_channel_port(vllm_config: VllmConfig) -> int:
 def _async_loop(loop: asyncio.AbstractEventLoop):
     asyncio.set_event_loop(loop)
     loop.run_forever()
+
+
+def _reject_custom_pp_partition() -> None:
+    """Reject Mooncake P/D when a process-local PP partition is set."""
+    partition = getattr(envs, "VLLM_PP_LAYER_PARTITION", None) or ""
+    if not partition:
+        return
+    raise RuntimeError(
+        "Mooncake P/D does not support VLLM_PP_LAYER_PARTITION; "
+        "unset it so both sides use the default even split."
+    )
 
 
 def _validate_mooncake_pcp_pd(vllm_config: VllmConfig) -> None:

--- a/vllm_hcu/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm_hcu/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -651,6 +651,8 @@ class MooncakeXferMetadata(
     model_layer_end: int = -1
     xfer_head_rank: int = -1
     remote_pp_size: int = 1
+    # Consumer's VLLM_PP_LAYER_PARTITION; empty means default even split.
+    pp_layer_partition: str = ""
 
 
 class MooncakeXferResponseStatus(IntEnum):
@@ -740,7 +742,6 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
         assert vllm_config.kv_transfer_config.engine_id is not None
         self.engine_id: EngineId = vllm_config.kv_transfer_config.engine_id
         _validate_mooncake_pcp_pd(vllm_config)
-        _reject_custom_pp_partition()
 
         if role == KVConnectorRole.SCHEDULER:
             assert kv_cache_config is not None, (
@@ -1512,6 +1513,14 @@ class MooncakeConnectorWorker:
             )
             await reject_metadata(msg)
             return
+        try:
+            self._reject_custom_partition_for_hetero_pp(
+                meta.remote_pp_size,
+                remote_partition=getattr(meta, "pp_layer_partition", "") or "",
+            )
+        except RuntimeError as e:
+            await reject_metadata(str(e))
+            return
         has_transfer_blocks = any(
             any(group for group in block_groups)
             for _, block_groups in meta.req_blocks.values()
@@ -1754,17 +1763,44 @@ class MooncakeConnectorWorker:
             )
             await sock.send_multipart((identity, self._encoder.encode(response)))
 
-    def _reject_custom_partition_for_hetero_pp(self, remote_pp_size: int) -> None:
-        """Reject process-local PP partitions; remote stage bounds are unknown.
+    def _reject_custom_partition_for_hetero_pp(
+        self,
+        remote_pp_size: int,
+        remote_partition: str | None = None,
+    ) -> None:
+        """Reject custom PP partitions that cannot be verified.
 
-        Same PP size is not enough: P/D may still set different
-        ``VLLM_PP_LAYER_PARTITION`` values. The same-PP path pairs by rank
-        and skips overlap checks, so extra consumer layers silently miss KV.
-        Fail closed until stage ``(start, end)`` is exchanged.
-        ``remote_pp_size`` is unused and kept for the call sites.
+        Same-PP P/D with a matching partition (including both unset) keeps
+        the rank-pair path. Heterogeneous PP cannot map remote stages from
+        the local env, so any custom partition is fail-closed.
         """
-        del remote_pp_size
-        _reject_custom_pp_partition()
+        local = _normalize_pp_layer_partition(
+            getattr(envs, "VLLM_PP_LAYER_PARTITION", None)
+        )
+        remote_pp_size = max(int(remote_pp_size), 1)
+        same_pp = remote_pp_size == int(self.pp_size)
+        if remote_partition is None:
+            if same_pp or not local:
+                return
+            raise RuntimeError(
+                "Mooncake heterogeneous PP does not support "
+                "VLLM_PP_LAYER_PARTITION; unset it so both sides use the "
+                "default even split."
+            )
+        remote = _normalize_pp_layer_partition(remote_partition)
+        if same_pp:
+            if local == remote:
+                return
+            raise RuntimeError(
+                "Mooncake same-PP P/D requires matching "
+                "VLLM_PP_LAYER_PARTITION "
+                f"(local={local!r} remote={remote!r})."
+            )
+        if local or remote:
+            raise RuntimeError(
+                "Mooncake heterogeneous PP does not support "
+                "VLLM_PP_LAYER_PARTITION; unset it on both sides."
+            )
 
     def _count_overlapping_remote_pp_stages(self, remote_pp_size: int) -> int:
         """How many consumer PP stages overlap this producer's layer range."""
@@ -2391,6 +2427,9 @@ class MooncakeConnectorWorker:
                 chunk_idx if chunk_idx is not None else self.tp_rank
             ),
             remote_pp_size=self.pp_size,
+            pp_layer_partition=_normalize_pp_layer_partition(
+                getattr(envs, "VLLM_PP_LAYER_PARTITION", None)
+            ),
         )
 
         encoded_data = self._encoder.encode(metadata)
@@ -2526,43 +2565,43 @@ class MooncakeConnectorWorker:
         selected_remote_pp: dict[int, list[int]] = {}
         needs_chunk_idx = len(remote_tp_ranks) > 1
         try:
+            for i, remote_tp_rank in enumerate(remote_tp_ranks):
+                pp_to_addr = self._remote_agents[remote_engine_id][remote_tp_rank]
+                remote_pp_size = len(pp_to_addr)
+                same_pp = self.pp_size == remote_pp_size and self.pp_rank in pp_to_addr
+                if same_pp:
+                    pp_ranks = [self.pp_rank]
+                else:
+                    self._reject_custom_partition_for_hetero_pp(remote_pp_size)
+                    pp_ranks = self._overlapping_remote_pp_ranks(
+                        remote_pp_size, sorted(pp_to_addr)
+                    )
+                selected_remote_pp[remote_tp_rank] = pp_ranks
+                chunk_idx = i if needs_chunk_idx else None
+                for pp_rank in pp_ranks:
+                    if same_pp:
+                        worker_jobs.append(
+                            (pp_to_addr[pp_rank], chunk_idx, -1, -1)
+                        )
+                        continue
+                    overlap_start, overlap_end = self._pp_overlap_layer_range(
+                        remote_pp_rank=pp_rank,
+                        remote_pp_size=remote_pp_size,
+                    )
+                    if overlap_start >= overlap_end:
+                        continue
+                    worker_jobs.append(
+                        (
+                            pp_to_addr[pp_rank],
+                            chunk_idx,
+                            overlap_start,
+                            overlap_end,
+                        )
+                    )
+        except (RuntimeError, ValueError) as e:
             # Config errors on this background path must finish the pull.
-            self._reject_custom_partition_for_hetero_pp(self.pp_size)
-        except RuntimeError as e:
             self._fail_pull_metas(pull_metas, str(e))
             return
-        for i, remote_tp_rank in enumerate(remote_tp_ranks):
-            pp_to_addr = self._remote_agents[remote_engine_id][remote_tp_rank]
-            remote_pp_size = len(pp_to_addr)
-            same_pp = self.pp_size == remote_pp_size and self.pp_rank in pp_to_addr
-            if same_pp:
-                pp_ranks = [self.pp_rank]
-            else:
-                pp_ranks = self._overlapping_remote_pp_ranks(
-                    remote_pp_size, sorted(pp_to_addr)
-                )
-            selected_remote_pp[remote_tp_rank] = pp_ranks
-            chunk_idx = i if needs_chunk_idx else None
-            for pp_rank in pp_ranks:
-                if same_pp:
-                    worker_jobs.append(
-                        (pp_to_addr[pp_rank], chunk_idx, -1, -1)
-                    )
-                    continue
-                overlap_start, overlap_end = self._pp_overlap_layer_range(
-                    remote_pp_rank=pp_rank,
-                    remote_pp_size=remote_pp_size,
-                )
-                if overlap_start >= overlap_end:
-                    continue
-                worker_jobs.append(
-                    (
-                        pp_to_addr[pp_rank],
-                        chunk_idx,
-                        overlap_start,
-                        overlap_end,
-                    )
-                )
 
         count = len(worker_jobs)
         logger.debug(
@@ -2827,15 +2866,11 @@ def _async_loop(loop: asyncio.AbstractEventLoop):
     loop.run_forever()
 
 
-def _reject_custom_pp_partition() -> None:
-    """Reject Mooncake P/D when a process-local PP partition is set."""
-    partition = getattr(envs, "VLLM_PP_LAYER_PARTITION", None) or ""
+def _normalize_pp_layer_partition(partition: str | None) -> str:
+    """Canonical comma-separated PP layer counts, or empty for even split."""
     if not partition:
-        return
-    raise RuntimeError(
-        "Mooncake P/D does not support VLLM_PP_LAYER_PARTITION; "
-        "unset it so both sides use the default even split."
-    )
+        return ""
+    return ",".join(part.strip() for part in str(partition).split(",") if part.strip())
 
 
 def _validate_mooncake_pcp_pd(vllm_config: VllmConfig) -> None:

--- a/vllm_hcu/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm_hcu/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -1733,23 +1733,29 @@ class MooncakeConnectorWorker:
             await sock.send_multipart((identity, self._encoder.encode(response)))
 
     def _reject_custom_partition_for_hetero_pp(self, remote_pp_size: int) -> None:
-        """Custom PP partitions are process-local and cannot map a remote PP size."""
-        if int(self.pp_size) == int(remote_pp_size):
-            return
+        """Reject process-local PP partitions; remote stage bounds are unknown.
+
+        Same PP size is not enough: P/D may still set different
+        ``VLLM_PP_LAYER_PARTITION`` values. The same-PP path pairs by rank
+        and skips overlap checks, so extra consumer layers silently miss KV.
+        Fail closed until stage ``(start, end)`` is exchanged.
+        ``remote_pp_size`` is unused and kept for the call sites.
+        """
+        del remote_pp_size
         partition = getattr(envs, "VLLM_PP_LAYER_PARTITION", None) or ""
         if not partition:
             return
         raise RuntimeError(
-            "Mooncake heterogeneous PP does not support VLLM_PP_LAYER_PARTITION; "
-            "unset it or use matching PP sizes."
+            "Mooncake P/D does not support VLLM_PP_LAYER_PARTITION; "
+            "unset it so both sides use the default even split."
         )
 
     def _count_overlapping_remote_pp_stages(self, remote_pp_size: int) -> int:
         """How many consumer PP stages overlap this producer's layer range."""
         remote_pp_size = max(int(remote_pp_size), 1)
+        self._reject_custom_partition_for_hetero_pp(remote_pp_size)
         if remote_pp_size == 1 or self.pp_size <= 0:
             return remote_pp_size
-        self._reject_custom_partition_for_hetero_pp(remote_pp_size)
         total_model_layers = self.model_config.get_total_num_hidden_layers()
         p_start, p_end = get_pp_indices(
             total_model_layers, self.pp_rank, self.pp_size
@@ -2506,6 +2512,8 @@ class MooncakeConnectorWorker:
         for i, remote_tp_rank in enumerate(remote_tp_ranks):
             pp_to_addr = self._remote_agents[remote_engine_id][remote_tp_rank]
             remote_pp_size = len(pp_to_addr)
+            # Same-PP still cannot infer the remote custom partition.
+            self._reject_custom_partition_for_hetero_pp(remote_pp_size)
             same_pp = self.pp_size == remote_pp_size and self.pp_rank in pp_to_addr
             if same_pp:
                 pp_ranks = [self.pp_rank]

--- a/vllm_hcu/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm_hcu/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -43,9 +43,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.stats import (
     MooncakeKVConnectorStats,
 )
 from vllm.distributed.parallel_state import (
-    # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
     get_pcp_group,
-    # === HCU_MOONCAKE_PCP_NIXL52779_END ===
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -741,9 +739,7 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
         assert vllm_config.kv_transfer_config is not None
         assert vllm_config.kv_transfer_config.engine_id is not None
         self.engine_id: EngineId = vllm_config.kv_transfer_config.engine_id
-        # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
         _validate_mooncake_pcp_pd(vllm_config)
-        # === HCU_MOONCAKE_PCP_NIXL52779_END ===
 
         if role == KVConnectorRole.SCHEDULER:
             assert kv_cache_config is not None, (
@@ -1232,7 +1228,6 @@ class MooncakeConnectorWorker:
         self.engine_id: EngineId = engine_id
         self.tp_rank = get_tensor_model_parallel_rank()
         self.tp_size = get_tensor_model_parallel_world_size()
-        # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
         # PCP adds KV replicas, not extra shards.
         self.pcp_size = int(
             getattr(vllm_config.parallel_config, "prefill_context_parallel_size", 1)
@@ -1245,7 +1240,6 @@ class MooncakeConnectorWorker:
         self.pcp_rank = (
             int(get_pcp_group().rank_in_group) if self.pcp_size > 1 else 0
         )
-        # === HCU_MOONCAKE_PCP_NIXL52779_END ===
         self.block_len_per_layer: list[int] = []
         self.kv_block_len_per_layer: list[int] = []
         self.registered_layer_names: list[str] = []
@@ -1738,11 +1732,24 @@ class MooncakeConnectorWorker:
             )
             await sock.send_multipart((identity, self._encoder.encode(response)))
 
+    def _reject_custom_partition_for_hetero_pp(self, remote_pp_size: int) -> None:
+        """Custom PP partitions are process-local and cannot map a remote PP size."""
+        if int(self.pp_size) == int(remote_pp_size):
+            return
+        partition = getattr(envs, "VLLM_PP_LAYER_PARTITION", None) or ""
+        if not partition:
+            return
+        raise RuntimeError(
+            "Mooncake heterogeneous PP does not support VLLM_PP_LAYER_PARTITION; "
+            "unset it or use matching PP sizes."
+        )
+
     def _count_overlapping_remote_pp_stages(self, remote_pp_size: int) -> int:
         """How many consumer PP stages overlap this producer's layer range."""
         remote_pp_size = max(int(remote_pp_size), 1)
         if remote_pp_size == 1 or self.pp_size <= 0:
             return remote_pp_size
+        self._reject_custom_partition_for_hetero_pp(remote_pp_size)
         total_model_layers = self.model_config.get_total_num_hidden_layers()
         p_start, p_end = get_pp_indices(
             total_model_layers, self.pp_rank, self.pp_size
@@ -2223,7 +2230,6 @@ class MooncakeConnectorWorker:
         # No need to launch server for D node.
         if self.is_kv_consumer:
             return
-        # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
         # Non-canonical PCP replicas do not listen or register.
         if not self._is_canonical_pcp_kv_replica():
             logger.info(
@@ -2233,7 +2239,6 @@ class MooncakeConnectorWorker:
                 self.pcp_size,
             )
             return
-        # === HCU_MOONCAKE_PCP_NIXL52779_END ===
 
         ready_event = threading.Event()
         asyncio.run_coroutine_threadsafe(
@@ -2625,7 +2630,6 @@ class MooncakeConnectorWorker:
             if send_meta is not None:
                 assert not send_meta.ready.is_set()
 
-    # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
     def _is_canonical_pcp_kv_replica(self) -> bool:
         """True if this rank owns the sendable PCP KV replica."""
 
@@ -2638,14 +2642,16 @@ class MooncakeConnectorWorker:
     ) -> None:
         """Mark send complete without transferring KV on non-rank0 PCP."""
 
-        for p_req_id, (_transfer_id, _block_ids) in metadata.reqs_to_send.items():
+        for p_req_id, (_transfer_id, block_ids) in metadata.reqs_to_send.items():
+            if not block_ids:
+                # Alloc-time placeholder; report complete on request_finished.
+                continue
             self.finished_sending_reqs.add(p_req_id)
         for transfer_id in metadata.reqs_not_processed:
             send_meta = self.reqs_need_send.pop(transfer_id, None)
             if send_meta is not None and send_meta.p_req_id:
                 self.finished_sending_reqs.add(send_meta.p_req_id)
 
-    # === HCU_MOONCAKE_PCP_NIXL52779_END ===
     def start_load_kv(self, metadata: MooncakeConnectorMetadata):
         if not self.is_kv_producer and metadata.reqs_to_recv:
             asyncio.run_coroutine_threadsafe(
@@ -2655,7 +2661,6 @@ class MooncakeConnectorWorker:
         if not self.is_kv_consumer and (
             metadata.reqs_to_send or metadata.reqs_not_processed
         ):
-            # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
             # Non-canonical PCP replicas only mark send complete.
             send_coro = (
                 self.record_send_reqs(metadata)
@@ -2663,7 +2668,6 @@ class MooncakeConnectorWorker:
                 else self._complete_noncanonical_pcp_sends(metadata)
             )
             asyncio.run_coroutine_threadsafe(send_coro, self.sender_loop)
-            # === HCU_MOONCAKE_PCP_NIXL52779_END ===
 
     def _producer_cache_is_replicated(self) -> bool:
         return self.transfer_topo.local_replicates_kv_cache
@@ -2671,6 +2675,7 @@ class MooncakeConnectorWorker:
     def _pp_overlap_layer_range(
         self, *, remote_pp_rank: int, remote_pp_size: int
     ) -> tuple[int, int]:
+        self._reject_custom_partition_for_hetero_pp(remote_pp_size)
         total_model_layers = self.model_config.get_total_num_hidden_layers()
         d_start, d_end = get_pp_indices(
             total_model_layers, self.pp_rank, self.pp_size
@@ -2794,7 +2799,6 @@ def _async_loop(loop: asyncio.AbstractEventLoop):
     loop.run_forever()
 
 
-# === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
 def _validate_mooncake_pcp_pd(vllm_config: VllmConfig) -> None:
     """Reject PCP on consumers, kv_both, DCP>1, and bidirectional xfer."""
 
@@ -2828,17 +2832,14 @@ def _validate_mooncake_pcp_pd(vllm_config: VllmConfig) -> None:
         )
 
 
-# === HCU_MOONCAKE_PCP_NIXL52779_END ===
 def should_launch_bootstrap_server(vllm_config: VllmConfig) -> bool:
     assert (parallel_config := vllm_config.parallel_config)
-    # === HCU_MOONCAKE_PCP_NIXL52779_BEGIN ===
     # TP=1 shares tp_rank=0 across PCP ranks; skip non-rank0 replicas.
     _pcp_size = int(
         getattr(parallel_config, "prefill_context_parallel_size", 1) or 1
     )
     if _pcp_size > 1 and int(get_pcp_group().rank_in_group) != 0:
         return False
-    # === HCU_MOONCAKE_PCP_NIXL52779_END ===
     # Only the TP=0, PP=0 worker of the designated engine should launch it.
     if get_tensor_model_parallel_rank() != 0:
         return False

--- a/vllm_hcu/models/hy_v4/attention.py
+++ b/vllm_hcu/models/hy_v4/attention.py
@@ -850,7 +850,8 @@ __all__ = [
     "require_local_indexer_producer",
     "require_hyv4_sink_backend",
 ]
-# === HCU_HYV4_PP_TOPK_V21_ALIGN_BEGIN ===
+
+
 def _hcu_hyv4_require_local_indexer_producer_v21(func):
     """Allow PP stages that start on a shared indexer layer."""
 
@@ -874,4 +875,3 @@ def _hcu_hyv4_require_local_indexer_producer_v21(func):
 require_local_indexer_producer = _hcu_hyv4_require_local_indexer_producer_v21(
     require_local_indexer_producer
 )
-# === HCU_HYV4_PP_TOPK_V21_ALIGN_END ===

--- a/vllm_hcu/models/hy_v4/attention.py
+++ b/vllm_hcu/models/hy_v4/attention.py
@@ -850,3 +850,28 @@ __all__ = [
     "require_local_indexer_producer",
     "require_hyv4_sink_backend",
 ]
+# === HCU_HYV4_PP_TOPK_V21_ALIGN_BEGIN ===
+def _hcu_hyv4_require_local_indexer_producer_v21(func):
+    """Allow PP stages that start on a shared indexer layer."""
+
+    if getattr(func, "_hcu_hyv4_pp_topk_wrapped", False):
+        return func
+
+    def _wrapped(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ValueError as exc:
+            text = str(exc)
+            if "top-k indices are not transferred between pipeline stages" in text:
+                return None
+            raise
+
+    _wrapped._hcu_hyv4_pp_topk_wrapped = True
+    _wrapped.__wrapped__ = func
+    return _wrapped
+
+
+require_local_indexer_producer = _hcu_hyv4_require_local_indexer_producer_v21(
+    require_local_indexer_producer
+)
+# === HCU_HYV4_PP_TOPK_V21_ALIGN_END ===

--- a/vllm_hcu/models/hy_v4/model.py
+++ b/vllm_hcu/models/hy_v4/model.py
@@ -1115,7 +1115,6 @@ class HYV4ForCausalLM(nn.Module, SupportsPP, SupportsLoRA, MixtureOfExperts):
         return self.model.get_expert_mapping()
 
 
-# === HCU_HYV4_PP_TOPK_V21_ALIGN_BEGIN ===
 def _hcu_hyv4_resolve_topk_buffer(model):
     """Return the live top-k buffer on this model or its inner module."""
 
@@ -1251,4 +1250,3 @@ if "HYV4ForCausalLM" in globals():
     _hcu_hyv4_orig_causal_fwd = HYV4ForCausalLM.forward
     if not getattr(_hcu_hyv4_orig_causal_fwd, "_hcu_hyv4_pp_topk_wrapped", False):
         HYV4ForCausalLM.forward = _hcu_hyv4_wrap_forward(_hcu_hyv4_orig_causal_fwd)
-# === HCU_HYV4_PP_TOPK_V21_ALIGN_END ===

--- a/vllm_hcu/models/hy_v4/model.py
+++ b/vllm_hcu/models/hy_v4/model.py
@@ -1161,13 +1161,19 @@ def _hcu_hyv4_append_topk_to_pp(model, intermediate_tensors):
     topk = buffer[:num_tokens]
     try:
         from vllm.forward_context import get_forward_context
+    except ImportError:
+        get_forward_context = None
+    if get_forward_context is not None:
+        try:
+            from vllm.forward_context import is_forward_context_available
+        except ImportError:
+            is_forward_context_available = lambda: True
+        if is_forward_context_available():
+            ctx = get_forward_context()
+            if getattr(ctx, "enable_lightly_cp", False):
+                from vllm.distributed.parallel_state import get_tp_group
 
-        if getattr(get_forward_context(), "enable_lightly_cp", False):
-            from vllm.distributed.parallel_state import get_tp_group
-
-            topk = get_tp_group().all_gather(topk.contiguous(), dim=0)
-    except Exception:
-        pass
+                topk = get_tp_group().all_gather(topk.contiguous(), dim=0)
     tensors["topk_indices_buffer"] = topk.clone()
 
 

--- a/vllm_hcu/models/hy_v4/model.py
+++ b/vllm_hcu/models/hy_v4/model.py
@@ -1244,9 +1244,4 @@ def _hcu_hyv4_model_init(self, *args, **kwargs):
 
 
 HYV4Model.__init__ = _hcu_hyv4_model_init
-
-# Wrap forward only; wrapping ForCausalLM.__init__ drops keyword-only args.
-if "HYV4ForCausalLM" in globals():
-    _hcu_hyv4_orig_causal_fwd = HYV4ForCausalLM.forward
-    if not getattr(_hcu_hyv4_orig_causal_fwd, "_hcu_hyv4_pp_topk_wrapped", False):
-        HYV4ForCausalLM.forward = _hcu_hyv4_wrap_forward(_hcu_hyv4_orig_causal_fwd)
+# Wrap HYV4Model.forward only; wrapping ForCausalLM again double-copies top-k.

--- a/vllm_hcu/models/hy_v4/model.py
+++ b/vllm_hcu/models/hy_v4/model.py
@@ -1113,3 +1113,142 @@ class HYV4ForCausalLM(nn.Module, SupportsPP, SupportsLoRA, MixtureOfExperts):
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()
+
+
+# === HCU_HYV4_PP_TOPK_V21_ALIGN_BEGIN ===
+def _hcu_hyv4_resolve_topk_buffer(model):
+    """Return the live top-k buffer on this model or its inner module."""
+
+    buffer = getattr(model, "topk_indices_buffer", None)
+    if buffer is not None:
+        return buffer
+    inner = getattr(model, "model", None)
+    return getattr(inner, "topk_indices_buffer", None) if inner is not None else None
+
+
+def _hcu_hyv4_intermediate_dict(intermediate_tensors):
+    tensors = getattr(intermediate_tensors, "tensors", None)
+    if isinstance(tensors, dict):
+        return tensors
+    return intermediate_tensors
+
+
+def _hcu_hyv4_sync_topk_from_pp(model, intermediate_tensors):
+    """Copy incoming PP top-k into the local live buffer."""
+
+    if intermediate_tensors is None:
+        return
+    incoming = _hcu_hyv4_intermediate_dict(intermediate_tensors).get(
+        "topk_indices_buffer"
+    )
+    buffer = _hcu_hyv4_resolve_topk_buffer(model)
+    if incoming is None or buffer is None:
+        return
+    num_tokens = min(incoming.shape[0], buffer.shape[0])
+    buffer[:num_tokens].copy_(incoming[:num_tokens], non_blocking=True)
+
+
+def _hcu_hyv4_append_topk_to_pp(model, intermediate_tensors):
+    """Attach the live top-k buffer to outgoing PP tensors."""
+
+    if intermediate_tensors is None:
+        return
+    buffer = _hcu_hyv4_resolve_topk_buffer(model)
+    if buffer is None:
+        return
+    tensors = _hcu_hyv4_intermediate_dict(intermediate_tensors)
+    hidden = tensors.get("hidden_states")
+    num_tokens = hidden.shape[0] if hidden is not None else buffer.shape[0]
+    topk = buffer[:num_tokens]
+    try:
+        from vllm.forward_context import get_forward_context
+
+        if getattr(get_forward_context(), "enable_lightly_cp", False):
+            from vllm.distributed.parallel_state import get_tp_group
+
+            topk = get_tp_group().all_gather(topk.contiguous(), dim=0)
+    except Exception:
+        pass
+    tensors["topk_indices_buffer"] = topk.clone()
+
+
+def _hcu_hyv4_wrap_make_empty(orig_empty):
+    """Reserve a top-k slot in empty PP intermediate tensors."""
+
+    if getattr(orig_empty, "_hcu_hyv4_pp_topk_wrapped", False):
+        return orig_empty
+
+    def _wrapped(batch_size, dtype, device, *args, **kwargs):
+        result = orig_empty(batch_size, dtype, device, *args, **kwargs)
+        model = getattr(_wrapped, "_hcu_hyv4_owner", None)
+        buffer = _hcu_hyv4_resolve_topk_buffer(model) if model is not None else None
+        tensors = _hcu_hyv4_intermediate_dict(result)
+        if buffer is not None and "topk_indices_buffer" not in tensors:
+            import torch
+
+            tensors["topk_indices_buffer"] = torch.zeros(
+                (int(batch_size), int(buffer.shape[-1])),
+                dtype=torch.int32,
+                device=device,
+            )
+        return result
+
+    _wrapped._hcu_hyv4_pp_topk_wrapped = True
+    return _wrapped
+
+
+def _hcu_hyv4_wrap_forward(orig_forward):
+    """Copy top-k across PP stages around the original forward."""
+
+    if getattr(orig_forward, "_hcu_hyv4_pp_topk_wrapped", False):
+        return orig_forward
+
+    def _wrapped(self, *args, **kwargs):
+        from vllm.distributed.parallel_state import get_pp_group
+
+        intermediate = kwargs.get("intermediate_tensors")
+        if intermediate is None and len(args) >= 3:
+            intermediate = args[2]
+        if intermediate is not None and not get_pp_group().is_first_rank:
+            _hcu_hyv4_sync_topk_from_pp(self, intermediate)
+        output = orig_forward(self, *args, **kwargs)
+        if hasattr(output, "tensors") and not get_pp_group().is_last_rank:
+            _hcu_hyv4_append_topk_to_pp(self, output)
+        return output
+
+    _wrapped._hcu_hyv4_pp_topk_wrapped = True
+    return _wrapped
+
+
+def _hcu_hyv4_install_pp_topk(model):
+    """Install PP top-k hooks on empty-tensor factory and forward."""
+
+    orig_empty = getattr(model, "make_empty_intermediate_tensors", None)
+    if orig_empty is not None:
+        wrapped_empty = _hcu_hyv4_wrap_make_empty(orig_empty)
+        wrapped_empty._hcu_hyv4_owner = model
+        model.make_empty_intermediate_tensors = wrapped_empty
+
+    if not getattr(type(model).forward, "_hcu_hyv4_pp_topk_wrapped", False):
+        type(model).forward = _hcu_hyv4_wrap_forward(type(model).forward)
+
+
+import functools as _hcu_hyv4_functools
+
+_hcu_hyv4_orig_model_init = HYV4Model.__init__
+
+
+@_hcu_hyv4_functools.wraps(_hcu_hyv4_orig_model_init)
+def _hcu_hyv4_model_init(self, *args, **kwargs):
+    _hcu_hyv4_orig_model_init(self, *args, **kwargs)
+    _hcu_hyv4_install_pp_topk(self)
+
+
+HYV4Model.__init__ = _hcu_hyv4_model_init
+
+# Wrap forward only; wrapping ForCausalLM.__init__ drops keyword-only args.
+if "HYV4ForCausalLM" in globals():
+    _hcu_hyv4_orig_causal_fwd = HYV4ForCausalLM.forward
+    if not getattr(_hcu_hyv4_orig_causal_fwd, "_hcu_hyv4_pp_topk_wrapped", False):
+        HYV4ForCausalLM.forward = _hcu_hyv4_wrap_forward(_hcu_hyv4_orig_causal_fwd)
+# === HCU_HYV4_PP_TOPK_V21_ALIGN_END ===

--- a/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
@@ -170,7 +170,29 @@ def _require_mrv2_pcp_contract(vllm_config: object) -> None:
     if kv_transfer_config is not None and _require_hcu_pcp_attribute(
         kv_transfer_config, "kv_connector", "KVTransferConfig"
     ) is not None:
-        raise ValueError("HCU PCP does not support P/D disaggregation.")
+        # HCU_MOONCAKE_PCP_NIXL52779: producer-only PCP, DCP=1.
+        kv_role = getattr(kv_transfer_config, "kv_role", None)
+        dcp_size = int(
+            _require_hcu_pcp_attribute(
+                parallel_config, "decode_context_parallel_size", "ParallelConfig"
+            )
+        )
+        extra = getattr(kv_transfer_config, "kv_connector_extra_config", None) or {}
+        if kv_role in ("kv_consumer", "kv_both"):
+            raise ValueError(
+                "HCU PCP currently supports kv_producer only. "
+                "Consumers and kv_both require prefill_context_parallel_size=1."
+            )
+        if dcp_size > 1:
+            raise ValueError(
+                "HCU PCP producers currently require decode_context_parallel_size=1."
+            )
+        if extra.get("bidirectional_kv_xfer"):
+            raise ValueError(
+                "HCU PCP producers do not support bidirectional KV transfer."
+            )
+        if kv_role != "kv_producer":
+            raise ValueError("HCU PCP does not support P/D disaggregation.")
 
     feature_config = get_hcu_config(vllm_config)
     if feature_config.enable_lightly_cp:

--- a/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
@@ -167,32 +167,40 @@ def _require_mrv2_pcp_contract(vllm_config: object) -> None:
     kv_transfer_config = _require_hcu_pcp_attribute(
         vllm_config, "kv_transfer_config", "VllmConfig"
     )
-    if kv_transfer_config is not None and _require_hcu_pcp_attribute(
-        kv_transfer_config, "kv_connector", "KVTransferConfig"
-    ) is not None:
-        # HCU_MOONCAKE_PCP_NIXL52779: producer-only PCP, DCP=1.
-        kv_role = getattr(kv_transfer_config, "kv_role", None)
-        dcp_size = int(
-            _require_hcu_pcp_attribute(
-                parallel_config, "decode_context_parallel_size", "ParallelConfig"
-            )
+    if kv_transfer_config is not None:
+        connector = _require_hcu_pcp_attribute(
+            kv_transfer_config, "kv_connector", "KVTransferConfig"
         )
-        extra = getattr(kv_transfer_config, "kv_connector_extra_config", None) or {}
-        if kv_role in ("kv_consumer", "kv_both"):
-            raise ValueError(
-                "HCU PCP currently supports kv_producer only. "
-                "Consumers and kv_both require prefill_context_parallel_size=1."
+        if connector is not None:
+            # Replica-dedup send path exists only on MooncakeConnector.
+            if connector != "MooncakeConnector":
+                raise ValueError(
+                    "HCU PCP P/D currently supports MooncakeConnector only; "
+                    f"got {connector!r}."
+                )
+            # Allow PCP on kv_producer only; require DCP=1.
+            kv_role = getattr(kv_transfer_config, "kv_role", None)
+            dcp_size = int(
+                _require_hcu_pcp_attribute(
+                    parallel_config, "decode_context_parallel_size", "ParallelConfig"
+                )
             )
-        if dcp_size > 1:
-            raise ValueError(
-                "HCU PCP producers currently require decode_context_parallel_size=1."
-            )
-        if extra.get("bidirectional_kv_xfer"):
-            raise ValueError(
-                "HCU PCP producers do not support bidirectional KV transfer."
-            )
-        if kv_role != "kv_producer":
-            raise ValueError("HCU PCP does not support P/D disaggregation.")
+            extra = getattr(kv_transfer_config, "kv_connector_extra_config", None) or {}
+            if kv_role in ("kv_consumer", "kv_both"):
+                raise ValueError(
+                    "HCU PCP currently supports kv_producer only. "
+                    "Consumers and kv_both require prefill_context_parallel_size=1."
+                )
+            if dcp_size > 1:
+                raise ValueError(
+                    "HCU PCP producers currently require decode_context_parallel_size=1."
+                )
+            if extra.get("bidirectional_kv_xfer"):
+                raise ValueError(
+                    "HCU PCP producers do not support bidirectional KV transfer."
+                )
+            if kv_role != "kv_producer":
+                raise ValueError("HCU PCP does not support P/D disaggregation.")
 
     feature_config = get_hcu_config(vllm_config)
     if feature_config.enable_lightly_cp:


### PR DESCRIPTION
## Summary

为 Hy4（MLA + DSA）补齐异构 tp/pp/cp pd 分离 能力，使 0.25.1+das 可以做：

- 同构 TP/PP/DP 的 P/D
- 异构 TP / 异构 PP 的 P/D
- **P 侧 PCP + D 无 PCP** 的异构 CP P/D（producer-only）

## Changes

### 1. Mooncake 21-align（`mooncake_connector.py`）

对齐 v0.21 的异构 KV 规划，解决 0.25 默认按同构 TP/PP、层一一对应传 KV 的问题。

- Bootstrap：内部 LB 只在全局 0 号启动；PCP 时非 rank0 也不起（TP=1 时各 PCP 副本 `tp_rank` 都是 0）
- 异构 PP：按 `get_pp_indices` 层区间求交，不按 PP rank 号对齐；P 按重叠 stage 数计算 `need_send`
- 异构 TP：`xfer_head_rank` 选择 head 切片；`_get_head_split_ratio` 将 TP ratio 收成正的切分数
- DSA：同层 indexer cache 排在 MLA 前面，避免异构 PP 切层时 indexer/MLA 错位

### 2. PCP producer-only（`patch_vllm_config.py` + `mooncake_connector.py`）

feat 已把 `HYV4ForCausalLM` 放进 MLA PCP 白名单。本改动只放开 **P 侧 PCP 作为 KV 副本维**：

- 允许：`kv_producer` + `pcp>1` + `dcp=1` + 非 bidirectional
- 拒绝：D 侧 PCP、`kv_both`、PCP+DCP、双向 KV；原有 PCP+PP / PCP+DP / LoRA / 多模态 / KV offload / lightly-CP 仍拒绝
- 只有 `pcp_rank==0` 注册、监听、发送；其它 PCP rank 立即标记 send 完成，避免 scheduler 卡住、D 收到多份相同 KV

对齐的是上游 #52779 的语义。

PCP 强制 DP=1，因此 P 不能用 `deepep_low_latency` / `deepep_auto`，需 `--all2all-backend allgather_reducescatter`。

### 3. Hy4 跨 PP top-k（`hy_v4/attention.py`、`hy_v4/model.py`）

Sparse MLA 的 shared indexer 在 PP>1 时后级拿不到 top-k，原逻辑直接 `ValueError`，导致无法测异构 PP（`P_PP != D_PP`）。

- wrap `require_local_indexer_producer`：仅吞掉「top-k 未跨 PP 传递」这项检查
- 前级把 `topk_indices_buffer` 写入 PP `IntermediateTensors`；后级 `copy_` 回 live buffer
- `make_empty_intermediate_tensors` 预留 top-k 槽
- 用 `functools.wraps` 包 `HYV4Model.__init__`（原 `vllm_config` 为 keyword-only）
- **只 wrap `HYV4ForCausalLM.forward`，不 wrap 其 `__init__`**

PP=1 时这些 wrap 基本为空操作。PCP 与 PP 互斥：异构 PP 走无 PCP；PCP 走 PP=1。

`tp1 pcp8` 单卡权重大，需小 batch，并显式设置 KV bytes，否则 dummy profile / 过低 `gpu_memory_utilization` 会 OOM 或 KV 为 0。

PP>1 仍不能开 `--speculative-config`（MTP draft 无 `SupportsPP`）；Hy4（Channel-FP8 w8a8）在本机 pipeline 超过 2 段时 chat 会乱码，其他模型没这个问题，根因在 Hy4 前向（iHC + DSA）。由于这两个问题出在Hy4，不在mooncake connector，因此暂时搁置.