### PR TITLE
fix: keep gated RMSNorm dynamic-shape graph safe

### DIFF
--- a/tests/runtime_patch/test_lightop_rmsnorm_gated.py
+++ b/tests/runtime_patch/test_lightop_rmsnorm_gated.py
@@ -102,7 +102,7 @@ def test_qwen_gated_rmsnorm_eligibility_is_strict(
     assert rms_norm_gated._is_qwen_gated_rmsnorm_eligible(
         _layer(256), x_256, _TensorMetadata((32, 256))
     )
-    assert not rms_norm_gated._is_qwen_gated_rmsnorm_eligible(
+    assert rms_norm_gated._is_qwen_gated_rmsnorm_eligible(
         _layer(), _TensorMetadata((3, 128)), _TensorMetadata((3, 128))
     )
     assert not rms_norm_gated._is_qwen_gated_rmsnorm_eligible(
@@ -238,6 +238,82 @@ def test_qwen_gated_rmsnorm_forward_dispatch_is_fullgraph_compilable(
     assert result.dtype is torch.bfloat16
 
 
+def test_qwen_gated_rmsnorm_ineligible_semantics_use_graph_safe_native_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(
+        henvs, "VLLM_HCU_USE_LIGHTOP_QWEN_RMSNORM_GATED", True
+    )
+    sentinel = object()
+    layer = _layer(
+        activation="sigmoid",
+        forward_native=lambda _x, _z: sentinel,
+        forward_cuda=lambda _x, _z: (_ for _ in ()).throw(
+            AssertionError("ineligible fallback must remain graph compilable")
+        ),
+    )
+    x = _TensorMetadata((32, 128))
+    z = _TensorMetadata((32, 128))
+
+    result = rms_norm_gated.HcuRMSNormGated.forward_hip(layer, x, z)
+
+    assert result is sentinel
+
+
+def test_qwen_gated_rmsnorm_dynamic_rows_do_not_specialize_fullgraph(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(
+        henvs, "VLLM_HCU_USE_LIGHTOP_QWEN_RMSNORM_GATED", True
+    )
+    with FakeTensorMode():
+        x = torch.empty((32, 128), device="cuda", dtype=torch.bfloat16)
+        z = torch.empty_like(x)
+        torch._dynamo.mark_dynamic(x, 0)
+        torch._dynamo.mark_dynamic(z, 0)
+        layer = _layer(
+            weight=torch.empty(
+                (128,), device="cuda", dtype=torch.bfloat16
+            )
+        )
+
+        def forward(a, b):
+            return rms_norm_gated.HcuRMSNormGated.forward_hip(layer, a, b)
+
+        result = torch.compile(forward, backend="eager", fullgraph=True)(x, z)
+
+    assert result.shape == x.shape
+
+
+def test_qwen_gated_rmsnorm_unverified_rows_fall_back_inside_custom_op(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        rms_norm_gated,
+        "_lightop_layer_norm_fwd_1pass_opt",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("unverified rows must not enter LightOp")
+        ),
+    )
+    sentinel = object()
+    monkeypatch.setattr(
+        rms_norm_gated,
+        "_vllm_qwen_rmsnorm_gated_fallback",
+        lambda *_args: sentinel,
+    )
+
+    result = rms_norm_gated._hcu_lightop_qwen_rmsnorm_gated_impl(
+        torch.zeros((3, 128), dtype=torch.bfloat16),
+        torch.zeros((3, 128), dtype=torch.bfloat16),
+        torch.ones((128,), dtype=torch.bfloat16),
+        1e-6,
+    )
+
+    assert result is sentinel
+
+
 def test_qwen_gated_rmsnorm_does_not_log_when_operator_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -246,6 +322,11 @@ def test_qwen_gated_rmsnorm_does_not_log_when_operator_fails(
 
     monkeypatch.setattr(
         rms_norm_gated, "_lightop_layer_norm_fwd_1pass_opt", lambda: fail
+    )
+    monkeypatch.setattr(
+        rms_norm_gated,
+        "_is_lightop_runtime_tensor_eligible",
+        lambda *_args: True,
     )
     monkeypatch.setattr(torch.cuda, "device", lambda _device: nullcontext())
     monkeypatch.setattr(
@@ -290,6 +371,11 @@ def test_qwen_gated_rmsnorm_uses_categorized_lightop_api(
     monkeypatch.setitem(sys.modules, "lightop", lightop)
     monkeypatch.setitem(sys.modules, "lightop.norm", norm)
     rms_norm_gated._lightop_layer_norm_fwd_1pass_opt.cache_clear()
+    monkeypatch.setattr(
+        rms_norm_gated,
+        "_is_lightop_runtime_tensor_eligible",
+        lambda *_args: True,
+    )
     monkeypatch.setattr(torch.cuda, "device", lambda _device: nullcontext())
     monkeypatch.setattr(
         torch.cuda,

--- a/vllm_hcu/ops/rms_norm_gated.py
+++ b/vllm_hcu/ops/rms_norm_gated.py
@@ -83,12 +83,40 @@ def _vllm_qwen_rmsnorm_gated_fallback(
     )
 
 
+def _is_lightop_runtime_tensor_eligible(
+    x: torch.Tensor,
+    z: torch.Tensor,
+    weight: torch.Tensor,
+) -> bool:
+    return (
+        x.ndim == 2
+        and z.ndim == 2
+        and weight.ndim == 1
+        and x.shape[0] in _VERIFIED_QWEN_ROWS
+        and x.shape[1] in _VERIFIED_QWEN_WIDTHS
+        and z.shape == x.shape
+        and weight.shape[0] == x.shape[1]
+        and x.dtype is torch.bfloat16
+        and z.dtype is x.dtype
+        and weight.dtype is x.dtype
+        and x.device.type == "cuda"
+        and z.device == x.device
+        and weight.device == x.device
+        and x.is_contiguous()
+        and z.is_contiguous()
+        and weight.is_contiguous()
+    )
+
+
 def _hcu_lightop_qwen_rmsnorm_gated_impl(
     x: torch.Tensor,
     z: torch.Tensor,
     weight: torch.Tensor,
     eps: float,
 ) -> torch.Tensor:
+    if not _is_lightop_runtime_tensor_eligible(x, z, weight):
+        return _vllm_qwen_rmsnorm_gated_fallback(x, z, weight, eps)
+
     layer_norm_fwd_1pass_opt = _lightop_layer_norm_fwd_1pass_opt()
     if layer_norm_fwd_1pass_opt is None:
         return _vllm_qwen_rmsnorm_gated_fallback(x, z, weight, eps)
@@ -151,13 +179,9 @@ def _is_qwen_gated_rmsnorm_eligible(
         and henvs.VLLM_HCU_USE_LIGHTOP_QWEN_RMSNORM_GATED
     ):
         return False
-    if (
-        x.ndim != 2
-        or x.shape[0] not in _VERIFIED_QWEN_ROWS
-        or x.shape[1] not in _VERIFIED_QWEN_WIDTHS
-    ):
+    if x.ndim != 2 or x.shape[1] not in _VERIFIED_QWEN_WIDTHS:
         return False
-    if z is None or z.shape != x.shape:
+    if z is None or z.ndim != 2 or z.shape[1] != x.shape[1]:
         return False
     weight = layer.weight
     if (
@@ -208,7 +232,7 @@ class HcuRMSNormGated(RMSNormGated):
                 self.weight,
                 self.eps,
             )
-        return self.forward_cuda(x, z)
+        return self.forward_native(x, z)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

- keep Qwen gated RMSNorm routing graph-safe with backed dynamic token dimensions
- move runtime row/shape/device checks into the registered HCU custom op
- retain official native fallback for unsupported static semantics and official FLA fallback for unsupported runtime shapes
- add dynamic fullgraph and unsupported-row regression coverage

## Root cause

The graph-visible eligibility predicate branched on `x.shape[0]` and compared the complete dynamic shape. On vLLM v0.28.1-dev, Dynamo specialized the `(1, 1024)` compile range to 1024 and raised `ConstraintViolationError` during Qwen3.5 graph compilation.

## Validation

- `pytest -q tests/runtime_patch/test_lightop_rmsnorm_gated.py`: 14 passed
- `pytest -q tests/runtime_patch`: 1189 passed
- Qwen3.5-35B-A3B-W8A8 HumanEval 8: pass@1 1.0 (8/8)
- Qwen3.5-35B-A3B-W8A8 HumanEval 32: pass@1 1.0 (32/32)
- 40 evaluation requests returned HTTP 200 with no server errors
- MTP 3 final average draft acceptance rate: 95.8%, mean acceptance length: 3.88
- self-developed AITER Int8 MoE ordinary and bottom configs selected
- LightOp Qwen gated RMSNorm executed
- default `FULL_AND_PIECEWISE` target/draft graph capture completed; no eager or explicit compilation config

## Server command

```bash
env \
  PYTHONPATH=/models/.installs/vllm-plugin-das-gated-rmsnorm-dynamic-v0281 \
  HIP_VISIBLE_DEVICES=7 \
  NO_PROXY=127.0.0.1,localhost \
  no_proxy=127.0.0.1,localhost \
  vllm serve /models/Qwen3.5-35B-A3B-W8A8 \
    --host 127.0.0.1 \
    --port 10150 \
    --served-model-name Qwen3.5-35B-A3B-W8A8 \
    --tensor-parallel-size 1 \
    --trust-remote-code \
    --language-model-only \
    --attention-backend FLASH_ATTN \
    --moe-backend aiter \
    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
    --enable-prefix-caching \
    --max-model-len 4096 \
    --max-num-batched-tokens 1024 \
    --max-num-seqs 8 \
    --gpu-memory-utilization 0.85
```
