### PR TITLE
feat: support GLM-5.3 Flash Channel-FP8 on vLLM main

### DIFF
--- a/.github/workflows/configs/hcu-test-map.yaml
+++ b/.github/workflows/configs/hcu-test-map.yaml
@@ -463,6 +463,30 @@
         }
       ]
     },
+    "glm53-flash-channel-fp8-humaneval": {
+      "runner": "hcu-linux-gfx938-8",
+      "arch": "gfx938",
+      "cards": 8,
+      "suite": "model",
+      "pytest_args": [
+        "-k",
+        "glm53_flash_channel_fp8_humaneval_evalscope_server"
+      ],
+      "timeout_minutes": 360,
+      "requirements": [
+        {
+          "kind": "distribution",
+          "name": "evalscope",
+          "match": "exact",
+          "version": "1.9.1"
+        },
+        {
+          "kind": "model",
+          "env": "VLLM_HCU_GLM53_FLASH_CHANNEL_FP8_MODEL",
+          "relative": "GLM-5.3-Flash-Channel-FP8-w8a8"
+        }
+      ]
+    },
     "single-node-topology": {
       "runner": "nmz36",
       "arch": "gfx938",
@@ -496,6 +520,7 @@
     {"job": "qwen38-flash-next-humaneval", "timeout_minutes": 210},
     {"job": "deepseek-gsm8k", "timeout_minutes": 360},
     {"job": "glm52-pcp", "timeout_minutes": 360},
+    {"job": "glm53-flash-channel-fp8-humaneval", "timeout_minutes": 360},
     {"job": "single-node-topology", "timeout_minutes": 30}
   ],
   "groups": {
@@ -679,6 +704,15 @@
         "glm52-pcp"
       ]
     },
+    "glm53-flash-channel-fp8-evalscope": {
+      "patterns": [
+        "tests/integration/server/test_evalscope_glm53_flash_channel_fp8_humaneval.py",
+        "tests/models/glm53_flash_channel_fp8_humaneval_evalscope.yaml"
+      ],
+      "jobs": [
+        "glm53-flash-channel-fp8-humaneval"
+      ]
+    },
     "model-runtime-helper": {
       "patterns": [
         "tests/integration/model_runtime.py"
@@ -780,7 +814,8 @@
         "qwen3-8b-gsm8k",
         "qwen38-flash-next-humaneval",
         "qwen3-vl-mmmu",
-        "deepseek-gsm8k"
+        "deepseek-gsm8k",
+        "glm53-flash-channel-fp8-humaneval"
       ]
     },
     "evalscope-report-tests": {

--- a/tests/hcu_ci_registry.py
+++ b/tests/hcu_ci_registry.py
@@ -41,6 +41,11 @@ register_hcu_ci(
 )
 register_hcu_ci(
     job="contract-hcu-gfx936",
+    target="tests/runtime_patch/test_glm53_channel_fp8.py",
+    est_time=60,
+)
+register_hcu_ci(
+    job="contract-hcu-gfx936",
     target="tests/patch/test_clean_process_bootstrap.py",
     est_time=300,
 )
@@ -284,6 +289,15 @@ register_hcu_ci(
         "required GLM-5.2 model is unavailable in the public and parastor CI "
         "model roots"
     ),
+)
+register_hcu_ci(
+    job="glm53-flash-channel-fp8-humaneval",
+    target=(
+        "tests/integration/server/"
+        "test_evalscope_glm53_flash_channel_fp8_humaneval.py::"
+        "test_glm53_flash_channel_fp8_humaneval_evalscope_server"
+    ),
+    est_time=14400,
 )
 register_hcu_ci(
     job="single-node-topology",

--- a/tests/integration/server/test_evalscope_glm53_flash_channel_fp8_humaneval.py
+++ b/tests/integration/server/test_evalscope_glm53_flash_channel_fp8_humaneval.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""GLM-5.3-Flash Channel-FP8 TP4 OpenAI/HumanEval acceptance."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.integration.server.evalscope_server import (
+    evalscope_command,
+    load_config,
+    run_evalscope_server_test,
+    server_command,
+)
+
+
+ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_CONFIG = (
+    ROOT / "tests/models/glm53_flash_channel_fp8_humaneval_evalscope.yaml"
+)
+CONFIG_ENV = "VLLM_HCU_GLM53_FLASH_CHANNEL_FP8_HUMANEVAL_CONFIG"
+MODEL_ENV = "VLLM_HCU_GLM53_FLASH_CHANNEL_FP8_MODEL"
+
+
+def _option_value(command: list[str], option: str) -> str:
+    index = command.index(option)
+    return command[index + 1]
+
+
+def test_glm53_flash_channel_fp8_command_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(CONFIG_ENV, raising=False)
+    monkeypatch.delenv(MODEL_ENV, raising=False)
+    config = load_config(DEFAULT_CONFIG, CONFIG_ENV)
+
+    server, host, port = server_command(config, model_env=MODEL_ENV)
+    evaluation = evalscope_command(
+        config,
+        model_env=MODEL_ENV,
+        host=host,
+        port=port,
+        work_dir=tmp_path,
+    )
+
+    assert server[:3] == [
+        "vllm",
+        "serve",
+        "/models/GLM-5.3-Flash-Channel-FP8-w8a8",
+    ]
+    assert _option_value(server, "--tensor-parallel-size") == "4"
+    assert _option_value(server, "--attention-backend") == "FLASHMLA_SPARSE"
+    assert _option_value(server, "--moe-backend") == "aiter"
+    assert json.loads(_option_value(server, "--speculative-config")) == {
+        "method": "mtp",
+        "num_speculative_tokens": 3,
+    }
+    assert json.loads(_option_value(server, "--compilation-config")) == {
+        "cudagraph_mode": "PIECEWISE"
+    }
+    assert _option_value(server, "--max-model-len") == "4096"
+    assert _option_value(server, "--max-num-batched-tokens") == "1024"
+    assert _option_value(server, "--max-num-seqs") == "8"
+    assert "--enforce-eager" not in server
+    assert "--quantization" not in server
+    assert json.loads(
+        _option_value(server, "--default-chat-template-kwargs")
+    ) == {"reasoning_effort": "low"}
+    assert _option_value(evaluation, "--datasets") == "humaneval"
+    assert _option_value(evaluation, "--limit") == "8"
+    assert _option_value(evaluation, "--eval-batch-size") == "8"
+    assert _option_value(evaluation, "--model") == _option_value(
+        server,
+        "--served-model-name",
+    )
+
+
+@pytest.mark.hcu
+@pytest.mark.model
+@pytest.mark.multi_hcu
+@pytest.mark.hcu_count(4)
+@pytest.mark.slow
+@pytest.mark.nightly
+@pytest.mark.external_service("evalscope")
+def test_glm53_flash_channel_fp8_humaneval_evalscope_server() -> None:
+    config = load_config(DEFAULT_CONFIG, CONFIG_ENV)
+    run_evalscope_server_test(
+        config,
+        model_env=MODEL_ENV,
+        model_label="GLM-5.3-Flash Channel-FP8 TP4+AITER+MTP3",
+        required_hcu_count=4,
+    )

--- a/tests/models/glm53_flash_channel_fp8_humaneval_evalscope.yaml
+++ b/tests/models/glm53_flash_channel_fp8_humaneval_evalscope.yaml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+
+name: glm53_flash_channel_fp8_humaneval_evalscope
+model: /models/GLM-5.3-Flash-Channel-FP8-w8a8
+
+server:
+  host: 127.0.0.1
+  port: 10153
+  startup_timeout_s: 7200
+  shutdown_timeout_s: 120
+  served_model_name: GLM-5.3-Flash-Channel-FP8-w8a8
+  args:
+    - --tensor-parallel-size
+    - "4"
+    - --attention-backend
+    - FLASHMLA_SPARSE
+    - --moe-backend
+    - aiter
+    - --speculative-config
+    - '{"method":"mtp","num_speculative_tokens":3}'
+    - --max-model-len
+    - "4096"
+    - --max-num-batched-tokens
+    - "1024"
+    - --max-num-seqs
+    - "8"
+    - --compilation-config
+    - '{"cudagraph_mode":"PIECEWISE"}'
+    - --default-chat-template-kwargs
+    - '{"reasoning_effort":"low"}'
+
+evalscope:
+  work_dir: /tmp/vllm-hcu-evalscope/glm53_flash_channel_fp8_humaneval
+  api_key: EMPTY
+  eval_type: openai_api
+  generation_config:
+    temperature: 0
+    do_sample: false
+    max_tokens: 2048
+    extra_body:
+      chat_template_kwargs:
+        reasoning_effort: low
+  stream: true
+  eval_batch_size: 8
+  timeout: 7200
+  limit: 8
+  datasets:
+    - humaneval
+  dataset_args:
+    humaneval: {}
+  pass_criteria:
+    dataset: humaneval
+    metric: mean_acc
+    display_name: Pass@1
+    minimum_score: 1.0
+  no_timestamp: true

--- a/tests/patch/test_base_linear_parameter.py
+++ b/tests/patch/test_base_linear_parameter.py
@@ -24,6 +24,7 @@ from vllm_hcu.patch.runtime_state import LatchedPatchError, PatchRegistry
 from vllm_hcu.runtime_compat.base_linear_parameter import (
     install_base_linear_parameter_compat,
 )
+from vllm_hcu.version import __vllm_target_version__
 
 
 TARGET = "vllm.model_executor.parameter"
@@ -211,6 +212,21 @@ def test_nn_layout_loaders_transpose_and_use_physical_dimensions(
     )
     local_column.load_column_parallel_weight(full_column[2:4])
     torch.testing.assert_close(local_column.data, full_column[2:4].t())
+
+    # KDA convolution weights add a singleton dimension after constructing a
+    # column-parallel linear. Preserve the HCU NN layout for that N-D weight.
+    full_conv = torch.arange(24).reshape(6, 1, 4)
+    conv_column = _instance(
+        module._ColumnvLLMParameter,
+        data=torch.zeros(4, 1, 3, dtype=full_conv.dtype),
+        output_dim=0,
+        tp_rank=1,
+    )
+    conv_column.load_column_parallel_weight(full_conv)
+    torch.testing.assert_close(
+        conv_column.data,
+        full_conv[3:6].permute(2, 1, 0),
+    )
 
     # Equal logical and physical shapes do not imply equal layouts.  Square
     # checkpoint matrices still require the NN-layout transpose.
@@ -408,6 +424,10 @@ def _clean_v0251_environment(cache_root: Path) -> dict[str, str]:
 
 
 @pytest.mark.hcu
+@pytest.mark.skipif(
+    not __vllm_target_version__.startswith("0.25."),
+    reason="full v0.25.1 bootstrap only applies to a v0.25.x plugin target",
+)
 def test_official_registry_stdin_protocol_applies_adapter_and_one_linear(
     tmp_path: Path,
 ):
