### PR TITLE
perf: route GDN FLA kernels through BoltOPs on v0.28.1-dev

### DIFF
--- a/tests/kernels/test_boltops_fla_numeric.py
+++ b/tests/kernels/test_boltops_fla_numeric.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""HCU numerical parity for the optional BoltOPs FLA chunk pipeline."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("lengths", [(64,), (32, 64)])
+def test_boltops_chunk_pipeline_matches_official(
+    monkeypatch: pytest.MonkeyPatch,
+    lengths: tuple[int, ...],
+):
+    if not torch.cuda.is_available():
+        pytest.skip("HCU is required")
+    pytest.importorskip("boltops.fla.gdn")
+
+    from vllm.third_party.flash_linear_attention.ops import chunk
+    from vllm_hcu.patch.worker.op_opt import (
+        patch_fla_chunk_delta_h,
+        patch_fla_chunk_o,
+        patch_fla_recompute_w_u,
+    )
+    from vllm_hcu.platforms import envs as henvs
+
+    patch_fla_chunk_delta_h.apply_to_module(chunk)
+    patch_fla_chunk_o.apply_to_module(chunk)
+    patch_fla_recompute_w_u.apply_to_module(chunk)
+
+    total_tokens = sum(lengths)
+    torch.manual_seed(7)
+    q = torch.randn(
+        1, total_tokens, 2, 64, device="cuda", dtype=torch.bfloat16
+    ) * 0.1
+    k = torch.randn_like(q) * 0.1
+    v = torch.randn_like(q) * 0.1
+    g = torch.nn.functional.logsigmoid(
+        torch.randn(1, total_tokens, 2, device="cuda", dtype=torch.float32)
+    )
+    beta = torch.sigmoid(
+        torch.randn(1, total_tokens, 2, device="cuda", dtype=torch.float32)
+    )
+    if len(lengths) == 1:
+        cu_seqlens = None
+        initial_state = None
+    else:
+        offsets = [0]
+        for length in lengths:
+            offsets.append(offsets[-1] + length)
+        cu_seqlens = torch.tensor(offsets, device="cuda", dtype=torch.long)
+        initial_state = torch.randn(
+            len(lengths), 2, 64, 64, device="cuda", dtype=torch.float32
+        ) * 0.01
+
+    def run(enabled: bool):
+        monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+        monkeypatch.setattr(
+            henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", enabled
+        )
+        output_buffer = torch.empty(
+            v.numel() + 16, device="cuda", dtype=v.dtype
+        )
+        output, final_state = chunk.chunk_gated_delta_rule(
+            q.clone(),
+            k.clone(),
+            v.clone(),
+            g.clone(),
+            beta.clone(),
+            initial_state=(
+                None if initial_state is None else initial_state.clone()
+            ),
+            output_final_state=True,
+            cu_seqlens=cu_seqlens,
+            core_attn_out=output_buffer,
+        )
+        torch.cuda.synchronize()
+        assert output.data_ptr() == output_buffer.data_ptr()
+        return output.clone(), final_state.clone()
+
+    expected_output, expected_state = run(False)
+    actual_output, actual_state = run(True)
+    torch.testing.assert_close(
+        actual_output, expected_output, rtol=5e-2, atol=5e-3
+    )
+    torch.testing.assert_close(
+        actual_state, expected_state, rtol=5e-2, atol=5e-3
+    )

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -687,13 +687,136 @@ def test_fla_chunk_o_feature_off_is_numerically_identical(monkeypatch):
     torch.testing.assert_close(module.chunk_fwd_o(x, x, x, x), original(x, x, x, x))
 
 
-def test_fla_chunk_delta_h_enabled_missing_aiter_fails_clearly(monkeypatch):
+def test_fla_chunk_delta_h_prefers_hip_kernel(monkeypatch):
     adapter = _adapter("patch_fla_chunk_delta_h")
+    calls = []
 
     def original(k, w, u, g=None, gk=None, initial_state=None,
                  output_final_state=False, chunk_size=64, save_new_value=True,
                  cu_seqlens=None, chunk_indices=None, chunk_offsets=None,
                  use_exp2=False):
