### PR TITLE
fix(hcu): support Qwen3 DSpark NN layout and FULL CUDA graphs

### DIFF
--- a/tests/accuracy/test_hcu_kernel_accuracy.py
+++ b/tests/accuracy/test_hcu_kernel_accuracy.py
@@ -190,6 +190,11 @@ def test_hcu_dspark_flash_attention_forward_accepts_expanded_descales(
     from vllm_hcu.v1.attention.backends import flash_attn as hcu_flash_attn
     from vllm_hcu.v1.attention.backends import fa_utils
 
+    monkeypatch.setattr(
+        hcu_flash_attn,
+        "_get_flash_attn_mode",
+        lambda: "varlen",
+    )
     monkeypatch.setattr(fa_utils, "get_kv_cache_layout", lambda: "NHD")
 
     device = _hcu_device()

--- a/tests/accuracy/test_hcu_kernel_accuracy.py
+++ b/tests/accuracy/test_hcu_kernel_accuracy.py
@@ -81,6 +81,85 @@ def _hcu_device() -> torch.device:
     return torch.device("cuda", 0)
 
 
+@pytest.mark.parametrize(
+    ("query_len", "causal"),
+    [(8, True), (7, False)],
+    ids=["target-verification", "dspark-drafter"],
+)
+def test_hcu_dspark_attention_matches_vendor_and_replays_in_cuda_graph(
+    query_len: int,
+    causal: bool,
+) -> None:
+    from flash_attn import flash_attn_varlen_func as vendor_varlen
+    from vllm_hcu.v1.attention.backends.fa_utils import (
+        _flash_attn_varlen_func_with_dspark_capture as hcu_varlen,
+    )
+
+    device = _hcu_device()
+    torch.manual_seed(42)
+    batch_size, q_heads, kv_heads, head_dim = 2, 16, 4, 128
+    q = torch.randn(
+        (batch_size * query_len, q_heads, head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    kv = torch.randn(
+        (4, 2, 64, kv_heads, head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k, v = kv.unbind(1)
+    cu_seqlens_q = torch.arange(
+        0,
+        (batch_size + 1) * query_len,
+        query_len,
+        device=device,
+        dtype=torch.int32,
+    )
+    seqused_k = torch.tensor(
+        [query_len, 128],
+        device=device,
+        dtype=torch.int32,
+    )
+    block_table = torch.tensor(
+        [[0, 1], [2, 3]],
+        device=device,
+        dtype=torch.int32,
+    )
+    common = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "cu_seqlens_q": cu_seqlens_q,
+        "max_seqlen_q": query_len,
+        "seqused_k": seqused_k,
+        "max_seqlen_k": 128,
+        "softmax_scale": head_dim**-0.5,
+        "causal": causal,
+        "window_size": (-1, -1),
+        "block_table": block_table,
+        "layout": "bshd",
+    }
+    reference_out = torch.empty_like(q)
+    actual_out = torch.empty_like(q)
+
+    reference = vendor_varlen(out=reference_out, **common).clone()
+    actual = hcu_varlen(out=actual_out, **common).clone()
+    torch.cuda.synchronize(device)
+    torch.testing.assert_close(actual, reference, rtol=1e-2, atol=1e-2)
+
+    hcu_varlen(out=actual_out, **common)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        hcu_varlen(out=actual_out, **common)
+    graph.replay()
+    torch.cuda.synchronize(device)
+    replay = actual_out.clone()
+    eager = hcu_varlen(out=actual_out, **common).clone()
+    torch.cuda.synchronize(device)
+    assert torch.equal(replay, eager)
+
+
 @pytest.mark.parametrize("layout", ["NHD", "HND"])
 @pytest.mark.parametrize(
     "cache_storage_dtype",

--- a/tests/accuracy/test_hcu_kernel_accuracy.py
+++ b/tests/accuracy/test_hcu_kernel_accuracy.py
@@ -152,12 +152,80 @@ def test_hcu_dspark_attention_matches_vendor_and_replays_in_cuda_graph(
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         hcu_varlen(out=actual_out, **common)
+
+    # Change captured inputs in place and poison the prior output so this test
+    # fails if replay is a no-op or reuses the warmup result.
+    q.neg_()
+    actual_out.fill_(float("nan"))
     graph.replay()
+    replay_reference = vendor_varlen(out=reference_out, **common).clone()
     torch.cuda.synchronize(device)
     replay = actual_out.clone()
-    eager = hcu_varlen(out=actual_out, **common).clone()
+    assert not torch.isnan(replay).any().item()
+    torch.testing.assert_close(replay, replay_reference, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize(
+    ("q_heads", "expected_paged_route"),
+    [(8, True), (9, False)],
+    ids=["flattened-head-limit", "above-flattened-head-limit"],
+)
+def test_hcu_dspark_paged_attention_head_limit_matches_vendor(
+    q_heads: int,
+    expected_paged_route: bool,
+) -> None:
+    from flash_attn import flash_attn_varlen_func as vendor_varlen
+    from vllm_hcu.v1.attention.backends.fa_utils import (
+        _flash_attn_varlen_func_with_dspark_capture as hcu_varlen,
+        _matches_dspark_attention_shape,
+    )
+
+    device = _hcu_device()
+    torch.manual_seed(42)
+    query_len, kv_heads, head_dim = 8, 1, 128
+    q = torch.randn(
+        (query_len, q_heads, head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    kv = torch.randn(
+        (1, 2, 64, kv_heads, head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k, v = kv.unbind(1)
+    common = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "cu_seqlens_q": torch.tensor(
+            [0, query_len], device=device, dtype=torch.int32
+        ),
+        "max_seqlen_q": query_len,
+        "seqused_k": torch.tensor([64], device=device, dtype=torch.int32),
+        "max_seqlen_k": 64,
+        "softmax_scale": head_dim**-0.5,
+        "causal": True,
+        "window_size": (-1, -1),
+        "block_table": torch.tensor([[0]], device=device, dtype=torch.int32),
+        "layout": "bshd",
+    }
+    reference_out = torch.empty_like(q)
+    actual_out = torch.empty_like(q)
+
+    assert (
+        _matches_dspark_attention_shape(
+            {**common, "out": actual_out},
+            query_len=query_len,
+            causal=True,
+        )
+        is expected_paged_route
+    )
+    reference = vendor_varlen(out=reference_out, **common).clone()
+    actual = hcu_varlen(out=actual_out, **common).clone()
     torch.cuda.synchronize(device)
-    assert torch.equal(replay, eager)
+
+    torch.testing.assert_close(actual, reference, rtol=1e-2, atol=1e-2)
 
 
 @pytest.mark.parametrize("layout", ["NHD", "HND"])

--- a/tests/accuracy/test_hcu_kernel_accuracy.py
+++ b/tests/accuracy/test_hcu_kernel_accuracy.py
@@ -126,6 +126,13 @@ def test_hcu_dspark_attention_matches_vendor_and_replays_in_cuda_graph(
         device=device,
         dtype=torch.int32,
     )
+    q_descale = torch.tensor(1.0, device=device).expand(batch_size, kv_heads)
+    k_descale = torch.tensor(1.0, device=device).expand(batch_size, kv_heads)
+    v_descale = torch.tensor(1.0, device=device).expand(batch_size, kv_heads)
+    for scale in (q_descale, k_descale, v_descale):
+        assert scale.dtype == torch.float32
+        assert scale.stride() == (0, 0)
+        assert not scale.is_contiguous()
     common = {
         "q": q,
         "k": k,
@@ -139,6 +146,9 @@ def test_hcu_dspark_attention_matches_vendor_and_replays_in_cuda_graph(
         "window_size": (-1, -1),
         "block_table": block_table,
         "layout": "bshd",
+        "q_descale": q_descale,
+        "k_descale": k_descale,
+        "v_descale": v_descale,
     }
     reference_out = torch.empty_like(q)
     actual_out = torch.empty_like(q)
@@ -163,6 +173,236 @@ def test_hcu_dspark_attention_matches_vendor_and_replays_in_cuda_graph(
     replay = actual_out.clone()
     assert not torch.isnan(replay).any().item()
     torch.testing.assert_close(replay, replay_reference, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize(
+    ("query_len", "causal"),
+    [(8, True), (7, False)],
+    ids=["target-verification", "dspark-drafter"],
+)
+def test_hcu_dspark_flash_attention_forward_accepts_expanded_descales(
+    monkeypatch: pytest.MonkeyPatch,
+    query_len: int,
+    causal: bool,
+) -> None:
+    """Run expanded production descales through eager, capture, and replay."""
+    from flash_attn import flash_attn_varlen_func as vendor_varlen
+    from vllm_hcu.v1.attention.backends import flash_attn as hcu_flash_attn
+    from vllm_hcu.v1.attention.backends import fa_utils
+
+    monkeypatch.setattr(fa_utils, "get_kv_cache_layout", lambda: "NHD")
+
+    device = _hcu_device()
+    torch.manual_seed(42)
+    batch_size, q_heads, kv_heads, head_dim = 2, 16, 4, 128
+    q = torch.randn(
+        (batch_size * query_len, q_heads, head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    key = torch.zeros(
+        (batch_size * query_len, kv_heads, head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    kv_cache = torch.randn(
+        (4, 2, 64, kv_heads, head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k, v = kv_cache.unbind(1)
+    cu_seqlens_q = torch.arange(
+        0,
+        (batch_size + 1) * query_len,
+        query_len,
+        device=device,
+        dtype=torch.int32,
+    )
+    seqused_k = torch.tensor(
+        [query_len, 128],
+        device=device,
+        dtype=torch.int32,
+    )
+    block_table = torch.tensor(
+        [[0, 1], [2, 3]],
+        device=device,
+        dtype=torch.int32,
+    )
+    layer = SimpleNamespace(
+        _q_scale=torch.tensor(1.0, device=device),
+        _k_scale=torch.tensor(1.0, device=device),
+        _v_scale=torch.tensor(1.0, device=device),
+    )
+    descale_shape = (batch_size, kv_heads)
+    q_descale = layer._q_scale.expand(descale_shape)
+    k_descale = layer._k_scale.expand(descale_shape)
+    v_descale = layer._v_scale.expand(descale_shape)
+    for scale in (q_descale, k_descale, v_descale):
+        assert scale.stride() == (0, 0)
+        assert not scale.is_contiguous()
+
+    metadata = SimpleNamespace(
+        num_actual_tokens=batch_size * query_len,
+        use_cascade=False,
+        query_start_loc=cu_seqlens_q,
+        seq_lens=seqused_k,
+        max_query_len=query_len,
+        max_seq_len=128,
+        block_table=block_table,
+        scheduler_metadata=None,
+        causal=causal,
+        sliding_window=None,
+    )
+    impl = object.__new__(hcu_flash_attn.FlashAttentionImpl)
+    impl.vllm_flash_attn_version = 3
+    impl.attn_type = hcu_flash_attn.AttentionType.DECODER
+    impl.kv_cache_dtype = "auto"
+    impl.num_kv_heads = kv_heads
+    impl.supports_quant_query_input = True
+    impl.dcp_world_size = 1
+    impl.scale = head_dim**-0.5
+    impl.alibi_slopes = None
+    impl.logits_soft_cap = 0.0
+    impl.sinks = None
+    impl.sliding_window = (-1, -1)
+    assert hcu_flash_attn._get_flash_attn_mode() == "varlen"
+
+    common = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "cu_seqlens_q": cu_seqlens_q,
+        "max_seqlen_q": query_len,
+        "seqused_k": seqused_k,
+        "max_seqlen_k": 128,
+        "softmax_scale": head_dim**-0.5,
+        "causal": causal,
+        "window_size": (-1, -1),
+        "block_table": block_table,
+        "layout": "bshd",
+        "q_descale": q_descale,
+        "k_descale": k_descale,
+        "v_descale": v_descale,
+    }
+    reference_out = torch.empty_like(q)
+    actual_out = torch.empty_like(q)
+
+    reference = vendor_varlen(out=reference_out, **common).clone()
+    actual = impl.forward(
+        layer,
+        q,
+        key,
+        key,
+        kv_cache,
+        metadata,
+        actual_out,
+    ).clone()
+    torch.cuda.synchronize(device)
+    torch.testing.assert_close(actual, reference, rtol=1e-2, atol=1e-2)
+
+    impl.forward(layer, q, key, key, kv_cache, metadata, actual_out)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        impl.forward(layer, q, key, key, kv_cache, metadata, actual_out)
+
+    q.neg_()
+    actual_out.fill_(float("nan"))
+    graph.replay()
+    replay_reference = vendor_varlen(out=reference_out, **common).clone()
+    torch.cuda.synchronize(device)
+    replay = actual_out.clone()
+    assert not torch.isnan(replay).any().item()
+    torch.testing.assert_close(replay, replay_reference, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("batch_size", [1, 64, 73])
+def test_hcu_dspark_eager_drafter_avoids_static_kv_scratch(
+    batch_size: int,
+) -> None:
+    """Keep eager qlen=7 scratch proportional to used KV, not max context."""
+    from vllm_hcu.v1.attention.backends.fa_utils import (
+        _flash_attn_varlen_func_with_dspark_capture as hcu_varlen,
+    )
+
+    device = _hcu_device()
+    assert not torch.cuda.is_current_stream_capturing()
+    query_len, q_heads, kv_heads, head_dim = 7, 16, 4, 128
+    max_seqlen_k = 4096
+    used_seqlen_k = 64
+    q = torch.randn(
+        (batch_size * query_len, q_heads, head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    kv = torch.randn(
+        (batch_size, 2, 64, kv_heads, head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k, v = kv.unbind(1)
+    out = torch.empty_like(q)
+    cu_seqlens_q = torch.arange(
+        0,
+        (batch_size + 1) * query_len,
+        query_len,
+        device=device,
+        dtype=torch.int32,
+    )
+    seqused_k = torch.full(
+        (batch_size,),
+        used_seqlen_k,
+        device=device,
+        dtype=torch.int32,
+    )
+    block_table = torch.zeros(
+        (batch_size, max_seqlen_k // 64),
+        device=device,
+        dtype=torch.int32,
+    )
+    block_table[:, 0] = torch.arange(batch_size, device=device)
+    scales = tuple(
+        torch.tensor(1.0, device=device).expand(batch_size, kv_heads)
+        for _ in range(3)
+    )
+    common = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "out": out,
+        "cu_seqlens_q": cu_seqlens_q,
+        "max_seqlen_q": query_len,
+        "seqused_k": seqused_k,
+        "max_seqlen_k": max_seqlen_k,
+        "softmax_scale": head_dim**-0.5,
+        "causal": False,
+        "window_size": (-1, -1),
+        "block_table": block_table,
+        "layout": "bshd",
+        "q_descale": scales[0],
+        "k_descale": scales[1],
+        "v_descale": scales[2],
+    }
+
+    hcu_varlen(**common)
+    torch.cuda.synchronize(device)
+    torch.cuda.empty_cache()
+    baseline = torch.cuda.memory_allocated(device)
+    torch.cuda.reset_peak_memory_stats(device)
+    hcu_varlen(**common)
+    torch.cuda.synchronize(device)
+    peak_delta = torch.cuda.max_memory_allocated(device) - baseline
+
+    used_kv_bytes = (
+        2
+        * batch_size
+        * used_seqlen_k
+        * kv_heads
+        * head_dim
+        * q.element_size()
+    )
+    # Allow kernel workspace and allocator rounding while rejecting the old
+    # 512/584 MiB batch*max_seqlen_k allocation at batch sizes 64 and 73.
+    assert peak_delta < used_kv_bytes * 4 + 16 * 1024**2
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime_patch/test_flash_attention_and_pp.py
+++ b/tests/runtime_patch/test_flash_attention_and_pp.py
@@ -537,6 +537,11 @@ def test_hcu_varlen_dspark_routes_fail_closed(
         monkeypatch,
         kv_cache_layout="HND" if unsupported_case == "layout" else "NHD",
     )
+    monkeypatch.setattr(
+        torch.cuda,
+        "is_current_stream_capturing",
+        lambda: query_len == 7,
+    )
     batch_size = 2
     q = torch.zeros((batch_size * query_len, 4, 128), dtype=torch.bfloat16)
     k = torch.zeros((4, 64, 2, 128), dtype=torch.bfloat16)

--- a/tests/runtime_patch/test_flash_attention_and_pp.py
+++ b/tests/runtime_patch/test_flash_attention_and_pp.py
@@ -174,6 +174,9 @@ def test_hcu_varlen_routes_dspark_q_len_8_to_paged_attention(
     cu_seqlens_q = torch.tensor([0, 8, 16], dtype=torch.int32)
     seqused_k = torch.tensor([96, 128], dtype=torch.int32)
     block_table = torch.zeros((2, 2), dtype=torch.int32)
+    q_descale = torch.tensor(1.0).expand(2, 2)
+    k_descale = torch.tensor(1.0).expand(2, 2)
+    v_descale = torch.tensor(1.0).expand(2, 2)
 
     result = fa_utils.flash_attn_varlen_func(
         q=q,
@@ -188,6 +191,9 @@ def test_hcu_varlen_routes_dspark_q_len_8_to_paged_attention(
         causal=True,
         window_size=(-1, -1),
         block_table=block_table,
+        q_descale=q_descale,
+        k_descale=k_descale,
+        v_descale=v_descale,
     )
 
     assert result is out
@@ -202,7 +208,10 @@ def test_hcu_varlen_routes_dspark_q_len_8_to_paged_attention(
     assert paged_args[4] == 128**-0.5
     assert paged_args[5] is block_table
     assert paged_args[6] is seqused_k
-    assert paged_args[7:12] == (None, "", None, None, None)
+    assert paged_args[7:9] == (None, "")
+    assert paged_args[9] is q_descale
+    assert paged_args[10] is k_descale
+    assert paged_args[11] is v_descale
     assert paged_args[12:] == (128, None, 2)
 
 
@@ -288,12 +297,75 @@ def test_hcu_varlen_drafter_route_respects_static_kv_scratch_limit(
     )
 
 
+@pytest.mark.parametrize("batch_size", [1, 64, 73])
+def test_hcu_varlen_drafter_uses_vendor_path_outside_graph_capture(
+    monkeypatch: pytest.MonkeyPatch,
+    batch_size: int,
+) -> None:
+    """An eager qlen=7 call must not allocate worst-case static KV scratch."""
+    fa_utils, calls = _load_hcu_fa_utils_module(
+        monkeypatch,
+        kv_cache_layout="NHD",
+    )
+    monkeypatch.setattr(
+        torch.cuda,
+        "is_current_stream_capturing",
+        lambda: False,
+    )
+    gather_calls: list[tuple[object, ...]] = []
+    varlen_calls: list[tuple[object, ...]] = []
+    flash_attn_interface = ModuleType("flash_attn.flash_attn_interface")
+    flash_attn_interface.flash_attn_cuda = SimpleNamespace(
+        pagedkv_to_contiguouskv=lambda *args: gather_calls.append(args),
+        varlen_fwd=lambda *args: varlen_calls.append(args),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        flash_attn_interface.__name__,
+        flash_attn_interface,
+    )
+
+    query_len = 7
+    q = torch.zeros(
+        (batch_size * query_len, 4, 128),
+        dtype=torch.bfloat16,
+    )
+    k = torch.zeros((1, 64, 2, 128), dtype=torch.bfloat16)
+    fa_utils.flash_attn_varlen_func(
+        q=q,
+        k=k,
+        v=torch.zeros_like(k),
+        out=torch.empty_like(q),
+        cu_seqlens_q=torch.arange(
+            0,
+            (batch_size + 1) * query_len,
+            query_len,
+            dtype=torch.int32,
+        ),
+        max_seqlen_q=query_len,
+        seqused_k=torch.full((batch_size,), 64, dtype=torch.int32),
+        max_seqlen_k=4096,
+        causal=False,
+        window_size=(-1, -1),
+        block_table=torch.zeros((batch_size, 64), dtype=torch.int32),
+    )
+
+    assert len(calls["flash_attn_varlen_func"]) == 1
+    assert gather_calls == []
+    assert varlen_calls == []
+
+
 def test_hcu_varlen_routes_dspark_drafter_q_len_7_to_static_varlen(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fa_utils, calls = _load_hcu_fa_utils_module(
         monkeypatch,
         kv_cache_layout="NHD",
+    )
+    monkeypatch.setattr(
+        torch.cuda,
+        "is_current_stream_capturing",
+        lambda: True,
     )
     gather_calls: list[tuple[object, ...]] = []
     varlen_calls: list[tuple[object, ...]] = []
@@ -315,6 +387,9 @@ def test_hcu_varlen_routes_dspark_drafter_q_len_7_to_static_varlen(
     cu_seqlens_q = torch.tensor([0, 7, 14], dtype=torch.int32)
     seqused_k = torch.tensor([96, 128], dtype=torch.int32)
     block_table = torch.zeros((2, 2), dtype=torch.int32)
+    q_descale = torch.tensor(1.0).expand(2, 2)
+    k_descale = torch.tensor(1.0).expand(2, 2)
+    v_descale = torch.tensor(1.0).expand(2, 2)
 
     result = fa_utils.flash_attn_varlen_func(
         q=q,
@@ -329,6 +404,9 @@ def test_hcu_varlen_routes_dspark_drafter_q_len_7_to_static_varlen(
         causal=False,
         window_size=(-1, -1),
         block_table=block_table,
+        q_descale=q_descale,
+        k_descale=k_descale,
+        v_descale=v_descale,
     )
 
     assert result is out
@@ -365,7 +443,10 @@ def test_hcu_varlen_routes_dspark_drafter_q_len_7_to_static_varlen(
         0.0,
         False,
     )
-    assert varlen_args[20:] == (None, None, None, None, None)
+    assert varlen_args[20] is q_descale
+    assert varlen_args[21] is k_descale
+    assert varlen_args[22] is v_descale
+    assert varlen_args[23:] == (None, None)
 
 
 @pytest.mark.parametrize(
@@ -439,6 +520,8 @@ def test_hcu_varlen_keeps_existing_path_outside_dspark_q_len_8_contract(
         "cp_world_size",
         "cp_rank",
         "cp_sequence_lengths",
+        "descale_shape",
+        "descale_dtype",
         "context_limit",
         "capture_token_limit",
         "block_table_capacity",
@@ -538,6 +621,14 @@ def test_hcu_varlen_dspark_routes_fail_closed(
         kwargs["cp_rank"] = 1
     elif unsupported_case == "cp_sequence_lengths":
         kwargs["cp_tot_seqused_k"] = torch.ones(2, dtype=torch.int32)
+    elif unsupported_case == "descale_shape":
+        kwargs["k_descale"] = torch.ones(batch_size, 1)
+    elif unsupported_case == "descale_dtype":
+        kwargs["k_descale"] = torch.ones(
+            batch_size,
+            k.shape[-2],
+            dtype=torch.bfloat16,
+        )
     elif unsupported_case == "context_limit":
         kwargs["max_seqlen_k"] = 4097
         kwargs["block_table"] = torch.zeros((batch_size, 65), dtype=torch.int32)
@@ -1167,6 +1258,92 @@ def test_hcu_flash_attention_varlen_mode_routes_layout_to_native_interface(
     assert calls["flash_attn_varlen_func"][0]["layout"] == expected_fa_layout
     assert calls["hg_flash_attn_varlen_func"] == []
     assert calls["varlen_fwd_unified"] == []
+
+
+def test_hcu_flash_attention_forward_passes_expanded_descales_to_varlen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise the production scale expansion before the native FA boundary."""
+    flash_attn = _load_hcu_flash_attention_module(monkeypatch)
+    impl = object.__new__(flash_attn.FlashAttentionImpl)
+    impl.vllm_flash_attn_version = 3
+    impl.attn_type = flash_attn.AttentionType.DECODER
+    impl.kv_cache_dtype = "auto"
+    impl.num_kv_heads = 2
+    impl.supports_quant_query_input = True
+    impl.dcp_world_size = 1
+    impl.scale = 128**-0.5
+    impl.alibi_slopes = None
+    impl.logits_soft_cap = 0.0
+    impl.sinks = None
+    impl.sliding_window = (-1, -1)
+
+    calls: list[dict[str, object]] = []
+
+    def native_forward(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(flash_attn, "_get_flash_attn_mode", lambda: "varlen")
+    monkeypatch.setattr(
+        flash_attn,
+        "canonicalize_singleton_dim_strides",
+        lambda tensor: tensor,
+    )
+    monkeypatch.setattr(
+        flash_attn,
+        "_select_flash_attn_varlen_func",
+        lambda: native_forward,
+    )
+
+    batch_size, query_len = 2, 7
+    metadata = SimpleNamespace(
+        num_actual_tokens=batch_size * query_len,
+        use_cascade=False,
+        query_start_loc=torch.tensor([0, 7, 14], dtype=torch.int32),
+        seq_lens=torch.tensor([64, 128], dtype=torch.int32),
+        max_query_len=query_len,
+        max_seq_len=128,
+        block_table=torch.zeros((batch_size, 2), dtype=torch.int32),
+        scheduler_metadata=None,
+        causal=False,
+        sliding_window=None,
+    )
+    layer = SimpleNamespace(
+        _q_scale=torch.tensor(1.0),
+        _k_scale=torch.tensor(1.0),
+        _v_scale=torch.tensor(1.0),
+    )
+    query = torch.zeros(
+        batch_size * query_len,
+        4,
+        128,
+        dtype=torch.bfloat16,
+    )
+    key = torch.zeros(
+        batch_size * query_len,
+        2,
+        128,
+        dtype=torch.bfloat16,
+    )
+
+    impl.forward(
+        layer,
+        query,
+        key,
+        key,
+        torch.zeros(4, 2, 64, 2, 128, dtype=torch.bfloat16),
+        metadata,
+        torch.empty_like(query),
+    )
+
+    assert len(calls) == 1
+    for name in ("q_descale", "k_descale", "v_descale"):
+        scale = calls[0][name]
+        assert isinstance(scale, torch.Tensor)
+        assert scale.shape == (batch_size, impl.num_kv_heads)
+        assert scale.dtype == torch.float32
+        assert scale.stride() == (0, 0)
+        assert not scale.is_contiguous()
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime_patch/test_flash_attention_and_pp.py
+++ b/tests/runtime_patch/test_flash_attention_and_pp.py
@@ -149,6 +149,342 @@ def test_hcu_fa_entrypoints_map_kv_cache_layout_to_kernel_layout(
     assert calls[entrypoint_name] == [{"layout": expected_fa_layout}]
 
 
+def test_hcu_varlen_routes_dspark_q_len_8_to_paged_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fa_utils, calls = _load_hcu_fa_utils_module(
+        monkeypatch,
+        kv_cache_layout="NHD",
+    )
+    paged_attention_calls: list[tuple[object, ...]] = []
+    flash_attn_interface = ModuleType("flash_attn.flash_attn_interface")
+    flash_attn_interface.flash_attn_cuda = SimpleNamespace(
+        paged_attention=lambda *args: paged_attention_calls.append(args)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        flash_attn_interface.__name__,
+        flash_attn_interface,
+    )
+
+    q = torch.zeros((16, 4, 128), dtype=torch.bfloat16)
+    kv = torch.zeros((4, 2, 64, 2, 128), dtype=torch.bfloat16)
+    k, v = kv.unbind(1)
+    out = torch.empty_like(q)
+    cu_seqlens_q = torch.tensor([0, 8, 16], dtype=torch.int32)
+    seqused_k = torch.tensor([96, 128], dtype=torch.int32)
+    block_table = torch.zeros((2, 2), dtype=torch.int32)
+
+    result = fa_utils.flash_attn_varlen_func(
+        q=q,
+        k=k,
+        v=v,
+        out=out,
+        cu_seqlens_q=cu_seqlens_q,
+        max_seqlen_q=8,
+        seqused_k=seqused_k,
+        max_seqlen_k=128,
+        softmax_scale=128**-0.5,
+        causal=True,
+        window_size=(-1, -1),
+        block_table=block_table,
+    )
+
+    assert result is out
+    assert calls["flash_attn_varlen_func"] == []
+    assert len(paged_attention_calls) == 1
+    paged_args = paged_attention_calls[0]
+    assert len(paged_args) == 15
+    assert paged_args[0] is out
+    assert paged_args[1].shape == (2, 8, 4, 128)
+    assert paged_args[2] is k
+    assert paged_args[3] is v
+    assert paged_args[4] == 128**-0.5
+    assert paged_args[5] is block_table
+    assert paged_args[6] is seqused_k
+    assert paged_args[7:12] == (None, "", None, None, None)
+    assert paged_args[12:] == (128, None, 2)
+
+
+def test_hcu_varlen_routes_dspark_drafter_q_len_7_to_static_varlen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fa_utils, calls = _load_hcu_fa_utils_module(
+        monkeypatch,
+        kv_cache_layout="NHD",
+    )
+    gather_calls: list[tuple[object, ...]] = []
+    varlen_calls: list[tuple[object, ...]] = []
+    flash_attn_interface = ModuleType("flash_attn.flash_attn_interface")
+    flash_attn_interface.flash_attn_cuda = SimpleNamespace(
+        pagedkv_to_contiguouskv=lambda *args: gather_calls.append(args),
+        varlen_fwd=lambda *args: varlen_calls.append(args),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        flash_attn_interface.__name__,
+        flash_attn_interface,
+    )
+
+    q = torch.zeros((14, 4, 128), dtype=torch.bfloat16)
+    kv = torch.zeros((4, 2, 64, 2, 128), dtype=torch.bfloat16)
+    k, v = kv.unbind(1)
+    out = torch.empty_like(q)
+    cu_seqlens_q = torch.tensor([0, 7, 14], dtype=torch.int32)
+    seqused_k = torch.tensor([96, 128], dtype=torch.int32)
+    block_table = torch.zeros((2, 2), dtype=torch.int32)
+
+    result = fa_utils.flash_attn_varlen_func(
+        q=q,
+        k=k,
+        v=v,
+        out=out,
+        cu_seqlens_q=cu_seqlens_q,
+        max_seqlen_q=7,
+        seqused_k=seqused_k,
+        max_seqlen_k=128,
+        softmax_scale=128**-0.5,
+        causal=False,
+        window_size=(-1, -1),
+        block_table=block_table,
+    )
+
+    assert result is out
+    assert calls["flash_attn_varlen_func"] == []
+    assert len(gather_calls) == 1
+    gathered_k, gathered_v = gather_calls[0][:2]
+    assert gathered_k.shape == (256, 2, 128)
+    assert gathered_v.shape == gathered_k.shape
+    assert gather_calls[0][2] is k
+    assert gather_calls[0][3] is v
+    assert gather_calls[0][4] is block_table
+    assert gather_calls[0][5] is seqused_k
+    assert gather_calls[0][6].shape == (3,)
+    assert gather_calls[0][7:] == (128, 2)
+    assert len(varlen_calls) == 1
+    varlen_args = varlen_calls[0]
+    assert len(varlen_args) == 25
+    assert varlen_args[0] is q
+    assert varlen_args[1] is gathered_k
+    assert varlen_args[2] is gathered_v
+    assert varlen_args[3] is out
+    assert varlen_args[4] is cu_seqlens_q
+    assert varlen_args[5] is gather_calls[0][6]
+    assert varlen_args[6:10] == (None, None, None, None)
+    assert varlen_args[10:20] == (
+        7,
+        128,
+        0.0,
+        128**-0.5,
+        False,
+        False,
+        -1,
+        -1,
+        0.0,
+        False,
+    )
+    assert varlen_args[20:] == (None, None, None, None, None)
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"max_seqlen_q": 9},
+        {"window_size": (128, 0)},
+        {"causal": False},
+        {"out": None},
+        {"return_softmax_lse": True},
+    ],
+)
+def test_hcu_varlen_keeps_existing_path_outside_dspark_q_len_8_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    override: dict[str, object],
+) -> None:
+    fa_utils, calls = _load_hcu_fa_utils_module(
+        monkeypatch,
+        kv_cache_layout="NHD",
+    )
+    q = torch.zeros((16, 4, 128), dtype=torch.bfloat16)
+    k = torch.zeros((4, 64, 2, 128), dtype=torch.bfloat16)
+    kwargs: dict[str, object] = {
+        "q": q,
+        "k": k,
+        "v": torch.zeros_like(k),
+        "out": torch.empty_like(q),
+        "cu_seqlens_q": torch.tensor([0, 8, 16], dtype=torch.int32),
+        "max_seqlen_q": 8,
+        "seqused_k": torch.tensor([96, 128], dtype=torch.int32),
+        "max_seqlen_k": 128,
+        "causal": True,
+        "window_size": (-1, -1),
+        "block_table": torch.zeros((2, 2), dtype=torch.int32),
+    }
+    kwargs.update(override)
+
+    fa_utils.flash_attn_varlen_func(**kwargs)
+
+    assert len(calls["flash_attn_varlen_func"]) == 1
+    assert calls["flash_attn_varlen_func"][0]["layout"] == "bshd"
+
+
+@pytest.mark.parametrize(
+    ("query_len", "causal"),
+    [(8, True), (7, False)],
+)
+@pytest.mark.parametrize(
+    "unsupported_case",
+    [
+        "wrong_causal",
+        "layout",
+        "window",
+        "dtype",
+        "block_size",
+        "head_dim",
+        "gqa",
+        "cu_rank",
+        "metadata_dtype",
+        "noncontiguous_query",
+        "kv_inner_stride",
+        "dropout",
+        "softcap",
+        "alibi",
+        "sink",
+        "q_v",
+        "cu_seqlens_k",
+        "deterministic",
+        "scheduler_metadata",
+        "num_splits",
+        "cp_world_size",
+        "cp_rank",
+        "cp_sequence_lengths",
+        "context_limit",
+        "capture_token_limit",
+        "block_table_capacity",
+    ],
+)
+def test_hcu_varlen_dspark_routes_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    query_len: int,
+    causal: bool,
+    unsupported_case: str,
+) -> None:
+    fa_utils, calls = _load_hcu_fa_utils_module(
+        monkeypatch,
+        kv_cache_layout="HND" if unsupported_case == "layout" else "NHD",
+    )
+    batch_size = 2
+    q = torch.zeros((batch_size * query_len, 4, 128), dtype=torch.bfloat16)
+    k = torch.zeros((4, 64, 2, 128), dtype=torch.bfloat16)
+    kwargs: dict[str, object] = {
+        "q": q,
+        "k": k,
+        "v": torch.zeros_like(k),
+        "out": torch.empty_like(q),
+        "cu_seqlens_q": torch.arange(
+            0,
+            (batch_size + 1) * query_len,
+            query_len,
+            dtype=torch.int32,
+        ),
+        "max_seqlen_q": query_len,
+        "seqused_k": torch.full((batch_size,), 128, dtype=torch.int32),
+        "max_seqlen_k": 128,
+        "causal": causal,
+        "window_size": (-1, -1),
+        "block_table": torch.zeros((batch_size, 2), dtype=torch.int32),
+    }
+
+    if unsupported_case == "wrong_causal":
+        kwargs["causal"] = not causal
+    elif unsupported_case == "window":
+        kwargs["window_size"] = (128, 0)
+    elif unsupported_case == "dtype":
+        kwargs["q"] = q.float()
+        kwargs["out"] = torch.empty_like(q.float())
+    elif unsupported_case == "block_size":
+        kwargs["k"] = torch.zeros((4, 32, 2, 128), dtype=torch.bfloat16)
+        kwargs["v"] = torch.zeros_like(kwargs["k"])
+    elif unsupported_case == "head_dim":
+        smaller_q = torch.zeros(
+            (batch_size * query_len, 4, 64), dtype=torch.bfloat16
+        )
+        kwargs["q"] = smaller_q
+        kwargs["out"] = torch.empty_like(smaller_q)
+    elif unsupported_case == "gqa":
+        incompatible_q = torch.zeros(
+            (batch_size * query_len, 3, 128), dtype=torch.bfloat16
+        )
+        kwargs["q"] = incompatible_q
+        kwargs["out"] = torch.empty_like(incompatible_q)
+    elif unsupported_case == "cu_rank":
+        kwargs["cu_seqlens_q"] = torch.tensor(0, dtype=torch.int32)
+    elif unsupported_case == "metadata_dtype":
+        kwargs["seqused_k"] = kwargs["seqused_k"].long()
+    elif unsupported_case == "noncontiguous_query":
+        noncontiguous_q = torch.zeros(
+            (batch_size * query_len, 128, 4), dtype=torch.bfloat16
+        ).transpose(1, 2)
+        kwargs["q"] = noncontiguous_q
+        kwargs["out"] = torch.empty_like(noncontiguous_q)
+    elif unsupported_case == "kv_inner_stride":
+        invalid_k = torch.zeros(
+            (4, 64, 128, 2), dtype=torch.bfloat16
+        ).transpose(2, 3)
+        kwargs["k"] = invalid_k
+        kwargs["v"] = torch.empty_like(invalid_k)
+    elif unsupported_case == "dropout":
+        kwargs["dropout_p"] = 0.1
+    elif unsupported_case == "softcap":
+        kwargs["softcap"] = 1.0
+    elif unsupported_case == "alibi":
+        kwargs["alibi_slopes"] = torch.ones(4)
+    elif unsupported_case == "sink":
+        kwargs["s_aux"] = torch.ones(1)
+    elif unsupported_case == "q_v":
+        kwargs["q_v"] = torch.ones(1)
+    elif unsupported_case == "cu_seqlens_k":
+        kwargs["cu_seqlens_k"] = torch.ones(3, dtype=torch.int32)
+    elif unsupported_case == "deterministic":
+        kwargs["deterministic"] = True
+    elif unsupported_case == "scheduler_metadata":
+        kwargs["scheduler_metadata"] = torch.ones(1)
+    elif unsupported_case == "num_splits":
+        kwargs["num_splits"] = 1
+    elif unsupported_case == "cp_world_size":
+        kwargs["cp_world_size"] = 2
+    elif unsupported_case == "cp_rank":
+        kwargs["cp_rank"] = 1
+    elif unsupported_case == "cp_sequence_lengths":
+        kwargs["cp_tot_seqused_k"] = torch.ones(2, dtype=torch.int32)
+    elif unsupported_case == "context_limit":
+        kwargs["max_seqlen_k"] = 4097
+        kwargs["block_table"] = torch.zeros((batch_size, 65), dtype=torch.int32)
+    elif unsupported_case == "capture_token_limit":
+        batch_size = 74
+        larger_q = torch.zeros(
+            (batch_size * query_len, 4, 128), dtype=torch.bfloat16
+        )
+        kwargs["q"] = larger_q
+        kwargs["out"] = torch.empty_like(larger_q)
+        kwargs["cu_seqlens_q"] = torch.arange(
+            0,
+            (batch_size + 1) * query_len,
+            query_len,
+            dtype=torch.int32,
+        )
+        kwargs["seqused_k"] = torch.full(
+            (batch_size,), 4096, dtype=torch.int32
+        )
+        kwargs["max_seqlen_k"] = 4096
+        kwargs["block_table"] = torch.zeros((batch_size, 64), dtype=torch.int32)
+    elif unsupported_case == "block_table_capacity":
+        kwargs["max_seqlen_k"] = 129
+
+    fa_utils.flash_attn_varlen_func(**kwargs)
+
+    assert len(calls["flash_attn_varlen_func"]) == 1
+
+
 def test_hcu_fa_boundary_rejects_interface_without_layout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runtime_patch/test_flash_attention_and_pp.py
+++ b/tests/runtime_patch/test_flash_attention_and_pp.py
@@ -206,6 +206,88 @@ def test_hcu_varlen_routes_dspark_q_len_8_to_paged_attention(
     assert paged_args[12:] == (128, None, 2)
 
 
+def test_hcu_varlen_q_len_8_falls_back_above_paged_attention_head_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep high-GQA callers on the vendor path instead of crashing."""
+    fa_utils, calls = _load_hcu_fa_utils_module(
+        monkeypatch,
+        kv_cache_layout="NHD",
+    )
+    paged_attention_calls: list[tuple[object, ...]] = []
+    flash_attn_interface = ModuleType("flash_attn.flash_attn_interface")
+    flash_attn_interface.flash_attn_cuda = SimpleNamespace(
+        paged_attention=lambda *args: paged_attention_calls.append(args)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        flash_attn_interface.__name__,
+        flash_attn_interface,
+    )
+
+    query_len = 8
+    q = torch.zeros((query_len, 16, 128), dtype=torch.bfloat16)
+    k = torch.zeros((1, 64, 1, 128), dtype=torch.bfloat16)
+    fa_utils.flash_attn_varlen_func(
+        q=q,
+        k=k,
+        v=torch.zeros_like(k),
+        out=torch.empty_like(q),
+        cu_seqlens_q=torch.tensor([0, query_len], dtype=torch.int32),
+        max_seqlen_q=query_len,
+        seqused_k=torch.tensor([64], dtype=torch.int32),
+        max_seqlen_k=64,
+        causal=True,
+        window_size=(-1, -1),
+        block_table=torch.zeros((1, 1), dtype=torch.int32),
+    )
+
+    assert len(calls["flash_attn_varlen_func"]) == 1
+    assert paged_attention_calls == []
+
+
+def test_hcu_varlen_drafter_route_respects_static_kv_scratch_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Do not admit other model shapes whose graph scratch can exceed TP2."""
+    fa_utils, _ = _load_hcu_fa_utils_module(
+        monkeypatch,
+        kv_cache_layout="NHD",
+    )
+    query_len = 7
+    batch_size = 37
+    q = torch.zeros(
+        (batch_size * query_len, 32, 128),
+        dtype=torch.bfloat16,
+    )
+    k = torch.zeros((1, 64, 8, 128), dtype=torch.bfloat16)
+    kwargs = {
+        "q": q,
+        "k": k,
+        "v": torch.zeros_like(k),
+        "out": torch.empty_like(q),
+        "cu_seqlens_q": torch.arange(
+            0,
+            (batch_size + 1) * query_len,
+            query_len,
+            dtype=torch.int32,
+        ),
+        "max_seqlen_q": query_len,
+        "seqused_k": torch.full((batch_size,), 4096, dtype=torch.int32),
+        "max_seqlen_k": 4096,
+        "causal": False,
+        "window_size": (-1, -1),
+        "block_table": torch.zeros((batch_size, 64), dtype=torch.int32),
+        "layout": "bshd",
+    }
+
+    assert not fa_utils._matches_dspark_attention_shape(
+        kwargs,
+        query_len=query_len,
+        causal=False,
+    )
+
+
 def test_hcu_varlen_routes_dspark_drafter_q_len_7_to_static_varlen(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runtime_patch/test_qwen3_dflash_nn_layout.py
+++ b/tests/runtime_patch/test_qwen3_dflash_nn_layout.py
@@ -183,6 +183,61 @@ def test_nn_layout_delegates_output_major_quantized_weights(
     )
 
 
+def test_nn_layout_rejects_mixed_quantization_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch = importlib.import_module(
+        "vllm_hcu.patch.worker.core_fix.patch_qwen3_dflash_nn_layout"
+    )
+    module = _upstream_module()
+    monkeypatch.setattr(patch, "_use_nn_layout", lambda: True)
+    assert patch.apply_to_module(module) is True
+
+    model = module.DFlashQwen3Model()
+    model.hidden_norm = SimpleNamespace(weight=torch.ones(4))
+    unquantized = _attention(
+        torch.arange(24, dtype=torch.float32).reshape(4, 6),
+        torch.arange(6, dtype=torch.float32),
+        torch.ones(2),
+    )
+    quantized = _attention(
+        torch.arange(24, dtype=torch.float32).reshape(6, 4),
+        torch.arange(6, dtype=torch.float32),
+        torch.ones(2),
+        input_size=4,
+        is_quantization=True,
+    )
+
+    with pytest.raises(PatchCompatibilityError, match="quantization.*inconsistent"):
+        model._build_context_kv_buffers(
+            [unquantized, quantized],
+            has_bias=False,
+        )
+
+
+def test_nn_layout_rejects_missing_quantization_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch = importlib.import_module(
+        "vllm_hcu.patch.worker.core_fix.patch_qwen3_dflash_nn_layout"
+    )
+    module = _upstream_module()
+    monkeypatch.setattr(patch, "_use_nn_layout", lambda: True)
+    assert patch.apply_to_module(module) is True
+
+    model = module.DFlashQwen3Model()
+    model.hidden_norm = SimpleNamespace(weight=torch.ones(4))
+    attention = _attention(
+        torch.arange(24, dtype=torch.float32).reshape(4, 6),
+        torch.arange(6, dtype=torch.float32),
+        torch.ones(2),
+    )
+    del attention.qkv_proj.is_quantization
+
+    with pytest.raises(PatchCompatibilityError, match="metadata.*missing"):
+        model._build_context_kv_buffers([attention], has_bias=False)
+
+
 def test_nn_layout_rejects_unexpected_unquantized_weight_shape(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runtime_patch/test_qwen3_dflash_nn_layout.py
+++ b/tests/runtime_patch/test_qwen3_dflash_nn_layout.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm_hcu.patch.worker.core_fix._common import PatchCompatibilityError
+
+
+TARGET_MODULE = "vllm.model_executor.models.qwen3_dflash"
+
+
+def _upstream_module() -> ModuleType:
+    module = ModuleType(TARGET_MODULE)
+
+    class DFlashQwen3Model:
+        def _build_context_kv_buffers(self, layers_attn, has_bias):
+            self._hidden_norm_weight = self.hidden_norm.weight.data
+            kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
+            self._fused_kv_weight = torch.cat(kv_weights, dim=0)
+            if has_bias:
+                self._fused_kv_bias = torch.cat(
+                    [a.qkv_proj.bias[a.q_size :] for a in layers_attn], dim=0
+                )
+            else:
+                self._fused_kv_bias = None
+            self._k_norm_weights = torch.stack(
+                [a.k_norm.weight.data for a in layers_attn], dim=0
+            ).contiguous()
+
+    module.DFlashQwen3Model = DFlashQwen3Model
+    return module
+
+
+def _attention(
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    k_norm: torch.Tensor,
+    *,
+    input_size: int | None = None,
+    is_quantization: bool = False,
+):
+    return SimpleNamespace(
+        q_size=2,
+        kv_size=2,
+        qkv_proj=SimpleNamespace(
+            weight=weight,
+            bias=bias,
+            input_size=weight.shape[0] if input_size is None else input_size,
+            is_quantization=is_quantization,
+        ),
+        k_norm=SimpleNamespace(weight=k_norm),
+    )
+
+
+def test_nn_layout_builds_output_major_context_kv_projection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    try:
+        patch = importlib.import_module(
+            "vllm_hcu.patch.worker.core_fix.patch_qwen3_dflash_nn_layout"
+        )
+    except ModuleNotFoundError:
+        pytest.fail("Qwen3 DSpark NN-layout compatibility patch is missing")
+
+    module = _upstream_module()
+    monkeypatch.setattr(patch, "_use_nn_layout", lambda: True)
+    assert patch.apply_to_module(module) is True
+
+    model = module.DFlashQwen3Model()
+    hidden_norm = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    model.hidden_norm = SimpleNamespace(weight=hidden_norm)
+    first = _attention(
+        torch.tensor(
+            [
+                [1.0, 2.0, 10.0, 11.0, 12.0, 13.0],
+                [3.0, 4.0, 20.0, 21.0, 22.0, 23.0],
+                [5.0, 6.0, 30.0, 31.0, 32.0, 33.0],
+                [7.0, 8.0, 40.0, 41.0, 42.0, 43.0],
+            ]
+        ),
+        torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
+        torch.tensor([0.5, 1.5]),
+    )
+    second = _attention(
+        torch.tensor(
+            [
+                [101.0, 102.0, 110.0, 111.0, 112.0, 113.0],
+                [103.0, 104.0, 120.0, 121.0, 122.0, 123.0],
+                [105.0, 106.0, 130.0, 131.0, 132.0, 133.0],
+                [107.0, 108.0, 140.0, 141.0, 142.0, 143.0],
+            ]
+        ),
+        torch.tensor([10.0, 11.0, 12.0, 13.0, 14.0, 15.0]),
+        torch.tensor([2.5, 3.5]),
+    )
+
+    model._build_context_kv_buffers([first, second], has_bias=True)
+
+    assert model._fused_kv_weight.shape == (8, 4)
+    projected = F.linear(
+        torch.tensor([[1.0, 2.0, 3.0, 4.0]]),
+        model._fused_kv_weight,
+        model._fused_kv_bias,
+    )
+    torch.testing.assert_close(
+        projected,
+        torch.tensor(
+            [[302.0, 313.0, 324.0, 335.0, 1312.0, 1323.0, 1334.0, 1345.0]]
+        ),
+    )
+    assert model._hidden_norm_weight.data_ptr() == hidden_norm.data_ptr()
+    torch.testing.assert_close(
+        model._k_norm_weights,
+        torch.tensor([[0.5, 1.5], [2.5, 3.5]]),
+    )
+
+
+def test_non_nn_layout_delegates_to_upstream_and_patch_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch = importlib.import_module(
+        "vllm_hcu.patch.worker.core_fix.patch_qwen3_dflash_nn_layout"
+    )
+    module = _upstream_module()
+    original = module.DFlashQwen3Model._build_context_kv_buffers
+    monkeypatch.setattr(patch, "_use_nn_layout", lambda: False)
+
+    assert patch.apply_to_module(module) is True
+    wrapped = module.DFlashQwen3Model._build_context_kv_buffers
+    assert wrapped is not original
+    assert patch.apply_to_module(module) is False
+    assert module.DFlashQwen3Model._build_context_kv_buffers is wrapped
+
+    model = module.DFlashQwen3Model()
+    model.hidden_norm = SimpleNamespace(weight=torch.ones(4))
+    attention = _attention(
+        torch.arange(24, dtype=torch.float32).reshape(6, 4),
+        torch.arange(6, dtype=torch.float32),
+        torch.ones(2),
+    )
+
+    model._build_context_kv_buffers([attention], has_bias=False)
+
+    torch.testing.assert_close(
+        model._fused_kv_weight,
+        attention.qkv_proj.weight[attention.q_size :],
+    )
+    assert model._fused_kv_bias is None
+
+
+def test_nn_layout_delegates_output_major_quantized_weights(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch = importlib.import_module(
+        "vllm_hcu.patch.worker.core_fix.patch_qwen3_dflash_nn_layout"
+    )
+    module = _upstream_module()
+    monkeypatch.setattr(patch, "_use_nn_layout", lambda: True)
+    assert patch.apply_to_module(module) is True
+
+    model = module.DFlashQwen3Model()
+    model.hidden_norm = SimpleNamespace(weight=torch.ones(4))
+    attention = _attention(
+        torch.arange(24, dtype=torch.float32).reshape(6, 4),
+        torch.arange(6, dtype=torch.float32),
+        torch.ones(2),
+        input_size=4,
+        is_quantization=True,
+    )
+
+    model._build_context_kv_buffers([attention], has_bias=False)
+
+    torch.testing.assert_close(
+        model._fused_kv_weight,
+        attention.qkv_proj.weight[attention.q_size :],
+    )
+
+
+def test_nn_layout_rejects_unexpected_unquantized_weight_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch = importlib.import_module(
+        "vllm_hcu.patch.worker.core_fix.patch_qwen3_dflash_nn_layout"
+    )
+    module = _upstream_module()
+    monkeypatch.setattr(patch, "_use_nn_layout", lambda: True)
+    assert patch.apply_to_module(module) is True
+
+    model = module.DFlashQwen3Model()
+    model.hidden_norm = SimpleNamespace(weight=torch.ones(4))
+    attention = _attention(
+        torch.arange(24, dtype=torch.float32).reshape(6, 4),
+        torch.arange(6, dtype=torch.float32),
+        torch.ones(2),
+        input_size=4,
+    )
+
+    with pytest.raises(PatchCompatibilityError, match="expected .* got"):
+        model._build_context_kv_buffers([attention], has_bias=False)

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -223,6 +223,7 @@ _CORE_CALLBACKS: tuple[_CallbackSpec, ...] = (
     _CallbackSpec(_adapter("core_fix", "patch_deepseek_v4_rocm_wo_a_layout")),
     _CallbackSpec(_adapter("core_fix", "patch_gpt_oss_mlp_block")),
     _CallbackSpec(_adapter("core_fix", "patch_qwen3_5_mamba_state_dtype")),
+    _CallbackSpec(_adapter("core_fix", "patch_qwen3_dflash_nn_layout")),
     _CallbackSpec(_adapter("core_fix", "patch_qwen3_vl")),
     _CallbackSpec(_adapter("core_fix", "patch_qwen3_vl_moe")),
 )

--- a/vllm_hcu/patch/worker/core_fix/__init__.py
+++ b/vllm_hcu/patch/worker/core_fix/__init__.py
@@ -17,6 +17,7 @@ from . import (
     patch_gpt_oss_mlp_block,
     patch_mhc_backend,
     patch_qwen3_5_mamba_state_dtype,
+    patch_qwen3_dflash_nn_layout,
     patch_qwen3_vl,
     patch_qwen3_vl_moe,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "patch_gpt_oss_mlp_block",
     "patch_mhc_backend",
     "patch_qwen3_5_mamba_state_dtype",
+    "patch_qwen3_dflash_nn_layout",
     "patch_qwen3_vl",
     "patch_qwen3_vl_moe",
 ]

--- a/vllm_hcu/patch/worker/core_fix/patch_qwen3_dflash_nn_layout.py
+++ b/vllm_hcu/patch/worker/core_fix/patch_qwen3_dflash_nn_layout.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Adapt Qwen3 DSpark context-KV fusion to the HCU NN weight layout."""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+import torch
+
+from ._common import (
+    PatchCompatibilityError,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_exact_signature,
+)
+
+TARGET_MODULE = "vllm.model_executor.models.qwen3_dflash"
+PATCH_ID = "worker.core_fix.qwen3_dflash.nn_layout"
+TARGET_SYMBOL = f"{TARGET_MODULE}.DFlashQwen3Model._build_context_kv_buffers"
+_CLASS_MARKER = "_vllm_hcu_qwen3_dflash_nn_layout_applied"
+_WRAPPER_MARKER = "_vllm_hcu_qwen3_dflash_nn_layout_wrapper"
+
+
+def _use_nn_layout() -> bool:
+    try:
+        from vllm_hcu.platforms import envs as henvs
+
+        return bool(henvs.VLLM_USE_NN)
+    except (AttributeError, ImportError) as exc:
+        raise PatchCompatibilityError(
+            "required HCU NN weight-layout feature flag is unavailable"
+        ) from exc
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    qwen3_dflash = load_exact_module(TARGET_MODULE, module)
+    model_class = require_class(
+        qwen3_dflash,
+        "DFlashQwen3Model",
+        f"{TARGET_MODULE}.DFlashQwen3Model",
+    )
+    original = require_callable(
+        model_class,
+        "_build_context_kv_buffers",
+        TARGET_SYMBOL,
+    )
+    require_exact_signature(
+        original,
+        TARGET_SYMBOL,
+        positional=("self", "layers_attn", "has_bias"),
+    )
+    if getattr(model_class, _CLASS_MARKER, False):
+        if not getattr(original, _WRAPPER_MARKER, False):
+            raise PatchCompatibilityError(
+                f"required HCU patch marker for {TARGET_SYMBOL} is stale"
+            )
+        return False
+
+    @functools.wraps(original)
+    def hcu_build_context_kv_buffers(self, layers_attn, has_bias):
+        if not _use_nn_layout():
+            return original(self, layers_attn, has_bias)
+
+        try:
+            quantized = [
+                bool(attention.qkv_proj.is_quantization)
+                for attention in layers_attn
+            ]
+        except AttributeError as exc:
+            raise PatchCompatibilityError(
+                f"required HCU NN weight metadata for {TARGET_SYMBOL} is missing"
+            ) from exc
+        if any(quantized):
+            if not all(quantized):
+                raise PatchCompatibilityError(
+                    f"required HCU QKV quantization for {TARGET_SYMBOL} is inconsistent"
+                )
+            return original(self, layers_attn, has_bias)
+
+        self._hidden_norm_weight = self.hidden_norm.weight.data
+        kv_weights = []
+        for attention in layers_attn:
+            projection = attention.qkv_proj
+            weight = projection.weight
+            expected_shape = (
+                projection.input_size,
+                attention.q_size + 2 * attention.kv_size,
+            )
+            if tuple(weight.shape) != expected_shape:
+                raise PatchCompatibilityError(
+                    f"required HCU NN weight layout for {TARGET_SYMBOL} "
+                    f"expected {expected_shape}, got {tuple(weight.shape)}"
+                )
+            kv_weights.append(weight[:, attention.q_size :].transpose(0, 1))
+        self._fused_kv_weight = torch.cat(kv_weights, dim=0).contiguous()
+
+        if has_bias:
+            self._fused_kv_bias = torch.cat(
+                [
+                    attention.qkv_proj.bias[attention.q_size :]
+                    for attention in layers_attn
+                ],
+                dim=0,
+            )
+        else:
+            self._fused_kv_bias = None
+        self._k_norm_weights = torch.stack(
+            [attention.k_norm.weight.data for attention in layers_attn], dim=0
+        ).contiguous()
+
+    setattr(hcu_build_context_kv_buffers, _WRAPPER_MARKER, True)
+    setattr(
+        model_class,
+        "_vllm_hcu_original_build_context_kv_buffers",
+        original,
+    )
+    setattr(
+        model_class,
+        "_build_context_kv_buffers",
+        hcu_build_context_kv_buffers,
+    )
+    setattr(model_class, _CLASS_MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "apply", "apply_to_module"]

--- a/vllm_hcu/v1/attention/backends/fa_utils.py
+++ b/vllm_hcu/v1/attention/backends/fa_utils.py
@@ -195,7 +195,10 @@ def _matches_dspark_attention_shape(
     for name in ("q_descale", "k_descale", "v_descale"):
         scale = kwargs.get(name)
         if scale is not None and (
-            not isinstance(scale, Tensor) or scale.device != q.device
+            not isinstance(scale, Tensor)
+            or scale.device != q.device
+            or scale.dtype != torch.float32
+            or scale.shape != (batch_size, k.shape[-2])
         ):
             return False
     return True
@@ -214,10 +217,13 @@ def _flash_attn_varlen_func_with_dspark_capture(
         query_len=8,
         causal=True,
     )
-    use_static_varlen = _matches_dspark_attention_shape(
-        kwargs,
-        query_len=7,
-        causal=False,
+    use_static_varlen = (
+        _matches_dspark_attention_shape(
+            kwargs,
+            query_len=7,
+            causal=False,
+        )
+        and torch.cuda.is_current_stream_capturing()
     )
     if not use_paged_attention and not use_static_varlen:
         return _flash_attn_varlen_func(**kwargs)

--- a/vllm_hcu/v1/attention/backends/fa_utils.py
+++ b/vllm_hcu/v1/attention/backends/fa_utils.py
@@ -19,6 +19,9 @@ from vllm.v1.attention.backends.utils import get_kv_cache_layout
 
 import vllm_hcu.hcu_ops as hcu_ops
 
+_DSPARK_MAX_CAPTURE_TOKENS = 512
+_DSPARK_MAX_CONTEXT_LENGTH = 4096
+
 
 def _flash_attn_layout() -> str:
     cache_layout = get_kv_cache_layout()
@@ -66,8 +69,230 @@ def _with_kv_cache_layout(function: Callable[..., Any], name: str):
     return wrapped
 
 
+def _matches_dspark_attention_shape(
+    kwargs: dict[str, Any],
+    *,
+    query_len: int,
+    causal: bool,
+) -> bool:
+    """Match a DSpark-7 attention shape with capture-safe static metadata."""
+    q = kwargs.get("q")
+    k = kwargs.get("k")
+    v = kwargs.get("v")
+    out = kwargs.get("out")
+    cu_seqlens_q = kwargs.get("cu_seqlens_q")
+    seqused_k = kwargs.get("seqused_k")
+    block_table = kwargs.get("block_table")
+    window_size = kwargs.get("window_size", (-1, -1))
+
+    if not all(isinstance(tensor, Tensor) for tensor in (q, k, v, out)):
+        return False
+    if not all(
+        isinstance(tensor, Tensor)
+        for tensor in (cu_seqlens_q, seqused_k, block_table)
+    ):
+        return False
+    if q.ndim != 3 or k.ndim != 4 or v.shape != k.shape:
+        return False
+    if out.shape != q.shape:
+        return False
+    tensors = (q, k, v, out, cu_seqlens_q, seqused_k, block_table)
+    if any(tensor.device != q.device for tensor in tensors):
+        return False
+    contiguous_tensors = (q, out, cu_seqlens_q, seqused_k, block_table)
+    if any(not tensor.is_contiguous() for tensor in contiguous_tensors):
+        return False
+    if kwargs.get("layout") != "bshd":
+        return False
+    if kwargs.get("max_seqlen_q") != query_len:
+        return False
+    if cu_seqlens_q.ndim != 1:
+        return False
+    batch_size = cu_seqlens_q.shape[0] - 1
+    if batch_size <= 0 or q.shape[0] != batch_size * query_len:
+        return False
+    if block_table.ndim != 2 or block_table.shape[0] != batch_size:
+        return False
+    if seqused_k.ndim != 1 or seqused_k.shape[0] != batch_size:
+        return False
+    if any(
+        tensor.dtype != torch.int32
+        for tensor in (cu_seqlens_q, seqused_k, block_table)
+    ):
+        return False
+    if k.shape[1] != 64 or q.shape[-1] != 128 or v.shape[-1] != 128:
+        return False
+    expected_inner_strides = (k.shape[-2] * k.shape[-1], k.shape[-1], 1)
+    if k.stride()[1:] != expected_inner_strides:
+        return False
+    if v.stride()[1:] != expected_inner_strides:
+        return False
+    if min(k.stride(0), v.stride(0)) < 64 * expected_inner_strides[0]:
+        return False
+    if k.shape[-2] <= 0 or q.shape[-2] % k.shape[-2] != 0:
+        return False
+    max_seqlen_k = kwargs.get("max_seqlen_k")
+    if (
+        not isinstance(max_seqlen_k, int)
+        or max_seqlen_k <= 0
+        or max_seqlen_k > _DSPARK_MAX_CONTEXT_LENGTH
+    ):
+        return False
+    if q.shape[0] > _DSPARK_MAX_CAPTURE_TOKENS:
+        return False
+    if block_table.shape[1] * 64 < max_seqlen_k:
+        return False
+    if any(tensor.dtype != torch.bfloat16 for tensor in (q, k, v, out)):
+        return False
+    if bool(kwargs.get("causal", False)) is not causal:
+        return False
+    if window_size is not None:
+        if not isinstance(window_size, (list, tuple)):
+            return False
+        if len(window_size) != 2 or tuple(window_size) != (-1, -1):
+            return False
+    if kwargs.get("dropout_p", 0.0) != 0.0:
+        return False
+    if kwargs.get("softcap", 0.0) != 0.0:
+        return False
+    if kwargs.get("alibi_slopes") is not None or kwargs.get("s_aux") is not None:
+        return False
+    if kwargs.get("q_v") is not None:
+        return False
+    if kwargs.get("return_attn_probs", False):
+        return False
+    if kwargs.get("return_softmax_lse", False):
+        return False
+    if kwargs.get("cu_seqlens_k") is not None:
+        return False
+    if kwargs.get("deterministic", False):
+        return False
+    if kwargs.get("scheduler_metadata") is not None:
+        return False
+    if kwargs.get("num_splits", 0) != 0:
+        return False
+    if kwargs.get("cp_world_size", 1) != 1:
+        return False
+    if kwargs.get("cp_rank", 0) != 0 or kwargs.get("cp_tot_seqused_k") is not None:
+        return False
+    for name in ("q_descale", "k_descale", "v_descale"):
+        scale = kwargs.get(name)
+        if scale is not None and (
+            not isinstance(scale, Tensor) or scale.device != q.device
+        ):
+            return False
+    return True
+
+
+@functools.wraps(_flash_attn_varlen_func)
+def _flash_attn_varlen_func_with_dspark_capture(
+    *args: Any,
+    **kwargs: Any,
+):
+    if args:
+        return _flash_attn_varlen_func(*args, **kwargs)
+
+    use_paged_attention = _matches_dspark_attention_shape(
+        kwargs,
+        query_len=8,
+        causal=True,
+    )
+    use_static_varlen = _matches_dspark_attention_shape(
+        kwargs,
+        query_len=7,
+        causal=False,
+    )
+    if not use_paged_attention and not use_static_varlen:
+        return _flash_attn_varlen_func(**kwargs)
+
+    from flash_attn.flash_attn_interface import flash_attn_cuda
+
+    q = kwargs["q"]
+    k = kwargs["k"]
+    v = kwargs["v"]
+    out = kwargs["out"]
+    cu_seqlens_q = kwargs["cu_seqlens_q"]
+    batch_size = cu_seqlens_q.shape[0] - 1
+    softmax_scale = kwargs.get("softmax_scale")
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** -0.5
+    if use_static_varlen:
+        # DSpark's non-causal draft block cannot use paged_attention, which
+        # applies a causal mask. Gather into a statically sized buffer instead
+        # of materializing seqused_k.sum() on the host during graph capture.
+        # The matcher bounds this scratch space to 584 MiB per Qwen3-8B TP2
+        # rank: 2 * floor(512 / 7) * 4096 * 4 * 128 * sizeof(bfloat16).
+        max_seqlen_k = kwargs["max_seqlen_k"]
+        total_k = batch_size * max_seqlen_k
+        contiguous_k = torch.empty(
+            (total_k, k.shape[-2], k.shape[-1]),
+            device=k.device,
+            dtype=k.dtype,
+        )
+        contiguous_v = torch.empty_like(contiguous_k)
+        cu_seqlens_k = torch.empty_like(cu_seqlens_q)
+        flash_attn_cuda.pagedkv_to_contiguouskv(
+            contiguous_k,
+            contiguous_v,
+            k,
+            v,
+            kwargs["block_table"],
+            kwargs["seqused_k"],
+            cu_seqlens_k,
+            max_seqlen_k,
+            2,
+        )
+        flash_attn_cuda.varlen_fwd(
+            q,
+            contiguous_k,
+            contiguous_v,
+            out,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            None,
+            None,
+            None,
+            None,
+            7,
+            max_seqlen_k,
+            0.0,
+            softmax_scale,
+            False,
+            False,
+            -1,
+            -1,
+            0.0,
+            False,
+            kwargs.get("q_descale"),
+            kwargs.get("k_descale"),
+            kwargs.get("v_descale"),
+            None,
+            None,
+        )
+        return out
+
+    flash_attn_cuda.paged_attention(
+        out,
+        q.reshape(batch_size, 8, q.shape[-2], q.shape[-1]),
+        k,
+        v,
+        softmax_scale,
+        kwargs["block_table"],
+        kwargs["seqused_k"],
+        None,
+        "",
+        kwargs.get("q_descale"),
+        kwargs.get("k_descale"),
+        kwargs.get("v_descale"),
+        kwargs["max_seqlen_k"],
+        None,
+        2,
+    )
+    return out
+
+
 flash_attn_varlen_func = _with_kv_cache_layout(
-    _flash_attn_varlen_func,
+    _flash_attn_varlen_func_with_dspark_capture,
     "flash_attn_varlen_func",
 )
 hg_flash_attn_varlen_func = _with_kv_cache_layout(

--- a/vllm_hcu/v1/attention/backends/fa_utils.py
+++ b/vllm_hcu/v1/attention/backends/fa_utils.py
@@ -21,6 +21,7 @@ import vllm_hcu.hcu_ops as hcu_ops
 
 _DSPARK_MAX_CAPTURE_TOKENS = 512
 _DSPARK_MAX_CONTEXT_LENGTH = 4096
+_DSPARK_MAX_STATIC_KV_SCRATCH_BYTES = 584 * 1024**2
 
 
 def _flash_attn_layout() -> str:
@@ -131,6 +132,11 @@ def _matches_dspark_attention_shape(
         return False
     if k.shape[-2] <= 0 or q.shape[-2] % k.shape[-2] != 0:
         return False
+    # The vendor paged-attention kernel flattens the query-token and query-head
+    # axes and accepts at most 64 such heads per KV head.  The qlen=7 route
+    # below uses varlen_fwd instead and does not have this restriction.
+    if causal and q.shape[-2] * query_len > k.shape[-2] * 64:
+        return False
     max_seqlen_k = kwargs.get("max_seqlen_k")
     if (
         not isinstance(max_seqlen_k, int)
@@ -144,6 +150,17 @@ def _matches_dspark_attention_shape(
         return False
     if any(tensor.dtype != torch.bfloat16 for tensor in (q, k, v, out)):
         return False
+    if not causal:
+        scratch_bytes = (
+            2
+            * batch_size
+            * max_seqlen_k
+            * k.shape[-2]
+            * k.shape[-1]
+            * k.element_size()
+        )
+        if scratch_bytes > _DSPARK_MAX_STATIC_KV_SCRATCH_BYTES:
+            return False
     if bool(kwargs.get("causal", False)) is not causal:
         return False
     if window_size is not None:
@@ -220,8 +237,9 @@ def _flash_attn_varlen_func_with_dspark_capture(
         # DSpark's non-causal draft block cannot use paged_attention, which
         # applies a causal mask. Gather into a statically sized buffer instead
         # of materializing seqused_k.sum() on the host during graph capture.
-        # The matcher bounds this scratch space to 584 MiB per Qwen3-8B TP2
-        # rank: 2 * floor(512 / 7) * 4096 * 4 * 128 * sizeof(bfloat16).
+        # The matcher bounds this scratch space to 584 MiB per rank, matching
+        # Qwen3-8B TP2 at its maximum admitted shape:
+        # 2 * floor(512 / 7) * 4096 * 4 * 128 * sizeof(bfloat16).
         max_seqlen_k = kwargs["max_seqlen_k"]
         total_k = batch_size * max_seqlen_k
         contiguous_k = torch.empty(


### PR DESCRIPTION
## Summary
- adapt Qwen3 DFlash context-KV fusion to the HCU NN physical weight layout while retaining the default `VLLM_USE_NN=True` behavior
- route Qwen3-8B DSpark target verification (qlen=8, causal) to capture-safe paged attention
- preserve the DSpark-7 drafter's qlen=7 non-causal semantics through bounded static KV gathering **only while the current stream is being captured**
- keep eager, `--enforce-eager`, and CUDA Graph miss qlen=7 requests on the original vendor varlen path, avoiding `batch_size * max_seqlen_k` scratch allocation
- validate the real FP32 `(batch_size, kv_heads)` zero-stride descale views produced by `FlashAttentionImpl.forward()` in eager, capture, and replay
- fail closed to the original vendor path outside the verified tensor/layout/kernel contract
- supersede and include the former NN-layout-only PR #81

## Root causes
1. With HCU NN enabled, unquantized QKV weights use input-major physical storage, while Qwen3 DFlash context-KV fusion slices the upstream output-major layout.
2. The vendor FlashAttention fallback materializes `seqused_k.sum()` on the host to size temporary KV tensors. That scalar synchronization is illegal during HIP/CUDA stream capture and raises `hipErrorStreamCaptureUnsupported` in `FULL_AND_PIECEWISE` mode.
3. The first graph-safe qlen=7 implementation selected static gathering by shape alone, so eager and graph-miss requests could allocate up to 584 MiB/rank unnecessarily. The route now additionally requires `torch.cuda.is_current_stream_capturing()`.

## Cross-model safety
- the NN layout wrapper targets only `DFlashQwen3Model._build_context_kv_buffers`
- `VLLM_USE_NN=False` delegates unchanged to upstream
- uniformly quantized QKV layers delegate unchanged; mixed quantization or malformed/missing layout metadata fail closed
- the attention fast routes require BF16, NHD/bshd, block size 64, head dimension 128, fixed qlen/causal mode, compatible metadata, context length <= 4096, and capture tokens <= 512
- q/k/v descales, when supplied, must be same-device FP32 tensors with shape `(batch_size, kv_heads)`; expanded zero-stride/non-contiguous views are intentionally accepted
- qlen=8 causal paged attention behavior is unchanged and enforces the vendor flattened-head limit: `q_heads * qlen <= kv_heads * 64`
- qlen=7 non-causal static gathering is capture-only and has a hard 584 MiB/rank scratch cap; eager and graph-miss execution uses the vendor path
- unsupported dtypes, layouts, windows, head ratios, TP/model shapes, context-parallel options, auxiliary modes, descale contracts, and larger scratch requirements retain the original vendor fallback
- fallback preserves existing behavior; FULL graph support is not claimed outside the guarded Qwen3-8B TP2 + DSpark-7 contract

## Validation
- exact vLLM: `0.25.1+das185.dtk2604.torch2110.2608171710.g7b108a`
- default `VLLM_USE_NN=True` (validation used `env -u VLLM_USE_NN`)
- full portable suite on final commit: **1757 passed**
  - `tests/runtime_patch`: 1358 passed
  - `tests/patch`: 258 passed
  - `tests/accuracy -m 'not hcu'`: 141 passed, 122 deselected
- live HCU kernel accuracy suite: **48 passed**, including production `FlashAttentionImpl.forward()`, expanded descales, eager/capture/replay, and batch 1/64/73 memory coverage
- CI-mode regression (`VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1`): full `tests/accuracy` **263 passed**; the production-forward varlen test selects its intended mode locally and leaves the surrounding cutlass CI mode unchanged
- focused attention/runtime file: 126 passed
- `git diff --check` and Python bytecode compilation passed; Ruff is not installed in the validation environment
- Qwen3-8B TP2 + DSpark-7, `max_model_len=4096`:
  - target PIECEWISE: 51/51 captured
  - target FULL: 48/48 captured
  - DSpark FULL: 48/48 captured
  - post-HumanEval graph-miss boundary: 73 concurrent requests, 73/73 HTTP 200, all completed with `finish_reason=length`
- independent code review: no Critical, Important, or remaining Minor findings; fail-closed coverage was fixed in `34dd921`, and CI-mode isolation in `713d0c4`

## Eager memory and latency A/B
Microbenchmark: qlen=7, BF16, max context 4096, actual used KV length 64, 16 query heads, 4 KV heads, 10 timed iterations. Latency is kernel-wrapper microbenchmark data, not end-to-end serving latency.

| Batch | Before peak allocation | Capture-gated eager peak | Before median | Capture-gated eager median |
|---:|---:|---:|---:|---:|
| 1 | 8.001 MiB | 0.127 MiB | 0.076 ms | 0.141 ms |
| 64 | 512.028 MiB | 8.529 MiB | 0.146 ms | 0.207 ms |
| 73 | 584.032 MiB | 9.158 MiB | 0.160 ms | 0.224 ms |

This confirms the reported eager-memory issue. The vendor fallback is about 0.06-0.08 ms slower in this microbenchmark, so the change is intentionally a memory-safety fix for eager/graph-miss execution, not an eager-latency optimization. Graph hits retain the static capture-safe route.

## HumanEval-32 and DSpark acceptance
- protocol: EvalScope 1.9.1, fixed first 32 HumanEval samples, seed 0, temperature 0, max_tokens 512, batch size 16, thinking disabled
- post-fix stats-enabled run: **30/32, Pass@1 93.75%**; all 32 API requests succeeded
- failures were only HumanEval/19 and HumanEval/26, identical to the prior exact-command and no-DSpark control pass/fail set; both were complete but semantically incorrect implementations, not truncation, graph replay, or runtime failures
- post-fix DSpark counters: **3,744 accepted / 4,256 drafted = 87.97%** across 608 draft steps
- accepted tokens per draft step: 6.16 of 7; mean acceptance length including the bonus token: 7.16
- per-position acceptance: 97.20%, 95.23%, 91.61%, 88.32%, 84.70%, 81.58%, 77.14% (positions 1 through 7), with the expected smooth decay

The acceptance run removed only `--disable-log-stats`, because that flag disables speculative counters. The launch command below intentionally retains the user's requested flag.

## Installation and launch command
The validated package version remains unchanged. This command does not override the default `VLLM_USE_NN=True`.

~~~bash
pip install vllm==0.25.1+das185.dtk2604.torch2110.2608171710.g7b108a \
  -i https://pypi.sourcefind.cn/nightly/dtk/

export VLLM_CUDART_SO_PATH=/opt/dtk/hip/lib/libgalaxyhip.so

vllm serve \
  /public/home/xingjl/models/Qwen3-8B \
  --dtype bfloat16 \
  --load-format auto \
  --distributed-executor-backend mp \
  --max-model-len 4096 \
  --max-num-seqs 256 \
  --enable-chunked-prefill \
  --max-num-batched-tokens 12288 \
  --enable-prefix-caching \
  --enable_sleep_mode \
  --logprobs-mode processed_logprobs \
  --gpu-memory-utilization 0.4 \
  --disable-log-stats \
  --tensor-parallel-size 2 \
  --seed 42 \
  --override-generation-config '{"temperature": 0.6, "top_k": -1, "top_p": 1, "repetition_penalty": 1.0, "max_new_tokens": 8192}' \
  --scheduling_policy fcfs \
  --compilation_config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
  --speculative_config '{"method": "dspark", "num_speculative_tokens": 7, "draft_sample_method": "greedy", "model": "/public/home/xingjl/models/dspark_qwen3_8b_block7"}'
~~~