@@ -504,6 +524,10 @@ def test_official_registry_stdin_protocol_applies_adapter_and_one_linear(
 
 
 @pytest.mark.hcu
+@pytest.mark.skipif(
+    not __vllm_target_version__.startswith("0.25."),
+    reason="full v0.25.1 bootstrap only applies to a v0.25.x plugin target",
+)
 def test_qwen35_real_inspect_cache_miss_uses_official_registry_command(
     tmp_path: Path,
 ):

--- a/tests/patch/test_hcu_ci_selector.py
+++ b/tests/patch/test_hcu_ci_selector.py
@@ -376,6 +376,7 @@ def test_evalscope_is_required_only_by_evalscope_jobs() -> None:
         "qwen38-flash-next-humaneval",
         "deepseek-gsm8k",
         "glm52-pcp",
+        "glm53-flash-channel-fp8-humaneval",
     }
     expected = {
         "kind": "distribution",

--- a/tests/runtime_patch/test_glm53_channel_fp8.py
+++ b/tests/runtime_patch/test_glm53_channel_fp8.py
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_hcu.patch.worker.core_fix import (
+    patch_glm5next_channel_fp8,
+    patch_rocm_mla_sparse_metadata,
+)
+from vllm_hcu.patch.platform.core_fix import patch_vllm_config
+from vllm_hcu.patch.worker.op_opt import patch_glm5next_kda_conv_weight
+
+
+def _fake_glm_model_module() -> ModuleType:
+    module = ModuleType(patch_glm5next_channel_fp8.TARGET_MODULE)
+
+    class Glm5NextForConditionalGeneration:
+        def __init__(self, *, vllm_config, prefix=""):
+            del vllm_config, prefix
+
+    class Glm5NextDecoderLayer:
+        def __init__(
+            self,
+            vllm_config,
+            config,
+            layer_idx,
+            prefix="",
+            topk_indices_buffer=None,
+            is_mtp_layer=False,
+            **kwargs,
+        ):
+            del (
+                vllm_config,
+                config,
+                layer_idx,
+                prefix,
+                topk_indices_buffer,
+                is_mtp_layer,
+                kwargs,
+            )
+
+    module.Glm5NextForConditionalGeneration = Glm5NextForConditionalGeneration
+    module.Glm5NextDecoderLayer = Glm5NextDecoderLayer
+    return module
+
+
+def _fake_kda_module() -> tuple[ModuleType, type]:
+    module = ModuleType(patch_glm5next_kda_conv_weight.TARGET_MODULE)
+
+    class Glm5NextLinearAttention:
+        def _forward(self, qkv_proj_states, g1, beta, core_attn_out):
+            del qkv_proj_states, g1, beta, core_attn_out
+            if self._merged_conv_weight is None:
+                def _w(conv):
+                    weight = conv.weight
+                    return weight.view(weight.size(0), weight.size(2))
+
+                self._merged_conv_weight = torch.cat(
+                    [_w(self.q_conv1d), _w(self.k_conv1d), _w(self.v_conv1d)],
+                    dim=0,
+                ).contiguous()
+            return self._merged_conv_weight
+
+    module.Glm5NextLinearAttention = Glm5NextLinearAttention
+    return module, Glm5NextLinearAttention
+
+
+def _fake_kda_layer(layer_cls: type, *, nn_layout: bool):
+    layer = layer_cls()
+    layer.local_projection_size = 5
+    layer.conv_size = 4
+    layer._merged_conv_weight = None
+    logical_weights = []
+    for offset, name in enumerate(("q_conv1d", "k_conv1d", "v_conv1d")):
+        logical = torch.arange(20, dtype=torch.float32).reshape(5, 1, 4) + 100 * offset
+        stored = logical.permute(2, 1, 0).contiguous() if nn_layout else logical
+        setattr(layer, name, SimpleNamespace(weight=stored))
+        logical_weights.append(logical.reshape(5, 4))
+    return layer, torch.cat(logical_weights, dim=0).contiguous()
+
+
+def test_glm5next_kda_restores_each_nn_conv_weight_before_merge(monkeypatch) -> None:
+    module, layer_cls = _fake_kda_module()
+    monkeypatch.setattr(patch_glm5next_kda_conv_weight, "use_nn_layout", lambda: True)
+
+    assert patch_glm5next_kda_conv_weight.apply_to_module(module) is True
+    assert patch_glm5next_kda_conv_weight.apply_to_module(module) is False
+    layer, expected = _fake_kda_layer(layer_cls, nn_layout=True)
+
+    merged = layer._forward(None, None, None, None)
+    torch.testing.assert_close(merged, expected)
+    first_data_ptr = merged.data_ptr()
+    assert layer._forward(None, None, None, None).data_ptr() == first_data_ptr
+
+
+def test_glm5next_kda_leaves_official_layout_untouched(monkeypatch) -> None:
+    module, layer_cls = _fake_kda_module()
+    monkeypatch.setattr(patch_glm5next_kda_conv_weight, "use_nn_layout", lambda: False)
+    patch_glm5next_kda_conv_weight.apply_to_module(module)
+    layer, expected = _fake_kda_layer(layer_cls, nn_layout=False)
+
+    torch.testing.assert_close(layer._forward(None, None, None, None), expected)
+
+
+def test_glm5next_kda_rejects_unknown_nn_conv_shape(monkeypatch) -> None:
+    module, layer_cls = _fake_kda_module()
+    monkeypatch.setattr(patch_glm5next_kda_conv_weight, "use_nn_layout", lambda: True)
+    patch_glm5next_kda_conv_weight.apply_to_module(module)
+    layer, _ = _fake_kda_layer(layer_cls, nn_layout=True)
+    layer.q_conv1d.weight = torch.empty(7, 1, 3)
+
+    with pytest.raises(RuntimeError, match="incompatible NN layout"):
+        layer._forward(None, None, None, None)
+
+
+def test_hcu_flashmla_sparse_accepts_glm5next_absorbed_head_size() -> None:
+    from vllm_hcu.v1.attention.backends.mla.flashmla_sparse import (
+        HcuFlashMLASparseBackend,
+    )
+
+    assert HcuFlashMLASparseBackend.get_supported_head_sizes() == [512, 576]
+
+
+def test_hcu_glm5next_kpool_cache_keeps_compression_without_deepgemm_page() -> None:
+    from vllm.v1.kv_cache_interface import MLAAttentionSpec
+
+    attention = ModuleType(patch_glm5next_channel_fp8.ATTENTION_MODULE)
+
+    class DeepseekV32IndexerCache:
+        def get_kv_cache_spec(self, vllm_config):
+            del vllm_config
+            return MLAAttentionSpec(
+                block_size=64,
+                num_kv_heads=1,
+                head_size=132,
+                dtype=torch.uint8,
+            )
+
+    class Glm5NextIndexerCache(DeepseekV32IndexerCache):
+        def get_kv_cache_spec(self, vllm_config):
+            del vllm_config
+            raise AssertionError("DeepGEMM requires a 32-state page")
+
+    attention.Glm5NextIndexerCache = Glm5NextIndexerCache
+    patch_glm5next_channel_fp8._patch_glm5next_indexer_cache(attention)
+
+    cache = Glm5NextIndexerCache()
+    cache._index_kpool = 4
+    spec = cache.get_kv_cache_spec(None)
+    assert spec.block_size == 64
+    assert spec.tokens_per_state == 4
+    assert spec.storage_block_size is None
+    assert spec.num_states == 16
+
+
+def test_glm5next_graph_auto_enables_breakable_cudagraph(monkeypatch) -> None:
+    from vllm.config.compilation import CUDAGraphMode
+
+    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            architectures=["Glm5NextForConditionalGeneration"],
+            enforce_eager=False,
+        ),
+        compilation_config=SimpleNamespace(cudagraph_mode=CUDAGraphMode.PIECEWISE),
+    )
+
+    patch_vllm_config._normalize_glm5next_breakable_cudagraph(config)
+
+    assert __import__("os").environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] == "1"
+
+
+def test_rocm_sparse_builder_disables_missing_aiter_metadata_api(
+    monkeypatch,
+) -> None:
+    aiter = ModuleType("aiter")
+    aiter.dtypes = SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "aiter", aiter)
+
+    module = ModuleType(patch_rocm_mla_sparse_metadata.TARGET_MODULE)
+
+    class ROCMAiterMLASparseMetadataBuilder:
+        def __init__(self):
+            from aiter import get_mla_metadata_info_v1
+
+            self._use_persistent_metadata = True
+            self.metadata_info = get_mla_metadata_info_v1("unused")
+
+    module.ROCMAiterMLASparseMetadataBuilder = ROCMAiterMLASparseMetadataBuilder
+    patch_rocm_mla_sparse_metadata.apply_to_module(module)
+
+    builder = ROCMAiterMLASparseMetadataBuilder()
+    assert builder._use_persistent_metadata is False
+    assert builder.metadata_info == ((0, torch.int32),) * 6
+    assert not hasattr(aiter, "get_mla_metadata_info_v1")
+
+
+def test_kpool_indexer_uses_official_triton_path_without_aiter() -> None:
+    module = ModuleType(patch_glm5next_channel_fp8.KPOOL_MODULE)
+    module.rocm_aiter_ops = SimpleNamespace(is_enabled=lambda: False)
+
+    class SparseAttnIndexerKpool:
+        def forward_hip(
+            self,
+            hidden_states,
+            q_quant,
+            k,
+            weights,
+            *,
+            gate_score=None,
+            compress_ape=None,
+            index_kpool=1,
+            positions=None,
+        ):
+            del hidden_states, q_quant, k, weights
+            del gate_score, compress_ape, index_kpool, positions
+            return "official-hip"
+
+        def forward_cuda(self, *args, **kwargs):
+            return "official-triton", args, kwargs
+
+    module.SparseAttnIndexerKpool = SparseAttnIndexerKpool
+    patch_glm5next_channel_fp8._patch_sparse_indexer_kpool(module)
+
+    indexer = SparseAttnIndexerKpool()
+    result, args, kwargs = indexer.forward_hip(
+        "hidden",
+        "query",
+        "key",
+        "weights",
+        gate_score="gate",
+        compress_ape="compress",
+        index_kpool=4,
+        positions="positions",
+    )
+    assert result == "official-triton"
+    assert args == ("hidden", "query", "key", "weights")
+    assert kwargs == {
+        "gate_score": "gate",
+        "compress_ape": "compress",
+        "index_kpool": 4,
+        "positions": "positions",
+    }
+    assert indexer.forward_hip(
+        "hidden", "query", "key", "weights", index_kpool=1
+    ) == "official-hip"
+
+
+def test_indexer_derives_gate_weight_from_hcu_nn_layout() -> None:
+    attention = ModuleType(patch_glm5next_channel_fp8.ATTENTION_MODULE)
+
+    class Indexer:
+        def forward(self, hidden_states, qr, positions, rotary_emb):
+            del qr, positions, rotary_emb
+            if self._wp_fp32 is None:
+                self._wp_fp32 = (
+                    self.wk_weights_proj.weight.data[self.head_dim :, :]
+                    .t()
+                    .contiguous()
+                    .float()
+                )
+            return torch.mm(hidden_states.float(), self._wp_fp32)
+
+    attention.Indexer = Indexer
+    patch_glm5next_channel_fp8._patch_indexer_nn_layout(attention)
+
+    instance = Indexer()
+    instance.head_dim = 3
+    instance.n_head = 2
+    instance._wp_fp32 = None
+    logical_weight = torch.arange(20, dtype=torch.bfloat16).reshape(5, 4)
+    instance.wk_weights_proj = SimpleNamespace(
+        weight=SimpleNamespace(data=logical_weight.t().contiguous())
+    )
+
+    hidden_states = torch.ones(2, 4, dtype=torch.bfloat16)
+    result = instance.forward(hidden_states, None, None, None)
+    expected_weight = logical_weight[3:, :].t().float()
+    torch.testing.assert_close(instance._wp_fp32, expected_weight)
+    torch.testing.assert_close(result, hidden_states.float() @ expected_weight)
+
+
+def test_indexer_keeps_official_output_input_layout() -> None:
+    attention = ModuleType(patch_glm5next_channel_fp8.ATTENTION_MODULE)
+
+    class Indexer:
+        def forward(self, hidden_states, qr, positions, rotary_emb):
+            del qr, positions, rotary_emb
+            if self._wp_fp32 is None:
+                self._wp_fp32 = (
+                    self.wk_weights_proj.weight.data[self.head_dim :, :]
+                    .t()
+                    .contiguous()
+                    .float()
+                )
+            return torch.mm(hidden_states.float(), self._wp_fp32)
+
+    attention.Indexer = Indexer
+    patch_glm5next_channel_fp8._patch_indexer_nn_layout(attention)
+
+    instance = Indexer()
+    instance.head_dim = 3
+    instance.n_head = 2
+    instance._wp_fp32 = None
+    logical_weight = torch.arange(20, dtype=torch.bfloat16).reshape(5, 4)
+    instance.wk_weights_proj = SimpleNamespace(
+        weight=SimpleNamespace(data=logical_weight.contiguous())
+    )
+
+    hidden_states = torch.ones(2, 4, dtype=torch.bfloat16)
+    result = instance.forward(hidden_states, None, None, None)
+    expected_weight = logical_weight[3:, :].t().float()
+    torch.testing.assert_close(instance._wp_fp32, expected_weight)
+    torch.testing.assert_close(result, hidden_states.float() @ expected_weight)
+
+
+def test_channel_fp8_projection_kept_in_bf16_is_dequantized() -> None:
+    module = _fake_glm_model_module()
+    module._FP8_ATTN_PROJS = {
+        ".kv_a_proj_with_mqa.": (
+            "kv_a",
+            "fused_qkv_a_proj",
+            1,
+            True,
+        )
+    }
+
+    def official(
+        name,
+        tensor,
+        buf,
+        params_dict,
+        loaded_params,
+        kv_a_pad_size,
+    ):
+        del name, tensor, buf, params_dict, loaded_params, kv_a_pad_size
+        return False
+
+    module._try_load_fp8_attn_proj = official
+    patch_glm5next_channel_fp8.apply_to_module(module)
+
+    loaded = []
+
+    def weight_loader(param, tensor, shard_id):
+        del param
+        loaded.append((tensor, shard_id))
+
+    target = "layers.11.self_attn.fused_qkv_a_proj.weight"
+    params = {target: SimpleNamespace(weight_loader=weight_loader)}
+    buffered = {}
+    loaded_params = set()
+    weight = torch.tensor(
+        [[1.0, -2.0], [3.0, 4.0]],
+        dtype=torch.float8_e4m3fn,
+    )
+    scale = torch.tensor([[0.5], [2.0]], dtype=torch.bfloat16)
+
+    helper = module._try_load_fp8_attn_proj
+    assert helper(
+        "layers.11.self_attn.kv_a_proj_with_mqa.weight",
+        weight,
+        buffered,
+        params,
+        loaded_params,
+        1,
+    )
+    assert helper(
+        "layers.11.self_attn.kv_a_proj_with_mqa.weight_scale",
+        scale,
+        buffered,
+        params,
+        loaded_params,
+        1,
+    )
+
+    expected = torch.nn.functional.pad(
+        (weight.float() * scale.float()).to(torch.bfloat16),
+        (0, 0, 0, 1),
+    )
+    torch.testing.assert_close(loaded[0][0], expected)
+    assert loaded[0][1] == 1
+    assert loaded_params == {target}
+    assert buffered == {}
+
+
+def test_quantized_channel_fp8_target_stays_on_official_loader_path() -> None:
+    module = _fake_glm_model_module()
+    module._FP8_ATTN_PROJS = {
+        ".o_proj.": ("o_proj", "o_proj", None, False)
+    }
+
+    def official(
+        name,
+        tensor,
+        buf,
+        params_dict,
+        loaded_params,
+        kv_a_pad_size,
+    ):
+        del name, tensor, buf, params_dict, loaded_params, kv_a_pad_size
+        raise AssertionError("wrapper must leave this tensor to the caller")
+
+    module._try_load_fp8_attn_proj = official
+    patch_glm5next_channel_fp8.apply_to_module(module)
+    params = {
+        "layers.3.self_attn.o_proj.weight": object(),
+        "layers.3.self_attn.o_proj.weight_scale": object(),
+    }
+
+    assert not module._try_load_fp8_attn_proj(
+        "layers.3.self_attn.o_proj.weight_scale",
+        torch.ones(2, 1),
+        {},
+        params,
+        set(),
+        0,
+    )

