### PR TITLE
fix(hcu): support Qwen3 DSpark NN weight layout

### DIFF
--- a/tests/runtime_patch/test_qwen3_dflash_nn_layout.py
+++ b/tests/runtime_patch/test_qwen3_dflash_nn_layout.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm_hcu.patch.worker.core_fix._common import PatchCompatibilityError
+
+
+TARGET_MODULE = "vllm.model_executor.models.qwen3_dflash"
+
+
+def _upstream_module() -> ModuleType:
+    module = ModuleType(TARGET_MODULE)
+
+    class DFlashQwen3Model:
+        def _build_context_kv_buffers(self, layers_attn, has_bias):
+            self._hidden_norm_weight = self.hidden_norm.weight.data
+            kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
+            self._fused_kv_weight = torch.cat(kv_weights, dim=0)
+            if has_bias:
+                self._fused_kv_bias = torch.cat(
+                    [a.qkv_proj.bias[a.q_size :] for a in layers_attn], dim=0
+                )
+            else:
+                self._fused_kv_bias = None
+            self._k_norm_weights = torch.stack(
+                [a.k_norm.weight.data for a in layers_attn], dim=0
+            ).contiguous()
+
+    module.DFlashQwen3Model = DFlashQwen3Model
+    return module
+
+
+def _attention(
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    k_norm: torch.Tensor,
+    *,
+    input_size: int | None = None,
+    is_quantization: bool = False,
+):
+    return SimpleNamespace(
+        q_size=2,
+        kv_size=2,
+        qkv_proj=SimpleNamespace(
+            weight=weight,
+            bias=bias,
+            input_size=weight.shape[0] if input_size is None else input_size,
+            is_quantization=is_quantization,
+        ),
+        k_norm=SimpleNamespace(weight=k_norm),
+    )
+
+
+def test_nn_layout_builds_output_major_context_kv_projection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    try:
+        patch = importlib.import_module(
+            "vllm_hcu.patch.worker.core_fix.patch_qwen3_dflash_nn_layout"
+        )
+    except ModuleNotFoundError:
+        pytest.fail("Qwen3 DSpark NN-layout compatibility patch is missing")
+
+    module = _upstream_module()
+    monkeypatch.setattr(patch, "_use_nn_layout", lambda: True)
+    assert patch.apply_to_module(module) is True
+
+    model = module.DFlashQwen3Model()
+    hidden_norm = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    model.hidden_norm = SimpleNamespace(weight=hidden_norm)
+    first = _attention(
+        torch.tensor(
+            [
+                [1.0, 2.0, 10.0, 11.0, 12.0, 13.0],
+                [3.0, 4.0, 20.0, 21.0, 22.0, 23.0],
+                [5.0, 6.0, 30.0, 31.0, 32.0, 33.0],
+                [7.0, 8.0, 40.0, 41.0, 42.0, 43.0],
+            ]
+        ),
+        torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
+        torch.tensor([0.5, 1.5]),
+    )
+    second = _attention(
+        torch.tensor(
+            [
+                [101.0, 102.0, 110.0, 111.0, 112.0, 113.0],
+                [103.0, 104.0, 120.0, 121.0, 122.0, 123.0],
+                [105.0, 106.0, 130.0, 131.0, 132.0, 133.0],
+                [107.0, 108.0, 140.0, 141.0, 142.0, 143.0],
+            ]
+        ),
+        torch.tensor([10.0, 11.0, 12.0, 13.0, 14.0, 15.0]),
+        torch.tensor([2.5, 3.5]),
+    )
+
+    model._build_context_kv_buffers([first, second], has_bias=True)
+
+    assert model._fused_kv_weight.shape == (8, 4)
+    projected = F.linear(
+        torch.tensor([[1.0, 2.0, 3.0, 4.0]]),
+        model._fused_kv_weight,
+        model._fused_kv_bias,
+    )
+    torch.testing.assert_close(
+        projected,
+        torch.tensor(
+            [[302.0, 313.0, 324.0, 335.0, 1312.0, 1323.0, 1334.0, 1345.0]]
+        ),
+    )
+    assert model._hidden_norm_weight.data_ptr() == hidden_norm.data_ptr()
+    torch.testing.assert_close(
+        model._k_norm_weights,
+        torch.tensor([[0.5, 1.5], [2.5, 3.5]]),
+    )
+
+
+def test_non_nn_layout_delegates_to_upstream_and_patch_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch = importlib.import_module(
+        "vllm_hcu.patch.worker.core_fix.patch_qwen3_dflash_nn_layout"
+    )
+    module = _upstream_module()
+    original = module.DFlashQwen3Model._build_context_kv_buffers
+    monkeypatch.setattr(patch, "_use_nn_layout", lambda: False)
+
+    assert patch.apply_to_module(module) is True
+    wrapped = module.DFlashQwen3Model._build_context_kv_buffers
+    assert wrapped is not original
+    assert patch.apply_to_module(module) is False
+    assert module.DFlashQwen3Model._build_context_kv_buffers is wrapped
+
+    model = module.DFlashQwen3Model()
+    model.hidden_norm = SimpleNamespace(weight=torch.ones(4))
+    attention = _attention(
+        torch.arange(24, dtype=torch.float32).reshape(6, 4),
+        torch.arange(6, dtype=torch.float32),
+        torch.ones(2),
+    )
+
+    model._build_context_kv_buffers([attention], has_bias=False)
+
+    torch.testing.assert_close(
+        model._fused_kv_weight,
+        attention.qkv_proj.weight[attention.q_size :],
+    )
+    assert model._fused_kv_bias is None
+
+
+def test_nn_layout_delegates_output_major_quantized_weights(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch = importlib.import_module(
+        "vllm_hcu.patch.worker.core_fix.patch_qwen3_dflash_nn_layout"
+    )
+    module = _upstream_module()
+    monkeypatch.setattr(patch, "_use_nn_layout", lambda: True)
+    assert patch.apply_to_module(module) is True
+
+    model = module.DFlashQwen3Model()
+    model.hidden_norm = SimpleNamespace(weight=torch.ones(4))
+    attention = _attention(
+        torch.arange(24, dtype=torch.float32).reshape(6, 4),
+        torch.arange(6, dtype=torch.float32),
+        torch.ones(2),
+        input_size=4,
+        is_quantization=True,
+    )
+
+    model._build_context_kv_buffers([attention], has_bias=False)
+
+    torch.testing.assert_close(
+        model._fused_kv_weight,
+        attention.qkv_proj.weight[attention.q_size :],
+    )
+
+
+def test_nn_layout_rejects_unexpected_unquantized_weight_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch = importlib.import_module(
+        "vllm_hcu.patch.worker.core_fix.patch_qwen3_dflash_nn_layout"
+    )
+    module = _upstream_module()
+    monkeypatch.setattr(patch, "_use_nn_layout", lambda: True)
+    assert patch.apply_to_module(module) is True
+
+    model = module.DFlashQwen3Model()
+    model.hidden_norm = SimpleNamespace(weight=torch.ones(4))
+    attention = _attention(
+        torch.arange(24, dtype=torch.float32).reshape(6, 4),
+        torch.arange(6, dtype=torch.float32),
+        torch.ones(2),
+        input_size=4,
+    )
+
+    with pytest.raises(PatchCompatibilityError, match="expected .* got"):
+        model._build_context_kv_buffers([attention], has_bias=False)

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -223,6 +223,7 @@ _CORE_CALLBACKS: tuple[_CallbackSpec, ...] = (
     _CallbackSpec(_adapter("core_fix", "patch_deepseek_v4_rocm_wo_a_layout")),
     _CallbackSpec(_adapter("core_fix", "patch_gpt_oss_mlp_block")),
     _CallbackSpec(_adapter("core_fix", "patch_qwen3_5_mamba_state_dtype")),
+    _CallbackSpec(_adapter("core_fix", "patch_qwen3_dflash_nn_layout")),
     _CallbackSpec(_adapter("core_fix", "patch_qwen3_vl")),
     _CallbackSpec(_adapter("core_fix", "patch_qwen3_vl_moe")),
 )

--- a/vllm_hcu/patch/worker/core_fix/__init__.py
+++ b/vllm_hcu/patch/worker/core_fix/__init__.py
@@ -17,6 +17,7 @@ from . import (
     patch_gpt_oss_mlp_block,
     patch_mhc_backend,
     patch_qwen3_5_mamba_state_dtype,
+    patch_qwen3_dflash_nn_layout,
     patch_qwen3_vl,
     patch_qwen3_vl_moe,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "patch_gpt_oss_mlp_block",
     "patch_mhc_backend",
     "patch_qwen3_5_mamba_state_dtype",
+    "patch_qwen3_dflash_nn_layout",
     "patch_qwen3_vl",
     "patch_qwen3_vl_moe",
 ]

--- a/vllm_hcu/patch/worker/core_fix/patch_qwen3_dflash_nn_layout.py
+++ b/vllm_hcu/patch/worker/core_fix/patch_qwen3_dflash_nn_layout.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Adapt Qwen3 DSpark context-KV fusion to the HCU NN weight layout."""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+import torch
+
+from ._common import (
+    PatchCompatibilityError,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_exact_signature,
+)
+
+TARGET_MODULE = "vllm.model_executor.models.qwen3_dflash"
+PATCH_ID = "worker.core_fix.qwen3_dflash.nn_layout"
+TARGET_SYMBOL = f"{TARGET_MODULE}.DFlashQwen3Model._build_context_kv_buffers"
+_CLASS_MARKER = "_vllm_hcu_qwen3_dflash_nn_layout_applied"
+_WRAPPER_MARKER = "_vllm_hcu_qwen3_dflash_nn_layout_wrapper"
+
+
+def _use_nn_layout() -> bool:
+    try:
+        from vllm_hcu.platforms import envs as henvs
+
+        return bool(henvs.VLLM_USE_NN)
+    except (AttributeError, ImportError) as exc:
+        raise PatchCompatibilityError(
+            "required HCU NN weight-layout feature flag is unavailable"
+        ) from exc
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    qwen3_dflash = load_exact_module(TARGET_MODULE, module)
+    model_class = require_class(
+        qwen3_dflash,
+        "DFlashQwen3Model",
+        f"{TARGET_MODULE}.DFlashQwen3Model",
+    )
+    original = require_callable(
+        model_class,
+        "_build_context_kv_buffers",
+        TARGET_SYMBOL,
+    )
+    require_exact_signature(
+        original,
+        TARGET_SYMBOL,
+        positional=("self", "layers_attn", "has_bias"),
+    )
+    if getattr(model_class, _CLASS_MARKER, False):
+        if not getattr(original, _WRAPPER_MARKER, False):
+            raise PatchCompatibilityError(
+                f"required HCU patch marker for {TARGET_SYMBOL} is stale"
+            )
+        return False
+
+    @functools.wraps(original)
+    def hcu_build_context_kv_buffers(self, layers_attn, has_bias):
+        if not _use_nn_layout():
+            return original(self, layers_attn, has_bias)
+
+        try:
+            quantized = [
+                bool(attention.qkv_proj.is_quantization)
+                for attention in layers_attn
+            ]
+        except AttributeError as exc:
+            raise PatchCompatibilityError(
+                f"required HCU NN weight metadata for {TARGET_SYMBOL} is missing"
+            ) from exc
+        if any(quantized):
+            if not all(quantized):
+                raise PatchCompatibilityError(
+                    f"required HCU QKV quantization for {TARGET_SYMBOL} is inconsistent"
+                )
+            return original(self, layers_attn, has_bias)
+
+        self._hidden_norm_weight = self.hidden_norm.weight.data
+        kv_weights = []
+        for attention in layers_attn:
+            projection = attention.qkv_proj
+            weight = projection.weight
+            expected_shape = (
+                projection.input_size,
+                attention.q_size + 2 * attention.kv_size,
+            )
+            if tuple(weight.shape) != expected_shape:
+                raise PatchCompatibilityError(
+                    f"required HCU NN weight layout for {TARGET_SYMBOL} "
+                    f"expected {expected_shape}, got {tuple(weight.shape)}"
+                )
+            kv_weights.append(weight[:, attention.q_size :].transpose(0, 1))
+        self._fused_kv_weight = torch.cat(kv_weights, dim=0).contiguous()
+
+        if has_bias:
+            self._fused_kv_bias = torch.cat(
+                [
+                    attention.qkv_proj.bias[attention.q_size :]
+                    for attention in layers_attn
+                ],
+                dim=0,
+            )
+        else:
+            self._fused_kv_bias = None
+        self._k_norm_weights = torch.stack(
+            [attention.k_norm.weight.data for attention in layers_attn], dim=0
+        ).contiguous()
+
+    setattr(hcu_build_context_kv_buffers, _WRAPPER_MARKER, True)
+    setattr(
+        model_class,
+        "_vllm_hcu_original_build_context_kv_buffers",
+        original,
+    )
+    setattr(
+        model_class,
+        "_build_context_kv_buffers",
+        hcu_build_context_kv_buffers,
+    )
+    setattr(model_class, _CLASS_MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "apply", "apply_to_module"]


### PR DESCRIPTION
## Summary
- adapt Qwen3 DSpark fused context-KV buffers to HCU's NN `[in, out]` QKV weight layout
- preserve the upstream path for `VLLM_USE_NN=False` and quantized output-major weights
- validate the exact physical layout before slicing and add numeric/compatibility regression coverage

## Validation
- `1545 passed` in `tests/runtime_patch` and `tests/patch`
- plugin doctor passes against `vllm==0.25.1+das185.dtk2604.torch2110.2608171710.g7b108a`
- TP2 Qwen3-8B + 7-token DSpark smoke test with default `VLLM_USE_NN=True`: health, models, and chat endpoints returned HTTP 200

## Scope
This PR only addresses the NN weight-layout incompatibility. The separate HCU FULL cudagraph stream-capture issue is intentionally out of scope; the live smoke test used `PIECEWISE`.