+        return "official"
+
+    def hip(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "hip-h", "hip-v", "hip-final"
+
+    module = _module(
+        adapter.TARGET_MODULE,
+        FLA_CHUNK_SIZE=64,
+        chunk_gated_delta_rule_fwd_h=original,
+        prepare_chunk_indices=lambda *_args: torch.tensor([[0, 0]]),
+        prepare_chunk_offsets=lambda *_args: torch.tensor([0]),
+        triton=SimpleNamespace(cdiv=lambda value, divisor: (value + divisor - 1) // divisor),
+        torch=torch,
+    )
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.fla",
+        chunk_gated_delta_rule_fwd_vllm_hip_blockdim64=hip,
+    )
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.vllm.chunk_delta_h",
+        launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64=lambda **_kwargs: pytest.fail(
+            "HIP must have priority"
+        ),
+    )
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    cu_seqlens = torch.tensor([0, 2])
+    result = module.chunk_gated_delta_rule_fwd_h(
+        torch.empty(1, 2, 1, 4),
+        torch.empty(1),
+        torch.empty(1, 2, 1, 4),
+        output_final_state=True,
+        chunk_size=32,
+        save_new_value=False,
+        cu_seqlens=cu_seqlens,
+        use_exp2=True,
+    )
+
+    assert result == ("hip-h", "hip-v", "hip-final")
+    assert len(calls) == 1
+    _, kwargs = calls[0]
+    assert kwargs["cu_seqlens"] is cu_seqlens
+    assert kwargs["chunk_size"] == 32
+    assert kwargs["output_final_state"] is True
+    assert kwargs["save_new_value"] is False
+    assert kwargs["use_exp2"] is True
+    assert kwargs["transpose_state_layout"] is True
+
+
+def test_fla_chunk_o_prefers_hip_and_preserves_output_buffer(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_o")
+    calls = []
+
+    def original(q, k, v, h, g=None, scale=None, cu_seqlens=None,
+                 chunk_indices=None, chunk_size=64, core_attn_out=None):
+        return "official"
+
+    def hip(**kwargs):
+        calls.append(kwargs)
+        return kwargs["v"] + 3
+
+    module = _module(
+        adapter.TARGET_MODULE,
+        FLA_CHUNK_SIZE=64,
+        chunk_fwd_o=original,
+        prepare_chunk_indices=lambda *_args: torch.tensor([[0, 0]]),
+        triton=SimpleNamespace(cdiv=lambda value, divisor: (value + divisor - 1) // divisor),
+        torch=torch,
+    )
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.fla",
+        chunk_fwd_o_vllm_hip_blockdim64=hip,
+    )
+    _install_fake_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.vllm.chunk_o",
+        launch_chunk_fwd_kernel_o=lambda **_kwargs: pytest.fail(
+            "HIP must have priority"
+        ),
+    )
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    q = torch.zeros(1, 2, 1, 4)
+    v = torch.ones_like(q)
+    core_attn_out = torch.empty(v.numel() + 8)
+    result = module.chunk_fwd_o(
+        q,
+        q,
+        v,
+        q,
+        scale=0.25,
+        chunk_size=32,
+        core_attn_out=core_attn_out,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["scale"] == 0.25
+    assert calls[0]["chunk_size"] == 32
+    assert calls[0]["transpose_state_layout"] is True
+    assert result.data_ptr() == core_attn_out.data_ptr()
+    torch.testing.assert_close(result, v + 3)
+
+
+def test_fla_chunk_delta_h_enabled_missing_aiter_falls_back(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_delta_h")
+    calls = []
+
+    def original(k, w, u, g=None, gk=None, initial_state=None,
+                 output_final_state=False, chunk_size=64, save_new_value=True,
+                 cu_seqlens=None, chunk_indices=None, chunk_offsets=None,
+                 use_exp2=False):
+        calls.append((chunk_indices, chunk_offsets, use_exp2))
         return k, u, None
 
     module = _module(
@@ -709,15 +832,73 @@ def test_fla_chunk_delta_h_enabled_missing_aiter_fails_clearly(monkeypatch):
     monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
     monkeypatch.setitem(
         sys.modules,
+        "aiter.ops.fla",
+        ModuleType("aiter.ops.fla"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
         "aiter.ops.triton.fla.vllm.chunk_delta_h",
         ModuleType("aiter.ops.triton.fla.vllm.chunk_delta_h"),
     )
-    with pytest.raises(RuntimeError, match="enabled but unavailable"):
-        module.chunk_gated_delta_rule_fwd_h(
-            torch.empty(1, 1, 1, 1),
-            torch.empty(1),
-            torch.empty(1, 1, 1, 1),
-        )
+    chunk_indices = torch.tensor([[0, 0]])
+    chunk_offsets = torch.tensor([0])
+    result = module.chunk_gated_delta_rule_fwd_h(
+        torch.empty(1, 1, 1, 1),
+        torch.empty(1),
+        torch.empty(1, 1, 1, 1),
+        chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
+        use_exp2=True,
+    )
+
+    assert len(result) == 3
+    assert calls == [(chunk_indices, chunk_offsets, True)]
+
+
+def test_fla_chunk_o_enabled_missing_aiter_falls_back(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_o")
+    calls = []
+
+    def original(q, k, v, h, g=None, scale=None, cu_seqlens=None,
+                 chunk_indices=None, chunk_size=64, core_attn_out=None):
+        calls.append((scale, chunk_indices, core_attn_out))
+        return "official"
+
+    module = _module(
+        adapter.TARGET_MODULE,
+        FLA_CHUNK_SIZE=64,
+        chunk_fwd_o=original,
+        torch=torch,
+    )
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.ops.fla",
+        ModuleType("aiter.ops.fla"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.ops.triton.fla.vllm.chunk_o",
+        ModuleType("aiter.ops.triton.fla.vllm.chunk_o"),
+    )
+    chunk_indices = torch.tensor([[0, 0]])
+    core_attn_out = torch.empty(8)
+    result = module.chunk_fwd_o(
+        torch.empty(1, 1, 1, 1),
+        torch.empty(1, 1, 1, 1),
+        torch.empty(1, 1, 1, 1),
+        torch.empty(1, 1, 1, 1),
+        scale=0.5,
+        chunk_indices=chunk_indices,
+        core_attn_out=core_attn_out,
+    )
+
+    assert result == "official"
+    assert calls == [(0.5, chunk_indices, core_attn_out)]
 
 
 def test_mamba_nn_sharded_loader_cpu_numeric():
@@ -897,6 +1078,31 @@ def test_gdn_runtime_adapter_has_stable_patch_id():
     )
 
 
+def _gdn_sigmoid_contract(
+    A_log,
+    a,
+    b,
+    dt_bias,
+    q,
+    k,
+    v,
+    beta=1.0,
+    threshold=20.0,
+    scale=None,
+    initial_state=None,
+    inplace_final_state=True,
+    cu_seqlens=None,
+    ssm_state_indices=None,
+    num_accepted_tokens=None,
+    use_qk_l2norm_in_kernel=False,
+    is_kda=False,
+):
+    del A_log, a, b, dt_bias, q, k, v, beta, threshold, scale
+    del initial_state, inplace_final_state, cu_seqlens, ssm_state_indices
+    del num_accepted_tokens, use_qk_l2norm_in_kernel, is_kda
+    return "official-sigmoid"
+
+
 def test_gdn_nn_layout_normalizes_all_conv_weight_consumers(monkeypatch):
     causal_adapter = _adapter("patch_gdn_causal_conv1d")
     qwen_adapter = _adapter("patch_gdn_linear_attention")
@@ -978,7 +1184,7 @@ def test_gdn_nn_layout_normalizes_all_conv_weight_consumers(monkeypatch):
         GDN_AITER_TRITON_AVAILABLE=True,
         gdn_aiter_fused_reshape_causal_conv1d_update_single_token=aiter_update,
         fused_recurrent_gated_delta_rule_packed_decode=lambda *a, **k: "official-recurrent",
-        fused_sigmoid_gating_delta_rule_update=lambda *a, **k: "official-sigmoid",
+        fused_sigmoid_gating_delta_rule_update=_gdn_sigmoid_contract,
         GatedDeltaNetAttention=GatedDeltaNetAttention,
         MambaStateDtypeCalculator=SimpleNamespace(
             gated_delta_net_state_dtype=lambda *a: "calculator"
@@ -1035,7 +1241,7 @@ def test_gdn_nn_layout_normalizes_all_conv_weight_consumers(monkeypatch):
     )
 
 
-def test_gdn_recurrent_and_sigmoid_remain_target_owned(monkeypatch):
+def test_gdn_recurrent_remains_target_owned_and_sigmoid_is_qwen_local(monkeypatch):
     adapter = _adapter("patch_gdn_linear_attention")
 
     _install_fake_module(
@@ -1057,9 +1263,7 @@ def test_gdn_recurrent_and_sigmoid_remain_target_owned(monkeypatch):
         del args, kwargs
         return "official-recurrent"
 
-    def sigmoid(*args, **kwargs):
-        del args, kwargs
-        return "official-sigmoid"
+    sigmoid = _gdn_sigmoid_contract
 
     module = _module(
         adapter.TARGET_MODULE,
@@ -1071,10 +1275,16 @@ def test_gdn_recurrent_and_sigmoid_remain_target_owned(monkeypatch):
     from vllm_hcu.platforms import envs as henvs
 
     monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", False)
     assert module.fused_recurrent_gated_delta_rule_packed_decode is recurrent
-    assert module.fused_sigmoid_gating_delta_rule_update is sigmoid
+    assert module.fused_sigmoid_gating_delta_rule_update is not sigmoid
+    assert module._vllm_hcu_original_fused_sigmoid is sigmoid
     assert module.fused_recurrent_gated_delta_rule_packed_decode() == "official-recurrent"
-    assert module.fused_sigmoid_gating_delta_rule_update() == "official-sigmoid"
+    sigmoid_args = tuple(torch.empty(1) for _ in range(7))
+    assert (
+        module.fused_sigmoid_gating_delta_rule_update(*sigmoid_args)
+        == "official-sigmoid"
+    )
 
 
 def test_gdn_state_dtype_feature_on_uses_auto_ssm_dtype(monkeypatch):

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -665,6 +665,30 @@ def test_lightop_fused_kv_store_routes_block_first_cache_to_stride_aware_writer(
     assert q.shape == (num_tokens, q_size // head_size, head_size)
 
 
+def _boltops_chunk_h_contract(
+    k, w, u, g=None, gk=None, initial_state=None,
+    initial_state_indices=None, output_final_state=True,
+    inplace_final_state=False, chunk_size=64, save_new_value=True,
+    cu_seqlens=None, chunk_indices=None, use_exp2=False,
+    transpose_state_layout=True, kernel_cfg=None,
+):
+    pass
+
+
+def _boltops_chunk_o_contract(
+    q, k, v, h, g=None, g_gamma=None, scale=None, cu_seqlens=None,
+    chunk_size=64, chunk_indices=None, use_exp2=False,
+    transpose_state_layout=False, kernel_cfg=None,
+):
+    pass
+
+
+def _boltops_recompute_contract(
+    k, v, beta, g_cumsum, A, cu_seqlens=None, chunk_indices=None,
+):
+    pass
+
+
 def test_fla_chunk_o_feature_off_is_numerically_identical(monkeypatch):
     adapter = _adapter("patch_fla_chunk_o")
 
@@ -700,6 +724,8 @@ def test_fla_chunk_delta_h_uses_boltops(monkeypatch):
     def boltops(*args, **kwargs):
         calls.append((args, kwargs))
         return "boltops-h", "boltops-v", "boltops-final"
+
+    boltops.__signature__ = inspect.signature(_boltops_chunk_h_contract)
 
     module = _module(
         adapter.TARGET_MODULE,
@@ -754,6 +780,8 @@ def test_fla_chunk_o_uses_boltops_and_preserves_output_buffer(monkeypatch):
     def boltops(**kwargs):
         calls.append(kwargs)
         return kwargs["v"] + 3
+
+    boltops.__signature__ = inspect.signature(_boltops_chunk_o_contract)
 
     module = _module(
         adapter.TARGET_MODULE,
@@ -888,6 +916,8 @@ def test_fla_recompute_w_u_uses_boltops(monkeypatch):
         calls.append((args, kwargs))
         return "boltops-w", "boltops-u"
 
+    boltops.__signature__ = inspect.signature(_boltops_recompute_contract)
+
     module = _module(adapter.TARGET_MODULE, recompute_w_u_fwd=original)
     _install_fake_module(
         monkeypatch,
@@ -944,6 +974,36 @@ def test_fla_recompute_w_u_missing_boltops_falls_back(monkeypatch):
 
     assert result == "official"
     assert calls == [(cu_seqlens, chunk_indices)]
+
+
+def test_fla_boltops_signature_drift_fails_closed(monkeypatch):
+    adapter = _adapter("patch_fla_chunk_o")
+
+    def original(q, k, v, h, g=None, scale=None, cu_seqlens=None,
+                 chunk_indices=None, chunk_size=64, core_attn_out=None):
+        return "official"
+
+    def incompatible(q, k, v):
+        return q
+
+    module = _module(
+        adapter.TARGET_MODULE,
+        FLA_CHUNK_SIZE=64,
+        chunk_fwd_o=original,
+    )
+    _install_fake_module(
+        monkeypatch,
+        "boltops.fla.gdn",
+        chunk_fwd_o=incompatible,
+    )
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    adapter.apply_to_module(module)
+    compatibility_error = _adapter("_common").PatchCompatibilityError
+    with pytest.raises(compatibility_error, match="audited BoltOPs 0.1.0"):
+        module.chunk_fwd_o(*(torch.empty(1) for _ in range(4)))
 
 
 def test_mamba_nn_sharded_loader_cpu_numeric():

--- a/tests/runtime_patch/test_attention_mla_fla_mamba.py
+++ b/tests/runtime_patch/test_attention_mla_fla_mamba.py
@@ -687,7 +687,7 @@ def test_fla_chunk_o_feature_off_is_numerically_identical(monkeypatch):
     torch.testing.assert_close(module.chunk_fwd_o(x, x, x, x), original(x, x, x, x))
 
 
-def test_fla_chunk_delta_h_prefers_hip_kernel(monkeypatch):
+def test_fla_chunk_delta_h_uses_boltops(monkeypatch):
     adapter = _adapter("patch_fla_chunk_delta_h")
     calls = []
 
@@ -697,9 +697,9 @@ def test_fla_chunk_delta_h_prefers_hip_kernel(monkeypatch):
                  use_exp2=False):
         return "official"
 
-    def hip(*args, **kwargs):
+    def boltops(*args, **kwargs):
         calls.append((args, kwargs))
-        return "hip-h", "hip-v", "hip-final"
+        return "boltops-h", "boltops-v", "boltops-final"
 
     module = _module(
         adapter.TARGET_MODULE,
@@ -712,15 +712,8 @@ def test_fla_chunk_delta_h_prefers_hip_kernel(monkeypatch):
     )
     _install_fake_module(
         monkeypatch,
-        "aiter.ops.fla",
-        chunk_gated_delta_rule_fwd_vllm_hip_blockdim64=hip,
-    )
-    _install_fake_module(
-        monkeypatch,
-        "aiter.ops.triton.fla.vllm.chunk_delta_h",
-        launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64=lambda **_kwargs: pytest.fail(
-            "HIP must have priority"
-        ),
+        "boltops.fla.gdn",
+        chunk_gated_delta_rule_fwd_h=boltops,
     )
     adapter.apply_to_module(module)
     from vllm_hcu.platforms import envs as henvs
@@ -739,7 +732,7 @@ def test_fla_chunk_delta_h_prefers_hip_kernel(monkeypatch):
         use_exp2=True,
     )
 
-    assert result == ("hip-h", "hip-v", "hip-final")
+    assert result == ("boltops-h", "boltops-v", "boltops-final")
     assert len(calls) == 1
     _, kwargs = calls[0]
     assert kwargs["cu_seqlens"] is cu_seqlens
@@ -750,7 +743,7 @@ def test_fla_chunk_delta_h_prefers_hip_kernel(monkeypatch):
     assert kwargs["transpose_state_layout"] is True
 
 
-def test_fla_chunk_o_prefers_hip_and_preserves_output_buffer(monkeypatch):
+def test_fla_chunk_o_uses_boltops_and_preserves_output_buffer(monkeypatch):
     adapter = _adapter("patch_fla_chunk_o")
     calls = []
 
@@ -758,7 +751,7 @@ def test_fla_chunk_o_prefers_hip_and_preserves_output_buffer(monkeypatch):
                  chunk_indices=None, chunk_size=64, core_attn_out=None):
         return "official"
 
-    def hip(**kwargs):
+    def boltops(**kwargs):
         calls.append(kwargs)
         return kwargs["v"] + 3
 
@@ -772,15 +765,8 @@ def test_fla_chunk_o_prefers_hip_and_preserves_output_buffer(monkeypatch):
     )
     _install_fake_module(
         monkeypatch,
-        "aiter.ops.fla",
-        chunk_fwd_o_vllm_hip_blockdim64=hip,
-    )
-    _install_fake_module(
-        monkeypatch,
-        "aiter.ops.triton.fla.vllm.chunk_o",
-        launch_chunk_fwd_kernel_o=lambda **_kwargs: pytest.fail(
-            "HIP must have priority"
-        ),
+        "boltops.fla.gdn",
+        chunk_fwd_o=boltops,
     )
     adapter.apply_to_module(module)
     from vllm_hcu.platforms import envs as henvs
@@ -808,7 +794,7 @@ def test_fla_chunk_o_prefers_hip_and_preserves_output_buffer(monkeypatch):
     torch.testing.assert_close(result, v + 3)
 
 
-def test_fla_chunk_delta_h_enabled_missing_aiter_falls_back(monkeypatch):
+def test_fla_chunk_delta_h_enabled_missing_boltops_falls_back(monkeypatch):
     adapter = _adapter("patch_fla_chunk_delta_h")
     calls = []
 
@@ -832,13 +818,8 @@ def test_fla_chunk_delta_h_enabled_missing_aiter_falls_back(monkeypatch):
     monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
     monkeypatch.setitem(
         sys.modules,
-        "aiter.ops.fla",
-        ModuleType("aiter.ops.fla"),
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "aiter.ops.triton.fla.vllm.chunk_delta_h",
-        ModuleType("aiter.ops.triton.fla.vllm.chunk_delta_h"),
+        "boltops.fla.gdn",
+        ModuleType("boltops.fla.gdn"),
     )
     chunk_indices = torch.tensor([[0, 0]])
     chunk_offsets = torch.tensor([0])
@@ -855,7 +836,7 @@ def test_fla_chunk_delta_h_enabled_missing_aiter_falls_back(monkeypatch):
     assert calls == [(chunk_indices, chunk_offsets, True)]
 
 
-def test_fla_chunk_o_enabled_missing_aiter_falls_back(monkeypatch):
+def test_fla_chunk_o_enabled_missing_boltops_falls_back(monkeypatch):
     adapter = _adapter("patch_fla_chunk_o")
     calls = []
 
@@ -877,13 +858,8 @@ def test_fla_chunk_o_enabled_missing_aiter_falls_back(monkeypatch):
     monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
     monkeypatch.setitem(
         sys.modules,
-        "aiter.ops.fla",
-        ModuleType("aiter.ops.fla"),
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "aiter.ops.triton.fla.vllm.chunk_o",
-        ModuleType("aiter.ops.triton.fla.vllm.chunk_o"),
+        "boltops.fla.gdn",
+        ModuleType("boltops.fla.gdn"),
     )
     chunk_indices = torch.tensor([[0, 0]])
     core_attn_out = torch.empty(8)
@@ -899,6 +875,75 @@ def test_fla_chunk_o_enabled_missing_aiter_falls_back(monkeypatch):
 
     assert result == "official"
     assert calls == [(0.5, chunk_indices, core_attn_out)]
+
+
+def test_fla_recompute_w_u_uses_boltops(monkeypatch):
+    adapter = _adapter("patch_fla_recompute_w_u")
+    calls = []
+
+    def original(k, v, beta, g_cumsum, A, cu_seqlens, chunk_indices=None):
+        return "official"
+
+    def boltops(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "boltops-w", "boltops-u"
+
+    module = _module(adapter.TARGET_MODULE, recompute_w_u_fwd=original)
+    _install_fake_module(
+        monkeypatch,
+        "boltops.fla.gdn",
+        recompute_w_u_fwd=boltops,
+    )
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    tensors = tuple(torch.empty(1) for _ in range(5))
+    cu_seqlens = torch.tensor([0, 1])
+    chunk_indices = torch.tensor([[0, 0]])
+    result = module.recompute_w_u_fwd(
+        *tensors,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+    assert result == ("boltops-w", "boltops-u")
+    assert len(calls) == 1
+    assert calls[0][1]["cu_seqlens"] is cu_seqlens
+    assert calls[0][1]["chunk_indices"] is chunk_indices
+
+
+def test_fla_recompute_w_u_missing_boltops_falls_back(monkeypatch):
+    adapter = _adapter("patch_fla_recompute_w_u")
+    calls = []
+
+    def original(k, v, beta, g_cumsum, A, cu_seqlens, chunk_indices=None):
+        calls.append((cu_seqlens, chunk_indices))
+        return "official"
+
+    module = _module(adapter.TARGET_MODULE, recompute_w_u_fwd=original)
+    adapter.apply_to_module(module)
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setitem(
+        sys.modules,
+        "boltops.fla.gdn",
+        ModuleType("boltops.fla.gdn"),
+    )
+    tensors = tuple(torch.empty(1) for _ in range(5))
+    cu_seqlens = torch.tensor([0, 1])
+    chunk_indices = torch.tensor([[0, 0]])
+    result = module.recompute_w_u_fwd(
+        *tensors,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+    assert result == "official"
+    assert calls == [(cu_seqlens, chunk_indices)]
 
 
 def test_mamba_nn_sharded_loader_cpu_numeric():
@@ -1103,6 +1148,23 @@ def _gdn_sigmoid_contract(
     return "official-sigmoid"
 
 
+def _gdn_packed_recurrent_contract(
+    mixed_qkv,
+    a,
+    b,
+    A_log,
+    dt_bias,
+    scale,
+    initial_state,
+    out,
+    ssm_state_indices,
+    use_qk_l2norm_in_kernel=False,
+):
+    del mixed_qkv, a, b, A_log, dt_bias, scale, initial_state, out
+    del ssm_state_indices, use_qk_l2norm_in_kernel
+    return "official-recurrent"
+
+
 def test_gdn_nn_layout_normalizes_all_conv_weight_consumers(monkeypatch):
     causal_adapter = _adapter("patch_gdn_causal_conv1d")
     qwen_adapter = _adapter("patch_gdn_linear_attention")
@@ -1183,7 +1245,9 @@ def test_gdn_nn_layout_normalizes_all_conv_weight_consumers(monkeypatch):
         qwen_adapter.TARGET_MODULE,
         GDN_AITER_TRITON_AVAILABLE=True,
         gdn_aiter_fused_reshape_causal_conv1d_update_single_token=aiter_update,
-        fused_recurrent_gated_delta_rule_packed_decode=lambda *a, **k: "official-recurrent",
+        fused_recurrent_gated_delta_rule_packed_decode=(
+            _gdn_packed_recurrent_contract
+        ),
         fused_sigmoid_gating_delta_rule_update=_gdn_sigmoid_contract,
         GatedDeltaNetAttention=GatedDeltaNetAttention,
         MambaStateDtypeCalculator=SimpleNamespace(
@@ -1241,7 +1305,7 @@ def test_gdn_nn_layout_normalizes_all_conv_weight_consumers(monkeypatch):
     )
 
 
-def test_gdn_recurrent_remains_target_owned_and_sigmoid_is_qwen_local(monkeypatch):
+def test_gdn_recurrent_and_sigmoid_are_qwen_local(monkeypatch):
     adapter = _adapter("patch_gdn_linear_attention")
 
     _install_fake_module(
@@ -1259,9 +1323,7 @@ def test_gdn_recurrent_remains_target_owned_and_sigmoid_is_qwen_local(monkeypatc
         ),
     )
 
-    def recurrent(*args, **kwargs):
-        del args, kwargs
-        return "official-recurrent"
+    recurrent = _gdn_packed_recurrent_contract
 
     sigmoid = _gdn_sigmoid_contract
 
@@ -1276,10 +1338,21 @@ def test_gdn_recurrent_remains_target_owned_and_sigmoid_is_qwen_local(monkeypatc
 
     monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
     monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", False)
-    assert module.fused_recurrent_gated_delta_rule_packed_decode is recurrent
+    assert module.fused_recurrent_gated_delta_rule_packed_decode is not recurrent
+    assert module._vllm_hcu_original_fused_recurrent is recurrent
     assert module.fused_sigmoid_gating_delta_rule_update is not sigmoid
     assert module._vllm_hcu_original_fused_sigmoid is sigmoid
-    assert module.fused_recurrent_gated_delta_rule_packed_decode() == "official-recurrent"
+    recurrent_args = tuple(torch.empty(1) for _ in range(5))
+    assert (
+        module.fused_recurrent_gated_delta_rule_packed_decode(
+            *recurrent_args,
+            0.5,
+            torch.empty(1),
+            torch.empty(1),
+            torch.empty(1, dtype=torch.long),
+        )
+        == "official-recurrent"
+    )
     sigmoid_args = tuple(torch.empty(1) for _ in range(7))
     assert (
         module.fused_sigmoid_gating_delta_rule_update(*sigmoid_args)

--- a/tests/runtime_patch/test_gdn_v0251_ownership.py
+++ b/tests/runtime_patch/test_gdn_v0251_ownership.py
@@ -240,9 +240,11 @@ def _fake_qwen(*, aiter_available: bool = True):
     class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         pass
 
-    def recurrent(*args, **kwargs):
-        del args, kwargs
-        return "target-recurrent"
+    recurrent = _recording_callable(
+        _packed_recurrent_contract,
+        "packed_recurrent",
+        calls,
+    )
 
     sigmoid = _recording_callable(_sigmoid_contract, "sigmoid", calls)
 
@@ -288,6 +290,23 @@ def _sigmoid_contract(
     return "target-sigmoid"
 
 
+def _packed_recurrent_contract(
+    mixed_qkv,
+    a,
+    b,
+    A_log,
+    dt_bias,
+    scale,
+    initial_state,
+    out,
+    ssm_state_indices,
+    use_qk_l2norm_in_kernel=False,
+):
+    del mixed_qkv, a, b, A_log, dt_bias, scale, initial_state, out
+    del ssm_state_indices, use_qk_l2norm_in_kernel
+    return "target-recurrent"
+
+
 def _sigmoid_args(A_log_dtype=torch.bfloat16, q_dtype=torch.bfloat16):
     return (
         torch.empty(1, dtype=A_log_dtype),
@@ -300,27 +319,20 @@ def _sigmoid_args(A_log_dtype=torch.bfloat16, q_dtype=torch.bfloat16):
     )
 
 
-def test_qwen_sigmoid_prefers_aiter_hip_for_matching_dtype(monkeypatch):
+def test_qwen_sigmoid_uses_boltops(monkeypatch):
     adapter = _adapter("patch_gdn_linear_attention")
     module, _, _, _, _ = _fake_qwen(aiter_available=False)
     module.fused_sigmoid_gating_delta_rule_update = _sigmoid_contract
     calls = []
 
-    def hip(*args, **kwargs):
+    def boltops(*args, **kwargs):
         calls.append((args, kwargs))
-        return "hip"
+        return "boltops"
 
     _install_module(
         monkeypatch,
-        "aiter",
-        vllm_fused_sigmoid_gating_delta_rule_update=hip,
-    )
-    _install_module(
-        monkeypatch,
-        "aiter.ops.triton.fla.fused_sigmoid_gating",
-        fused_sigmoid_gating_delta_rule_update=lambda *_args, **_kwargs: pytest.fail(
-            "HIP must have priority"
-        ),
+        "boltops.fla.gdn",
+        fused_sigmoid_gating_delta_rule_update=boltops,
     )
     from vllm_hcu.platforms import envs as henvs
 
@@ -328,27 +340,23 @@ def test_qwen_sigmoid_prefers_aiter_hip_for_matching_dtype(monkeypatch):
     monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
     adapter.apply_to_module(module)
 
-    assert module.fused_sigmoid_gating_delta_rule_update(*_sigmoid_args()) == "hip"
+    assert (
+        module.fused_sigmoid_gating_delta_rule_update(*_sigmoid_args())
+        == "boltops"
+    )
     assert len(calls) == 1
 
 
-def test_qwen_sigmoid_uses_aiter_triton_for_mixed_dtype(monkeypatch):
+def test_qwen_sigmoid_uses_boltops_for_mixed_dtype(monkeypatch):
     adapter = _adapter("patch_gdn_linear_attention")
     module, _, _, _, _ = _fake_qwen(aiter_available=False)
     module.fused_sigmoid_gating_delta_rule_update = _sigmoid_contract
     calls = []
     _install_module(
         monkeypatch,
-        "aiter",
-        vllm_fused_sigmoid_gating_delta_rule_update=lambda *_args, **_kwargs: pytest.fail(
-            "mixed dtype must not enter HIP"
-        ),
-    )
-    _install_module(
-        monkeypatch,
-        "aiter.ops.triton.fla.fused_sigmoid_gating",
+        "boltops.fla.gdn",
         fused_sigmoid_gating_delta_rule_update=lambda *args, **kwargs: (
-            calls.append((args, kwargs)) or "triton"
+            calls.append((args, kwargs)) or "boltops"
         ),
     )
     from vllm_hcu.platforms import envs as henvs
@@ -360,8 +368,42 @@ def test_qwen_sigmoid_uses_aiter_triton_for_mixed_dtype(monkeypatch):
     result = module.fused_sigmoid_gating_delta_rule_update(
         *_sigmoid_args(torch.float32, torch.bfloat16)
     )
-    assert result == "triton"
+    assert result == "boltops"
     assert len(calls) == 1
+
+
+def test_qwen_packed_recurrent_uses_boltops(monkeypatch):
+    adapter = _adapter("patch_gdn_linear_attention")
+    module, _, _, _, _ = _fake_qwen(aiter_available=False)
+    calls = []
+
+    def boltops(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "boltops-out", "boltops-state"
+
+    _install_module(
+        monkeypatch,
+        "boltops.fla.gdn",
+        fused_recurrent_gated_delta_rule_packed_decode=boltops,
+    )
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    adapter.apply_to_module(module)
+    args = tuple(torch.empty(1) for _ in range(5))
+    result = module.fused_recurrent_gated_delta_rule_packed_decode(
+        *args,
+        0.5,
+        torch.empty(1),
+        torch.empty(1),
+        torch.empty(1, dtype=torch.long),
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    assert result == ("boltops-out", "boltops-state")
+    assert len(calls) == 1
+    assert calls[0][0][-1] is True
 
 
 def _install_module(monkeypatch: pytest.MonkeyPatch, name: str, **values):
@@ -448,9 +490,9 @@ def test_qwen_local_weight_deltas_and_target_fla_ownership(
     assert canonical.causal_conv1d_update is consumer.causal_conv1d_update
     assert module.causal_conv1d_fn is not canonical.causal_conv1d_fn
     assert module.causal_conv1d_update is not canonical.causal_conv1d_update
-    assert module.fused_recurrent_gated_delta_rule_packed_decode is recurrent
+    assert module.fused_recurrent_gated_delta_rule_packed_decode is not recurrent
+    assert module._vllm_hcu_original_fused_recurrent is recurrent
     assert module.fused_sigmoid_gating_delta_rule_update is not sigmoid
-    assert not hasattr(module, "_vllm_hcu_original_fused_recurrent")
     assert module._vllm_hcu_original_fused_sigmoid is sigmoid
 
     conv_state = torch.empty(1, 8, 3)
@@ -536,7 +578,8 @@ def test_native_aiter_unavailable_is_idempotent_and_does_not_require_symbol():
     module, _, _, recurrent, sigmoid = _fake_qwen(aiter_available=False)
     assert adapter.apply_to_module(module) is True
     assert adapter.apply_to_module(module) is False
-    assert module.fused_recurrent_gated_delta_rule_packed_decode is recurrent
+    assert module.fused_recurrent_gated_delta_rule_packed_decode is not recurrent
+    assert module._vllm_hcu_original_fused_recurrent is recurrent
     assert module.fused_sigmoid_gating_delta_rule_update is not sigmoid
     assert module._vllm_hcu_original_fused_sigmoid is sigmoid
     assert not hasattr(
@@ -640,13 +683,16 @@ assert not getattr(base_method, "_vllm_hcu_gdn_base_wrapper", False)
 
 assert (
     qwen.fused_recurrent_gated_delta_rule_packed_decode
-    is fla.fused_recurrent_gated_delta_rule_packed_decode
+    is not fla.fused_recurrent_gated_delta_rule_packed_decode
 )
 assert (
     qwen.fused_sigmoid_gating_delta_rule_update
     is not fla.fused_sigmoid_gating_delta_rule_update
 )
-assert not hasattr(qwen, "_vllm_hcu_original_fused_recurrent")
+assert (
+    qwen._vllm_hcu_original_fused_recurrent
+    is fla.fused_recurrent_gated_delta_rule_packed_decode
+)
 assert (
     qwen._vllm_hcu_original_fused_sigmoid
     is fla.fused_sigmoid_gating_delta_rule_update

--- a/tests/runtime_patch/test_gdn_v0251_ownership.py
+++ b/tests/runtime_patch/test_gdn_v0251_ownership.py
@@ -213,7 +213,7 @@ def _recording_callable(contract, name: str, calls: dict[str, object]):
             "raw_kwargs": dict(kwargs),
             "arguments": dict(bound.arguments),
         }
-        return bound.arguments["weight"]
+        return bound.arguments.get("weight", f"target-{name}")
 
     target.__name__ = name
     target.__signature__ = signature  # type: ignore[attr-defined]
@@ -244,9 +244,7 @@ def _fake_qwen(*, aiter_available: bool = True):
         del args, kwargs
         return "target-recurrent"
 
-    def sigmoid(*args, **kwargs):
-        del args, kwargs
-        return "target-sigmoid"
+    sigmoid = _recording_callable(_sigmoid_contract, "sigmoid", calls)
 
     values = {
         "GDN_AITER_TRITON_AVAILABLE": aiter_available,
@@ -263,6 +261,107 @@ def _fake_qwen(*, aiter_available: bool = True):
     module = ModuleType(QWEN_MODULE)
     module.__dict__.update(values)
     return module, calls, GatedDeltaNetAttention, recurrent, sigmoid
+
+
+def _sigmoid_contract(
+    A_log,
+    a,
+    b,
+    dt_bias,
+    q,
+    k,
+    v,
+    beta=1.0,
+    threshold=20.0,
+    scale=None,
+    initial_state=None,
+    inplace_final_state=True,
+    cu_seqlens=None,
+    ssm_state_indices=None,
+    num_accepted_tokens=None,
+    use_qk_l2norm_in_kernel=False,
+    is_kda=False,
+):
+    del A_log, a, b, dt_bias, q, k, v, beta, threshold, scale
+    del initial_state, inplace_final_state, cu_seqlens, ssm_state_indices
+    del num_accepted_tokens, use_qk_l2norm_in_kernel, is_kda
+    return "target-sigmoid"
+
+
+def _sigmoid_args(A_log_dtype=torch.bfloat16, q_dtype=torch.bfloat16):
+    return (
+        torch.empty(1, dtype=A_log_dtype),
+        torch.empty(1),
+        torch.empty(1),
+        torch.empty(1),
+        torch.empty(1, dtype=q_dtype),
+        torch.empty(1),
+        torch.empty(1),
+    )
+
+
+def test_qwen_sigmoid_prefers_aiter_hip_for_matching_dtype(monkeypatch):
+    adapter = _adapter("patch_gdn_linear_attention")
+    module, _, _, _, _ = _fake_qwen(aiter_available=False)
+    module.fused_sigmoid_gating_delta_rule_update = _sigmoid_contract
+    calls = []
+
+    def hip(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "hip"
+
+    _install_module(
+        monkeypatch,
+        "aiter",
+        vllm_fused_sigmoid_gating_delta_rule_update=hip,
+    )
+    _install_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.fused_sigmoid_gating",
+        fused_sigmoid_gating_delta_rule_update=lambda *_args, **_kwargs: pytest.fail(
+            "HIP must have priority"
+        ),
+    )
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    adapter.apply_to_module(module)
+
+    assert module.fused_sigmoid_gating_delta_rule_update(*_sigmoid_args()) == "hip"
+    assert len(calls) == 1
+
+
+def test_qwen_sigmoid_uses_aiter_triton_for_mixed_dtype(monkeypatch):
+    adapter = _adapter("patch_gdn_linear_attention")
+    module, _, _, _, _ = _fake_qwen(aiter_available=False)
+    module.fused_sigmoid_gating_delta_rule_update = _sigmoid_contract
+    calls = []
+    _install_module(
+        monkeypatch,
+        "aiter",
+        vllm_fused_sigmoid_gating_delta_rule_update=lambda *_args, **_kwargs: pytest.fail(
+            "mixed dtype must not enter HIP"
+        ),
+    )
+    _install_module(
+        monkeypatch,
+        "aiter.ops.triton.fla.fused_sigmoid_gating",
+        fused_sigmoid_gating_delta_rule_update=lambda *args, **kwargs: (
+            calls.append((args, kwargs)) or "triton"
+        ),
+    )
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    adapter.apply_to_module(module)
+
+    result = module.fused_sigmoid_gating_delta_rule_update(
+        *_sigmoid_args(torch.float32, torch.bfloat16)
+    )
+    assert result == "triton"
+    assert len(calls) == 1
 
 
 def _install_module(monkeypatch: pytest.MonkeyPatch, name: str, **values):
@@ -350,9 +449,9 @@ def test_qwen_local_weight_deltas_and_target_fla_ownership(
     assert module.causal_conv1d_fn is not canonical.causal_conv1d_fn
     assert module.causal_conv1d_update is not canonical.causal_conv1d_update
     assert module.fused_recurrent_gated_delta_rule_packed_decode is recurrent
-    assert module.fused_sigmoid_gating_delta_rule_update is sigmoid
+    assert module.fused_sigmoid_gating_delta_rule_update is not sigmoid
     assert not hasattr(module, "_vllm_hcu_original_fused_recurrent")
-    assert not hasattr(module, "_vllm_hcu_original_fused_sigmoid")
+    assert module._vllm_hcu_original_fused_sigmoid is sigmoid
 
     conv_state = torch.empty(1, 8, 3)
     x_fn = torch.empty(8, 2)
@@ -438,7 +537,8 @@ def test_native_aiter_unavailable_is_idempotent_and_does_not_require_symbol():
     assert adapter.apply_to_module(module) is True
     assert adapter.apply_to_module(module) is False
     assert module.fused_recurrent_gated_delta_rule_packed_decode is recurrent
-    assert module.fused_sigmoid_gating_delta_rule_update is sigmoid
+    assert module.fused_sigmoid_gating_delta_rule_update is not sigmoid
+    assert module._vllm_hcu_original_fused_sigmoid is sigmoid
     assert not hasattr(
         module,
         "gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
@@ -454,7 +554,7 @@ def test_native_aiter_signature_and_keyword_calls_fail_closed(
 
     monkeypatch.setattr(henvs, "VLLM_USE_NN", True)
     assert adapter.apply_to_module(module) is True
-    with pytest.raises(PatchCompatibilityError, match="audited vLLM v0.25.1"):
+    with pytest.raises(PatchCompatibilityError, match="audited vLLM v0.28.1"):
         module.gdn_aiter_fused_reshape_causal_conv1d_update_single_token(
             x=torch.empty(1),
             unexpected=torch.empty(1),
@@ -544,10 +644,13 @@ assert (
 )
 assert (
     qwen.fused_sigmoid_gating_delta_rule_update
-    is fla.fused_sigmoid_gating_delta_rule_update
+    is not fla.fused_sigmoid_gating_delta_rule_update
 )
 assert not hasattr(qwen, "_vllm_hcu_original_fused_recurrent")
-assert not hasattr(qwen, "_vllm_hcu_original_fused_sigmoid")
+assert (
+    qwen._vllm_hcu_original_fused_sigmoid
+    is fla.fused_sigmoid_gating_delta_rule_update
+)
 assert not bool(qwen.GDN_AITER_TRITON_AVAILABLE)
 assert getattr(qwen, "_vllm_hcu_qwen_gdn_aiter_layout_applied", False)
 from vllm_hcu.ops.rms_norm_gated import HcuRMSNormGated

--- a/tests/runtime_patch/test_gdn_v0251_ownership.py
+++ b/tests/runtime_patch/test_gdn_v0251_ownership.py
@@ -307,6 +307,22 @@ def _packed_recurrent_contract(
     return "target-recurrent"
 
 
+def _boltops_sigmoid_contract(
+    A_log, a, b, dt_bias, q, k, v, beta=1.0, threshold=20.0,
+    scale=None, initial_state=None, inplace_final_state=True,
+    cu_seqlens=None, ssm_state_indices=None, num_accepted_tokens=None,
+    use_qk_l2norm_in_kernel=False, is_kda=False, kernel_cfg=None,
+):
+    pass
+
+
+def _boltops_packed_recurrent_contract(
+    mixed_qkv, a, b, A_log, dt_bias, scale, initial_state, out,
+    ssm_state_indices, use_qk_l2norm_in_kernel=False, kernel_cfg=None,
+):
+    pass
+
+
 def _sigmoid_args(A_log_dtype=torch.bfloat16, q_dtype=torch.bfloat16):
     return (
         torch.empty(1, dtype=A_log_dtype),
@@ -328,6 +344,8 @@ def test_qwen_sigmoid_uses_boltops(monkeypatch):
     def boltops(*args, **kwargs):
         calls.append((args, kwargs))
         return "boltops"
+
+    boltops.__signature__ = inspect.signature(_boltops_sigmoid_contract)
 
     _install_module(
         monkeypatch,
@@ -352,12 +370,14 @@ def test_qwen_sigmoid_uses_boltops_for_mixed_dtype(monkeypatch):
     module, _, _, _, _ = _fake_qwen(aiter_available=False)
     module.fused_sigmoid_gating_delta_rule_update = _sigmoid_contract
     calls = []
+    boltops = lambda *args, **kwargs: (
+        calls.append((args, kwargs)) or "boltops"
+    )
+    boltops.__signature__ = inspect.signature(_boltops_sigmoid_contract)
     _install_module(
         monkeypatch,
         "boltops.fla.gdn",
-        fused_sigmoid_gating_delta_rule_update=lambda *args, **kwargs: (
-            calls.append((args, kwargs)) or "boltops"
-        ),
+        fused_sigmoid_gating_delta_rule_update=boltops,
     )
     from vllm_hcu.platforms import envs as henvs
 
@@ -380,6 +400,10 @@ def test_qwen_packed_recurrent_uses_boltops(monkeypatch):
     def boltops(*args, **kwargs):
         calls.append((args, kwargs))
         return "boltops-out", "boltops-state"
+
+    boltops.__signature__ = inspect.signature(
+        _boltops_packed_recurrent_contract
+    )
 
     _install_module(
         monkeypatch,
@@ -404,6 +428,41 @@ def test_qwen_packed_recurrent_uses_boltops(monkeypatch):
     assert result == ("boltops-out", "boltops-state")
     assert len(calls) == 1
     assert calls[0][0][-1] is True
+
+
+def test_qwen_sigmoid_missing_boltops_symbol_falls_back(monkeypatch):
+    adapter = _adapter("patch_gdn_linear_attention")
+    module, _, _, _, _ = _fake_qwen(aiter_available=False)
+    _install_module(monkeypatch, "boltops.fla.gdn")
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    adapter.apply_to_module(module)
+    assert (
+        module.fused_sigmoid_gating_delta_rule_update(*_sigmoid_args())
+        == "target-sigmoid"
+    )
+
+
+def test_qwen_packed_recurrent_missing_boltops_symbol_falls_back(monkeypatch):
+    adapter = _adapter("patch_gdn_linear_attention")
+    module, _, _, _, _ = _fake_qwen(aiter_available=False)
+    _install_module(monkeypatch, "boltops.fla.gdn")
+    from vllm_hcu.platforms import envs as henvs
+
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_OPS", True)
+    monkeypatch.setattr(henvs, "VLLM_HCU_USE_CUSTOM_AITER_FLA", True)
+    adapter.apply_to_module(module)
+    args = tuple(torch.empty(1) for _ in range(5))
+    result = module.fused_recurrent_gated_delta_rule_packed_decode(
+        *args,
+        0.5,
+        torch.empty(1),
+        torch.empty(1),
+        torch.empty(1, dtype=torch.long),
+    )
+    assert result == "target-packed_recurrent"
 
 
 def _install_module(monkeypatch: pytest.MonkeyPatch, name: str, **values):

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -243,6 +243,7 @@ _OP_CALLBACKS: tuple[_CallbackSpec, ...] = (
     _CallbackSpec(_adapter("op_opt", "patch_mla_indexer")),
     _CallbackSpec(_adapter("op_opt", "patch_flashmla_sparse")),
     _CallbackSpec(_adapter("op_opt", "patch_fla_chunk_delta_h")),
+    _CallbackSpec(_adapter("op_opt", "patch_fla_recompute_w_u")),
     _CallbackSpec(_adapter("op_opt", "patch_fla_chunk_o")),
     _CallbackSpec(_adapter("op_opt", "patch_mamba_mixer")),
     _CallbackSpec(_adapter("op_opt", "patch_mamba_mixer2")),

--- a/vllm_hcu/patch/worker/op_opt/_boltops_fla.py
+++ b/vllm_hcu/patch/worker/op_opt/_boltops_fla.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Lazy, ABI-checked access to optional BoltOPs GDN kernels."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable
+
+from ._common import PatchCompatibilityError, require_exact_signature
+
+_MODULE = "boltops.fla.gdn"
+_AUDITED_VERSION = "0.1.0"
+
+_CONTRACTS: dict[str, tuple[tuple[str, ...], dict[str, object]]] = {
+    "chunk_gated_delta_rule_fwd_h": (
+        (
+            "k", "w", "u", "g", "gk", "initial_state",
+            "initial_state_indices", "output_final_state",
+            "inplace_final_state", "chunk_size", "save_new_value",
+            "cu_seqlens", "chunk_indices", "use_exp2",
+            "transpose_state_layout", "kernel_cfg",
+        ),
+        {
+            "g": None,
+            "gk": None,
+            "initial_state": None,
+            "initial_state_indices": None,
+            "output_final_state": True,
+            "inplace_final_state": False,
+            "chunk_size": 64,
+            "save_new_value": True,
+            "cu_seqlens": None,
+            "chunk_indices": None,
+            "use_exp2": False,
+            "transpose_state_layout": True,
+            "kernel_cfg": None,
+        },
+    ),
+    "chunk_fwd_o": (
+        (
+            "q", "k", "v", "h", "g", "g_gamma", "scale",
+            "cu_seqlens", "chunk_size", "chunk_indices", "use_exp2",
+            "transpose_state_layout", "kernel_cfg",
+        ),
+        {
+            "g": None,
+            "g_gamma": None,
+            "scale": None,
+            "cu_seqlens": None,
+            "chunk_size": 64,
+            "chunk_indices": None,
+            "use_exp2": False,
+            "transpose_state_layout": False,
+            "kernel_cfg": None,
+        },
+    ),
+    "recompute_w_u_fwd": (
+        (
+            "k", "v", "beta", "g_cumsum", "A", "cu_seqlens",
+            "chunk_indices",
+        ),
+        {"cu_seqlens": None, "chunk_indices": None},
+    ),
+    "fused_sigmoid_gating_delta_rule_update": (
+        (
+            "A_log", "a", "b", "dt_bias", "q", "k", "v", "beta",
+            "threshold", "scale", "initial_state", "inplace_final_state",
+            "cu_seqlens", "ssm_state_indices", "num_accepted_tokens",
+            "use_qk_l2norm_in_kernel", "is_kda", "kernel_cfg",
+        ),
+        {
+            "beta": 1.0,
+            "threshold": 20.0,
+            "scale": None,
+            "initial_state": None,
+            "inplace_final_state": True,
+            "cu_seqlens": None,
+            "ssm_state_indices": None,
+            "num_accepted_tokens": None,
+            "use_qk_l2norm_in_kernel": False,
+            "is_kda": False,
+            "kernel_cfg": None,
+        },
+    ),
+    "fused_recurrent_gated_delta_rule_packed_decode": (
+        (
+            "mixed_qkv", "a", "b", "A_log", "dt_bias", "scale",
+            "initial_state", "out", "ssm_state_indices",
+            "use_qk_l2norm_in_kernel", "kernel_cfg",
+        ),
+        {"use_qk_l2norm_in_kernel": False, "kernel_cfg": None},
+    ),
+}
+
+
+def make_boltops_gdn_resolver(name: str) -> Callable[[], Callable | None]:
+    """Build a per-patch lazy resolver for an audited public BoltOPs ABI."""
+    positional, defaults = _CONTRACTS[name]
+    resolved = False
+    kernel: Callable | None = None
+
+    def resolve() -> Callable | None:
+        nonlocal kernel, resolved
+        if resolved:
+            return kernel
+        try:
+            module = importlib.import_module(_MODULE)
+        except ModuleNotFoundError as exc:
+            if exc.name not in {"boltops", "boltops.fla", _MODULE}:
+                raise
+            resolved = True
+            return None
+
+        candidate = getattr(module, name, None)
+        if candidate is None:
+            resolved = True
+            return None
+        if not callable(candidate):
+            raise PatchCompatibilityError(
+                f"optional {_MODULE}.{name} exists but is not callable"
+            )
+        require_exact_signature(
+            candidate,
+            f"{_MODULE}.{name} (audited BoltOPs {_AUDITED_VERSION})",
+            positional=positional,
+            defaults=defaults,
+        )
+        kernel = candidate
+        resolved = True
+        return kernel
+
+    return resolve
+
+
+__all__ = ["make_boltops_gdn_resolver"]

--- a/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_delta_h.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_delta_h.py
@@ -13,6 +13,7 @@ from ._common import (
     require_callable,
     require_exact_signature,
 )
+from ._boltops_fla import make_boltops_gdn_resolver
 
 TARGET_MODULE = "vllm.third_party.flash_linear_attention.ops.chunk"
 PATCH_ID = "worker.op_opt.fla.chunk_delta_h.boltops"
@@ -57,6 +58,9 @@ def apply_to_module(module: ModuleType) -> bool:
             "use_exp2": False,
         },
     )
+    resolve_boltops = make_boltops_gdn_resolver(
+        "chunk_gated_delta_rule_fwd_h"
+    )
 
     @functools.wraps(original)
     def hcu_chunk_delta_h(
@@ -80,11 +84,8 @@ def apply_to_module(module: ModuleType) -> bool:
                 chunk_size, save_new_value, cu_seqlens, chunk_indices,
                 chunk_offsets, use_exp2,
             )
-        try:
-            from boltops.fla.gdn import (
-                chunk_gated_delta_rule_fwd_h as boltops_kernel,
-            )
-        except ImportError:
+        boltops_kernel = resolve_boltops()
+        if boltops_kernel is None:
             return original(
                 k, w, u, g, gk, initial_state, output_final_state,
                 chunk_size, save_new_value, cu_seqlens, chunk_indices,

--- a/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_delta_h.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_delta_h.py
@@ -55,11 +55,26 @@ def apply_to_module(module: ModuleType) -> bool:
                             chunk_size, save_new_value, cu_seqlens, chunk_indices,
                             chunk_offsets, use_exp2)
         try:
+            from aiter.ops.fla import (
+                chunk_gated_delta_rule_fwd_vllm_hip_blockdim64 as hip_kernel,
+            )
+        except ImportError:
+            hip_kernel = None
+        try:
             from aiter.ops.triton.fla.vllm.chunk_delta_h import (
                 launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64,
             )
-        except ImportError as exc:
-            raise RuntimeError("HCU AITER FLA chunk_delta_h is enabled but unavailable") from exc
+        except ImportError:
+            launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64 = None
+        if (
+            hip_kernel is None
+            and launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64 is None
+        ):
+            return original(
+                k, w, u, g, gk, initial_state, output_final_state,
+                chunk_size, save_new_value, cu_seqlens, chunk_indices,
+                chunk_offsets, use_exp2,
+            )
 
         B, T, Hg, K, V = *k.shape, u.shape[-1]
         H, BT = u.shape[-2], chunk_size
@@ -71,6 +86,28 @@ def apply_to_module(module: ModuleType) -> bool:
             N, NT = len(cu_seqlens) - 1, len(chunk_indices)
             if chunk_offsets is None:
                 chunk_offsets = chunk.prepare_chunk_offsets(cu_seqlens, BT)
+
+        if hip_kernel is not None:
+            return hip_kernel(
+                k,
+                w,
+                u,
+                g=g,
+                gk=gk,
+                initial_state=initial_state,
+                initial_state_indices=None,
+                output_final_state=output_final_state,
+                chunk_size=chunk_size,
+                save_new_value=save_new_value,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+                chunk_offsets=chunk_offsets,
+                use_exp2=use_exp2,
+                transpose_state_layout=True,
+                kernel_cfg=None,
+            )
+
+        assert launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64 is not None
         if K > 256:
             raise ValueError("HCU AITER FLA does not support head dimension > 256")
         h = k.new_empty(B, NT, H, V, K)

--- a/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_delta_h.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_delta_h.py
@@ -1,30 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
-"""Select the HCU AITER gated-delta state kernel without source mutation."""
+"""Route the vLLM FLA chunk-state kernel through BoltOPs on HCU."""
 
 from __future__ import annotations
 
 import functools
 from types import ModuleType
 
-from ._common import already_applied, load_exact_module, require_callable, require_exact_signature
+from ._common import (
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_exact_signature,
+)
 
-TARGET_MODULE = "vllm.third_party.flash_linear_attention.ops.chunk_delta_h"
-PATCH_ID = "worker.op_opt.fla.chunk_delta_h.aiter"
+TARGET_MODULE = "vllm.third_party.flash_linear_attention.ops.chunk"
+PATCH_ID = "worker.op_opt.fla.chunk_delta_h.boltops"
 TARGETS = (f"{TARGET_MODULE}.chunk_gated_delta_rule_fwd_h",)
-_MARKER = "_vllm_hcu_chunk_delta_h_applied"
-_WRAPPER = "_vllm_hcu_chunk_delta_h_wrapper"
+_MARKER = "_vllm_hcu_fla_chunk_delta_h_applied"
+_WRAPPER = "_vllm_hcu_fla_chunk_delta_h_wrapper"
 
 
 def _enabled() -> bool:
     from vllm_hcu.platforms import envs as henvs
 
-    return bool(henvs.VLLM_HCU_USE_CUSTOM_AITER_FLA and henvs.VLLM_HCU_USE_CUSTOM_OPS)
+    return bool(
+        henvs.VLLM_HCU_USE_CUSTOM_OPS
+        and henvs.VLLM_HCU_USE_CUSTOM_AITER_FLA
+    )
 
 
 def apply_to_module(module: ModuleType) -> bool:
     chunk = load_exact_module(TARGET_MODULE, module)
-    if already_applied(chunk, _MARKER, ((chunk, "chunk_gated_delta_rule_fwd_h", TARGETS[0], _WRAPPER),)):
+    wrapped = ((chunk, "chunk_gated_delta_rule_fwd_h", TARGETS[0], _WRAPPER),)
+    if already_applied(chunk, _MARKER, wrapped):
         return False
     original = require_callable(chunk, "chunk_gated_delta_rule_fwd_h", TARGETS[0])
     require_exact_signature(
@@ -32,13 +41,18 @@ def apply_to_module(module: ModuleType) -> bool:
         TARGETS[0],
         positional=(
             "k", "w", "u", "g", "gk", "initial_state", "output_final_state",
-            "chunk_size", "save_new_value", "cu_seqlens", "chunk_indices", "chunk_offsets",
-            "use_exp2",
+            "chunk_size", "save_new_value", "cu_seqlens", "chunk_indices",
+            "chunk_offsets", "use_exp2",
         ),
         defaults={
-            "g": None, "gk": None, "initial_state": None,
-            "output_final_state": False, "chunk_size": chunk.FLA_CHUNK_SIZE,
-            "save_new_value": True, "cu_seqlens": None, "chunk_indices": None,
+            "g": None,
+            "gk": None,
+            "initial_state": None,
+            "output_final_state": False,
+            "chunk_size": chunk.FLA_CHUNK_SIZE,
+            "save_new_value": True,
+            "cu_seqlens": None,
+            "chunk_indices": None,
             "chunk_offsets": None,
             "use_exp2": False,
         },
@@ -46,84 +60,56 @@ def apply_to_module(module: ModuleType) -> bool:
 
     @functools.wraps(original)
     def hcu_chunk_delta_h(
-        k, w, u, g=None, gk=None, initial_state=None, output_final_state=False,
-        chunk_size=chunk.FLA_CHUNK_SIZE, save_new_value=True, cu_seqlens=None,
-        chunk_indices=None, chunk_offsets=None, use_exp2=False,
+        k,
+        w,
+        u,
+        g=None,
+        gk=None,
+        initial_state=None,
+        output_final_state=False,
+        chunk_size=chunk.FLA_CHUNK_SIZE,
+        save_new_value=True,
+        cu_seqlens=None,
+        chunk_indices=None,
+        chunk_offsets=None,
+        use_exp2=False,
     ):
         if not _enabled():
-            return original(k, w, u, g, gk, initial_state, output_final_state,
-                            chunk_size, save_new_value, cu_seqlens, chunk_indices,
-                            chunk_offsets, use_exp2)
+            return original(
+                k, w, u, g, gk, initial_state, output_final_state,
+                chunk_size, save_new_value, cu_seqlens, chunk_indices,
+                chunk_offsets, use_exp2,
+            )
         try:
-            from aiter.ops.fla import (
-                chunk_gated_delta_rule_fwd_vllm_hip_blockdim64 as hip_kernel,
+            from boltops.fla.gdn import (
+                chunk_gated_delta_rule_fwd_h as boltops_kernel,
             )
         except ImportError:
-            hip_kernel = None
-        try:
-            from aiter.ops.triton.fla.vllm.chunk_delta_h import (
-                launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64,
-            )
-        except ImportError:
-            launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64 = None
-        if (
-            hip_kernel is None
-            and launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64 is None
-        ):
             return original(
                 k, w, u, g, gk, initial_state, output_final_state,
                 chunk_size, save_new_value, cu_seqlens, chunk_indices,
                 chunk_offsets, use_exp2,
             )
 
-        B, T, Hg, K, V = *k.shape, u.shape[-1]
-        H, BT = u.shape[-2], chunk_size
-        if chunk_indices is None and cu_seqlens is not None:
-            chunk_indices = chunk.prepare_chunk_indices(cu_seqlens, chunk_size)
-        if cu_seqlens is None:
-            N, NT, chunk_offsets = B, chunk.triton.cdiv(T, BT), None
-        else:
-            N, NT = len(cu_seqlens) - 1, len(chunk_indices)
-            if chunk_offsets is None:
-                chunk_offsets = chunk.prepare_chunk_offsets(cu_seqlens, BT)
-
-        if hip_kernel is not None:
-            return hip_kernel(
-                k,
-                w,
-                u,
-                g=g,
-                gk=gk,
-                initial_state=initial_state,
-                initial_state_indices=None,
-                output_final_state=output_final_state,
-                chunk_size=chunk_size,
-                save_new_value=save_new_value,
-                cu_seqlens=cu_seqlens,
-                chunk_indices=chunk_indices,
-                chunk_offsets=chunk_offsets,
-                use_exp2=use_exp2,
-                transpose_state_layout=True,
-                kernel_cfg=None,
-            )
-
-        assert launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64 is not None
-        if K > 256:
-            raise ValueError("HCU AITER FLA does not support head dimension > 256")
-        h = k.new_empty(B, NT, H, V, K)
-        final_state = (
-            k.new_empty(N, H, V, K, dtype=chunk.torch.float32)
-            if output_final_state else None
+        # BoltOPs derives chunk offsets from cu_seqlens and chunk_size.
+        return boltops_kernel(
+            k,
+            w,
+            u,
+            g=g,
+            gk=gk,
+            initial_state=initial_state,
+            initial_state_indices=None,
+            output_final_state=output_final_state,
+            inplace_final_state=False,
+            chunk_size=chunk_size,
+            save_new_value=save_new_value,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            use_exp2=use_exp2,
+            transpose_state_layout=True,
+            kernel_cfg=None,
         )
-        v_new = chunk.torch.empty_like(u) if save_new_value else None
-        launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
-            k=k, u=u, w=w, v_new=v_new, g=g, gk=gk, h=h,
-            initial_state=initial_state, initial_state_indices=None,
-            final_state=final_state, cu_seqlens=cu_seqlens,
-            chunk_offsets=chunk_offsets, N=N, T=T, H=H, Hg=Hg, K=K, V=V,
-            BT=BT, use_exp2=use_exp2, transpose_state_layout=True, kernel_cfg=None,
-        )
-        return h, v_new, final_state
 
     setattr(hcu_chunk_delta_h, _WRAPPER, True)
     setattr(chunk, "_vllm_hcu_original_chunk_gated_delta_rule_fwd_h", original)

--- a/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py
@@ -1,106 +1,105 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
-"""Select the HCU AITER FLA output kernel without source mutation."""
+"""Route the vLLM FLA chunk-output kernel through BoltOPs on HCU."""
 
 from __future__ import annotations
 
 import functools
 from types import ModuleType
 
-from ._common import already_applied, load_exact_module, require_callable, require_exact_signature
+from ._common import (
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_exact_signature,
+)
 
-TARGET_MODULE = "vllm.third_party.flash_linear_attention.ops.chunk_o"
-PATCH_ID = "worker.op_opt.fla.chunk_o.aiter"
+TARGET_MODULE = "vllm.third_party.flash_linear_attention.ops.chunk"
+PATCH_ID = "worker.op_opt.fla.chunk_o.boltops"
 TARGETS = (f"{TARGET_MODULE}.chunk_fwd_o",)
-_MARKER = "_vllm_hcu_chunk_o_applied"
-_WRAPPER = "_vllm_hcu_chunk_o_wrapper"
+_MARKER = "_vllm_hcu_fla_chunk_o_applied"
+_WRAPPER = "_vllm_hcu_fla_chunk_o_wrapper"
 
 
 def _enabled() -> bool:
     from vllm_hcu.platforms import envs as henvs
 
-    return bool(henvs.VLLM_HCU_USE_CUSTOM_AITER_FLA and henvs.VLLM_HCU_USE_CUSTOM_OPS)
+    return bool(
+        henvs.VLLM_HCU_USE_CUSTOM_OPS
+        and henvs.VLLM_HCU_USE_CUSTOM_AITER_FLA
+    )
 
 
 def apply_to_module(module: ModuleType) -> bool:
     chunk = load_exact_module(TARGET_MODULE, module)
-    if already_applied(chunk, _MARKER, ((chunk, "chunk_fwd_o", TARGETS[0], _WRAPPER),)):
+    wrapped = ((chunk, "chunk_fwd_o", TARGETS[0], _WRAPPER),)
+    if already_applied(chunk, _MARKER, wrapped):
         return False
     original = require_callable(chunk, "chunk_fwd_o", TARGETS[0])
     require_exact_signature(
         original,
         TARGETS[0],
-        positional=("q", "k", "v", "h", "g", "scale", "cu_seqlens", "chunk_indices", "chunk_size", "core_attn_out"),
-        defaults={"g": None, "scale": None, "cu_seqlens": None, "chunk_indices": None,
-                  "chunk_size": chunk.FLA_CHUNK_SIZE, "core_attn_out": None},
+        positional=(
+            "q", "k", "v", "h", "g", "scale", "cu_seqlens",
+            "chunk_indices", "chunk_size", "core_attn_out",
+        ),
+        defaults={
+            "g": None,
+            "scale": None,
+            "cu_seqlens": None,
+            "chunk_indices": None,
+            "chunk_size": chunk.FLA_CHUNK_SIZE,
+            "core_attn_out": None,
+        },
     )
 
     @functools.wraps(original)
-    def hcu_chunk_o(q, k, v, h, g=None, scale=None, cu_seqlens=None,
-                    chunk_indices=None, chunk_size=chunk.FLA_CHUNK_SIZE,
-                    core_attn_out=None):
+    def hcu_chunk_o(
+        q,
+        k,
+        v,
+        h,
+        g=None,
+        scale=None,
+        cu_seqlens=None,
+        chunk_indices=None,
+        chunk_size=chunk.FLA_CHUNK_SIZE,
+        core_attn_out=None,
+    ):
         if not _enabled():
-            return original(q, k, v, h, g, scale, cu_seqlens, chunk_indices,
-                            chunk_size, core_attn_out)
+            return original(
+                q, k, v, h, g, scale, cu_seqlens, chunk_indices,
+                chunk_size, core_attn_out,
+            )
         try:
-            from aiter.ops.fla import chunk_fwd_o_vllm_hip_blockdim64 as hip_kernel
+            from boltops.fla.gdn import chunk_fwd_o as boltops_kernel
         except ImportError:
-            hip_kernel = None
-        try:
-            from aiter.ops.triton.fla.vllm.chunk_o import launch_chunk_fwd_kernel_o
-        except ImportError:
-            launch_chunk_fwd_kernel_o = None
-        if hip_kernel is None and launch_chunk_fwd_kernel_o is None:
             return original(
                 q, k, v, h, g, scale, cu_seqlens, chunk_indices,
                 chunk_size, core_attn_out,
             )
 
-        B, T, Hg, K, V = *q.shape, v.shape[-1]
-        H, BT = v.shape[-2], chunk_size
-        if chunk_indices is None and cu_seqlens is not None:
-            chunk_indices = chunk.prepare_chunk_indices(cu_seqlens, BT)
-        NT = chunk.triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
-        if scale is None:
-            scale = k.shape[-1] ** -0.5
-
-        if hip_kernel is not None:
-            hip_output = hip_kernel(
-                q=q,
-                k=k,
-                v=v,
-                h=h,
-                g=g,
-                g_gamma=None,
-                scale=scale,
-                cu_seqlens=cu_seqlens,
-                chunk_size=chunk_size,
-                chunk_indices=chunk_indices,
-                use_exp2=False,
-                transpose_state_layout=True,
-                kernel_cfg=None,
-            )
-            if core_attn_out is None:
-                return hip_output
-            if core_attn_out.numel() < v.numel():
-                raise ValueError("core_attn_out is too small for HCU FLA chunk_o")
-            out = core_attn_out[:v.numel()].view(*v.shape)
-            out.copy_(hip_output)
-            return out
-
-        assert launch_chunk_fwd_kernel_o is not None
-        if core_attn_out is not None:
-            if core_attn_out.numel() < v.numel():
-                raise ValueError("core_attn_out is too small for HCU FLA chunk_o")
-            out = core_attn_out[:v.numel()].view(*v.shape)
-        else:
-            out = chunk.torch.empty_like(v)
-        launch_chunk_fwd_kernel_o(
-            q=q, k=k, v=v, h=h, g=g, g_gamma=None, o=out,
-            cu_seqlens=cu_seqlens, chunk_indices=chunk_indices, scale=scale,
-            T=T, H=H, Hg=Hg, K=K, V=V, BT=BT, NT=NT, B=B,
-            use_exp2=False, transpose_state_layout=True, kernel_cfg=None,
+        boltops_output = boltops_kernel(
+            q=q,
+            k=k,
+            v=v,
+            h=h,
+            g=g,
+            g_gamma=None,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_size=chunk_size,
+            chunk_indices=chunk_indices,
+            use_exp2=False,
+            transpose_state_layout=True,
+            kernel_cfg=None,
         )
+        if core_attn_out is None:
+            return boltops_output
+        if core_attn_out.numel() < v.numel():
+            raise ValueError("core_attn_out is too small for HCU FLA chunk_o")
+        out = core_attn_out[:v.numel()].view(*v.shape)
+        out.copy_(boltops_output)
         return out
 
     setattr(hcu_chunk_o, _WRAPPER, True)

--- a/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py
@@ -13,6 +13,7 @@ from ._common import (
     require_callable,
     require_exact_signature,
 )
+from ._boltops_fla import make_boltops_gdn_resolver
 
 TARGET_MODULE = "vllm.third_party.flash_linear_attention.ops.chunk"
 PATCH_ID = "worker.op_opt.fla.chunk_o.boltops"
@@ -52,6 +53,7 @@ def apply_to_module(module: ModuleType) -> bool:
             "core_attn_out": None,
         },
     )
+    resolve_boltops = make_boltops_gdn_resolver("chunk_fwd_o")
 
     @functools.wraps(original)
     def hcu_chunk_o(
@@ -71,9 +73,8 @@ def apply_to_module(module: ModuleType) -> bool:
                 q, k, v, h, g, scale, cu_seqlens, chunk_indices,
                 chunk_size, core_attn_out,
             )
-        try:
-            from boltops.fla.gdn import chunk_fwd_o as boltops_kernel
-        except ImportError:
+        boltops_kernel = resolve_boltops()
+        if boltops_kernel is None:
             return original(
                 q, k, v, h, g, scale, cu_seqlens, chunk_indices,
                 chunk_size, core_attn_out,

--- a/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_fla_chunk_o.py
@@ -43,9 +43,19 @@ def apply_to_module(module: ModuleType) -> bool:
             return original(q, k, v, h, g, scale, cu_seqlens, chunk_indices,
                             chunk_size, core_attn_out)
         try:
+            from aiter.ops.fla import chunk_fwd_o_vllm_hip_blockdim64 as hip_kernel
+        except ImportError:
+            hip_kernel = None
+        try:
             from aiter.ops.triton.fla.vllm.chunk_o import launch_chunk_fwd_kernel_o
-        except ImportError as exc:
-            raise RuntimeError("HCU AITER FLA chunk_o is enabled but unavailable") from exc
+        except ImportError:
+            launch_chunk_fwd_kernel_o = None
+        if hip_kernel is None and launch_chunk_fwd_kernel_o is None:
+            return original(
+                q, k, v, h, g, scale, cu_seqlens, chunk_indices,
+                chunk_size, core_attn_out,
+            )
+
         B, T, Hg, K, V = *q.shape, v.shape[-1]
         H, BT = v.shape[-2], chunk_size
         if chunk_indices is None and cu_seqlens is not None:
@@ -53,6 +63,32 @@ def apply_to_module(module: ModuleType) -> bool:
         NT = chunk.triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
         if scale is None:
             scale = k.shape[-1] ** -0.5
+
+        if hip_kernel is not None:
+            hip_output = hip_kernel(
+                q=q,
+                k=k,
+                v=v,
+                h=h,
+                g=g,
+                g_gamma=None,
+                scale=scale,
+                cu_seqlens=cu_seqlens,
+                chunk_size=chunk_size,
+                chunk_indices=chunk_indices,
+                use_exp2=False,
+                transpose_state_layout=True,
+                kernel_cfg=None,
+            )
+            if core_attn_out is None:
+                return hip_output
+            if core_attn_out.numel() < v.numel():
+                raise ValueError("core_attn_out is too small for HCU FLA chunk_o")
+            out = core_attn_out[:v.numel()].view(*v.shape)
+            out.copy_(hip_output)
+            return out
+
+        assert launch_chunk_fwd_kernel_o is not None
         if core_attn_out is not None:
             if core_attn_out.numel() < v.numel():
                 raise ValueError("core_attn_out is too small for HCU FLA chunk_o")

--- a/vllm_hcu/patch/worker/op_opt/patch_fla_recompute_w_u.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_fla_recompute_w_u.py
@@ -13,6 +13,7 @@ from ._common import (
     require_callable,
     require_exact_signature,
 )
+from ._boltops_fla import make_boltops_gdn_resolver
 
 TARGET_MODULE = "vllm.third_party.flash_linear_attention.ops.chunk"
 PATCH_ID = "worker.op_opt.fla.recompute_w_u.boltops"
@@ -45,6 +46,7 @@ def apply_to_module(module: ModuleType) -> bool:
         ),
         defaults={"chunk_indices": None},
     )
+    resolve_boltops = make_boltops_gdn_resolver("recompute_w_u_fwd")
 
     @functools.wraps(original)
     def hcu_recompute_w_u(
@@ -60,9 +62,8 @@ def apply_to_module(module: ModuleType) -> bool:
             return original(
                 k, v, beta, g_cumsum, A, cu_seqlens, chunk_indices,
             )
-        try:
-            from boltops.fla.gdn import recompute_w_u_fwd as boltops_kernel
-        except ImportError:
+        boltops_kernel = resolve_boltops()
+        if boltops_kernel is None:
             return original(
                 k, v, beta, g_cumsum, A, cu_seqlens, chunk_indices,
             )

--- a/vllm_hcu/patch/worker/op_opt/patch_fla_recompute_w_u.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_fla_recompute_w_u.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Route the vLLM FLA recompute_w_u helper through BoltOPs on HCU."""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+from ._common import (
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_exact_signature,
+)
+
+TARGET_MODULE = "vllm.third_party.flash_linear_attention.ops.chunk"
+PATCH_ID = "worker.op_opt.fla.recompute_w_u.boltops"
+TARGETS = (f"{TARGET_MODULE}.recompute_w_u_fwd",)
+_MARKER = "_vllm_hcu_fla_recompute_w_u_applied"
+_WRAPPER = "_vllm_hcu_fla_recompute_w_u_wrapper"
+
+
+def _enabled() -> bool:
+    from vllm_hcu.platforms import envs as henvs
+
+    return bool(
+        henvs.VLLM_HCU_USE_CUSTOM_OPS
+        and henvs.VLLM_HCU_USE_CUSTOM_AITER_FLA
+    )
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    chunk = load_exact_module(TARGET_MODULE, module)
+    wrapped = ((chunk, "recompute_w_u_fwd", TARGETS[0], _WRAPPER),)
+    if already_applied(chunk, _MARKER, wrapped):
+        return False
+    original = require_callable(chunk, "recompute_w_u_fwd", TARGETS[0])
+    require_exact_signature(
+        original,
+        TARGETS[0],
+        positional=(
+            "k", "v", "beta", "g_cumsum", "A", "cu_seqlens",
+            "chunk_indices",
+        ),
+        defaults={"chunk_indices": None},
+    )
+
+    @functools.wraps(original)
+    def hcu_recompute_w_u(
+        k,
+        v,
+        beta,
+        g_cumsum,
+        A,
+        cu_seqlens,
+        chunk_indices=None,
+    ):
+        if not _enabled():
+            return original(
+                k, v, beta, g_cumsum, A, cu_seqlens, chunk_indices,
+            )
+        try:
+            from boltops.fla.gdn import recompute_w_u_fwd as boltops_kernel
+        except ImportError:
+            return original(
+                k, v, beta, g_cumsum, A, cu_seqlens, chunk_indices,
+            )
+        return boltops_kernel(
+            k,
+            v,
+            beta,
+            g_cumsum,
+            A,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+
+    setattr(hcu_recompute_w_u, _WRAPPER, True)
+    setattr(chunk, "_vllm_hcu_original_recompute_w_u_fwd", original)
+    setattr(chunk, "recompute_w_u_fwd", hcu_recompute_w_u)
+    setattr(chunk, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]

--- a/vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py
@@ -29,10 +29,12 @@ PATCH_ID = "worker.op_opt.mamba.gdn.qwen_kernel_bindings"
 TARGETS = (
     f"{TARGET_MODULE}.gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
     f"{TARGET_MODULE}.fused_sigmoid_gating_delta_rule_update",
+    f"{TARGET_MODULE}.fused_recurrent_gated_delta_rule_packed_decode",
 )
 _MARKER = "_vllm_hcu_qwen_gdn_aiter_layout_applied"
 _WRAPPER = "_vllm_hcu_qwen_gdn_aiter_layout_wrapper"
 _SIGMOID_WRAPPER = "_vllm_hcu_qwen_gdn_sigmoid_wrapper"
+_RECURRENT_WRAPPER = "_vllm_hcu_qwen_gdn_recurrent_wrapper"
 
 # This is the audited vLLM v0.28.1 AITER launcher contract.  Binding by name is
 # intentional: the old HCU adapter rewrote args[10], which could silently
@@ -68,6 +70,7 @@ def apply_to_module(module: ModuleType) -> bool:
     aiter_available = bool(getattr(qwen, "GDN_AITER_TRITON_AVAILABLE", False))
     wrapped = [
         (qwen, TARGETS[1].rsplit(".", 1)[-1], TARGETS[1], _SIGMOID_WRAPPER),
+        (qwen, TARGETS[2].rsplit(".", 1)[-1], TARGETS[2], _RECURRENT_WRAPPER),
     ]
     if aiter_available:
         wrapped.insert(
@@ -118,30 +121,59 @@ def apply_to_module(module: ModuleType) -> bool:
         },
     )
     sigmoid_signature = inspect.signature(official_sigmoid)
+    official_recurrent = require_callable(
+        qwen,
+        "fused_recurrent_gated_delta_rule_packed_decode",
+        TARGETS[2],
+    )
+    require_exact_signature(
+        official_recurrent,
+        TARGETS[2],
+        positional=(
+            "mixed_qkv",
+            "a",
+            "b",
+            "A_log",
+            "dt_bias",
+            "scale",
+            "initial_state",
+            "out",
+            "ssm_state_indices",
+            "use_qk_l2norm_in_kernel",
+        ),
+        defaults={"use_qk_l2norm_in_kernel": False},
+    )
+    recurrent_signature = inspect.signature(official_recurrent)
 
     @functools.wraps(official_sigmoid)
     def hcu_sigmoid_update(*args, **kwargs):
         bound = sigmoid_signature.bind(*args, **kwargs)
         bound.apply_defaults()
-        if _sigmoid_enabled():
-            if bound.arguments["A_log"].dtype == bound.arguments["q"].dtype:
-                try:
-                    from aiter import (
-                        vllm_fused_sigmoid_gating_delta_rule_update as hip_kernel,
-                    )
-                except ImportError:
-                    hip_kernel = None
-                if hip_kernel is not None:
-                    return hip_kernel(*bound.args, **bound.kwargs)
+        if _boltops_enabled():
             try:
-                from aiter.ops.triton.fla.fused_sigmoid_gating import (
-                    fused_sigmoid_gating_delta_rule_update as triton_kernel,
+                from boltops.fla.gdn import (
+                    fused_sigmoid_gating_delta_rule_update as boltops_kernel,
                 )
             except ImportError:
-                triton_kernel = None
-            if triton_kernel is not None:
-                return triton_kernel(*bound.args, **bound.kwargs)
+                boltops_kernel = None
+            if boltops_kernel is not None:
+                return boltops_kernel(*bound.args, **bound.kwargs)
         return official_sigmoid(*bound.args, **bound.kwargs)
+
+    @functools.wraps(official_recurrent)
+    def hcu_recurrent_update(*args, **kwargs):
+        bound = recurrent_signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        if _boltops_enabled():
+            try:
+                from boltops.fla.gdn import (
+                    fused_recurrent_gated_delta_rule_packed_decode as boltops_kernel,
+                )
+            except ImportError:
+                boltops_kernel = None
+            if boltops_kernel is not None:
+                return boltops_kernel(*bound.args, **bound.kwargs)
+        return official_recurrent(*bound.args, **bound.kwargs)
 
     if aiter_available:
         aiter_update = require_callable(
@@ -179,8 +211,15 @@ def apply_to_module(module: ModuleType) -> bool:
             return aiter_update(*bound.args, **bound.kwargs)
 
     setattr(hcu_sigmoid_update, _SIGMOID_WRAPPER, True)
+    setattr(hcu_recurrent_update, _RECURRENT_WRAPPER, True)
     setattr(qwen, "_vllm_hcu_original_fused_sigmoid", official_sigmoid)
+    setattr(qwen, "_vllm_hcu_original_fused_recurrent", official_recurrent)
     setattr(qwen, "fused_sigmoid_gating_delta_rule_update", hcu_sigmoid_update)
+    setattr(
+        qwen,
+        "fused_recurrent_gated_delta_rule_packed_decode",
+        hcu_recurrent_update,
+    )
     if aiter_available:
         setattr(hcu_aiter_update, _WRAPPER, True)
         setattr(qwen, "_vllm_hcu_original_gdn_aiter_update", aiter_update)
@@ -193,7 +232,7 @@ def apply_to_module(module: ModuleType) -> bool:
     return True
 
 
-def _sigmoid_enabled() -> bool:
+def _boltops_enabled() -> bool:
     from vllm_hcu.platforms import envs as henvs
 
     return bool(

--- a/vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
-"""NN-layout adapter for vLLM v0.25.1's native Qwen GDN AITER path."""
+"""HCU kernel bindings for vLLM v0.28.1 Qwen GDN."""
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ from ._common import (
     already_applied,
     load_exact_module,
     require_callable,
+    require_exact_signature,
 )
 from ._gdn_common import (
     normalize_nn_conv_weight,
@@ -27,11 +28,13 @@ TARGET_MODULE = (
 PATCH_ID = "worker.op_opt.mamba.gdn.qwen_kernel_bindings"
 TARGETS = (
     f"{TARGET_MODULE}.gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
+    f"{TARGET_MODULE}.fused_sigmoid_gating_delta_rule_update",
 )
 _MARKER = "_vllm_hcu_qwen_gdn_aiter_layout_applied"
 _WRAPPER = "_vllm_hcu_qwen_gdn_aiter_layout_wrapper"
+_SIGMOID_WRAPPER = "_vllm_hcu_qwen_gdn_sigmoid_wrapper"
 
-# This is the audited vLLM v0.25.1 AITER launcher contract.  Binding by name is
+# This is the audited vLLM v0.28.1 AITER launcher contract.  Binding by name is
 # intentional: the old HCU adapter rewrote args[10], which could silently
 # transpose the wrong object if AITER inserted or reordered a parameter.
 _AITER_UPDATE_PARAMETERS = (
@@ -63,59 +66,140 @@ _AITER_UPDATE_PARAMETERS = (
 def apply_to_module(module: ModuleType) -> bool:
     qwen = load_exact_module(TARGET_MODULE, module)
     aiter_available = bool(getattr(qwen, "GDN_AITER_TRITON_AVAILABLE", False))
-    wrapped = (
-        (qwen, TARGETS[0].rsplit(".", 1)[-1], TARGETS[0], _WRAPPER),
-    ) if aiter_available else ()
+    wrapped = [
+        (qwen, TARGETS[1].rsplit(".", 1)[-1], TARGETS[1], _SIGMOID_WRAPPER),
+    ]
+    if aiter_available:
+        wrapped.insert(
+            0,
+            (qwen, TARGETS[0].rsplit(".", 1)[-1], TARGETS[0], _WRAPPER),
+        )
     if already_applied(qwen, _MARKER, wrapped):
         return False
 
-    if not aiter_available:
-        setattr(qwen, _MARKER, True)
-        return True
-
-    aiter_update = require_callable(
+    official_sigmoid = require_callable(
         qwen,
-        "gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
-        TARGETS[0],
+        "fused_sigmoid_gating_delta_rule_update",
+        TARGETS[1],
     )
-    require_parameter_names(
-        aiter_update,
-        TARGETS[0],
-        _AITER_UPDATE_PARAMETERS,
+    require_exact_signature(
+        official_sigmoid,
+        TARGETS[1],
+        positional=(
+            "A_log",
+            "a",
+            "b",
+            "dt_bias",
+            "q",
+            "k",
+            "v",
+            "beta",
+            "threshold",
+            "scale",
+            "initial_state",
+            "inplace_final_state",
+            "cu_seqlens",
+            "ssm_state_indices",
+            "num_accepted_tokens",
+            "use_qk_l2norm_in_kernel",
+            "is_kda",
+        ),
+        defaults={
+            "beta": 1.0,
+            "threshold": 20.0,
+            "scale": None,
+            "initial_state": None,
+            "inplace_final_state": True,
+            "cu_seqlens": None,
+            "ssm_state_indices": None,
+            "num_accepted_tokens": None,
+            "use_qk_l2norm_in_kernel": False,
+            "is_kda": False,
+        },
     )
-    aiter_signature = inspect.signature(aiter_update)
+    sigmoid_signature = inspect.signature(official_sigmoid)
 
-    @functools.wraps(aiter_update)
-    def hcu_aiter_update(*args, **kwargs):
-        if not use_nn_layout():
-            return aiter_update(*args, **kwargs)
-        try:
-            bound = aiter_signature.bind(*args, **kwargs)
-        except TypeError as exc:
-            raise PatchCompatibilityError(
-                f"required HCU call for {TARGETS[0]} does not match the "
-                f"audited vLLM v0.25.1 AITER contract {aiter_signature}"
-            ) from exc
-        conv_state = bound.arguments.get("conv_state")
-        if conv_state is None or "weight" not in bound.arguments:
-            raise PatchCompatibilityError(
-                f"required HCU call for {TARGETS[0]} is missing conv_state or weight"
-            )
-        expected_dim = shape_dim(conv_state, -2)
-        bound.arguments["weight"] = normalize_nn_conv_weight(
-            bound.arguments["weight"], expected_dim, TARGETS[0]
+    @functools.wraps(official_sigmoid)
+    def hcu_sigmoid_update(*args, **kwargs):
+        bound = sigmoid_signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        if _sigmoid_enabled():
+            if bound.arguments["A_log"].dtype == bound.arguments["q"].dtype:
+                try:
+                    from aiter import (
+                        vllm_fused_sigmoid_gating_delta_rule_update as hip_kernel,
+                    )
+                except ImportError:
+                    hip_kernel = None
+                if hip_kernel is not None:
+                    return hip_kernel(*bound.args, **bound.kwargs)
+            try:
+                from aiter.ops.triton.fla.fused_sigmoid_gating import (
+                    fused_sigmoid_gating_delta_rule_update as triton_kernel,
+                )
+            except ImportError:
+                triton_kernel = None
+            if triton_kernel is not None:
+                return triton_kernel(*bound.args, **bound.kwargs)
+        return official_sigmoid(*bound.args, **bound.kwargs)
+
+    if aiter_available:
+        aiter_update = require_callable(
+            qwen,
+            "gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
+            TARGETS[0],
         )
-        return aiter_update(*bound.args, **bound.kwargs)
+        require_parameter_names(
+            aiter_update,
+            TARGETS[0],
+            _AITER_UPDATE_PARAMETERS,
+        )
+        aiter_signature = inspect.signature(aiter_update)
 
-    setattr(hcu_aiter_update, _WRAPPER, True)
-    setattr(qwen, "_vllm_hcu_original_gdn_aiter_update", aiter_update)
-    setattr(
-        qwen,
-        "gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
-        hcu_aiter_update,
-    )
+        @functools.wraps(aiter_update)
+        def hcu_aiter_update(*args, **kwargs):
+            if not use_nn_layout():
+                return aiter_update(*args, **kwargs)
+            try:
+                bound = aiter_signature.bind(*args, **kwargs)
+            except TypeError as exc:
+                raise PatchCompatibilityError(
+                    f"required HCU call for {TARGETS[0]} does not match the "
+                    f"audited vLLM v0.28.1 AITER contract {aiter_signature}"
+                ) from exc
+            conv_state = bound.arguments.get("conv_state")
+            if conv_state is None or "weight" not in bound.arguments:
+                raise PatchCompatibilityError(
+                    f"required HCU call for {TARGETS[0]} is missing conv_state or weight"
+                )
+            expected_dim = shape_dim(conv_state, -2)
+            bound.arguments["weight"] = normalize_nn_conv_weight(
+                bound.arguments["weight"], expected_dim, TARGETS[0]
+            )
+            return aiter_update(*bound.args, **bound.kwargs)
+
+    setattr(hcu_sigmoid_update, _SIGMOID_WRAPPER, True)
+    setattr(qwen, "_vllm_hcu_original_fused_sigmoid", official_sigmoid)
+    setattr(qwen, "fused_sigmoid_gating_delta_rule_update", hcu_sigmoid_update)
+    if aiter_available:
+        setattr(hcu_aiter_update, _WRAPPER, True)
+        setattr(qwen, "_vllm_hcu_original_gdn_aiter_update", aiter_update)
+        setattr(
+            qwen,
+            "gdn_aiter_fused_reshape_causal_conv1d_update_single_token",
+            hcu_aiter_update,
+        )
     setattr(qwen, _MARKER, True)
     return True
+
+
+def _sigmoid_enabled() -> bool:
+    from vllm_hcu.platforms import envs as henvs
+
+    return bool(
+        henvs.VLLM_HCU_USE_CUSTOM_OPS
+        and henvs.VLLM_HCU_USE_CUSTOM_AITER_FLA
+    )
 
 
 def apply(module: ModuleType | None = None) -> bool:

--- a/vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_gdn_linear_attention.py
@@ -15,6 +15,7 @@ from ._common import (
     require_callable,
     require_exact_signature,
 )
+from ._boltops_fla import make_boltops_gdn_resolver
 from ._gdn_common import (
     normalize_nn_conv_weight,
     require_parameter_names,
@@ -144,18 +145,19 @@ def apply_to_module(module: ModuleType) -> bool:
         defaults={"use_qk_l2norm_in_kernel": False},
     )
     recurrent_signature = inspect.signature(official_recurrent)
+    resolve_boltops_sigmoid = make_boltops_gdn_resolver(
+        "fused_sigmoid_gating_delta_rule_update"
+    )
+    resolve_boltops_recurrent = make_boltops_gdn_resolver(
+        "fused_recurrent_gated_delta_rule_packed_decode"
+    )
 
     @functools.wraps(official_sigmoid)
     def hcu_sigmoid_update(*args, **kwargs):
         bound = sigmoid_signature.bind(*args, **kwargs)
         bound.apply_defaults()
         if _boltops_enabled():
-            try:
-                from boltops.fla.gdn import (
-                    fused_sigmoid_gating_delta_rule_update as boltops_kernel,
-                )
-            except ImportError:
-                boltops_kernel = None
+            boltops_kernel = resolve_boltops_sigmoid()
             if boltops_kernel is not None:
                 return boltops_kernel(*bound.args, **bound.kwargs)
         return official_sigmoid(*bound.args, **bound.kwargs)
@@ -165,12 +167,7 @@ def apply_to_module(module: ModuleType) -> bool:
         bound = recurrent_signature.bind(*args, **kwargs)
         bound.apply_defaults()
         if _boltops_enabled():
-            try:
-                from boltops.fla.gdn import (
-                    fused_recurrent_gated_delta_rule_packed_decode as boltops_kernel,
-                )
-            except ImportError:
-                boltops_kernel = None
+            boltops_kernel = resolve_boltops_recurrent()
             if boltops_kernel is not None:
                 return boltops_kernel(*bound.args, **bound.kwargs)
         return official_recurrent(*bound.args, **bound.kwargs)


### PR DESCRIPTION
## Summary

- Port PR #72's Qwen GDN/FLA optimizations to vLLM v0.28.1 by current API contracts rather than cherry-picking its historical commit range.
- Route `chunk_gated_delta_rule_fwd_h`, `chunk_fwd_o`, `recompute_w_u_fwd`, `fused_recurrent_gated_delta_rule_packed_decode`, and `fused_sigmoid_gating_delta_rule_update` through public `boltops.fla.gdn` interfaces.
- Preserve exact current vLLM signatures, varlen metadata, state-update semantics, and the official `core_attn_out` output-buffer contract.
- Use the official vLLM implementation when BoltOPs cannot be imported or the feature is disabled. Runtime failures from a selected BoltOPs kernel are propagated.
- Keep `VLLM_HCU_USE_CUSTOM_AITER_FLA` as a compatibility capability switch without adding a new environment variable.
- Keep BoltOPs FLA independent from self-developed AITER MoE. `--moe-backend aiter` continues to select AITER MoE.
- Do not add the BoltOPs recurrent-extra API because current vLLM has no model callsite requiring that separate contract.
- Do not port the old causal-conv path because v0.28.1 owns expanded speculative, varlen, APC, metadata, and output-buffer contracts.

## Validation

- Focused BoltOPs routing/fallback tests: 7 passed.
- Affected runtime files: 51 passed, 14 warnings.
- Full `tests/runtime_patch`: 1197 passed, 14 warnings.
- Final wheel: `vllm_hcu-0.28.1rc1.dev490+das.7ab7631.dtk2604-cp310-cp310-linux_x86_64.whl`.
- Final wheel SHA256: `7cafa3989e5f6cd32c7d6c6fe85f62ec5a883811528f09488b6bcba248276360`.
- Real import ownership confirmed all five current vLLM callsites resolve to HCU BoltOPs wrappers.
- Qwen3.5-35B-A3B BF16, TP1, FLASH_ATTN, AITER MoE, MTP=3, prefix cache, default CUDA graph strategy: target and draft FULL/PIECEWISE capture completed.
- HumanEval 32/32, mean accuracy and Pass@1 both 1.0, thinking disabled.
- All 32 chat requests returned HTTP 200 with no ERROR, traceback, graph constraint, HIP, or CUDA failure.
- MTP draft acceptance was 94.1% to 97.6% across measured windows.

## Model launch

```bash
env \
  PYTHONPATH=/models/.installs/vllm-plugin-das-pr72-kernels-v0281 \
  HIP_VISIBLE_DEVICES=7 \
  NO_PROXY=127.0.0.1,localhost \
  no_proxy=127.0.0.1,localhost \
  vllm serve /models/Qwen3.5-35B-A3B \
    --host 127.0.0.1 \
    --port 10151 \
    --served-model-name Qwen3.5-35B-A3B \
    --tensor-parallel-size 1 \
    --trust-remote-code \
    --language-model-only \
    --attention-backend FLASH_ATTN \
    --moe-backend aiter \
    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
    --enable-prefix-caching \
    --max-model-len 4096 \
    --max-num-batched-tokens 1024 \
    --max-num-seqs 8 \
    --gpu-memory-utilization 0.85
```

No explicit `PIECEWISE`, eager mode, or legacy unified-FlashAttention environment variable is required.
