### PR TITLE
feat(hyv4): 复用 aiter W4A8 加载自定义 INT4 checkpoint，验证 CUDA Graph + MTP

### DIFF
--- a/.github/workflows/configs/hcu-test-map.yaml
+++ b/.github/workflows/configs/hcu-test-map.yaml
@@ -629,6 +629,7 @@
       "patterns": [
         "vllm_hcu/model_executor/layers/fused_moe/**",
         "vllm_hcu/model_executor/layers/quantization/**",
+        "tests/accuracy/test_hyv4_w4a8_kernels.py",
         "vllm_hcu/patch/worker/**moe*",
         "tests/gemma4_test/**"
       ],

--- a/docs/hyv4-custom-w4a8.md
+++ b/docs/hyv4-custom-w4a8.md
@@ -1,0 +1,72 @@
+# HYV4 custom W4A8 on HCU
+
+This adapter loads `hy4-w4a8-custom-v1` checkpoints through the HCU runtime plugin and existing aiter signed INT4-weight / dynamic INT8-activation kernels. Enable it explicitly through the `slimquant_w4a8` registry entry and `checkpoint_format` in the HF quantization override. The normal SlimQuant path retains its existing behavior.
+
+## Launch
+
+The local validation environment has vLLM `0.25.1+das185.dtk2604.torch2110.2608171710.g7b108a`, aiter `0.1.6+dtk2604.torch2110.2609082106.g31fdae`, and eight 64 GiB Hygon accelerators. Install/build the plugin against the matching environment. For this checkout, the existing matching `vllm_hcu/hcu_ops` binary was copied from the installed plugin; no installed vLLM or aiter source was edited.
+
+```bash
+bash tools/hy_v4/serve_custom_w4a8.sh
+```
+
+Use `--enforce-eager` only when explicitly testing the eager baseline. The script uses `/data/models/hy4_w4a8_unverified`, TP8, aiter, CUDA Graphs, one sequence and a 1024-token context. It binds the OpenAI-compatible API to `127.0.0.1:8000`, with model name `hy4-w4a8`. It adds this checkout to `PYTHONPATH`; keep all HCU plugin entry points enabled (`VLLM_PLUGINS` unset, or `hcu,hcu_model,hcu_ops`). The model files are read-only inputs; HF overrides supply the quantization declaration missing from their `config.json`.
+
+```bash
+curl --noproxy '*' http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"hy4-w4a8","messages":[{"role":"user","content":"你好，请用一句话介绍自己。"}],"temperature":0,"max_tokens":64,"chat_template_kwargs":{"reasoning_effort":"no_think"}}'
+```
+
+## Format and execution
+
+- `conversion.json` identifies the quantized modules. Only those modules receive INT4 parameters. BF16 attention, dense layers, embeddings and the unquantized MTP layer retain their declared precision.
+- Custom `.int4_packed` names map to the model's existing weight loaders; `.scale` maps to channel scales. Expert scales gain a trailing singleton dimension so the HYV4 fused gate/up loader splits the correct axis.
+- Checkpoint bytes have the even input element in the low nibble. aiter's contiguous channelwise W4A8 kernel expects the even input element in the high nibble. The adapter swaps nibbles after tensor-parallel loading and processes one local expert at a time. Signed two's-complement values and scales are preserved.
+- The RTN checkpoint's `input_scale` tensors are identity smoothing vectors. Every loaded vector is checked; nonidentity vectors are rejected because this adapter does not implement their smoothing semantics. Runtime activation scales come from aiter's per-token INT8 quantizer.
+- Routed experts call `aiter.ops.triton.fused_moe.fused_experts_impl` with W4A8 channel quantization and the model's `swiglu_limit`. Quantized shared Linear layers call aiter's W4A8 GEMM through the single-expert interface, with no additional activation or routing multiplier.
+- The existing vLLM MoE runner owns expert selection, shared-expert combination, the routed scaling factor, and TP reductions. The adapter does not apply these a second time.
+
+## Validation
+
+```bash
+python -m pytest tests/models/hy_v4/test_custom_w4a8.py tests/ops/test_hyv4_w4a8_kernels.py -q
+python -m pytest tests/models/hy_v4 tests/hy_v4 -q
+PYTHONPATH="$PWD" python -m vllm_hcu.doctor
+```
+
+GPU tests compare aiter against explicit signed INT4 integer matrices and per-token INT8 reference calculations, including HYV4 shared-Linear dimensions and routed SwiGLU clipping. They test runtime arithmetic, not the quality loss from converting the original checkpoint. The supplied model's conversion manifest says `NOT_EVALUATED` and records uncalibrated RTN conversion.
+
+The checkpoint chat template uses `reasoning_effort: no_think` to request a direct answer; it does not use `enable_thinking`. Local API clients must bypass this environment's HTTP proxy (`curl --noproxy '*'` or a proxy-free HTTP client).
+
+HYV4's FP8 indexer cache also needs two gfx936 runtime adaptations in this branch: select cache readers/writers by the cache storage dtype, and use aiter's FP8 prefill logits implementation on gfx936. GPU checks cover FP8 cache roundtrip plus prefill/decode logits for 8 and 129 keys. These are HCU-owned runtime changes.
+
+## MTP on this gfx936 environment
+
+The BF16 MTP expert geometry has no matching aiter ASM W16A16 solution in the installed build. Select Triton for the unquantized MTP layer:
+
+```bash
+bash tools/hy_v4/serve_custom_w4a8.sh \
+  --moe-backend triton \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
+```
+
+`HYV4W4A8MoEMethod` explicitly calls aiter's W4A8 kernel, so this backend argument changes the unquantized MTP implementation; the target's quantized experts and shared Linear layers continue to use aiter W4A8.
+
+## Local run results (2026-09-10)
+
+208 affected tests passed: 140 HYV4, 6 W4A8 numerical, 58 indexer regression, and 4 indexer GPU tests. Plugin doctor passed. Baseline TP8 loaded 52.53 GiB of model weights per device and served both completion and chat requests.
+
+The MTP configuration above also served both requests. The direct Chinese chat returned `你好！我是混元，是由腾讯开发的大模型。` (13 tokens), matching baseline text. The 32-token completion was coherent and had finite log probabilities, but differed from baseline tokens; exact MTP equivalence is **not established**. Smoke timings include differing warmup conditions and are not a performance benchmark. The checkpoint still requires model-quality evaluation.
+
+Machine-readable run results and logs are in `/tmp/hy4-validation/summary.json` and `/tmp/hy4-validation/`.
+
+## CUDA Graph validation
+
+The launch script defaults to `enforce_eager=False`. On this V2 runner, the existing breakable-CUDA-Graph configuration sets `compilation_config.mode=NONE` and `cudagraph_mode=FULL_AND_PIECEWISE`; this run tests Graph capture/replay, not Inductor compilation. With TP8 and MTP 3 tokens, prefill and decode Graph capture completed in 20 seconds and used 0.40 GiB per device.
+
+The Graph-enabled completion matched all 32 baseline tokens, and the Chinese chat matched baseline text. Three further completion requests also matched baseline tokens (about 2.71–2.72 seconds each). These short requests are smoke tests, not throughput or quality benchmarks. The earlier eager MTP difference remains recorded above and should not be interpreted as broad equivalence across execution modes.
+
+A 207-token prompt also exercised chunked prefill with the 128-token batch limit and returned a correct answer (32 generated tokens, finite log probabilities).
+
+The plugin contract suite (`python tools/run_patch_tests.py --suite contract -- -q`) also passed: 1317 tests, exit code 0.

