### PR TITLE
feat: backport PCP+EP and DeepEP-LL bubble optimizations

### DIFF
--- a/tests/runtime_patch/test_patch_base_communicator_pcp.py
+++ b/tests/runtime_patch/test_patch_base_communicator_pcp.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Tests for patch_base_communicator_pcp: widens use_all2all under PCP + EP."""
+
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from vllm_hcu.patch.worker.framework_opt import patch_base_communicator_pcp
+
+
+# ---------------------------------------------------------------------------
+# Fake vLLM ``base_device_communicator`` module
+# ---------------------------------------------------------------------------
+
+
+def _module(name: str, **attributes: object) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    return module
+
+
+def _fake_base_communicator_module() -> ModuleType:
+    """Reproduce the audited vLLM 0.25.1 DeviceCommunicatorBase surface.
+
+    Only the parts our patch inspects are modeled: the constructor signature,
+    ``is_ep_communicator``/``use_all2all``/``all2all_backend`` attributes.
+    """
+
+    class DeviceCommunicatorBase:
+        def __init__(
+            self,
+            cpu_group,
+            device=None,
+            device_group=None,
+            unique_name: str = "",
+            global_ranks=None,
+            global_world_size=None,
+        ):
+            self.cpu_group = cpu_group
+            self.device = device
+            self.device_group = device_group
+            self.unique_name = unique_name
+            # Reproduce the upstream deduction of these three attributes;
+            # only their final values matter to the patch.
+            self.is_ep_communicator = unique_name.split(":")[0] == "ep"
+            self.use_all2all = False
+            self.all2all_backend = None
+
+    return _module(
+        patch_base_communicator_pcp.TARGET_MODULE,
+        DeviceCommunicatorBase=DeviceCommunicatorBase,
+    )
+
+
+def _install_vllm_config(monkeypatch: pytest.MonkeyPatch, config: object) -> None:
+    import vllm.config
+
+    monkeypatch.setattr(
+        vllm.config, "get_current_vllm_config_or_none", lambda: config
+    )
+
+
+def _pcp_ep_config(
+    *,
+    pcp_size: int = 8,
+    ep_enabled: bool = True,
+    backend: str | None = "deepep_high_throughput",
+) -> SimpleNamespace:
+    parallel = SimpleNamespace(
+        prefill_context_parallel_size=pcp_size,
+        enable_expert_parallel=ep_enabled,
+        all2all_backend=backend,
+        data_parallel_size=1,
+    )
+    return SimpleNamespace(parallel_config=parallel)
+
+
+# ---------------------------------------------------------------------------
+# Positive path: PCP + EP + DeepEP backend forces use_all2all=True
+# ---------------------------------------------------------------------------
+
+
+def test_base_pcp_ep_forces_use_all2all_for_pcp_ep_deepep_ht(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(monkeypatch, _pcp_ep_config())
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.is_ep_communicator is True
+    assert communicator.use_all2all is True
+
+
+def test_base_pcp_ep_forces_use_all2all_for_pcp_ep_deepep_ll(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(
+        monkeypatch, _pcp_ep_config(backend="deepep_low_latency")
+    )
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.use_all2all is True
+
+
+# ---------------------------------------------------------------------------
+# Negative paths: patch must leave use_all2all=False in every other scenario
+# ---------------------------------------------------------------------------
+
+
+def test_base_pcp_ep_ignores_non_ep_communicator(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(monkeypatch, _pcp_ep_config())
+    for unique_name in ("tp:0", "pp:0", "dp:0", "world", ""):
+        communicator = module.DeviceCommunicatorBase(
+            object(), unique_name=unique_name
+        )
+        assert communicator.is_ep_communicator is False
+        assert communicator.use_all2all is False, unique_name
+
+
+def test_base_pcp_ep_ignores_non_deepep_backend(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    for backend in ("naive", "pynccl", "allgather_reducescatter", None):
+        _install_vllm_config(
+            monkeypatch, _pcp_ep_config(backend=backend)
+        )
+        communicator = module.DeviceCommunicatorBase(
+            object(), unique_name="ep:0"
+        )
+        assert communicator.use_all2all is False, backend
+
+
+def test_base_pcp_ep_ignores_pcp_size_one(monkeypatch: pytest.MonkeyPatch):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(monkeypatch, _pcp_ep_config(pcp_size=1))
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.use_all2all is False
+
+
+def test_base_pcp_ep_ignores_expert_parallel_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(monkeypatch, _pcp_ep_config(ep_enabled=False))
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.use_all2all is False
+
+
+def test_base_pcp_ep_preserves_upstream_use_all2all_true(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When upstream already flipped use_all2all=True (DP>1 case), do nothing."""
+    module = _fake_base_communicator_module()
+
+    class UpstreamAlreadyEnabled(module.DeviceCommunicatorBase):
+        def __init__(
+            self,
+            cpu_group,
+            device=None,
+            device_group=None,
+            unique_name: str = "",
+            global_ranks=None,
+            global_world_size=None,
+        ):
+            super().__init__(
+                cpu_group,
+                device=device,
+                device_group=device_group,
+                unique_name=unique_name,
+                global_ranks=global_ranks,
+                global_world_size=global_world_size,
+            )
+            # Simulate upstream having chosen to enable all2all already.
+            self.use_all2all = True
+
+    module.DeviceCommunicatorBase = UpstreamAlreadyEnabled
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    # Even if PCP+EP is off, upstream's True must remain True.
+    _install_vllm_config(
+        monkeypatch, _pcp_ep_config(pcp_size=1, ep_enabled=False)
+    )
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.use_all2all is True
+
+
+def test_base_pcp_ep_tolerates_missing_vllm_config(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(monkeypatch, None)
+    # Should not raise; use_all2all stays False.
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.use_all2all is False
+
+
+def test_base_pcp_ep_tolerates_missing_parallel_config(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+
+    _install_vllm_config(monkeypatch, SimpleNamespace(parallel_config=None))
+    communicator = module.DeviceCommunicatorBase(
+        object(), unique_name="ep:0"
+    )
+    assert communicator.use_all2all is False
+
+
+# ---------------------------------------------------------------------------
+# Contract tests: idempotency, signature validation
+# ---------------------------------------------------------------------------
+
+
+def test_base_pcp_ep_apply_is_idempotent():
+    module = _fake_base_communicator_module()
+    assert patch_base_communicator_pcp.apply_to_module(module) is True
+    # Second call must report no-op via the marker path.
+    assert patch_base_communicator_pcp.apply_to_module(module) is False
+
+
+def test_base_pcp_ep_rejects_incompatible_init_signature():
+    from vllm_hcu.patch.worker.framework_opt._common import (
+        PatchCompatibilityError,
+    )
+
+    class DeviceCommunicatorBase:
+        def __init__(self, cpu_group):  # missing keyword args
+            self.cpu_group = cpu_group
+
+    module = _module(
+        patch_base_communicator_pcp.TARGET_MODULE,
+        DeviceCommunicatorBase=DeviceCommunicatorBase,
+    )
+    with pytest.raises(PatchCompatibilityError):
+        patch_base_communicator_pcp.apply_to_module(module)
+
+
+def test_base_pcp_ep_rejects_missing_class():
+    from vllm_hcu.patch.worker.framework_opt._common import (
+        PatchCompatibilityError,
+    )
+
+    module = _module(patch_base_communicator_pcp.TARGET_MODULE)
+    with pytest.raises(PatchCompatibilityError):
+        patch_base_communicator_pcp.apply_to_module(module)
+
+
+# ---------------------------------------------------------------------------
+# Registration tests
+# ---------------------------------------------------------------------------
+
+
+def test_base_pcp_ep_registered_as_deepep_gated_callback():
+    from vllm_hcu.patch import worker as worker_dispatcher
+
+    names = worker_dispatcher.worker_callback_names()
+    assert (
+        patch_base_communicator_pcp.PATCH_ID,
+        patch_base_communicator_pcp.TARGET_MODULE,
+    ) in names
+
+    features = worker_dispatcher._patch_features()
+    assert features[patch_base_communicator_pcp.PATCH_ID] == "deepep"
+
+
+def test_base_pcp_ep_dispatched_before_deep_ep_runtime():
+    """Must run before patch_all2all so use_all2all is set first."""
+    from vllm_hcu.patch import worker as worker_dispatcher
+
+    order = [
+        patch_id
+        for patch_id, _target in worker_dispatcher.worker_callback_names()
+    ]
+    assert (
+        patch_base_communicator_pcp.PATCH_ID in order
+        and "worker.framework_opt.communicator.deep_ep_runtime" in order
+    )
+    assert order.index(patch_base_communicator_pcp.PATCH_ID) < order.index(
+        "worker.framework_opt.communicator.deep_ep_runtime"
+    )
+
+
+def test_base_pcp_ep_patch_id_matches_adapter():
+    """PATCH_ID string must match the one declared inside the adapter."""
+    assert (
+        patch_base_communicator_pcp.PATCH_ID
+        == "worker.framework_opt.communicator.base_pcp_ep"
+    )
+    assert (
+        patch_base_communicator_pcp.TARGET_MODULE
+        == "vllm.distributed.device_communicators.base_device_communicator"
+    )
+    assert patch_base_communicator_pcp.TARGETS == (
+        f"{patch_base_communicator_pcp.TARGET_MODULE}"
+        ".DeviceCommunicatorBase.__init__",
+    )

--- a/tests/runtime_patch/test_worker_framework_opt.py
+++ b/tests/runtime_patch/test_worker_framework_opt.py
@@ -26,8 +26,10 @@ from vllm_hcu.patch.worker.framework_opt import (
     patch_base_device_communicator,
     patch_cuda_communicator,
     patch_dp_utils,
+    patch_draft_speculator_inputs,
     patch_eagle_utils,
     patch_forward_context,
+    patch_gpu_dp_utils,
     patch_gpu_ubatch_wrapper,
     patch_llm_base_proposer,
     patch_pynccl,
@@ -1186,6 +1188,78 @@ def test_dp_coordination_deepep_low_latency_and_feature_off_delegation():
     assert calls == [(4, normal)]
 
 
+def test_gpu_dp_cg_padding_sync_skip_for_deepep_low_latency():
+    calls: list[object] = []
+
+    def sync_cudagraph_and_dp_padding(
+        cudagraph_manager,
+        desired_batch_desc,
+        num_tokens,
+        num_reqs,
+        uniform_token_count,
+        dp_size,
+        dp_rank,
+        num_active_loras=0,
+    ):
+        calls.append(desired_batch_desc)
+        return "synced", "tokens"
+
+    module = _module(
+        patch_gpu_dp_utils.TARGET_MODULE,
+        sync_cudagraph_and_dp_padding=sync_cudagraph_and_dp_padding,
+    )
+    patch_gpu_dp_utils.bind_skip_cross_dp_cg_sync(enabled=True)
+    try:
+        assert patch_gpu_dp_utils.apply_to_module(module) is True
+        assert patch_gpu_dp_utils.apply_to_module(module) is False
+        assert module.sync_cudagraph_and_dp_padding(
+            None, "local_desc", 4, 2, None, 32, 0
+        ) == ("local_desc", None)
+        assert calls == []
+        patch_gpu_dp_utils.bind_skip_cross_dp_cg_sync(enabled=False)
+        assert module.sync_cudagraph_and_dp_padding(
+            None, "local_desc", 4, 2, None, 32, 0
+        ) == ("synced", "tokens")
+        assert calls == ["local_desc"]
+    finally:
+        patch_gpu_dp_utils.bind_skip_cross_dp_cg_sync(enabled=False)
+
+
+def test_draft_speculator_temperature_seeds_zero_copy():
+    class _IdxMapping:
+        def __getitem__(self, key):
+            return self
+
+        def copy_(self, other):
+            self.copied = other
+
+        def fill_(self, value):
+            self.filled = value
+
+    class DraftModelSpeculator:
+        def __init__(self):
+            self.temperature = SimpleNamespace(name="buf_t")
+            self.seeds = SimpleNamespace(name="buf_s")
+            self.idx_mapping = _IdxMapping()
+            self.draft_logits = None
+
+        def _copy_request_inputs(self, num_reqs, idx_mapping, temperature, seeds):
+            raise AssertionError("original should be wrapped")
+
+    module = _module(patch_draft_speculator_inputs.TARGET_MODULE)
+    module.DraftModelSpeculator = DraftModelSpeculator
+    assert patch_draft_speculator_inputs.apply_to_module(module) is True
+    assert patch_draft_speculator_inputs.apply_to_module(module) is False
+    obj = DraftModelSpeculator()
+    temperature = SimpleNamespace(name="caller_t")
+    seeds = SimpleNamespace(name="caller_s")
+    idx = object()
+    obj._copy_request_inputs(2, idx, temperature, seeds)
+    assert obj.temperature is temperature
+    assert obj.seeds is seeds
+    assert obj.idx_mapping.copied is idx
+
+
 class _Buffer:
     def __init__(self, size, **kwargs):
         self.size = size
@@ -1900,13 +1974,15 @@ assert target_file.is_relative_to(target_root), (
 print('VLLM_SOURCE', vllm.__file__)
 from vllm_hcu.patch.worker.framework_opt import (
     patch_all2all, patch_base_device_communicator, patch_cuda_communicator,
-    patch_dp_utils, patch_eagle_utils, patch_forward_context,
+    patch_dp_utils, patch_draft_speculator_inputs, patch_eagle_utils,
+    patch_forward_context, patch_gpu_dp_utils,
     patch_gpu_ubatch_wrapper, patch_llm_base_proposer, patch_pynccl,
     patch_pynccl_wrapper, patch_ubatch_utils,
 )
 adapters = (
     patch_all2all, patch_base_device_communicator, patch_forward_context,
-    patch_llm_base_proposer, patch_dp_utils, patch_eagle_utils,
+    patch_llm_base_proposer, patch_dp_utils, patch_gpu_dp_utils,
+    patch_draft_speculator_inputs, patch_eagle_utils,
     patch_gpu_ubatch_wrapper, patch_ubatch_utils,
 )
 for adapter in adapters:

--- a/tests/runtime_patch/test_worker_framework_opt.py
+++ b/tests/runtime_patch/test_worker_framework_opt.py
@@ -1225,7 +1225,7 @@ def test_gpu_dp_cg_padding_sync_skip_for_deepep_low_latency():
         patch_gpu_dp_utils.bind_skip_cross_dp_cg_sync(enabled=False)
 
 
-def test_draft_speculator_temperature_seeds_zero_copy():
+def test_draft_speculator_eager_temperature_seeds_zero_copy():
     class _IdxMapping:
         def __getitem__(self, key):
             return self
@@ -1238,6 +1238,9 @@ def test_draft_speculator_temperature_seeds_zero_copy():
 
     class DraftModelSpeculator:
         def __init__(self):
+            self.vllm_config = SimpleNamespace(
+                compilation_config=SimpleNamespace(cudagraph_mode=False)
+            )
             self.temperature = SimpleNamespace(name="buf_t")
             self.seeds = SimpleNamespace(name="buf_s")
             self.idx_mapping = _IdxMapping()
@@ -1258,6 +1261,134 @@ def test_draft_speculator_temperature_seeds_zero_copy():
     assert obj.temperature is temperature
     assert obj.seeds is seeds
     assert obj.idx_mapping.copied is idx
+
+
+def test_draft_speculator_full_graph_keeps_fixed_inputs_across_uva_rotation():
+    class _FixedGraphInput:
+        def __init__(self):
+            self.value = None
+
+        def copy_(self, other):
+            self.value = other.value
+
+    class _IdxMapping:
+        def __getitem__(self, key):
+            return self
+
+        def copy_(self, other):
+            self.copied = other
+
+        def fill_(self, value):
+            self.filled = value
+
+    class DraftModelSpeculator:
+        def __init__(self):
+            self.vllm_config = SimpleNamespace(
+                compilation_config=SimpleNamespace(cudagraph_mode=True)
+            )
+            self.temperature = _FixedGraphInput()
+            self.seeds = _FixedGraphInput()
+            self.idx_mapping = _IdxMapping()
+            self.draft_logits = None
+
+        def _copy_request_inputs(self, num_reqs, idx_mapping, temperature, seeds):
+            self.temperature.copy_(temperature)
+            self.seeds.copy_(seeds)
+            self.idx_mapping[:num_reqs].copy_(idx_mapping)
+
+    module = _module(patch_draft_speculator_inputs.TARGET_MODULE)
+    module.DraftModelSpeculator = DraftModelSpeculator
+    assert patch_draft_speculator_inputs.apply_to_module(module) is True
+
+    obj = DraftModelSpeculator()
+    fixed_temperature = obj.temperature
+    fixed_seeds = obj.seeds
+
+    # First staged write selects UVA views A. A full graph captures the
+    # addresses held by the speculator after this copy.
+    obj._copy_request_inputs(
+        1,
+        object(),
+        SimpleNamespace(value=0.25),
+        SimpleNamespace(value=101),
+    )
+    captured_temperature = obj.temperature
+    captured_seeds = obj.seeds
+
+    # The next staged write rotates the caller to UVA views B. Replaying the
+    # graph must still read its stable inputs, now updated with B's values.
+    obj._copy_request_inputs(
+        1,
+        object(),
+        SimpleNamespace(value=0.75),
+        SimpleNamespace(value=202),
+    )
+
+    assert obj.temperature is fixed_temperature is captured_temperature
+    assert obj.seeds is fixed_seeds is captured_seeds
+    assert captured_temperature.value == 0.75
+    assert captured_seeds.value == 202
+
+
+@pytest.mark.hcu
+def test_draft_speculator_full_graph_replay_reads_rotated_sampling_inputs():
+    if not torch.cuda.is_available():
+        pytest.skip("requires an HCU device")
+
+    class DraftModelSpeculator:
+        def __init__(self):
+            self.vllm_config = SimpleNamespace(
+                compilation_config=SimpleNamespace(cudagraph_mode=True)
+            )
+            self.temperature = torch.zeros(1, dtype=torch.float32, device="cuda")
+            self.seeds = torch.zeros(1, dtype=torch.int64, device="cuda")
+            self.idx_mapping = torch.zeros(1, dtype=torch.int32, device="cuda")
+            self.draft_logits = None
+            self.original_calls = 0
+
+        def _copy_request_inputs(self, num_reqs, idx_mapping, temperature, seeds):
+            self.original_calls += 1
+            self.temperature[:num_reqs].copy_(temperature)
+            self.seeds[:num_reqs].copy_(seeds)
+            self.idx_mapping[:num_reqs].copy_(idx_mapping)
+
+    module = _module(patch_draft_speculator_inputs.TARGET_MODULE)
+    module.DraftModelSpeculator = DraftModelSpeculator
+    assert patch_draft_speculator_inputs.apply_to_module(module) is True
+
+    obj = DraftModelSpeculator()
+    fixed_temperature_ptr = obj.temperature.data_ptr()
+    fixed_seeds_ptr = obj.seeds.data_ptr()
+    idx_mapping = torch.tensor([0], dtype=torch.int32, device="cuda")
+
+    # These distinct allocations model consecutive views selected from the
+    # rotating UVA pool without requiring the UVA extension in contract CI.
+    temperature_a = torch.tensor([0.25], dtype=torch.float32, device="cuda")
+    seeds_a = torch.tensor([101], dtype=torch.int64, device="cuda")
+    temperature_b = torch.tensor([0.75], dtype=torch.float32, device="cuda")
+    seeds_b = torch.tensor([202], dtype=torch.int64, device="cuda")
+    assert temperature_a.data_ptr() != temperature_b.data_ptr()
+    assert seeds_a.data_ptr() != seeds_b.data_ptr()
+
+    obj._copy_request_inputs(1, idx_mapping, temperature_a, seeds_a)
+    torch.cuda.synchronize()
+
+    output_temperature = torch.empty_like(obj.temperature)
+    output_seeds = torch.empty_like(obj.seeds)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output_temperature.copy_(obj.temperature)
+        output_seeds.copy_(obj.seeds)
+
+    obj._copy_request_inputs(1, idx_mapping, temperature_b, seeds_b)
+    assert obj.temperature.data_ptr() == fixed_temperature_ptr
+    assert obj.seeds.data_ptr() == fixed_seeds_ptr
+
+    graph.replay()
+    torch.cuda.synchronize()
+    assert output_temperature.cpu().item() == 0.75
+    assert output_seeds.cpu().item() == 202
+    assert obj.original_calls == 2
 
 
 class _Buffer:

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -350,6 +350,10 @@ _FRAMEWORK_CALLBACKS: tuple[_CallbackSpec, ...] = (
     _CallbackSpec(_adapter("framework_opt", "patch_gpu_ubatch_wrapper")),
     _CallbackSpec(_adapter("framework_opt", "patch_ubatch_utils")),
     _CallbackSpec(
+        _adapter("framework_opt", "patch_base_communicator_pcp"),
+        feature="deepep",
+    ),
+    _CallbackSpec(
         _adapter("framework_opt", "patch_all2all"), feature="deepep"
     ),
     _CallbackSpec(

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -322,6 +322,10 @@ _FRAMEWORK_CALLBACKS: tuple[_CallbackSpec, ...] = (
         feature="deepep_low_latency",
     ),
     _CallbackSpec(
+        _adapter("framework_opt", "patch_gpu_dp_utils"),
+        feature="deepep_low_latency",
+    ),
+    _CallbackSpec(
         _adapter("framework_opt", "patch_forward_context"),
         feature="forward_context",
     ),
@@ -346,6 +350,9 @@ _FRAMEWORK_CALLBACKS: tuple[_CallbackSpec, ...] = (
     _CallbackSpec(
         _adapter("framework_opt", "patch_eagle_utils"),
         feature="multi_layers_mtp",
+    ),
+    _CallbackSpec(
+        _adapter("framework_opt", "patch_draft_speculator_inputs"),
     ),
     _CallbackSpec(_adapter("framework_opt", "patch_gpu_ubatch_wrapper")),
     _CallbackSpec(_adapter("framework_opt", "patch_ubatch_utils")),
@@ -797,6 +804,14 @@ def apply_worker_patches(vllm_config: object | None = None) -> None:
         states = _feature_states(vllm_config, config)
         for patch_id, feature in _patch_features().items():
             IMPORT_COORDINATOR.set_feature_enabled(patch_id, states[feature])
+        from vllm_hcu.patch.worker.framework_opt import patch_gpu_dp_utils
+
+        patch_gpu_dp_utils.bind_skip_cross_dp_cg_sync(
+            enabled=(
+                _parallel_backend(vllm_config) == "deepep_low_latency"
+                and not config.deepep_auto
+            )
+        )
         _raise_latched_or_required_failures(IMPORT_COORDINATOR)
 
 

--- a/vllm_hcu/patch/worker/framework_opt/patch_base_communicator_pcp.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_base_communicator_pcp.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Enable DeepEP all2all under PCP + EP even when DP=TP=1.
+
+Upstream vLLM (base_device_communicator.DeviceCommunicatorBase.__init__)
+computes ``use_all2all = is_ep_communicator and (dp_size > 1 or
+use_sequence_parallel_moe)``. In the HCU PCP + EP scenario with DP=TP=1,
+this evaluates to False, so cuda_communicator never constructs a
+DeepEP all2all manager. This adapter widens the gate to also cover
+PCP > 1 + EP + explicit DeepEP backend.
+"""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+from ._common import (
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_exact_signature,
+)
+
+TARGET_MODULE = "vllm.distributed.device_communicators.base_device_communicator"
+PATCH_ID = "worker.framework_opt.communicator.base_pcp_ep"
+TARGETS = (f"{TARGET_MODULE}.DeviceCommunicatorBase.__init__",)
+_MARKER = "_vllm_hcu_base_pcp_ep_applied"
+_WRAPPER = "_vllm_hcu_base_pcp_ep_wrapper"
+
+_DEEPEP_BACKENDS = frozenset(
+    {"deepep_high_throughput", "deepep_low_latency"}
+)
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    base_mod = load_exact_module(TARGET_MODULE, module)
+    cls = require_class(
+        base_mod,
+        "DeviceCommunicatorBase",
+        f"{TARGET_MODULE}.DeviceCommunicatorBase",
+    )
+    wrapped = ((cls, "__init__", TARGETS[0], _WRAPPER),)
+    if already_applied(base_mod, _MARKER, wrapped):
+        return False
+
+    original_init = require_callable(cls, "__init__", TARGETS[0])
+    require_exact_signature(
+        original_init,
+        TARGETS[0],
+        positional=(
+            "self",
+            "cpu_group",
+            "device",
+            "device_group",
+            "unique_name",
+            "global_ranks",
+            "global_world_size",
+        ),
+        defaults={
+            "device": None,
+            "device_group": None,
+            "unique_name": "",
+            "global_ranks": None,
+            "global_world_size": None,
+        },
+    )
+
+    @functools.wraps(original_init)
+    def hcu_init(
+        self,
+        cpu_group,
+        device=None,
+        device_group=None,
+        unique_name="",
+        global_ranks=None,
+        global_world_size=None,
+    ):
+        original_init(
+            self,
+            cpu_group,
+            device=device,
+            device_group=device_group,
+            unique_name=unique_name,
+            global_ranks=global_ranks,
+            global_world_size=global_world_size,
+        )
+        # Upstream already enabled all2all via DP>1 / use_sequence_parallel_moe.
+        if getattr(self, "use_all2all", False):
+            return
+        # Only EP communicators care about all2all managers.
+        if not getattr(self, "is_ep_communicator", False):
+            return
+
+        from vllm.config import get_current_vllm_config_or_none
+
+        cfg = get_current_vllm_config_or_none()
+        if cfg is None:
+            return
+        pc = getattr(cfg, "parallel_config", None)
+        if pc is None:
+            return
+        pcp_size = int(getattr(pc, "prefill_context_parallel_size", 1) or 1)
+        ep_enabled = bool(getattr(pc, "enable_expert_parallel", False))
+        backend = getattr(pc, "all2all_backend", None)
+        if (
+            pcp_size > 1
+            and ep_enabled
+            and backend in _DEEPEP_BACKENDS
+        ):
+            self.use_all2all = True
+            print(
+                "[HCU PATCH base_pcp_ep] force use_all2all=True "
+                f"pcp={pcp_size} backend={backend} unique_name={unique_name!r}",
+                flush=True,
+            )
+
+    setattr(hcu_init, _WRAPPER, True)
+    setattr(cls, "_vllm_hcu_original_init", original_init)
+    setattr(cls, "__init__", hcu_init)
+    setattr(base_mod, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/worker/framework_opt/patch_draft_speculator_inputs.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_draft_speculator_inputs.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
-"""Avoid per-step H2D by reusing caller temperature/seeds buffers."""
+"""Reuse caller sampling buffers only when CUDA graphs are disabled."""
 
 from __future__ import annotations
 
@@ -39,8 +39,21 @@ def apply_to_module(module: ModuleType) -> bool:
 
     @functools.wraps(original)
     def hcu_copy_request_inputs(self, num_reqs, idx_mapping, temperature, seeds):
-        # Alias caller buffers (often UVA views) instead of H2D copy_.
-        # idx_mapping still copied into the fixed CG-padded buffer.
+        compilation_config = getattr(
+            getattr(self, "vllm_config", None),
+            "compilation_config",
+            None,
+        )
+        cudagraph_mode = getattr(compilation_config, "cudagraph_mode", None)
+        if cudagraph_mode is None or bool(cudagraph_mode):
+            # Full graphs capture the addresses of the fixed speculator inputs.
+            # SamplingStates rotates its UVA views, so aliasing a later view
+            # would leave graph replay reading stale temperature/seed values.
+            return original(self, num_reqs, idx_mapping, temperature, seeds)
+
+        # With CUDA graphs explicitly disabled, alias caller buffers (often
+        # UVA views) instead of copying them H2D. idx_mapping still uses the
+        # fixed padded buffer expected by the remaining speculator code.
         self.temperature = temperature
         self.seeds = seeds
         self.idx_mapping[:num_reqs].copy_(idx_mapping)

--- a/vllm_hcu/patch/worker/framework_opt/patch_draft_speculator_inputs.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_draft_speculator_inputs.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Avoid per-step H2D by reusing caller temperature/seeds buffers."""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+from ._common import (
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_exact_signature,
+)
+
+TARGET_MODULE = "vllm.v1.worker.gpu.spec_decode.speculator"
+PATCH_ID = "worker.framework_opt.spec_decode.draft_input_zero_copy"
+TARGETS = (f"{TARGET_MODULE}.DraftModelSpeculator._copy_request_inputs",)
+_MARKER = "_vllm_hcu_draft_input_zero_copy_applied"
+_WRAPPER = "_vllm_hcu_draft_input_zero_copy_wrapper"
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    spec = load_exact_module(TARGET_MODULE, module)
+    cls = require_class(
+        spec, "DraftModelSpeculator", f"{TARGET_MODULE}.DraftModelSpeculator"
+    )
+    wrapped = ((cls, "_copy_request_inputs", TARGETS[0], _WRAPPER),)
+    if already_applied(spec, _MARKER, wrapped):
+        return False
+    original = require_callable(cls, "_copy_request_inputs", TARGETS[0])
+    require_exact_signature(
+        original,
+        TARGETS[0],
+        positional=("self", "num_reqs", "idx_mapping", "temperature", "seeds"),
+    )
+
+    @functools.wraps(original)
+    def hcu_copy_request_inputs(self, num_reqs, idx_mapping, temperature, seeds):
+        # Alias caller buffers (often UVA views) instead of H2D copy_.
+        # idx_mapping still copied into the fixed CG-padded buffer.
+        self.temperature = temperature
+        self.seeds = seeds
+        self.idx_mapping[:num_reqs].copy_(idx_mapping)
+        if self.draft_logits is not None:
+            self.idx_mapping[num_reqs:].fill_(-1)
+
+    setattr(hcu_copy_request_inputs, _WRAPPER, True)
+    setattr(cls, "_vllm_hcu_original_copy_request_inputs", original)
+    setattr(cls, "_copy_request_inputs", hcu_copy_request_inputs)
+    setattr(spec, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/worker/framework_opt/patch_gpu_dp_utils.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_gpu_dp_utils.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Skip MRV2 cross-DP CG padding gloo allreduce for DeepEP-LL."""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+from ._common import already_applied, load_exact_module, require_callable, require_exact_signature
+
+TARGET_MODULE = "vllm.v1.worker.gpu.dp_utils"
+PATCH_ID = "worker.framework_opt.dp.gpu_deepep_low_latency"
+TARGETS = (f"{TARGET_MODULE}.sync_cudagraph_and_dp_padding",)
+_MARKER = "_vllm_hcu_gpu_dp_low_latency_applied"
+_WRAPPER = "_vllm_hcu_gpu_dp_low_latency_wrapper"
+
+# Set by apply_worker_patches (explicit deepep_low_latency, not deepep_auto).
+_SKIP = False
+
+
+def bind_skip_cross_dp_cg_sync(*, enabled: bool) -> None:
+    global _SKIP
+    _SKIP = bool(enabled)
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    dp = load_exact_module(TARGET_MODULE, module)
+    wrapped = ((dp, "sync_cudagraph_and_dp_padding", TARGETS[0], _WRAPPER),)
+    if already_applied(dp, _MARKER, wrapped):
+        return False
+    original = require_callable(dp, "sync_cudagraph_and_dp_padding", TARGETS[0])
+    require_exact_signature(
+        original,
+        TARGETS[0],
+        positional=(
+            "cudagraph_manager",
+            "desired_batch_desc",
+            "num_tokens",
+            "num_reqs",
+            "uniform_token_count",
+            "dp_size",
+            "dp_rank",
+            "num_active_loras",
+        ),
+        defaults={"num_active_loras": 0},
+    )
+
+    @functools.wraps(original)
+    def hcu_sync(
+        cudagraph_manager,
+        desired_batch_desc,
+        num_tokens,
+        num_reqs,
+        uniform_token_count,
+        dp_size,
+        dp_rank,
+        num_active_loras=0,
+    ):
+        if _SKIP:
+            return desired_batch_desc, None
+        return original(
+            cudagraph_manager,
+            desired_batch_desc,
+            num_tokens,
+            num_reqs,
+            uniform_token_count,
+            dp_size,
+            dp_rank,
+            num_active_loras=num_active_loras,
+        )
+
+    setattr(hcu_sync, _WRAPPER, True)
+    setattr(dp, "_vllm_hcu_original_sync_cudagraph_and_dp_padding", original)
+    setattr(dp, "sync_cudagraph_and_dp_padding", hcu_sync)
+    setattr(dp, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = [
+    "PATCH_ID",
+    "TARGET_MODULE",
+    "TARGETS",
+    "apply",
+    "apply_to_module",
+    "bind_skip_cross_dp_cg_sync",
+]


### PR DESCRIPTION
## Summary

- backport `dd947f41d5fa2a3df3d12e0d02263404c1d1604a` so PCP + EP with DP=TP=1 can initialize the explicit DeepEP high-throughput or low-latency all-to-all manager
- backport `b4e11f3441ccc8c3472ed0a7aaf9d4222af1ddf2` to remove fixed DeepEP low-latency scheduling bubbles by skipping redundant cross-DP CUDA-graph padding synchronization
- retain the draft temperature/seed zero-copy optimization only when CUDA graphs are explicitly disabled; graph modes preserve vLLM's fixed graph-visible buffers and copy the current rotating UVA views into them
- preserve the original backport authors and keep this standalone change limited to six files

## v0.25.1 adaptation

The PCP+EP commit applied cleanly. The DeepEP-LL commit conflicted only in the shared worker-framework test import list because its source parent also contained an unrelated EPLB communicator adapter. The resolution keeps the current v0.25.1 tests and adds only `patch_gpu_dp_utils` and `patch_draft_speculator_inputs` from the requested commit; no EPLB communicator code was imported.

Runtime scope remains narrow:

- PCP communicator widening requires PCP > 1, EP enabled, an EP communicator, and an explicit `deepep_high_throughput` or `deepep_low_latency` backend
- the CUDA-graph DP synchronization skip is bound only for explicit `deepep_low_latency` and remains disabled for `deepep_auto`
- draft temperature/seed aliases are used only for `CUDAGraphMode.NONE`; FULL, PIECEWISE, mixed, and conservatively unknown graph modes call the upstream fixed-buffer copy path
- all other backends retain the upstream paths

## CUDA Graph correctness follow-up

Review identified that assigning rotating `UvaBackedTensor.gpu` views directly to `self.temperature` and `self.seeds` is unsafe after CUDA Graph capture: replay retains the captured device pointer even if the Python attribute later points to another UVA pool slot.

Commit `b743430c02480f3c3f558bf81d476c0af0d57bf6` fixes this by keeping the preallocated graph-visible buffers whenever CUDA Graph is enabled, while retaining eager-only aliasing. It adds both a portable pointer-lifetime regression and a real HCU graph capture/replay regression.

## Commits

- `677928d5e5b1fd234cef93f339b8b87e7a1be9b3` — adapted from `dd947f41d5fa2a3df3d12e0d02263404c1d1604a`
- `6cd989f25163e97837f07c884650268ea45f2fd4` — adapted from `b4e11f3441ccc8c3472ed0a7aaf9d4222af1ddf2`
- `b743430c02480f3c3f558bf81d476c0af0d57bf6` — preserve CUDA Graph sampling-buffer addresses across UVA rotation

## Validation

- focused worker/PCP suite: `77 passed`, 14 pre-existing TorchScript deprecation warnings
- portable eager/graph sampling-buffer regressions: `2 passed`
- real BW1100 CUDA Graph regression registered in HCU CI: `1 passed`; capture with view A, switch to a distinct-address view B, replay reads temperature `0.75` and seed `202`
- additional BW1100 run with the actual vLLM `UvaBackedTensor` pool: temperature and seed UVA pointers rotated A -> B, fixed speculator input pointers stayed stable, and graph replay read `0.75` / `202`
- full v0.25.1 non-HCU contract from final commit: `1633 passed, 164 deselected, 16 warnings`
- patch inventory: `82 passed`
- patch coverage: 100 adapters, no missing contracts or untested modules
- production boundary: clean across 262 Python files
- compileall, duplicate test-basename scan, credential scan, and diff checks passed

This standalone backport does not claim a new full-model run; the correctness follow-up was validated directly on the affected CUDA Graph + rotating-input mechanism.