--- a/tests/runtime_patch/test_glm53_native_mhc.py
+++ b/tests/runtime_patch/test_glm53_native_mhc.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import torch
 
 from vllm_hcu.patch.worker.core_fix.patch_glm5next_channel_fp8 import (
+    _bind_glm5next_boltops_mhc,
     _bind_glm5next_native_mhc,
 )
 
@@ -69,3 +70,89 @@ def test_bind_glm5next_native_mhc_preserves_norm_semantics():
     )
     assert fused[:3] == (one, two, three)
     assert torch.equal(fused[3], torch.tensor(6.5))
+
+
+def test_bind_glm5next_boltops_mhc_preserves_official_norm_semantics():
+    one = torch.tensor(1.0)
+    two = torch.tensor(2.0)
+    three = torch.tensor(3.0)
+    four = torch.tensor(4.0)
+    calls = []
+
+    class Backend:
+        @staticmethod
+        def mhc_pre(*args, **kwargs):
+            calls.append(("pre", args, kwargs))
+            return one, two, three
+
+        @staticmethod
+        def mhc_post(*args, **kwargs):
+            calls.append(("post", args, kwargs))
+            return four
+
+        @staticmethod
+        def mhc_fused_post_pre(*args, **kwargs):
+            calls.append(("fused", args, kwargs))
+            return one, two, three, four
+
+    layer = SimpleNamespace(
+        mhc_pre_op=_FakeOp(None),
+        mhc_post_op=_FakeOp(None),
+        mhc_fused_post_pre_op=_FakeOp(None),
+    )
+    mhc = SimpleNamespace(
+        _apply_mhc_norm=lambda value, weight, eps: value + weight + eps
+    )
+
+    _bind_glm5next_boltops_mhc(layer, mhc, Backend)
+
+    pre = layer.mhc_pre_op._forward_method(
+        one,
+        one,
+        one,
+        one,
+        1e-5,
+        0.0,
+        0.0,
+        1.0,
+        1,
+        norm_weight=two,
+        norm_eps=0.5,
+    )
+    post = layer.mhc_post_op._forward_method(one, one, one, one)
+    fused = layer.mhc_fused_post_pre_op._forward_method(
+        one,
+        one,
+        one,
+        one,
+        one,
+        one,
+        one,
+        1e-5,
+        0.0,
+        0.0,
+        1.0,
+        1,
+        norm_weight=two,
+        norm_eps=0.5,
+    )
+
+    assert pre[:2] == (one, two)
+    assert torch.equal(pre[2], torch.tensor(5.5))
+    assert post is four
+    assert fused[:3] == (one, two, three)
+    assert torch.equal(fused[3], torch.tensor(6.5))
+    assert [call[0] for call in calls] == ["pre", "post", "fused"]
+    assert all("norm_weight" not in call[2] for call in calls)
+    assert all("norm_eps" not in call[2] for call in calls)
+
+
+def test_hcu_mhc_backend_symbols_are_bound_to_boltops():
+    from vllm_hcu.model_executor.layers import mhc as backend
+
+    assert backend._boltops_mhc_fused_tilelang.__module__.startswith("boltops.mhc")
+    assert backend._boltops_mhc_post_fwd.__module__.startswith("boltops.mhc")
+    assert backend._boltops_mhc_pre_big_fuse.__module__.startswith("boltops.mhc")
+    assert backend._boltops_pre_big_fuse_tilelang.__module__.startswith(
+        "boltops.mhc"
+    )

--- a/tests/runtime_patch/test_glm53_native_mhc.py
+++ b/tests/runtime_patch/test_glm53_native_mhc.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+import torch
+
+from vllm_hcu.patch.worker.core_fix.patch_glm5next_channel_fp8 import (
+    _bind_glm5next_native_mhc,
+)
+
+
+class _FakeOp:
+    def __init__(self, result):
+        self.result = result
+        self._forward_method = lambda *args, **kwargs: None
+
+    def forward_native(self, *args, **kwargs):
+        return self.result
+
+
+def test_bind_glm5next_native_mhc_preserves_norm_semantics():
+    one = torch.tensor(1.0)
+    two = torch.tensor(2.0)
+    three = torch.tensor(3.0)
+    four = torch.tensor(4.0)
+    layer = SimpleNamespace(
+        mhc_pre_op=_FakeOp((one, two, three)),
+        mhc_post_op=_FakeOp(four),
+        mhc_fused_post_pre_op=_FakeOp((one, two, three, four)),
+    )
+    mhc = SimpleNamespace(
+        _apply_mhc_norm=lambda value, weight, eps: value + weight + eps
+    )
+
+    _bind_glm5next_native_mhc(layer, mhc)
+
+    pre = layer.mhc_pre_op._forward_method(
+        one,
+        one,
+        one,
+        one,
+        1e-5,
+        0.0,
+        0.0,
+        1.0,
+        1,
+        norm_weight=two,
+        norm_eps=0.5,
+    )
+    assert pre[:2] == (one, two)
+    assert torch.equal(pre[2], torch.tensor(5.5))
+
+    post = layer.mhc_post_op._forward_method(one, one, one, one)
+    assert torch.equal(post, four)
+
+    fused = layer.mhc_fused_post_pre_op._forward_method(
+        one,
+        one,
+        one,
+        one,
+        one,
+        one,
+        one,
+        1e-5,
+        0.0,
+        0.0,
+        1.0,
+        1,
+        norm_weight=two,
+        norm_eps=0.5,
+    )
+    assert fused[:3] == (one, two, three)
+    assert torch.equal(fused[3], torch.tensor(6.5))

--- a/tests/runtime_patch/test_glm53_quant_ignore_aliases.py
+++ b/tests/runtime_patch/test_glm53_quant_ignore_aliases.py
@@ -1,0 +1,35 @@
+from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    should_ignore_layer,
+)
+
+from vllm_hcu.patch.worker.core_fix.patch_glm5next_channel_fp8 import (
+    _expand_glm5next_multimodal_ignore_aliases,
+)
+
+
+def test_glm53_multimodal_regex_ignore_matches_runtime_prefix():
+    original = [
+        "re:^model\\.layers\\.[012]\\..*",
+        "re:^model\\.layers\\.\\d+\\.self_attn\\.o_proj$",
+        "visual",
+    ]
+
+    expanded = _expand_glm5next_multimodal_ignore_aliases(original)
+
+    assert expanded[: len(original)] == original
+    assert "re:^language_model\\.model\\.layers\\.[012]\\..*" in expanded
+    assert should_ignore_layer(
+        "language_model.model.layers.0.mlp.down_proj",
+        ignore=expanded,
+    )
+    assert should_ignore_layer(
+        "language_model.model.layers.4.self_attn.o_proj",
+        ignore=expanded,
+    )
+
+
+def test_glm53_multimodal_regex_ignore_expansion_is_idempotent():
+    original = ["re:^model\\.layers\\.[012]\\..*"]
+    once = _expand_glm5next_multimodal_ignore_aliases(original)
+
+    assert _expand_glm5next_multimodal_ignore_aliases(once) == once