--- a/docs/hyv4-custom-w4a8.md
+++ b/docs/hyv4-custom-w4a8.md
@@ -30,7 +30,7 @@ curl --noproxy '*' http://127.0.0.1:8000/v1/chat/completions \
 ## Validation
 
 ```bash
-python -m pytest tests/models/hy_v4/test_custom_w4a8.py tests/ops/test_hyv4_w4a8_kernels.py -q
+python -m pytest tests/models/hy_v4/test_custom_w4a8.py tests/accuracy/test_hyv4_w4a8_kernels.py -q
 python -m pytest tests/models/hy_v4 tests/hy_v4 -q
 PYTHONPATH="$PWD" python -m vllm_hcu.doctor
 ```
@@ -70,3 +70,5 @@ The Graph-enabled completion matched all 32 baseline tokens, and the Chinese cha
 A 207-token prompt also exercised chunked prefill with the 128-token batch limit and returned a correct answer (32 generated tokens, finite log probabilities).
 
 The plugin contract suite (`python tools/run_patch_tests.py --suite contract -- -q`) also passed: 1317 tests, exit code 0.
+
+W4A8 kernel tests live in `tests/accuracy/test_hyv4_w4a8_kernels.py`. The CPU nibble reference is unmarked and runs in the contract suite; the five GPU numerical cases carry `hcu` and run in `accuracy-hcu` and nightly. Hardware availability is checked in a fixture at execution time.

--- a/tests/accuracy/test_hcu_kernel_accuracy.py
+++ b/tests/accuracy/test_hcu_kernel_accuracy.py
@@ -806,3 +806,45 @@ def test_triton_moe_sum_uses_fp32_accumulation_on_hcu() -> None:
 
     expected = expert_output.float().sum(dim=1).to(torch.bfloat16)
     torch.testing.assert_close(reduced, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize('seq_len', [8, 129])
+def test_hyv4_fp8_indexer_prefill_and_decode_match_reference(seq_len):
+    device = _hcu_device()
+    from vllm.platforms import current_platform
+    from vllm_hcu.v1.attention.ops import rocm_aiter_mla_sparse as sparse
+    if not current_platform.is_rocm():
+        pytest.skip('enable HCU plugins for native indexer validation')
+    torch.manual_seed(27)
+    dtype = current_platform.fp8_dtype()
+    q = torch.randn(1, 32, 128, device=device).to(dtype)
+    k = torch.randn(seq_len, 128, device=device).to(dtype)
+    scales = torch.full((seq_len, 1), .25, device=device)
+    weights = torch.rand(1, 32, device=device)
+    starts = torch.tensor([0], device=device, dtype=torch.int32)
+    ends = torch.tensor([seq_len], device=device, dtype=torch.int32)
+    expected = (
+        torch.relu(torch.einsum('mhd,nd->mhn', q.float(), k.float()))
+        * weights[:, :, None]
+    ).sum(1) * scales.T
+    actual = sparse.rocm_fp8_mqa_logits(q, (k, scales), weights, starts, ends)
+    torch.testing.assert_close(actual, expected, rtol=.03, atol=.05)
+
+    block_size = 64
+    num_pages = (seq_len + block_size - 1) // block_size
+    cache = torch.zeros(num_pages, block_size, 1, 132, device=device,
+                        dtype=torch.uint8)
+    # NORMAL indexer layout stores all FP8 values before all FP32 scales
+    # within each page; it is not an interleaved 132-byte token layout.
+    pages = cache.view(num_pages, -1)
+    values = torch.zeros(num_pages * block_size, 128, device=device,
+                         dtype=torch.uint8)
+    values[:seq_len] = k.view(torch.uint8)
+    pages[:, :block_size * 128] = values.view(num_pages, -1)
+    pages[:, block_size * 128:].view(torch.float32).fill_(.25)
+    table = torch.arange(num_pages, device=device, dtype=torch.int32)[None]
+    actual = sparse.rocm_fp8_paged_mqa_logits(
+        q[:, None], cache, weights, ends, table, None,
+        num_pages * block_size,
+    )
+    torch.testing.assert_close(actual[:, :seq_len], expected, rtol=.03, atol=.05)

--- a/tests/accuracy/test_hyv4_w4a8_kernels.py
+++ b/tests/accuracy/test_hyv4_w4a8_kernels.py
@@ -15,6 +15,12 @@ def runtime():
     return module
 
 
+@pytest.fixture
+def hcu_runtime():
+    if torch.version.hip is None or not torch.cuda.is_available():
+        pytest.skip("a live HCU/ROCm device is required")
+
+
 def pack(values):
     return (((values[..., ::2].to(torch.int16) & 15) << 4)
             | (values[..., 1::2].to(torch.int16) & 15)).to(torch.int8)
@@ -25,9 +31,9 @@ def test_signed_nibble_reference():
     torch.testing.assert_close(values, torch.tensor([[-8, -1, 0, 7, -6, 5]], dtype=torch.int8))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason='requires Hygon GPU')
+@pytest.mark.hcu
 @pytest.mark.parametrize('m,k,n', [(1,128,64), (35,256,96), (2,6144,512), (1,256,6144)])
-def test_linear_matches_quantized_reference(m,k,n):
+def test_linear_matches_quantized_reference(hcu_runtime,m,k,n):
     torch.manual_seed(12)
     x = torch.randn(m,k,device='cuda',dtype=torch.bfloat16)
     w = torch.randint(-8,8,(n,k),device='cuda',dtype=torch.int8)
@@ -39,8 +45,8 @@ def test_linear_matches_quantized_reference(m,k,n):
     torch.testing.assert_close(actual,expected,rtol=.008,atol=.002)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason='requires Hygon GPU')
-def test_moe_preserves_gate_up_clamp_and_routing():
+@pytest.mark.hcu
+def test_moe_preserves_gate_up_clamp_and_routing(hcu_runtime):
     torch.manual_seed(22)
     m,k,n,e = 5,128,128,3
     x = torch.randn(m,k,device='cuda',dtype=torch.bfloat16) * 3

--- a/tests/hcu_ci_registry.py
+++ b/tests/hcu_ci_registry.py
@@ -15,6 +15,11 @@ from __future__ import annotations
 
 register_hcu_ci(
     job="accuracy-gfx936",
+    target="tests/accuracy/test_hyv4_w4a8_kernels.py",
+    est_time=60,
+)
+register_hcu_ci(
+    job="accuracy-gfx936",
     target="tests/accuracy/test_hcu_kernel_accuracy.py",
     est_time=900,
 )

--- a/tests/models/hy_v4/test_custom_w4a8.py
+++ b/tests/models/hy_v4/test_custom_w4a8.py
@@ -1,0 +1,107 @@
+import importlib
+import json
+
+import pytest
+import torch
+
+MODULE = 'vllm_hcu.model_executor.layers.quantization.hyv4_w4a8_weights'
+
+
+def adapter():
+    import importlib.util
+    assert importlib.util.find_spec(MODULE) is not None, 'custom W4A8 adapter is missing'
+    return importlib.import_module(MODULE)
+
+
+def test_signed_nibble_conversion_preserves_all_values():
+    mod = adapter()
+    values = torch.arange(-8, 8, dtype=torch.int8)
+    packed = ((values[::2].to(torch.uint8) & 15) | ((values[1::2].to(torch.uint8) & 15) << 4)).view(torch.int8)
+    actual = mod.to_aiter_packing(packed)
+    u = actual.to(torch.uint8)
+    unpacked = torch.stack([u >> 4, u & 15], -1).flatten().int()
+    unpacked = torch.where(unpacked >= 8, unpacked - 16, unpacked)
+    torch.testing.assert_close(unpacked, values.int())
+
+
+def test_stream_maps_fused_experts_and_shared_linear():
+    mod = adapter()
+    p = 'layers.1.mlp.'
+    packed = torch.tensor([[[0x87, 0x10]]], dtype=torch.uint8)
+    scales = torch.tensor([[0.5]])
+    source = [(p+'experts.gate_up_proj.int4_packed', packed),
+              (p+'experts.gate_up_proj.scale', scales),
+              (p+'experts.gate_up_proj.input_scale', torch.ones(1, 4)),
+              (p+'shared_experts.gate_proj.weight.int4_packed', packed[0]),
+              (p+'shared_experts.gate_proj.weight.scale', scales[0]),
+              ('layers.0.self_attn.q_a_proj.weight', torch.ones(2, 2))]
+    result = dict(mod.adapt_weights(source))
+    assert set(result) == {p+'experts.gate_up_proj', p+'experts.gate_up_proj_scale', p+'shared_experts.gate_proj.weight', p+'shared_experts.gate_proj.weight_scale', 'layers.0.self_attn.q_a_proj.weight'}
+    assert result[p+'experts.gate_up_proj'].data_ptr() == packed.data_ptr()
+    assert result[p+'experts.gate_up_proj_scale'].shape == (1, 1, 1)
+    assert result[p+'shared_experts.gate_proj.weight_scale'].shape == (1, 1)
+
+
+def test_nonidentity_smoothing_scale_is_rejected():
+    with pytest.raises(ValueError, match='identity input_scale'):
+        list(adapter().adapt_weights([('layers.1.mlp.experts.down_proj.input_scale', torch.tensor([2.]))]))
+
+
+def test_manifest_selects_quantized_modules(tmp_path):
+    mod = adapter()
+    path = tmp_path/'conversion.json'
+    path.write_text(json.dumps({'provenance': {'format':'hy4-w4a8-custom-v1'}, 'quantized_tensors':{
+        'model.layers.1.mlp.experts.gate_up_proj': {'packing':'signed nibble, even input in low bits'},
+        'model.layers.1.mlp.shared_experts.gate_proj.weight': {'packing':'signed nibble, even input in low bits'},
+        'model.layers.1.mlp.shared_experts.up_proj.weight': {'packing':'signed nibble, even input in low bits'}}}))
+    modules = mod.read_quantized_modules(str(path))
+    assert 'model.layers.1.mlp.experts' in modules
+    assert 'model.layers.1.mlp.shared_experts.gate_up_proj' in modules
+    assert 'model.layers.0.self_attn.q_a_proj' not in modules
+    assert 'model.layers.78.mlp.experts' not in modules
+
+
+def test_custom_quant_config_dispatch_and_linear_storage(tmp_path):
+    from vllm_hcu.model_executor.layers.quantization.slimquant_w4a8 import SlimQuantW4A8Int8Config
+    path = tmp_path/'conversion.json'
+    path.write_text(json.dumps({'provenance': {'format':'hy4-w4a8-custom-v1'}, 'quantized_tensors':{
+        'model.layers.1.mlp.shared_experts.down_proj.weight': {'packing':'signed nibble, even input in low bits'}}}))
+    config = SlimQuantW4A8Int8Config.from_config({'checkpoint_format':'hy4-w4a8-custom-v1', 'conversion_manifest':str(path)})
+    assert getattr(config, 'checkpoint_format', None) == 'hy4-w4a8-custom-v1'
+    from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+    layer = LinearBase.__new__(LinearBase)
+    torch.nn.Module.__init__(layer)
+    method = config.get_quant_method(layer, 'model.layers.1.mlp.shared_experts.down_proj')
+    method.create_weights(layer, 128, [256], 128, 256, torch.bfloat16, weight_loader=lambda *a:None)
+    assert layer.weight.shape == (256, 64)
+    assert layer.weight.dtype == torch.int8
+    assert layer.weight_scale.shape == (256, 1)
+    assert isinstance(config.get_quant_method(layer, 'model.layers.0.self_attn.q_a_proj'), UnquantizedLinearMethod)
+    layer.weight.data.fill_(0x12)
+    layer.weight_scale.data.fill_(1.)
+    method.process_weights_after_loading(layer)
+    assert torch.all(layer.weight == 0x21)
+
+
+def test_custom_config_selects_routed_experts_and_reorders_local_shards(tmp_path):
+    from types import SimpleNamespace
+    from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+    from vllm_hcu.model_executor.layers.quantization.hyv4_w4a8 import HYV4W4A8Config, HYV4W4A8MoEMethod
+    path = tmp_path/'conversion.json'
+    path.write_text(json.dumps({'provenance': {'format':'hy4-w4a8-custom-v1'}, 'quantized_tensors':{
+        'model.layers.1.mlp.experts.down_proj': {'packing':'signed nibble, even input in low bits'}}}))
+    config = HYV4W4A8Config(str(path))
+    layer = RoutedExperts.__new__(RoutedExperts)
+    torch.nn.Module.__init__(layer)
+    layer.moe_config = SimpleNamespace(swiglu_limit=10.)
+    method = config.get_quant_method(layer, 'model.layers.1.mlp.experts')
+    assert isinstance(method, HYV4W4A8MoEMethod)
+    method.create_weights(layer, 4, 128, 64, torch.bfloat16)
+    assert layer.w13_weight.shape == (4, 128, 64)
+    assert layer.w2_weight.shape == (4, 128, 32)
+    layer.w13_weight.data.fill_(0x12)
+    layer.w2_weight.data.fill_(0x34)
+    method.process_weights_after_loading(layer)
+    assert torch.all(layer.w13_weight == 0x21)
+    assert torch.all(layer.w2_weight == 0x43)
+    assert config.get_quant_method(layer, 'model.layers.78.mlp.experts') is None