--- a/tests/runtime_patch/test_mla_target_ownership.py
+++ b/tests/runtime_patch/test_mla_target_ownership.py
@@ -1089,6 +1089,17 @@ def test_hcu_sparse_mla_dcp_localizes_owned_indices_and_masks_empty_rows(
     )
     assert calls[-1][0] == "upstream"
 
+    impl.q_concat_buffer = torch.empty(2, 8, 3)
+    q_pe_empty = torch.empty(2, 4, 0)
+    assert impl.forward_mqa((q_nope, q_pe_empty), cache, metadata, layer) == (
+        "upstream-output",
+        None,
+    )
+    upstream_query = calls[-1][1]
+    assert isinstance(upstream_query, torch.Tensor)
+    assert upstream_query.shape == (2, 4, 3)
+    torch.testing.assert_close(upstream_query, q_nope)
+
 
 def test_flashmla_cat_route_consumes_split_query(
     monkeypatch,

--- a/tests/runtime_patch/test_platform_hcu_config.py
+++ b/tests/runtime_patch/test_platform_hcu_config.py
@@ -1609,6 +1609,52 @@ def test_sparse_flashmla_sets_engine_cache_block_size_before_worker_start(
     assert config.cache_config.block_size == 64
 
 
+def test_sparse_flashmla_preserves_official_hybrid_manager_block_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.v1.attention.backends.registry import AttentionBackendEnum
+    from vllm_hcu.platforms.hcu import HCUPlatform
+
+    config = _validation_config(HcuFeatureConfig())
+    config.cache_config = SimpleNamespace(
+        user_specified_block_size=False,
+        block_size=16,
+        kv_cache_dtype_skip_layers=[],
+    )
+    config.attention_config = SimpleNamespace(
+        backend=AttentionBackendEnum.FLASHMLA_SPARSE
+    )
+    config.model_config.is_hybrid = True
+
+    class IndexerBackend:
+        @staticmethod
+        def get_preferred_block_size(_default):
+            return 16
+
+        @staticmethod
+        def get_name():
+            return "DEEPSEEK_V32_INDEXER"
+
+    monkeypatch.setattr(
+        HCUPlatform,
+        "_find_non_ssm_backend",
+        classmethod(lambda cls, vllm_config: IndexerBackend),
+    )
+    monkeypatch.setattr(
+        HCUPlatform,
+        "_align_hybrid_block_size",
+        classmethod(
+            lambda cls, vllm_config, backend_cls: setattr(
+                vllm_config.cache_config, "block_size", 640
+            )
+        ),
+    )
+
+    HCUPlatform.update_block_size_for_backend(config)
+
+    assert config.cache_config.block_size == 640
+
+
 @pytest.mark.parametrize(
     ("backend_name", "expected_path"),
     [

--- a/tests/runtime_patch/test_qwen4_exp_mtp_metadata.py
+++ b/tests/runtime_patch/test_qwen4_exp_mtp_metadata.py
@@ -61,7 +61,9 @@ def test_qsa_draft_metadata_refresh_reuses_official_builder_in_place():
     assert metadata.fast_build is True
 
 
-@pytest.mark.parametrize("model_type", ["qwen4_exp"])
+@pytest.mark.parametrize(
+    "model_type", ["qwen3_5_moe", "qwen3_5_moe_text", "qwen4_exp"]
+)
 def test_qwen_mtp_groups_are_annotated_without_target_mamba_groups(model_type):
     module = ModuleType(kv_groups_patch.TARGET_MODULE)
     original_calls = []

--- a/tests/runtime_patch/test_worker_core_fix.py
+++ b/tests/runtime_patch/test_worker_core_fix.py
@@ -403,6 +403,11 @@ def _qwen4_exp_module(calls: list[tuple[object, ...]]) -> ModuleType:
     )
 
 
+def test_qwen4_exp_patch_targets_concrete_hcu_model_module():
+    assert patch_qwen4_exp.TARGET_MODULE == "vllm.models.qwen4_exp.amd.model"
+    assert "vllm.models.qwen4_exp" not in patch_qwen4_exp.TARGET_MODULES
+
+
 @pytest.mark.parametrize(
     ("top_value", "text_value", "expected_text"),
     [

--- a/vllm_hcu/model_executor/layers/mhc.py
+++ b/vllm_hcu/model_executor/layers/mhc.py
@@ -28,11 +28,11 @@ else:
     T = None  # type: ignore[assignment]
     
 import vllm_hcu.platforms.envs as henvs
-from aiter.ops.tilelang import (
-    mhc_fused_tilelang,
-    mhc_post_fwd,
-    mhc_pre_big_fuse,
-    pre_big_fuse_tilelang,
+from boltops.mhc import (
+    mhc_fused_tilelang as _boltops_mhc_fused_tilelang,
+    mhc_post_fwd as _boltops_mhc_post_fwd,
+    mhc_pre_big_fuse as _boltops_mhc_pre_big_fuse,
+    pre_big_fuse_tilelang as _boltops_pre_big_fuse_tilelang,
 )
 
 _DEEPGEMM_MHC_SUPPORTED_SPLITS = (1, 2, 4, 8)
@@ -497,7 +497,7 @@ def mhc_pre(
     fn_flat = fn
 
     if henvs.VLLM_HCU_USE_CUSTOM_OPS and henvs.VLLM_HCU_USE_AITER_MHC:
-        post_mix, comb_mix, layer_input = mhc_pre_big_fuse(
+        post_mix, comb_mix, layer_input = _boltops_mhc_pre_big_fuse(
             residual=residual_flat,
             fn=fn_flat,
             mhc_scale=hc_scale,
@@ -594,7 +594,7 @@ def mhc_pre(
     )
 
     if henvs.VLLM_HCU_USE_CUSTOM_OPS and henvs.VLLM_HCU_USE_AITER_MHC:
-        pre_big_fuse_tilelang(
+        _boltops_pre_big_fuse_tilelang(
             gemm_out_mul,
             gemm_out_sqrsum,
             hc_scale,
@@ -877,7 +877,7 @@ def mhc_post(
         hc_mult = residual.shape[-2]
         hidden_size = residual.shape[-1]
         outer_shape = residual.shape[:-2]
-        out = mhc_post_fwd(
+        out = _boltops_mhc_post_fwd(
             x.reshape(-1, hidden_size).contiguous(),
             residual.reshape(-1, hc_mult, hidden_size),
             post_layer_mix.reshape(-1, hc_mult).contiguous(),
@@ -1020,7 +1020,7 @@ def mhc_fused_post_pre(
     )
 
     if num_tokens <= fma_token_threshold:
-        mhc_fused_tilelang(
+        _boltops_mhc_fused_tilelang(
             comb_res_mix,
             residual,
             post_layer_mix.squeeze(-1),
@@ -1052,7 +1052,7 @@ def mhc_fused_post_pre(
         # )
     else:
         if henvs.VLLM_HCU_USE_CUSTOM_OPS and henvs.VLLM_HCU_USE_AITER_MHC:
-            mhc_post_fwd(
+            _boltops_mhc_post_fwd(
                 x_flat,
                 residual_flat,
                 post_layer_mix_flat,
@@ -1089,7 +1089,7 @@ def mhc_fused_post_pre(
             )
 
     if henvs.VLLM_HCU_USE_CUSTOM_OPS and henvs.VLLM_HCU_USE_AITER_MHC:
-        pre_big_fuse_tilelang(
+        _boltops_pre_big_fuse_tilelang(
             gemm_out_mul,
             gemm_out_sqrsum,
             hc_scale,

--- a/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
@@ -28,6 +28,13 @@ TARGETS = (
 )
 _MARKER = "_vllm_hcu_feature_config_patch_applied"
 _GLM_DSA_ARCHITECTURE = "GlmMoeDsaForCausalLM"
+_GLM5NEXT_BREAKABLE_CUDAGRAPH_ARCHITECTURES = frozenset(
+    {
+        "Glm5NextForCausalLM",
+        "Glm5NextForConditionalGeneration",
+        "Glm5NextMTPModel",
+    }
+)
 _REQUEST_CAPTURE_SIZES = (
     *range(1, 9),
     *range(10, 33, 2),
@@ -44,6 +51,25 @@ def _normalize_hcu_model_runner(model_config: object) -> None:
         and "VLLM_USE_V2_MODEL_RUNNER" not in os.environ
     ):
         os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"
+
+
+def _normalize_glm5next_breakable_cudagraph(vllm_config: object) -> None:
+    """Restore upstream's architecture opt-in for GLM5Next on HCU."""
+
+    if "VLLM_USE_BREAKABLE_CUDAGRAPH" in os.environ:
+        return
+    model_config = getattr(vllm_config, "model_config", None)
+    architectures = set(getattr(model_config, "architectures", ()) or ())
+    if not architectures & _GLM5NEXT_BREAKABLE_CUDAGRAPH_ARCHITECTURES:
+        return
+    if bool(getattr(model_config, "enforce_eager", False)):
+        return
+    compilation_config = getattr(vllm_config, "compilation_config", None)
+    cudagraph_mode = getattr(compilation_config, "cudagraph_mode", None)
+    none_mode = getattr(type(cudagraph_mode), "NONE", None)
+    if cudagraph_mode is None or cudagraph_mode == none_mode:
+        return
+    os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
 
 
 def _require_hcu_pcp_attribute(owner: object, name: str, owner_name: str) -> Any:
@@ -221,6 +247,7 @@ def _validate_dspark_pd_scope(vllm_config: object) -> None:
 
 def validate_and_update_hcu_config(vllm_config: object) -> HcuFeatureConfig:
     _normalize_hcu_model_runner(vllm_config.model_config)
+    _normalize_glm5next_breakable_cudagraph(vllm_config)
     """Validate cross-config invariants and bind the compilation adapter."""
 
     _validate_hcu_pcp_scope(vllm_config)

--- a/vllm_hcu/patch/platform/framework_opt/patch_qwen4_exp_mtp_kv_cache_groups.py
+++ b/vllm_hcu/patch/platform/framework_opt/patch_qwen4_exp_mtp_kv_cache_groups.py
@@ -30,6 +30,8 @@ _GROUPS_WRAPPER = "_vllm_hcu_qwen4_exp_mtp_get_kv_groups_wrapper"
 logger = init_logger(__name__)
 _SUPPORTED_MODEL_TYPES = frozenset(
     {
+        "qwen3_5_moe",
+        "qwen3_5_moe_text",
         "qwen4_exp",
     }
 )

--- a/vllm_hcu/patch/platform/framework_opt/patch_scheduler.py
+++ b/vllm_hcu/patch/platform/framework_opt/patch_scheduler.py
@@ -38,6 +38,10 @@ def _mark_qwen_hybrid_mtp_groups(
 ) -> None:
     if not _is_qwen_hybrid_mtp(vllm_config):
         return
+    model_config = getattr(vllm_config, "model_config", None)
+    hf_config = getattr(model_config, "hf_config", None)
+    if getattr(hf_config, "model_type", None) != "qwen4_exp":
+        return
 
     marked_group_ids = []
     for index, group in enumerate(

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -216,10 +216,12 @@ _CORE_CALLBACKS: tuple[_CallbackSpec, ...] = (
     _CallbackSpec(_adapter("core_fix", "patch_deepseek_v4_rocm_dspark_metadata")),
     _CallbackSpec(_adapter("core_fix", "patch_deepseek_v4_rocm_wo_a_layout")),
     _CallbackSpec(_adapter("core_fix", "patch_gpt_oss_mlp_block")),
+    _CallbackSpec(_adapter("core_fix", "patch_glm5next_channel_fp8")),
     _CallbackSpec(_adapter("core_fix", "patch_qwen3_5_mamba_state_dtype")),
     _CallbackSpec(_adapter("core_fix", "patch_qwen3_vl")),
     _CallbackSpec(_adapter("core_fix", "patch_qwen3_vl_moe")),
     _CallbackSpec(_adapter("core_fix", "patch_qwen4_exp")),
+    _CallbackSpec(_adapter("core_fix", "patch_rocm_mla_sparse_metadata")),
 )
 
 
@@ -240,13 +242,14 @@ _OP_CALLBACKS: tuple[_CallbackSpec, ...] = (
     _CallbackSpec(_adapter("op_opt", "patch_fla_chunk_o")),
     _CallbackSpec(_adapter("op_opt", "patch_mamba_mixer")),
     _CallbackSpec(_adapter("op_opt", "patch_mamba_mixer2")),
-    # All GDN deltas bind Qwen's module-local symbols/class only.  The
+    # GDN deltas bind model-local symbols/classes only. The canonical
     # canonical causal-conv module and the shared GDN base remain vLLM-owned
     # so Kimi, Olmo, MambaMixer, MambaMixer2, and ShortConv are not patched by
     # the GDN adapters.
     _CallbackSpec(_adapter("op_opt", "patch_gdn_causal_conv1d")),
     _CallbackSpec(_adapter("op_opt", "patch_gdn_base")),
     _CallbackSpec(_adapter("op_opt", "patch_gdn_linear_attention")),
+    _CallbackSpec(_adapter("op_opt", "patch_glm5next_kda_conv_weight")),
     _CallbackSpec(_adapter("op_opt", "patch_gate_linear")),
     _CallbackSpec(_adapter("op_opt", "patch_activation")),
     _CallbackSpec(_adapter("op_opt", "patch_layers_utils")),

--- a/vllm_hcu/patch/worker/core_fix/__init__.py
+++ b/vllm_hcu/patch/worker/core_fix/__init__.py
@@ -15,11 +15,13 @@ from . import (
     patch_deepseek_v4_rocm_dspark_metadata,
     patch_deepseek_v4_rocm_wo_a_layout,
     patch_gpt_oss_mlp_block,
+    patch_glm5next_channel_fp8,
     patch_mhc_backend,
     patch_qwen3_5_mamba_state_dtype,
     patch_qwen3_vl,
     patch_qwen3_vl_moe,
     patch_qwen4_exp,
+    patch_rocm_mla_sparse_metadata,
 )
 
 __all__ = [
@@ -30,9 +32,11 @@ __all__ = [
     "patch_deepseek_v4_rocm_dspark_metadata",
     "patch_deepseek_v4_rocm_wo_a_layout",
     "patch_gpt_oss_mlp_block",
+    "patch_glm5next_channel_fp8",
     "patch_mhc_backend",
     "patch_qwen3_5_mamba_state_dtype",
     "patch_qwen3_vl",
     "patch_qwen3_vl_moe",
     "patch_qwen4_exp",
+    "patch_rocm_mla_sparse_metadata",
 ]

--- a/vllm_hcu/patch/worker/core_fix/patch_glm5next_channel_fp8.py
+++ b/vllm_hcu/patch/worker/core_fix/patch_glm5next_channel_fp8.py
@@ -1,0 +1,589 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Adapt Channel-FP8 loading and correctness fallbacks for GLM5Next."""
+
+from __future__ import annotations
+
+import functools
+import sys
+from types import ModuleType
+
+import torch
+
+from ._common import (
+    PatchCompatibilityError,
+    load_exact_module,
+    require_callable,
+    require_exact_signature,
+)
+
+TARGET_MODULE = "vllm.models.glm5next.nvidia.model"
+ATTENTION_MODULE = "vllm.models.glm5next.nvidia.attention"
+KPOOL_MODULE = "vllm.model_executor.layers.sparse_attn_indexer_kpool"
+MTP_MODULE = "vllm.models.glm5next.nvidia.mtp"
+PATCH_ID = "worker.core_fix.glm5next.channel_fp8_attn_projection_loader"
+TARGET_SYMBOL = f"{TARGET_MODULE}._try_load_fp8_attn_proj"
+_PATCH_MARKER = "_vllm_hcu_glm5next_channel_fp8_applied"
+_WRAPPER_MARKER = "_vllm_hcu_glm5next_channel_fp8_wrapper"
+_INDEXER_PATCH_MARKER = "_vllm_hcu_glm5next_indexer_nn_layout_applied"
+_INDEXER_WRAPPER_MARKER = "_vllm_hcu_glm5next_indexer_nn_layout_wrapper"
+_KPOOL_PATCH_MARKER = "_vllm_hcu_sparse_indexer_kpool_triton_applied"
+_KPOOL_WRAPPER_MARKER = "_vllm_hcu_sparse_indexer_kpool_triton_wrapper"
+_INDEXER_CACHE_PATCH_MARKER = "_vllm_hcu_glm5next_indexer_cache_applied"
+_INDEXER_CACHE_WRAPPER_MARKER = "_vllm_hcu_glm5next_indexer_cache_wrapper"
+_QUANT_IGNORE_PATCH_MARKER = "_vllm_hcu_glm5next_quant_ignore_applied"
+_QUANT_IGNORE_WRAPPER_MARKER = "_vllm_hcu_glm5next_quant_ignore_wrapper"
+_MHC_PATCH_MARKER = "_vllm_hcu_glm5next_native_mhc_applied"
+_MHC_WRAPPER_MARKER = "_vllm_hcu_glm5next_native_mhc_wrapper"
+
+
+def _native_mhc_pre(
+    mhc,
+    op,
+    residual,
+    fn,
+    hc_scale,
+    hc_base,
+    rms_eps,
+    hc_pre_eps,
+    hc_sinkhorn_eps,
+    hc_post_mult_value,
+    sinkhorn_repeat,
+    n_splits=1,
+    norm_weight=None,
+    norm_eps=0.0,
+):
+    post_mix, comb_mix, layer_input = op.forward_native(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+        n_splits,
+        norm_weight,
+        norm_eps,
+    )
+    return (
+        post_mix,
+        comb_mix,
+        mhc._apply_mhc_norm(layer_input, norm_weight, norm_eps),
+    )
+
+
+def _native_mhc_post(mhc, op, x, residual, post_layer_mix, comb_res_mix):
+    del mhc
+    return op.forward_native(x, residual, post_layer_mix, comb_res_mix)
+
+
+def _native_mhc_fused_post_pre(
+    mhc,
+    op,
+    x,
+    residual,
+    post_layer_mix,
+    comb_res_mix,
+    fn,
+    hc_scale,
+    hc_base,
+    rms_eps,
+    hc_pre_eps,
+    hc_sinkhorn_eps,
+    hc_post_mult_value,
+    sinkhorn_repeat,
+    n_splits=1,
+    tile_n=1,
+    norm_weight=None,
+    norm_eps=0.0,
+):
+    residual_cur, post_mix, comb_mix, layer_input = op.forward_native(
+        x,
+        residual,
+        post_layer_mix,
+        comb_res_mix,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+        n_splits,
+        tile_n,
+        norm_weight,
+        norm_eps,
+    )
+    return (
+        residual_cur,
+        post_mix,
+        comb_mix,
+        mhc._apply_mhc_norm(layer_input, norm_weight, norm_eps),
+    )
+
+
+def _bind_glm5next_native_mhc(layer, mhc) -> None:
+    """Keep GLM5Next on the official native mHC equations on HCU."""
+
+    layer.mhc_pre_op._forward_method = functools.partial(
+        _native_mhc_pre, mhc, layer.mhc_pre_op
+    )
+    layer.mhc_post_op._forward_method = functools.partial(
+        _native_mhc_post, mhc, layer.mhc_post_op
+    )
+    layer.mhc_fused_post_pre_op._forward_method = functools.partial(
+        _native_mhc_fused_post_pre,
+        mhc,
+        layer.mhc_fused_post_pre_op,
+    )
+
+
+def _patch_glm5next_native_mhc(glm_model: ModuleType) -> bool:
+    decoder_cls = vars(glm_model).get("Glm5NextDecoderLayer")
+    if not isinstance(decoder_cls, type):
+        raise PatchCompatibilityError(
+            f"required class {TARGET_MODULE}.Glm5NextDecoderLayer is missing"
+        )
+    original = require_callable(
+        decoder_cls,
+        "__init__",
+        f"{TARGET_MODULE}.Glm5NextDecoderLayer.__init__",
+    )
+    if getattr(decoder_cls, _MHC_PATCH_MARKER, False):
+        if not getattr(original, _MHC_WRAPPER_MARKER, False):
+            raise PatchCompatibilityError("GLM5Next native-mHC patch marker is stale")
+        return False
+
+    @functools.wraps(original)
+    def hcu_decoder_init(
+        self,
+        vllm_config,
+        config,
+        layer_idx,
+        prefix="",
+        topk_indices_buffer=None,
+        is_mtp_layer=False,
+        **kwargs,
+    ):
+        original(
+            self,
+            vllm_config,
+            config,
+            layer_idx,
+            prefix,
+            topk_indices_buffer,
+            is_mtp_layer,
+            **kwargs,
+        )
+        if getattr(self, "mhc", False) and not getattr(
+            self, "is_mtp_layer", False
+        ):
+            from vllm.model_executor.layers import mhc
+
+            _bind_glm5next_native_mhc(self, mhc)
+
+    setattr(hcu_decoder_init, _MHC_WRAPPER_MARKER, True)
+    setattr(decoder_cls, "_vllm_hcu_original_init", original)
+    setattr(decoder_cls, "__init__", hcu_decoder_init)
+    setattr(decoder_cls, _MHC_PATCH_MARKER, True)
+    return True
+
+
+def _expand_glm5next_multimodal_ignore_aliases(ignore: list[str]) -> list[str]:
+    """Add runtime aliases for checkpoint-rooted GLM5Next regex ignores."""
+    expanded = list(ignore)
+    checkpoint_prefix = "re:^model\\.layers\\."
+    runtime_prefix = "re:^language_model\\.model\\.layers\\."
+    for pattern in ignore:
+        if pattern.startswith(checkpoint_prefix):
+            alias = runtime_prefix + pattern[len(checkpoint_prefix) :]
+            if alias not in expanded:
+                expanded.append(alias)
+    return expanded
+
+
+def _patch_multimodal_quant_ignore(glm_model: ModuleType) -> bool:
+    model_cls = vars(glm_model).get("Glm5NextForConditionalGeneration")
+    if not isinstance(model_cls, type):
+        raise PatchCompatibilityError(
+            f"required class {TARGET_MODULE}.Glm5NextForConditionalGeneration "
+            "is missing"
+        )
+    original = require_callable(
+        model_cls,
+        "__init__",
+        f"{TARGET_MODULE}.Glm5NextForConditionalGeneration.__init__",
+    )
+    if getattr(model_cls, _QUANT_IGNORE_PATCH_MARKER, False):
+        if not getattr(original, _QUANT_IGNORE_WRAPPER_MARKER, False):
+            raise PatchCompatibilityError(
+                "GLM5Next quant-ignore patch marker is stale"
+            )
+        return False
+    require_exact_signature(
+        original,
+        f"{TARGET_MODULE}.Glm5NextForConditionalGeneration.__init__",
+        positional=("self",),
+        keyword_only=("vllm_config", "prefix"),
+        defaults={"prefix": ""},
+    )
+
+    @functools.wraps(original)
+    def hcu_init(self, *, vllm_config, prefix=""):
+        quant_config = getattr(vllm_config, "quant_config", None)
+        if (
+            quant_config is not None
+            and callable(getattr(quant_config, "get_name", None))
+            and quant_config.get_name() == "compressed-tensors"
+            and isinstance(getattr(quant_config, "ignore", None), list)
+        ):
+            quant_config.ignore = _expand_glm5next_multimodal_ignore_aliases(
+                quant_config.ignore
+            )
+        return original(self, vllm_config=vllm_config, prefix=prefix)
+
+    setattr(hcu_init, _QUANT_IGNORE_WRAPPER_MARKER, True)
+    setattr(model_cls, "_vllm_hcu_original_init", original)
+    setattr(model_cls, "__init__", hcu_init)
+    setattr(model_cls, _QUANT_IGNORE_PATCH_MARKER, True)
+    return True
+
+
+def _patch_glm5next_indexer_cache(attention: ModuleType) -> bool:
+    cache_cls = vars(attention).get("Glm5NextIndexerCache")
+    if not isinstance(cache_cls, type):
+        raise PatchCompatibilityError(
+            f"required class {ATTENTION_MODULE}.Glm5NextIndexerCache is missing"
+        )
+    original = require_callable(
+        cache_cls,
+        "get_kv_cache_spec",
+        f"{ATTENTION_MODULE}.Glm5NextIndexerCache.get_kv_cache_spec",
+    )
+    if getattr(cache_cls, _INDEXER_CACHE_PATCH_MARKER, False):
+        if not getattr(original, _INDEXER_CACHE_WRAPPER_MARKER, False):
+            raise PatchCompatibilityError(
+                "GLM5Next indexer cache patch marker is stale"
+            )
+        return False
+    require_exact_signature(
+        original,
+        f"{ATTENTION_MODULE}.Glm5NextIndexerCache.get_kv_cache_spec",
+        positional=("self", "vllm_config"),
+    )
+    base_get_kv_cache_spec = require_callable(
+        cache_cls.__mro__[1],
+        "get_kv_cache_spec",
+        f"{cache_cls.__mro__[1].__name__}.get_kv_cache_spec",
+    )
+    require_exact_signature(
+        base_get_kv_cache_spec,
+        f"{cache_cls.__mro__[1].__name__}.get_kv_cache_spec",
+        positional=("self", "vllm_config"),
+    )
+
+    @functools.wraps(original)
+    def hcu_get_kv_cache_spec(self, vllm_config):
+        from dataclasses import replace
+
+        from vllm.v1.kv_cache_interface import MLAAttentionSpec
+
+        spec = base_get_kv_cache_spec(self, vllm_config)
+        if not isinstance(spec, MLAAttentionSpec):
+            raise PatchCompatibilityError(
+                "GLM5Next indexer cache parent returned a non-MLA spec"
+            )
+        # The official override adds a DeepGEMM-only 32/64-state page
+        # constraint. HCU uses the ROCm generic indexer path, whose cache page
+        # width is the natural block_size // index_kpool value.
+        return replace(spec, tokens_per_state=self._index_kpool)
+
+    setattr(hcu_get_kv_cache_spec, _INDEXER_CACHE_WRAPPER_MARKER, True)
+    setattr(cache_cls, "_vllm_hcu_original_get_kv_cache_spec", original)
+    setattr(cache_cls, "get_kv_cache_spec", hcu_get_kv_cache_spec)
+    setattr(cache_cls, _INDEXER_CACHE_PATCH_MARKER, True)
+    return True
+
+
+def _patch_sparse_indexer_kpool(kpool: ModuleType) -> bool:
+    indexer = vars(kpool).get("SparseAttnIndexerKpool")
+    if not isinstance(indexer, type):
+        raise PatchCompatibilityError(
+            f"required class {KPOOL_MODULE}.SparseAttnIndexerKpool is missing"
+        )
+    original = require_callable(
+        indexer,
+        "forward_hip",
+        f"{KPOOL_MODULE}.SparseAttnIndexerKpool.forward_hip",
+    )
+    if getattr(indexer, _KPOOL_PATCH_MARKER, False):
+        if not getattr(original, _KPOOL_WRAPPER_MARKER, False):
+            raise PatchCompatibilityError(
+                "sparse indexer kpool Triton fallback patch marker is stale"
+            )
+        return False
+    require_exact_signature(
+        original,
+        f"{KPOOL_MODULE}.SparseAttnIndexerKpool.forward_hip",
+        positional=("self", "hidden_states", "q_quant", "k", "weights"),
+        keyword_only=("gate_score", "compress_ape", "index_kpool", "positions"),
+        defaults={
+            "gate_score": None,
+            "compress_ape": None,
+            "index_kpool": 1,
+            "positions": None,
+        },
+    )
+
+    @functools.wraps(original)
+    def hcu_forward_hip(
+        self,
+        hidden_states,
+        q_quant,
+        k,
+        weights,
+        *,
+        gate_score=None,
+        compress_ape=None,
+        index_kpool=1,
+        positions=None,
+    ):
+        if index_kpool > 1 and not kpool.rocm_aiter_ops.is_enabled():
+            # Upstream already delegates kpool>1 to this implementation when
+            # AITER is enabled.  The implementation is Triton on ROCm and does
+            # not require the upstream AITER sparse-indexer extension.
+            return self.forward_cuda(
+                hidden_states,
+                q_quant,
+                k,
+                weights,
+                gate_score=gate_score,
+                compress_ape=compress_ape,
+                index_kpool=index_kpool,
+                positions=positions,
+            )
+        return original(
+            self,
+            hidden_states,
+            q_quant,
+            k,
+            weights,
+            gate_score=gate_score,
+            compress_ape=compress_ape,
+            index_kpool=index_kpool,
+            positions=positions,
+        )
+
+    setattr(hcu_forward_hip, _KPOOL_WRAPPER_MARKER, True)
+    setattr(indexer, "_vllm_hcu_original_forward_hip", original)
+    setattr(indexer, "forward_hip", hcu_forward_hip)
+    setattr(indexer, _KPOOL_PATCH_MARKER, True)
+    return True
+
+
+def _patch_indexer_nn_layout(attention: ModuleType) -> bool:
+    indexer = vars(attention).get("Indexer")
+    if not isinstance(indexer, type):
+        raise PatchCompatibilityError(
+            f"required class {ATTENTION_MODULE}.Indexer is missing"
+        )
+    original = require_callable(
+        indexer,
+        "forward",
+        f"{ATTENTION_MODULE}.Indexer.forward",
+    )
+    if getattr(indexer, _INDEXER_PATCH_MARKER, False):
+        if not getattr(original, _INDEXER_WRAPPER_MARKER, False):
+            raise PatchCompatibilityError(
+                "GLM5 Indexer NN-layout patch marker is stale"
+            )
+        return False
+    require_exact_signature(
+        original,
+        f"{ATTENTION_MODULE}.Indexer.forward",
+        positional=("self", "hidden_states", "qr", "positions", "rotary_emb"),
+    )
+
+    @functools.wraps(original)
+    def hcu_indexer_forward(self, hidden_states, qr, positions, rotary_emb):
+        if self._wp_fp32 is None:
+            weight = self.wk_weights_proj.weight.data
+            hidden_size = hidden_states.shape[-1]
+            output_size = self.head_dim + self.n_head
+            if tuple(weight.shape) == (hidden_size, output_size):
+                # HCU NN linear storage is [in, out].  Official Indexer.forward
+                # directly reads the parameter as [out, in] to cache the gate
+                # projection, bypassing the layout-aware linear implementation.
+                self._wp_fp32 = (
+                    weight[:, self.head_dim :].contiguous().float()
+                )
+        return original(self, hidden_states, qr, positions, rotary_emb)
+
+    setattr(hcu_indexer_forward, _INDEXER_WRAPPER_MARKER, True)
+    setattr(indexer, "_vllm_hcu_original_forward", original)
+    setattr(indexer, "forward", hcu_indexer_forward)
+    setattr(indexer, _INDEXER_PATCH_MARKER, True)
+    return True
+
+
+def _projection(module: ModuleType, name: str):
+    for suffix, info in module._FP8_ATTN_PROJS.items():
+        if suffix in name:
+            layer_prefix = name.rsplit(suffix, 1)[0]
+            key, target_base, shard_id, is_kva = info
+            target = f"{layer_prefix}.{target_base}"
+            return layer_prefix, key, target, shard_id, is_kva
+    return None
+
+
+def _dequantize_channel_fp8(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+) -> torch.Tensor:
+    if weight.ndim != 2:
+        raise ValueError(
+            f"Channel-FP8 weight must be 2-D, got {tuple(weight.shape)}"
+        )
+    if scale.ndim == 1:
+        scale = scale.unsqueeze(1)
+    if scale.shape != (weight.shape[0], 1):
+        raise ValueError(
+            "Channel-FP8 scale must have shape (out_features, 1), got "
+            f"weight={tuple(weight.shape)}, scale={tuple(scale.shape)}"
+        )
+    return (weight.float() * scale.float()).to(torch.bfloat16).contiguous()
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    glm_model = load_exact_module(TARGET_MODULE, module)
+    changed = _patch_multimodal_quant_ignore(glm_model)
+    changed = _patch_glm5next_native_mhc(glm_model) or changed
+    kpool = sys.modules.get(KPOOL_MODULE)
+    if isinstance(kpool, ModuleType):
+        changed = _patch_sparse_indexer_kpool(kpool)
+    attention = sys.modules.get(ATTENTION_MODULE)
+    if isinstance(attention, ModuleType):
+        changed = _patch_glm5next_indexer_cache(attention) or changed
+        changed = _patch_indexer_nn_layout(attention) or changed
+    original = require_callable(
+        glm_model,
+        "_try_load_fp8_attn_proj",
+        TARGET_SYMBOL,
+    )
+    if getattr(glm_model, _PATCH_MARKER, False):
+        current = vars(glm_model).get("_try_load_fp8_attn_proj")
+        if not getattr(current, _WRAPPER_MARKER, False):
+            raise PatchCompatibilityError(
+                f"required HCU patch marker for {TARGET_SYMBOL} is stale"
+            )
+        return changed
+    require_exact_signature(
+        original,
+        TARGET_SYMBOL,
+        positional=(
+            "name",
+            "tensor",
+            "buf",
+            "params_dict",
+            "loaded_params",
+            "kv_a_pad_size",
+        ),
+    )
+
+    @functools.wraps(original)
+    def hcu_try_load_fp8_attn_proj(
+        name,
+        tensor,
+        buf,
+        params_dict,
+        loaded_params,
+        kv_a_pad_size,
+    ):
+        projection = _projection(glm_model, name)
+        if projection is None:
+            return original(
+                name,
+                tensor,
+                buf,
+                params_dict,
+                loaded_params,
+                kv_a_pad_size,
+            )
+
+        layer_prefix, key, target, shard_id, is_kva = projection
+        target_weight = f"{target}.weight"
+        target_scale = f"{target}.weight_scale"
+        target_scale_inv = f"{target}.weight_scale_inv"
+        is_weight = name.endswith(".weight") and tensor.dtype == torch.float8_e4m3fn
+        is_channel_scale = name.endswith(".weight_scale")
+
+        # A target that remains quantized owns both tensors and must use the
+        # normal official stacked/direct loading path.
+        if target_scale in params_dict or target_scale_inv in params_dict:
+            if is_weight or is_channel_scale:
+                return False
+
+        if not is_weight and not is_channel_scale:
+            return original(
+                name,
+                tensor,
+                buf,
+                params_dict,
+                loaded_params,
+                kv_a_pad_size,
+            )
+
+        entry = buf.setdefault(layer_prefix, {}).setdefault(key, {})
+        entry["weight" if is_weight else "scale"] = tensor
+        if "weight" not in entry or "scale" not in entry:
+            return True
+
+        weight_bf16 = _dequantize_channel_fp8(entry["weight"], entry["scale"])
+        buf[layer_prefix].pop(key, None)
+        if not buf[layer_prefix]:
+            buf.pop(layer_prefix, None)
+
+        if is_kva and kv_a_pad_size > 0:
+            weight_bf16 = torch.nn.functional.pad(
+                weight_bf16,
+                (0, 0, 0, kv_a_pad_size),
+            )
+
+        param = params_dict[target_weight]
+        if shard_id is None:
+            param.weight_loader(param, weight_bf16)
+        else:
+            param.weight_loader(param, weight_bf16, shard_id)
+        loaded_params.add(target_weight)
+        return True
+
+    setattr(hcu_try_load_fp8_attn_proj, _WRAPPER_MARKER, True)
+    setattr(glm_model, "_vllm_hcu_original_try_load_fp8_attn_proj", original)
+    setattr(glm_model, "_try_load_fp8_attn_proj", hcu_try_load_fp8_attn_proj)
+    setattr(glm_model, _PATCH_MARKER, True)
+
+    # MTP imports the helper by value. Refresh an already-imported module;
+    # later imports naturally observe the patched model-module attribute.
+    mtp = sys.modules.get(MTP_MODULE)
+    if isinstance(mtp, ModuleType) and getattr(
+        mtp, "_try_load_fp8_attn_proj", None
+    ) is original:
+        mtp._try_load_fp8_attn_proj = hcu_try_load_fp8_attn_proj
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = [
+    "ATTENTION_MODULE",
+    "KPOOL_MODULE",
+    "PATCH_ID",
+    "TARGET_MODULE",
+    "apply",
+    "apply_to_module",
+]

--- a/vllm_hcu/patch/worker/core_fix/patch_glm5next_channel_fp8.py
+++ b/vllm_hcu/patch/worker/core_fix/patch_glm5next_channel_fp8.py
@@ -33,8 +33,8 @@ _INDEXER_CACHE_PATCH_MARKER = "_vllm_hcu_glm5next_indexer_cache_applied"
 _INDEXER_CACHE_WRAPPER_MARKER = "_vllm_hcu_glm5next_indexer_cache_wrapper"
 _QUANT_IGNORE_PATCH_MARKER = "_vllm_hcu_glm5next_quant_ignore_applied"
 _QUANT_IGNORE_WRAPPER_MARKER = "_vllm_hcu_glm5next_quant_ignore_wrapper"
-_MHC_PATCH_MARKER = "_vllm_hcu_glm5next_native_mhc_applied"
-_MHC_WRAPPER_MARKER = "_vllm_hcu_glm5next_native_mhc_wrapper"
+_MHC_PATCH_MARKER = "_vllm_hcu_glm5next_boltops_mhc_applied"
+_MHC_WRAPPER_MARKER = "_vllm_hcu_glm5next_boltops_mhc_wrapper"
 
 
 def _native_mhc_pre(
@@ -141,7 +141,112 @@ def _bind_glm5next_native_mhc(layer, mhc) -> None:
     )
 
 
-def _patch_glm5next_native_mhc(glm_model: ModuleType) -> bool:
+def _boltops_mhc_pre(
+    backend,
+    mhc,
+    residual,
+    fn,
+    hc_scale,
+    hc_base,
+    rms_eps,
+    hc_pre_eps,
+    hc_sinkhorn_eps,
+    hc_post_mult_value,
+    sinkhorn_repeat,
+    n_splits=1,
+    norm_weight=None,
+    norm_eps=0.0,
+):
+    post_mix, comb_mix, layer_input = backend.mhc_pre(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+        n_splits,
+    )
+    return (
+        post_mix,
+        comb_mix,
+        mhc._apply_mhc_norm(layer_input, norm_weight, norm_eps),
+    )
+
+
+def _boltops_mhc_post(
+    backend,
+    x,
+    residual,
+    post_layer_mix,
+    comb_res_mix,
+):
+    return backend.mhc_post(x, residual, post_layer_mix, comb_res_mix)
+
+
+def _boltops_mhc_fused_post_pre(
+    backend,
+    mhc,
+    x,
+    residual,
+    post_layer_mix,
+    comb_res_mix,
+    fn,
+    hc_scale,
+    hc_base,
+    rms_eps,
+    hc_pre_eps,
+    hc_sinkhorn_eps,
+    hc_post_mult_value,
+    sinkhorn_repeat,
+    n_splits=1,
+    tile_n=1,
+    norm_weight=None,
+    norm_eps=0.0,
+):
+    residual_cur, post_mix, comb_mix, layer_input = backend.mhc_fused_post_pre(
+        x,
+        residual,
+        post_layer_mix,
+        comb_res_mix,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+        n_splits,
+        tile_n,
+    )
+    return (
+        residual_cur,
+        post_mix,
+        comb_mix,
+        mhc._apply_mhc_norm(layer_input, norm_weight, norm_eps),
+    )
+
+
+def _bind_glm5next_boltops_mhc(layer, mhc, backend) -> None:
+    """Bind GLM5Next to BoltOPs while preserving the official main ABI."""
+
+    layer.mhc_pre_op._forward_method = functools.partial(
+        _boltops_mhc_pre, backend, mhc
+    )
+    layer.mhc_post_op._forward_method = functools.partial(
+        _boltops_mhc_post, backend
+    )
+    layer.mhc_fused_post_pre_op._forward_method = functools.partial(
+        _boltops_mhc_fused_post_pre,
+        backend,
+        mhc,
+    )
+
+
+def _patch_glm5next_boltops_mhc(glm_model: ModuleType) -> bool:
     decoder_cls = vars(glm_model).get("Glm5NextDecoderLayer")
     if not isinstance(decoder_cls, type):
         raise PatchCompatibilityError(
@@ -154,7 +259,7 @@ def _patch_glm5next_native_mhc(glm_model: ModuleType) -> bool:
     )
     if getattr(decoder_cls, _MHC_PATCH_MARKER, False):
         if not getattr(original, _MHC_WRAPPER_MARKER, False):
-            raise PatchCompatibilityError("GLM5Next native-mHC patch marker is stale")
+            raise PatchCompatibilityError("GLM5Next BoltOPs-mHC patch marker is stale")
         return False
 
     @functools.wraps(original)
@@ -182,8 +287,9 @@ def _patch_glm5next_native_mhc(glm_model: ModuleType) -> bool:
             self, "is_mtp_layer", False
         ):
             from vllm.model_executor.layers import mhc
+            from vllm_hcu.model_executor.layers import mhc as boltops_mhc
 
-            _bind_glm5next_native_mhc(self, mhc)
+            _bind_glm5next_boltops_mhc(self, mhc, boltops_mhc)
 
     setattr(hcu_decoder_init, _MHC_WRAPPER_MARKER, True)
     setattr(decoder_cls, "_vllm_hcu_original_init", original)
@@ -460,7 +566,7 @@ def _dequantize_channel_fp8(
 def apply_to_module(module: ModuleType) -> bool:
     glm_model = load_exact_module(TARGET_MODULE, module)
     changed = _patch_multimodal_quant_ignore(glm_model)
-    changed = _patch_glm5next_native_mhc(glm_model) or changed
+    changed = _patch_glm5next_boltops_mhc(glm_model) or changed
     kpool = sys.modules.get(KPOOL_MODULE)
     if isinstance(kpool, ModuleType):
         changed = _patch_sparse_indexer_kpool(kpool)

--- a/vllm_hcu/patch/worker/core_fix/patch_qwen4_exp.py
+++ b/vllm_hcu/patch/worker/core_fix/patch_qwen4_exp.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
-"""Normalize `tie_word_embeddings` for Qwen4-Exp constructors."""
+"""Normalize `tie_word_embeddings` for HCU Qwen4-Exp constructors."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ from ._common import (
     require_class,
 )
 
-TARGET_MODULE = "vllm.models.qwen4_exp"
+TARGET_MODULE = "vllm.models.qwen4_exp.amd.model"
 TARGET_MODULES = (
     TARGET_MODULE,
     "vllm.model_executor.models.qwen4_exp",

--- a/vllm_hcu/patch/worker/core_fix/patch_rocm_mla_sparse_metadata.py
+++ b/vllm_hcu/patch/worker/core_fix/patch_rocm_mla_sparse_metadata.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Allow Triton sparse MLA with an AITER build lacking metadata helpers."""
+
+from __future__ import annotations
+
+import functools
+import importlib
+from types import ModuleType
+
+import torch
+
+from ._common import (
+    PatchCompatibilityError,
+    load_exact_module,
+    require_callable,
+    require_class,
+)
+
+TARGET_MODULE = "vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse"
+PATCH_ID = "worker.core_fix.rocm_mla_sparse.triton_metadata_fallback"
+_MARKER = "_vllm_hcu_rocm_mla_sparse_metadata_fallback_applied"
+_WRAPPER_MARKER = "_vllm_hcu_rocm_mla_sparse_metadata_init_wrapper"
+
+
+def _empty_metadata_info(*args, **kwargs):
+    del args, kwargs
+    return ((0, torch.int32),) * 6
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    sparse = load_exact_module(TARGET_MODULE, module)
+    builder = require_class(
+        sparse,
+        "ROCMAiterMLASparseMetadataBuilder",
+        f"{TARGET_MODULE}.ROCMAiterMLASparseMetadataBuilder",
+    )
+    original = require_callable(
+        builder,
+        "__init__",
+        f"{TARGET_MODULE}.ROCMAiterMLASparseMetadataBuilder.__init__",
+    )
+    if getattr(sparse, _MARKER, False):
+        if not getattr(vars(builder).get("__init__"), _WRAPPER_MARKER, False):
+            raise PatchCompatibilityError(
+                f"required HCU patch marker for {TARGET_MODULE} is stale"
+            )
+        return False
+
+    @functools.wraps(original)
+    def hcu_builder_init(self, *args, **kwargs):
+        aiter = importlib.import_module("aiter")
+        if hasattr(aiter, "get_mla_metadata_info_v1"):
+            return original(self, *args, **kwargs)
+
+        # This HCU AITER build intentionally carries MoE kernels but not the
+        # upstream sparse-MLA metadata API.  The rope-free BF16 GLM path uses
+        # vLLM's Triton sparse attention, so persistent AITER metadata is dead
+        # state.  Let upstream initialize its remaining buffers unchanged.
+        aiter.get_mla_metadata_info_v1 = _empty_metadata_info
+        try:
+            original(self, *args, **kwargs)
+        finally:
+            if getattr(aiter, "get_mla_metadata_info_v1", None) is _empty_metadata_info:
+                delattr(aiter, "get_mla_metadata_info_v1")
+        self._use_persistent_metadata = False
+
+    setattr(hcu_builder_init, _WRAPPER_MARKER, True)
+    setattr(builder, "_vllm_hcu_original_init", original)
+    setattr(builder, "__init__", hcu_builder_init)
+    setattr(sparse, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/worker/op_opt/patch_glm5next_kda_conv_weight.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_glm5next_kda_conv_weight.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Adapt GLM5Next KDA short-conv weights at the HCU NN-layout boundary."""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+import torch
+
+from ._common import (
+    PatchCompatibilityError,
+    load_exact_module,
+    require_callable,
+    require_exact_signature,
+)
+from ._gdn_common import use_nn_layout
+
+
+TARGET_MODULE = "vllm.models.glm5next.nvidia.kda"
+TARGET_CLASS = "Glm5NextLinearAttention"
+PATCH_ID = "worker.op_opt.mamba.glm5next_kda_conv_weight"
+TARGET_SYMBOL = f"{TARGET_MODULE}.{TARGET_CLASS}._forward"
+_PATCH_MARKER = "_vllm_hcu_glm5next_kda_conv_weight_applied"
+_WRAPPER_MARKER = "_vllm_hcu_glm5next_kda_conv_weight_wrapper"
+
+
+def _logical_conv_weight(module, projection_size: int, conv_size: int):
+    weight = module.weight
+    logical_shape = (projection_size, 1, conv_size)
+    physical_shape = (conv_size, 1, projection_size)
+    shape = tuple(weight.shape)
+    if shape == logical_shape:
+        return weight.reshape(projection_size, conv_size)
+    if shape == physical_shape:
+        return weight.permute(2, 1, 0).reshape(projection_size, conv_size)
+    raise RuntimeError(
+        "HCU GLM5Next KDA conv weight has an incompatible NN layout: "
+        f"got {shape}, expected {physical_shape} or {logical_shape}"
+    )
+
+
+def _build_merged_conv_weight(layer) -> torch.Tensor:
+    projection_size = int(layer.local_projection_size)
+    conv_size = int(layer.conv_size)
+    weights = (
+        _logical_conv_weight(layer.q_conv1d, projection_size, conv_size),
+        _logical_conv_weight(layer.k_conv1d, projection_size, conv_size),
+        _logical_conv_weight(layer.v_conv1d, projection_size, conv_size),
+    )
+    return torch.cat(weights, dim=0).contiguous()
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    kda = load_exact_module(TARGET_MODULE, module)
+    layer_cls = vars(kda).get(TARGET_CLASS)
+    if not isinstance(layer_cls, type):
+        raise PatchCompatibilityError(
+            f"required class {TARGET_MODULE}.{TARGET_CLASS} is missing"
+        )
+
+    original = require_callable(layer_cls, "_forward", TARGET_SYMBOL)
+    if getattr(layer_cls, _PATCH_MARKER, False):
+        if not getattr(original, _WRAPPER_MARKER, False):
+            raise PatchCompatibilityError(
+                f"required HCU patch marker for {TARGET_SYMBOL} is stale"
+            )
+        return False
+
+    require_exact_signature(
+        original,
+        TARGET_SYMBOL,
+        positional=(
+            "self",
+            "qkv_proj_states",
+            "g1",
+            "beta",
+            "core_attn_out",
+        ),
+    )
+
+    @functools.wraps(original)
+    def hcu_forward(self, qkv_proj_states, g1, beta, core_attn_out):
+        if use_nn_layout() and self._merged_conv_weight is None:
+            # vLLM merges q/k/v only after viewing each [out, 1, kernel]
+            # tensor. HCU NN storage reverses that shape to [kernel, 1, out],
+            # so each projection must be restored before concatenation. A
+            # transpose of the already merged [3*kernel, out] tensor cannot
+            # recover the official [3*out, kernel] ordering.
+            self._merged_conv_weight = _build_merged_conv_weight(self)
+        return original(self, qkv_proj_states, g1, beta, core_attn_out)
+
+    setattr(hcu_forward, _WRAPPER_MARKER, True)
+    setattr(layer_cls, "_vllm_hcu_original_forward", original)
+    setattr(layer_cls, "_forward", hcu_forward)
+    setattr(layer_cls, _PATCH_MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = [
+    "PATCH_ID",
+    "TARGET_CLASS",
+    "TARGET_MODULE",
+    "TARGET_SYMBOL",
+    "apply",
+    "apply_to_module",
+]

--- a/vllm_hcu/platforms/hcu.py
+++ b/vllm_hcu/platforms/hcu.py
@@ -661,9 +661,9 @@ class HCUPlatform(Platform):
     def update_block_size_for_backend(cls, vllm_config: "VllmConfig") -> None:
         # Preserve upstream backend/hybrid alignment first. Sparse MLA models
         # also contain an indexer attention layer, which upstream can discover
-        # before the configured MLA backend and therefore reset the page size
-        # to 16. Apply the configured HCU kernel's hard page-size constraint
-        # last so both the pre-fork config and worker-local config stay aligned.
+        # before the configured MLA backend and therefore select a 16-token
+        # block. Keep the manager block at least 64 and 64-aligned without
+        # shrinking a larger hybrid block selected by upstream.
         super().update_block_size_for_backend(vllm_config)
 
         cache_config = getattr(vllm_config, "cache_config", None)
@@ -677,11 +677,18 @@ class HCUPlatform(Platform):
                 AttentionBackendEnum.FLASHMLA,
                 AttentionBackendEnum.FLASHMLA_SPARSE,
             )
-            and cache_config.block_size != 64
+            and (
+                cache_config.block_size < 64
+                or cache_config.block_size % 64 != 0
+            )
         ):
-            cache_config.block_size = 64
+            cache_config.block_size = max(
+                64,
+                ((cache_config.block_size + 63) // 64) * 64,
+            )
             logger.info(
-                "Setting kv cache block size to 64 for HCU %s backend.",
+                "Aligning kv cache block size to %d for HCU %s backend.",
+                cache_config.block_size,
                 backend.name,
             )
 

--- a/vllm_hcu/runtime_compat/base_linear_parameter.py
+++ b/vllm_hcu/runtime_compat/base_linear_parameter.py
@@ -174,13 +174,22 @@ def _nn_layout_enabled() -> bool:
 
 
 def _nn_storage_dim(data: Any, logical_dim: int) -> int | None:
-    """Return the transposed physical dimension for a 2-D NN-layout tensor."""
+    """Return the reversed physical dimension for an NN-layout tensor."""
 
-    if getattr(data, "ndim", None) != 2:
+    ndim = getattr(data, "ndim", None)
+    if ndim is None or ndim < 2:
         return None
-    if logical_dim not in (0, 1):
-        raise _fail(f"NN layout requires logical dimension 0 or 1, got {logical_dim}")
-    return 1 - logical_dim
+    if logical_dim < 0 or logical_dim >= ndim:
+        raise _fail(
+            f"NN layout dimension {logical_dim} is invalid for a {ndim}-D tensor"
+        )
+    return ndim - 1 - logical_dim
+
+
+def _to_nn_layout(tensor: Any) -> Any:
+    """Reverse logical dimensions to match HCU NN physical storage."""
+
+    return tensor.permute(tuple(range(tensor.ndim - 1, -1, -1)))
 
 
 def _verify_parent_exports(module: ModuleType) -> None:
@@ -311,16 +320,19 @@ def _install_base_linear_parameter_compat_unlocked(
         # tensor that has already been narrowed to this TP rank.  The latter
         # is common for Mamba weights loaded through weight_loader_v2.  Do not
         # narrow an already-local shard a second time.
-        if loaded_weight.transpose(0, 1).shape == self.data.shape:
-            self.data.copy_(loaded_weight.t())
+        loaded_weight_nn = _to_nn_layout(loaded_weight)
+        if loaded_weight_nn.shape == self.data.shape:
+            self.data.copy_(loaded_weight_nn)
             return
 
         shard_size = self.data.shape[storage_dim]
-        loaded_weight = loaded_weight.narrow(
-            self.output_dim,
-            self.tp_rank * shard_size,
-            shard_size,
-        ).t()
+        loaded_weight = _to_nn_layout(
+            loaded_weight.narrow(
+                self.output_dim,
+                self.tp_rank * shard_size,
+                shard_size,
+            )
+        )
         if self.data.shape != loaded_weight.shape:
             raise AssertionError(
                 "HCU NN-layout column weight shape mismatch: "

--- a/vllm_hcu/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm_hcu/v1/attention/backends/mla/flashmla_sparse.py
@@ -24,6 +24,15 @@ class HcuFlashMLASparseImpl(FlashMLASparseImpl):
         attn_metadata,
         layer,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        # Match the official ROCm sparse-MLA handling for native NoPE models.
+        # The stable concat_mla_q kernel only accepts a 64-wide RoPE component,
+        # so materialize the zero-RoPE query in the preallocated graph buffer.
+        if isinstance(q, tuple) and q[1].shape[-1] == 0:
+            ql_nope, _ = q
+            q_buffer = self.q_concat_buffer[: ql_nope.shape[0]]
+            q_buffer[:, : ql_nope.shape[1], :].copy_(ql_nope)
+            q = q_buffer[:, : ql_nope.shape[1], :]
+
         if self.dcp_world_size <= 1:
             return super().forward_mqa(
                 q,
@@ -88,6 +97,12 @@ class HcuFlashMLASparseImpl(FlashMLASparseImpl):
 
 
 class HcuFlashMLASparseBackend(FlashMLASparseBackend):
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        # vLLM selects an MLA backend with kv_lora_rank + qk_rope_head_dim.
+        # GLM5Next therefore selects D512, while DeepSeek uses D576.
+        return [512, 576]
+
     @staticmethod
     def get_name() -> str:
         return "FLASHMLA_SPARSE"


### PR DESCRIPTION
## Summary
- align the HCU plugin with the OpenDAS vLLM main build based on official main commit 58ad1f3
- support GLM-5.3-Flash-Channel-FP8-w8a8, including channel-wise FP8 linear paths and GLM-5.3 model registration
- bind GLM-5.3 mHC pre/post/fused operations to the HCU BoltOPs provider
- avoid Qwen4Exp config circular imports by patching the concrete HCU model module instead of the lazy model package
- classify Qwen3.5/Qwen4Exp MTP draft KV groups at the official KV-cache grouping boundary while keeping the official Qwen3.5 scheduler and block size
- retain self-developed AITER config-first MoE selection with vLLM Triton fallback when no matching config exists

## Validation
- runtime patch suite: 1084 passed
- GLM-5.3-Flash-Channel-FP8-w8a8: TP4, FLASHMLA_SPARSE, AITER, MTP3, PIECEWISE graph, HumanEval 8/8
- Qwen3-8B: TP1, FLASH_ATTN, PIECEWISE graph, HumanEval 8/8
- Qwen3.8-Flash-Next-FP8-Channelwise: TP4, FLASH_ATTN, AITER config-first with Triton fallback, MTP3, PIECEWISE graph, HumanEval 8/8
- Qwen3.5-35B-A3B: TP4, FLASH_ATTN, AITER config-first with Triton fallback, MTP3, PIECEWISE graph, HumanEval 8/8; draft KV group is identified without a scheduler/block-size override
- GLM-5-W8A8: TP8, FLASHMLA_SPARSE, AITER Int8 W8A8 config hit, MTP3, PIECEWISE graph, HumanEval 8/8 with enable_thinking=false
- all 8 HCU cards released after validation

## Notes
- GLM-5-W8A8 is approximately 704 GiB and requires TP8 on the available 8 x 144 GiB cards; TP4 fails at model construction due to capacity.
- Legacy GLM-5 uses chat_template_kwargs.enable_thinking=false; reasoning_effort=low does not disable its reasoning template and causes generation to hit max_tokens.