--- a/tests/ops/test_hyv4_w4a8_kernels.py
+++ b/tests/ops/test_hyv4_w4a8_kernels.py
@@ -1,0 +1,70 @@
+"""Numerical coverage: nibble order, routing, gate/up order and clamp."""
+import importlib.util
+from pathlib import Path
+import pytest
+import torch
+
+MODULE = Path(__file__).resolve().parents[2] / 'vllm_hcu/model_executor/layers/quantization/hyv4_w4a8_kernels.py'
+
+
+def runtime():
+    assert MODULE.exists(), 'HYV4 aiter W4A8 runtime is missing'
+    spec = importlib.util.spec_from_file_location('hyv4_w4a8_kernels', MODULE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def pack(values):
+    return (((values[..., ::2].to(torch.int16) & 15) << 4)
+            | (values[..., 1::2].to(torch.int16) & 15)).to(torch.int8)
+
+
+def test_signed_nibble_reference():
+    values = runtime().unpack_int4(torch.tensor([[-113, 7, -91]], dtype=torch.int8))
+    torch.testing.assert_close(values, torch.tensor([[-8, -1, 0, 7, -6, 5]], dtype=torch.int8))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='requires Hygon GPU')
+@pytest.mark.parametrize('m,k,n', [(1,128,64), (35,256,96), (2,6144,512), (1,256,6144)])
+def test_linear_matches_quantized_reference(m,k,n):
+    torch.manual_seed(12)
+    x = torch.randn(m,k,device='cuda',dtype=torch.bfloat16)
+    w = torch.randint(-8,8,(n,k),device='cuda',dtype=torch.int8)
+    scale = torch.rand(n,1,device='cuda') * .03
+    from aiter import per_token_quant_triton
+    q, xs = per_token_quant_triton(x,quant_dtype=torch.int8)
+    expected = ((q.float() @ w.float().T) * xs * scale.T).to(x.dtype)
+    actual = runtime().linear(x,pack(w),scale)
+    torch.testing.assert_close(actual,expected,rtol=.008,atol=.002)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='requires Hygon GPU')
+def test_moe_preserves_gate_up_clamp_and_routing():
+    torch.manual_seed(22)
+    m,k,n,e = 5,128,128,3
+    x = torch.randn(m,k,device='cuda',dtype=torch.bfloat16) * 3
+    w13 = torch.randint(-8,8,(e,2*n,k),device='cuda',dtype=torch.int8)
+    w2 = torch.randint(-8,8,(e,k,n),device='cuda',dtype=torch.int8)
+    s13 = torch.full((e,2*n,1),.15,device='cuda')
+    s2 = torch.full((e,k,1),.015,device='cuda')
+    ids = torch.tensor([[0,1],[1,2],[2,0],[0,2],[1,0]],device='cuda',dtype=torch.int32)
+    weights = torch.tensor([[.2,.8]]*m,device='cuda')
+    from aiter import per_token_quant_triton
+    q,xs = per_token_quant_triton(x,quant_dtype=torch.int8)
+    expected = torch.zeros_like(x)
+    routes = []
+    for j in range(2):
+        route = []
+        for i in range(m):
+            expert = ids[i,j].item()
+            pre = ((q[i].float() @ w13[expert].float().T)*xs[i]*s13[expert,:,0]).to(x.dtype).float()
+            gate,up = pre.chunk(2)
+            bridge = (torch.nn.functional.silu(gate.clamp(max=10))*up.clamp(-10,10)).to(x.dtype)[None,:]
+            bq,bs = per_token_quant_triton(bridge,quant_dtype=torch.int8)
+            out = ((bq.float() @ w2[expert].float().T)*bs*s2[expert,:,0]*weights[i,j]).to(x.dtype)
+            route.append(out)
+        routes.append(torch.cat(route))
+    expected = (routes[0].float()+routes[1].float()).to(x.dtype)
+    actual = runtime().moe(x,pack(w13),pack(w2),s13,s2,weights,ids,gemm1_limit=10.)
+    torch.testing.assert_close(actual,expected,rtol=.025,atol=.125)

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -1563,7 +1563,8 @@ def test_indexer_wrappers_filter_zero_chunks_and_propagate_kv_count():
     assert Builder().build(0, common).num_kv_actual_tokens == 5
 
 
-def test_gfx938_sparse_indexer_uses_triton_fp8_cache_insert(monkeypatch):
+@pytest.mark.parametrize("gfx938", [True, False])
+def test_hcu_uint8_indexer_uses_triton_fp8_cache_insert(monkeypatch, gfx938):
     from vllm import _custom_ops as ops
     from vllm_hcu.v1.attention.ops import rocm_aiter_mla_sparse as sparse
 
@@ -1590,7 +1591,7 @@ def test_gfx938_sparse_indexer_uses_triton_fp8_cache_insert(monkeypatch):
             fp8_dtype=lambda: torch.float8_e4m3fn,
         ),
     )
-    monkeypatch.setattr(sparse, "on_gfx938", lambda: True)
+    monkeypatch.setattr(sparse, "on_gfx938", lambda: gfx938)
     monkeypatch.setattr(
         sparse,
         "indexer_k_quant_and_cache_triton",
@@ -1626,8 +1627,9 @@ def test_gfx938_sparse_indexer_uses_triton_fp8_cache_insert(monkeypatch):
     torch.testing.assert_close(topk_indices, torch.full_like(topk_indices, -1))
 
 
-def test_gfx938_sparse_indexer_prefill_uses_triton_fp8_cache_gather(
-    monkeypatch,
+@pytest.mark.parametrize("gfx938", [True, False])
+def test_hcu_uint8_indexer_prefill_uses_triton_fp8_cache_gather(
+    monkeypatch, gfx938,
 ):
     from vllm import _custom_ops as ops
     from vllm_hcu.v1.attention.ops import rocm_aiter_mla_sparse as sparse
@@ -1666,7 +1668,7 @@ def test_gfx938_sparse_indexer_prefill_uses_triton_fp8_cache_gather(
             fp8_dtype=lambda: torch.float8_e4m3fn,
         ),
     )
-    monkeypatch.setattr(sparse, "on_gfx938", lambda: True)
+    monkeypatch.setattr(sparse, "on_gfx938", lambda: gfx938)
 
     def gather(*args, **kwargs):
         calls.append((args, kwargs))

--- a/tools/hy_v4/serve_custom_w4a8.sh
+++ b/tools/hy_v4/serve_custom_w4a8.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+plugin_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+export PYTHONPATH="$plugin_root${PYTHONPATH:+:$PYTHONPATH}"
+export VLLM_USE_V2_MODEL_RUNNER=1
+exec vllm serve /data/models/hy4_w4a8_unverified \
+  --served-model-name hy4-w4a8 \
+  --tensor-parallel-size 8 --moe-backend aiter \
+  --quantization slimquant_w4a8 \
+  --hf-overrides '{"quantization_config":{"quant_method":"slimquant_w4a8","checkpoint_format":"hy4-w4a8-custom-v1","conversion_manifest":"/data/models/hy4_w4a8_unverified/conversion.json"}}' \
+  --gpu-memory-utilization 0.95 --max-model-len 1024 \
+  --max-num-seqs 1 --max-num-batched-tokens 128 \
+  --host 127.0.0.1 --port 8000 "$@"

--- a/vllm_hcu/model_executor/layers/quantization/hyv4_w4a8.py
+++ b/vllm_hcu/model_executor/layers/quantization/hyv4_w4a8.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Explicit HYV4 custom-format quantization, using aiter W4A8 kernels."""
+
+import torch
+from torch.nn import Parameter
+
+from vllm.model_executor.layers.linear import (
+    LinearBase, LinearMethodBase, UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+from vllm.model_executor.utils import set_weight_attrs
+
+from .slimquant_w4a8 import (
+    SlimQuantW4A8Int8Config, SlimQuantW4A8Int8AiterMoEMethod,
+)
+from .hyv4_w4a8_weights import (
+    CHECKPOINT_FORMAT, read_quantized_modules, to_aiter_packing,
+)
+
+
+class HYV4W4A8Config(SlimQuantW4A8Int8Config):
+    checkpoint_format = CHECKPOINT_FORMAT
+
+    def __init__(self, conversion_manifest: str):
+        self.quantized_modules = read_quantized_modules(conversion_manifest)
+
+    def get_quant_method(self, layer, prefix):
+        quantized = prefix.removesuffix(".routed_experts") in self.quantized_modules
+        if isinstance(layer, LinearBase):
+            return HYV4W4A8LinearMethod() if quantized else UnquantizedLinearMethod()
+        if isinstance(layer, RoutedExperts) and quantized:
+            return HYV4W4A8MoEMethod(self, layer.moe_config)
+        return None
+
+
+class HYV4W4A8LinearMethod(LinearMethodBase):
+    def create_weights(self, layer, input_size_per_partition,
+                       output_partition_sizes, input_size, output_size,
+                       params_dtype, **extra_weight_attrs):
+        if input_size_per_partition % 2:
+            raise ValueError("HYV4 INT4 requires an even local input dimension")
+        n = sum(output_partition_sizes)
+        weight = Parameter(torch.empty(n, input_size_per_partition // 2,
+                                       dtype=torch.int8), requires_grad=False)
+        scale = Parameter(torch.empty(n, 1, dtype=torch.float32), requires_grad=False)
+        set_weight_attrs(weight, {**extra_weight_attrs, "input_dim": 1,
+                                  "output_dim": 0, "packed_dim": 1,
+                                  "packed_factor": 2})
+        set_weight_attrs(scale, {**extra_weight_attrs, "output_dim": 0})
+        layer.register_parameter("weight", weight)
+        layer.register_parameter("weight_scale", scale)
+
+    def process_weights_after_loading(self, layer):
+        layer.weight.data.copy_(to_aiter_packing(layer.weight.data))
+
+    def apply(self, layer, x, bias=None):
+        from .hyv4_w4a8_kernels import linear
+
+        shape = x.shape[:-1]
+        result = linear(x.reshape(-1, x.shape[-1]), layer.weight,
+                        layer.weight_scale, bias)
+        return result.reshape(*shape, layer.weight.shape[0])
+
+
+class HYV4W4A8MoEMethod(SlimQuantW4A8Int8AiterMoEMethod):
+    def process_weights_after_loading(self, layer):
+        super().process_weights_after_loading(layer)
+        # Convert only local shards, expert by expert to bound peak memory.
+        for parameter in (layer.w13_weight, layer.w2_weight):
+            for expert in parameter.data:
+                expert.copy_(to_aiter_packing(expert))
+
+    def apply(self, layer, x, topk_weights, topk_ids,
+              shared_experts_input=None, **kwargs):
+        from .hyv4_w4a8_kernels import moe
+
+        return moe(
+            x, layer.w13_weight, layer.w2_weight,
+            layer.w13_weight_scale, layer.w2_weight_scale,
+            topk_weights, topk_ids,
+            gemm1_limit=self.moe.swiglu_limit,
+            expert_map=layer.expert_map,
+            global_num_experts=layer.global_num_experts,
+            apply_router_weight_on_input=layer.apply_router_weight_on_input,
+        )

--- a/vllm_hcu/model_executor/layers/quantization/hyv4_w4a8_kernels.py
+++ b/vllm_hcu/model_executor/layers/quantization/hyv4_w4a8_kernels.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Plugin-owned adapters for aiter's contiguous, signed W4A8 GEMMs.
+
+Weights store even K in the high nibble and odd K in the low nibble.
+Scales are dequantization multipliers per output channel. No weight
+unpacking, layout shuffle, or new GPU kernel is used during inference.
+"""
+import torch
+
+
+def unpack_int4(packed: torch.Tensor) -> torch.Tensor:
+    """Portable numerical-reference unpacker; not used during inference."""
+    pair = torch.stack(((packed >> 4) & 15, packed & 15), dim=-1)
+    return torch.where(pair >= 8, pair - 16, pair).to(torch.int8).flatten(-2)
+
+
+def linear(x: torch.Tensor, packed: torch.Tensor, scales: torch.Tensor,
+           bias: torch.Tensor | None = None) -> torch.Tensor:
+    """Apply [N,K/2] INT4 weight to [M,K], quantizing each input row to INT8."""
+    from aiter import per_token_quant_triton
+    from aiter.ops.triton.moe_op import fused_moe
+    import triton.language as tl
+
+    if x.ndim != 2 or packed.ndim != 2 or x.shape[1] != 2 * packed.shape[1]:
+        raise ValueError('W4A8 linear requires x[M,K], packed[N,K/2]')
+    if scales.shape != (packed.shape[0], 1):
+        raise ValueError('W4A8 linear requires channel scales[N,1]')
+    m, n = x.shape[0], packed.shape[0]
+    output = torch.empty((m,n),dtype=x.dtype,device=x.device)
+    if m == 0:
+        return output
+    q, xscale = per_token_quant_triton(x.contiguous(), quant_dtype=torch.int8)
+    block_m = 16
+    padded = (m + block_m - 1) // block_m * block_m
+    # A single expert needs no sorting: padding IDs are >= the token count.
+    sorted_ids = torch.arange(padded,device=x.device,dtype=torch.int32)
+    expert_ids = torch.zeros((padded//block_m,),device=x.device,dtype=torch.int32)
+    token_count = torch.full((1,),padded,device=x.device,dtype=torch.int32)
+    ids = torch.zeros((m,1),device=x.device,dtype=torch.int32)
+    compute_type = {torch.bfloat16:tl.bfloat16,torch.float16:tl.float16,
+                    torch.float32:tl.float32}[x.dtype]
+    fused_moe(q, packed.unsqueeze(0), output, xscale, scales.unsqueeze(0),
+              None, None, ids, sorted_ids, None, expert_ids, token_count,
+              False, 1, compute_type, use_int4_w4a8=True,
+              per_channel_quant=True,
+              config={'BLOCK_SIZE_M':block_m,'BLOCK_SIZE_N':64,
+                      'BLOCK_SIZE_K':128,'GROUP_SIZE_M':1,
+                      'num_warps':4,'num_stages':2})
+    if bias is not None:
+        output.add_(bias)
+    return output
+
+
+def moe(x: torch.Tensor, w13: torch.Tensor, w2: torch.Tensor,
+        s13: torch.Tensor, s2: torch.Tensor, topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor, *, gemm1_limit: float = 10.,
+        expert_map: torch.Tensor | None = None, global_num_experts: int = -1,
+        apply_router_weight_on_input: bool = False,
+        routed_scaling_factor: float = 1.) -> torch.Tensor:
+    """Apply routed W4A8 experts; w13 rows are [gate, up].
+
+    aiter applies SiLU(min(gate, limit)) * clamp(up, -limit, limit),
+    then dynamically quantizes the intermediate activation per token.
+    """
+    from aiter.ops.triton.fused_moe import fused_experts_impl
+
+    return fused_experts_impl(
+        x.contiguous(), w13, w2, topk_weights, topk_ids,
+        output_dtype=x.dtype, use_int4_w4a8=True, per_channel_quant=True,
+        w1_scale=s13, w2_scale=s2, activation='silu', is_gated=True,
+        gemm1_limit=gemm1_limit, expert_map=expert_map,
+        global_num_experts=global_num_experts,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+        routed_scaling_factor=routed_scaling_factor)

--- a/vllm_hcu/model_executor/layers/quantization/hyv4_w4a8_weights.py
+++ b/vllm_hcu/model_executor/layers/quantization/hyv4_w4a8_weights.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming adaptation of the explicit HYV4 custom INT4 checkpoint format."""
+
+import json
+from collections.abc import Iterable, Iterator
+
+import torch
+
+CHECKPOINT_FORMAT = "hy4-w4a8-custom-v1"
+
+
+def read_quantized_modules(manifest_path: str) -> frozenset[str]:
+    with open(manifest_path) as source:
+        manifest = json.load(source)
+    if manifest.get("provenance", {}).get("format") != CHECKPOINT_FORMAT:
+        raise ValueError(f"Expected {CHECKPOINT_FORMAT} conversion manifest")
+    modules = set()
+    for name, metadata in manifest["quantized_tensors"].items():
+        if metadata.get("packing") != "signed nibble, even input in low bits":
+            raise ValueError(f"Unsupported HYV4 INT4 packing for {name}")
+        name = name.removesuffix(".weight")
+        if ".experts." in name:
+            name = name.rsplit(".", 1)[0]
+        else:
+            name = name.replace(".gate_proj", ".gate_up_proj")
+            name = name.replace(".up_proj", ".gate_up_proj")
+        modules.add(name)
+    return frozenset(modules)
+
+
+def to_aiter_packing(weight: torch.Tensor) -> torch.Tensor:
+    """Signed two's-complement INT4: checkpoint low-first -> aiter high-first."""
+    if weight.dtype not in (torch.uint8, torch.int8):
+        raise ValueError("HYV4 packed INT4 must have byte storage")
+    unsigned = weight.view(torch.uint8)
+    return ((unsigned << 4) | (unsigned >> 4)).view(torch.int8)
+
+
+def adapt_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Map names without expanding or retaining whole expert tensors on CPU.
+
+    Nibble conversion occurs after local parameter sharding. Input scales in
+    this uncalibrated RTN format are identity smoothing vectors, not runtime
+    per-token activation scales; reject nonidentity vectors explicitly.
+    """
+    for name, weight in weights:
+        if name.endswith(".input_scale"):
+            if not torch.all(weight == 1).item():
+                raise ValueError(f"HYV4 W4A8 requires identity input_scale: {name}")
+            continue
+        if name.endswith(".int4_packed"):
+            if weight.dtype != torch.uint8:
+                raise ValueError(f"Expected UINT8 packed checkpoint tensor: {name}")
+            yield name.removesuffix(".int4_packed"), weight
+        elif name.endswith(".scale"):
+            if not torch.all(torch.isfinite(weight) & (weight > 0)).item():
+                raise ValueError(f"Invalid HYV4 W4A8 channel scale: {name}")
+            yield name.removesuffix(".scale") + "_scale", weight.unsqueeze(-1)
+        else:
+            yield name, weight

--- a/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
+++ b/vllm_hcu/model_executor/layers/quantization/slimquant_w4a8.py
@@ -57,6 +57,10 @@ class SlimQuantW4A8Int8Config(QuantizationConfig):
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "SlimQuantW4A8Int8Config":
+        if config.get("checkpoint_format") == "hy4-w4a8-custom-v1":
+            from .hyv4_w4a8 import HYV4W4A8Config
+
+            return HYV4W4A8Config(config["conversion_manifest"])
         return cls()
 
     def get_quant_method(

--- a/vllm_hcu/models/hy_v4/model.py
+++ b/vllm_hcu/models/hy_v4/model.py
@@ -684,6 +684,15 @@ class HYV4Model(nn.Module, MixtureOfExperts):
         return loaded_local_expert
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        checkpoint_format = getattr(
+            getattr(self, "quant_config", None), "checkpoint_format", None
+        )
+        if checkpoint_format == "hy4-w4a8-custom-v1":
+            from vllm_hcu.model_executor.layers.quantization.hyv4_w4a8_weights import (
+                adapt_weights,
+            )
+
+            weights = adapt_weights(weights)
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             (".qkv_proj", ".q_proj", "q"),

--- a/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -24,7 +24,7 @@ else:
     
 from vllm.v1.attention.backends.mla.indexer import DeepseekV32IndexerPrefillMetadata
 import vllm_hcu.platforms.envs as henvs 
-from vllm_hcu.platforms.hcu import on_gfx938
+from vllm_hcu.platforms.hcu import on_gfx938, on_gfx93x
 try:
     import lightop
     from lightop import gemmopt, op
@@ -966,8 +966,19 @@ def rocm_fp8_mqa_logits(
     from vllm._aiter_ops import rocm_aiter_ops
 
     aiter_mqa_logits_module = None
-    if rocm_aiter_ops.is_enabled():
+    # gfx936 LightOp's FP8 prefill entry can return zero logits. The aiter
+    # Triton implementation handles FP8 inputs on this device correctly.
+    use_gfx936_fp8 = (
+        current_platform.is_rocm()
+        and on_gfx93x()
+        and not on_gfx938()
+        and q.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+    )
+    if rocm_aiter_ops.is_enabled() or use_gfx936_fp8:
         aiter_mqa_logits_module = mqa_logits_module()
+
+    if use_gfx936_fp8 and aiter_mqa_logits_module is None:
+        raise RuntimeError("gfx936 FP8 indexer requires aiter fp8_mqa_logits")
 
     if aiter_mqa_logits_module is not None:
         fp8_mqa_logits = aiter_mqa_logits_module.fp8_mqa_logits
@@ -1245,7 +1256,11 @@ def rocm_aiter_sparse_attn_indexer_native(
 ) -> torch.Tensor:
     # careful! this will be None in dummy run
     attn_metadata = get_forward_context().attn_metadata
-    fp8_dtype = current_platform.fp8_dtype() if not current_platform.is_rocm() or on_gfx938() else k.dtype
+    # HYV4 uses a packed FP8 indexer cache on gfx936 as well as gfx938.
+    # Select the cache reader/writer from storage, not the device generation
+    # or the incoming K dtype (K can also be absent for a shared indexer).
+    use_fp8_cache = kv_cache.dtype == torch.uint8
+    fp8_dtype = current_platform.fp8_dtype() if use_fp8_cache else kv_cache.dtype
     from vllm import _custom_ops as ops
     from vllm.utils.torch_utils import _resolve_layer_name
 
@@ -1294,7 +1309,7 @@ def rocm_aiter_sparse_attn_indexer_native(
                 quant_block_size,
                 scale_fmt,
             )
-        elif on_gfx938():
+        elif use_fp8_cache:
             indexer_k_quant_and_cache_triton(
                 k,
                 kv_cache,
@@ -1339,7 +1354,7 @@ def rocm_aiter_sparse_attn_indexer_native(
                     chunk.block_table,
                     chunk.cu_seq_lens,
                 )
-            elif on_gfx938():
+            elif use_fp8_cache:
                 cp_gather_indexer_k_quant_cache_triton(
                     kv_cache,
                     k_fp8,


### PR DESCRIPTION
## Summary

让 `/data/models/hy4_w4a8_unverified` 的自定义 INT4 checkpoint 通过 HCU 插件复用 aiter W4A8（INT4 权重 / 动态 INT8 激活），支持 TP8 和 MTP。加载适配、量化方法和 gfx936 FP8 indexer 修复均位于插件内；不修改安装环境中的 vLLM/aiter 源码，不重写 checkpoint。

已验证的启动命令（在本分支根目录执行，**不加 `--enforce-eager`**）：

```bash
export PYTHONPATH="$PWD${PYTHONPATH:+:$PYTHONPATH}"
export VLLM_USE_V2_MODEL_RUNNER=1
export VLLM_PLUGINS=hcu,hcu_model,hcu_ops

vllm serve /data/models/hy4_w4a8_unverified \
  --served-model-name hy4-w4a8 \
  --tensor-parallel-size 8 \
  --moe-backend triton \
  --quantization slimquant_w4a8 \
  --hf-overrides '{"quantization_config":{"quant_method":"slimquant_w4a8","checkpoint_format":"hy4-w4a8-custom-v1","conversion_manifest":"/data/models/hy4_w4a8_unverified/conversion.json"}}' \
  --gpu-memory-utilization 0.95 \
  --max-model-len 1024 \
  --max-num-seqs 1 \
  --max-num-batched-tokens 128 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
  --host 127.0.0.1 --port 8000
```

也可以使用随 MR 提供的脚本：

```bash
bash tools/hy_v4/serve_custom_w4a8.sh \
  --moe-backend triton \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
```

这里 `--moe-backend triton` 用于 checkpoint 中未量化的 BF16 MTP 层：当前 aiter 构建缺少其 W16A16 ASM 方案。主模型的量化专家和 shared Linear 仍由本适配显式调用 **aiter W4A8**。

## Implementation

- 仅在显式指定 `checkpoint_format=hy4-w4a8-custom-v1` 时启用；依据 `conversion.json` 选择量化模块。
- 流式映射自定义权重名和 channel scale；本地 TP 分片加载后转换 nibble 顺序，并验证 identity input scale。
- 复用 aiter channelwise W4A8 Linear/MoE，保留 SwiGLU clipping 和 vLLM 原有路由、shared expert 合并及 TP reduction。
- gfx936 indexer 根据 cache dtype 选择 FP8 cache 读写；FP8 prefill 使用经数值验证的 aiter 实现。

## Validation

环境：8 张 64 GiB gfx936；vLLM `0.25.1+das185.dtk2604.torch2110.2608171710.g7b108a`；aiter `0.1.6+dtk2604.torch2110.2609082106.g31fdae`。

- 插件 contract suite：1317 项通过（退出码 0）。
- 204 项 HYV4 / W4A8 / indexer 回归测试通过，另有 4 项 indexer GPU 数值测试通过；插件 doctor 全部通过。
- `enforce_eager=False`，V2 runner 的 breakable Graph 路径启用 `FULL_AND_PIECEWISE`；主模型和 MTP 的 prefill/decode 捕获成功，20 秒、每卡额外约 0.40 GiB。该路径的 Inductor mode 为 `NONE`，不是 Inductor 编译测试。
- Graph 模式的 32-token 补全及额外 3 次重复请求均与非 MTP 基线逐 token 一致；中文对话文本一致。
- 207-token 输入覆盖 128-token batch limit 下的 chunked prefill，正确生成答案，输出 log probabilities 均有限。

限制：checkpoint 是未校准 RTN，manifest 标记 `NOT_EVALUATED`，本 MR 未做模型精度评测。此前 eager + MTP 的补全与基线出现 token 差异；当前 Graph 短请求通过不代表所有执行模式普遍等价。上述耗时仅为 smoke 数据，不作为性能基准。

更多说明见 [docs/hyv4-custom-w4a8.md](docs/hyv4-custom-w4a8.md)。


## Review fix: W4A8 CI coverage

- 将数值测试迁移至 `tests/accuracy/test_hyv4_w4a8_kernels.py`；CPU reference 进入 contract，5 个 GPU 用例以 `hcu` 标记进入 accuracy-hcu / nightly。
- 同步登记 CI 路径映射和 `tests/hcu_ci_registry.py` 的 `accuracy-gfx936` 执行目标；硬件检查在 fixture 运行阶段进行。
- 验证：contract 定向用例 1 项通过；accuracy-hcu 定向用例 5 项通过；nightly 收集到全部 5 个 GPU 用例；CI 选择器回归 42 项通过。
