### PR TITLE
fix(hcu): support DeepSeek V4 INT8 on gfx936 and bound sparse indexer fallback memory

### DIFF
--- a/tests/patch/test_module_exchange.py
+++ b/tests/patch/test_module_exchange.py
@@ -10,7 +10,7 @@ import importlib.util
 import os
 import sys
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -677,7 +677,9 @@ def test_sparse_replacements_keep_reviewed_hcu_deltas():
     build_tile_scheduler = sparse_swa_source.split(
         "    def build_tile_scheduler(", 1
     )[1].split("    def _build_deepseek_v4_metadata(", 1)[0]
-    assert "current_platform.is_rocm()" not in build_tile_scheduler
+    # ROCm may skip planning only for a decode path that does not consume it.
+    # Both native and generic ROCm builders are exercised below.
+    assert "VLLM_HCU_DEEPSEEK_V4_ROCM_DECODE_FALLBACK" in build_tile_scheduler
     assert "current_platform.is_xpu()" in build_tile_scheduler
     sparse_swa_tree = ast.parse(sparse_swa_source)
     backend_class = next(
@@ -834,3 +836,77 @@ def test_modular_kernel_strict_late_policy_keeps_official_and_hcu_exclusive(
     assert replacement not in sys.modules
     record = registry.get("module_exchange.modular_kernel")
     assert record is not None and record.status is PatchStatus.FAILED
+
+
+@pytest.mark.parametrize(
+    "platform,native_builder,fallback,num_decode_tokens,expects_scheduler",
+    [("rocm", False, False, 8, True),
+     ("rocm", False, True, 8, False),
+     ("rocm", True, False, 8, False),
+     ("rocm", True, True, 8, False),
+     ("rocm", False, False, 0, False),
+     ("xpu", False, False, 8, False),
+     ("sm120", False, False, 8, False),
+     ("cuda", False, False, 0, False),
+     ("cuda", False, False, 8, True),
+     ("cuda", False, True, 8, True)],
+)
+def test_sparse_swa_tile_scheduler_platform_behavior(
+    monkeypatch, platform, native_builder, fallback, num_decode_tokens,
+    expects_scheduler,
+):
+    # Execute the actual builder method without importing GPU extensions.
+    source = (REPO_ROOT / "vllm_hcu/v1/attention/backends/mla/sparse_swa.py").read_text(
+        encoding="utf-8"
+    )
+    tree = ast.parse(source)
+    builder = next(
+        node for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "DeepseekSparseSWAMetadataBuilder"
+    )
+    method = next(
+        node for node in builder.body
+        if isinstance(node, ast.FunctionDef) and node.name == "build_tile_scheduler"
+    )
+    class NativeBuilder:
+        pass
+
+    native_module = ModuleType("vllm.models.deepseek_v4.amd.rocm")
+    native_module.DeepseekV4ROCMAiterSparseSWAMetadataBuilder = NativeBuilder
+    monkeypatch.setitem(sys.modules, native_module.__name__, native_module)
+    calls = []
+
+    def get_metadata():
+        metadata = object()
+        calls.append(metadata)
+        return (metadata,)
+
+    namespace = {
+        "current_platform": SimpleNamespace(
+            is_rocm=lambda: platform == "rocm",
+            is_xpu=lambda: platform == "xpu",
+            is_device_capability_family=lambda family: platform == "sm120" and family == 120,
+        ),
+        "henvs": SimpleNamespace(VLLM_HCU_DEEPSEEK_V4_ROCM_DECODE_FALLBACK=fallback),
+        "get_mla_metadata": get_metadata,
+        "FlashMLASchedMeta": object,
+        "_LAYER_TYPE_SWAONLY": "swaonly",
+        "_LAYER_TYPE_C4A": "c4a",
+        "_LAYER_TYPE_C128A": "c128a",
+    }
+    exec(compile(ast.Module(body=[method], type_ignores=[]), "<tile_scheduler>", "exec"), namespace)
+    # Include an absent layer type to verify it retains the None sentinel.
+    instance = NativeBuilder() if native_builder else SimpleNamespace()
+    instance._layer_types = ["swaonly", "c4a"]
+    result = namespace["build_tile_scheduler"](instance, num_decode_tokens)
+    assert set(result) == {"swaonly", "c4a", "c128a"}
+    if expects_scheduler:
+        assert len(calls) == 2
+        assert result["swaonly"] is calls[0]
+        assert result["c4a"] is calls[1]
+        assert calls[0] is not calls[1]
+        assert result["c128a"] is None
+    else:
+        assert calls == []
+        assert all(value is None for value in result.values())

--- a/tests/runtime_patch/test_deepseek_v4_dspark_patches.py
+++ b/tests/runtime_patch/test_deepseek_v4_dspark_patches.py
@@ -445,7 +445,7 @@ def test_rocm_wo_a_cache_keeps_upstream_layout() -> None:
 def test_mhc_backend_switch_masks_aiter_only_when_hcu_option_is_off(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = _module(patch_mhc_backend.TARGET_MODULE, HAS_AITER_MHC=True)
+    module = _module(patch_mhc_backend.TARGET_MODULE, HAS_AITER_MHC=True, HAS_TILELANG_MHC=False)
     monkeypatch.setattr(
         "vllm_hcu.platforms.envs.VLLM_HCU_USE_AITER_MHC",
         False,
@@ -528,3 +528,17 @@ def test_mhc_patch_rejects_missing_capability_flag() -> None:
 
     with pytest.raises(PatchCompatibilityError, match="HAS_AITER_MHC"):
         patch_mhc_backend.apply_to_module(module)
+
+
+@pytest.mark.parametrize("rocm,available,expected", [(True, False, False), (True, True, True), (False, False, True)])
+def test_mhc_tilelang_requires_hip_codegen(monkeypatch, rocm, available, expected):
+    module = _module(patch_mhc_backend.TARGET_MODULE,
+                     HAS_AITER_MHC=False, HAS_TILELANG_MHC=True)
+    module.current_platform = SimpleNamespace(is_rocm=lambda: rocm)
+    tvm = _module("tvm", ffi=SimpleNamespace(
+        get_global_func=lambda name, allow_missing: object() if available else None))
+    monkeypatch.setitem(sys.modules, "tvm", tvm)
+    assert patch_mhc_backend.apply_to_module(module) is True
+    assert module.HAS_TILELANG_MHC is expected
+    assert module._vllm_hcu_original_has_tilelang_mhc is True
+    assert patch_mhc_backend.apply_to_module(module) is False

--- a/tests/runtime_patch/test_deepseek_v4_dspark_patches.py
+++ b/tests/runtime_patch/test_deepseek_v4_dspark_patches.py
@@ -537,7 +537,7 @@ def test_mhc_tilelang_requires_hip_codegen(monkeypatch, rocm, available, expecte
     module.current_platform = SimpleNamespace(is_rocm=lambda: rocm)
     tvm = _module("tvm", ffi=SimpleNamespace(
         get_global_func=lambda name, allow_missing: object() if available else None))
-    monkeypatch.setitem(sys.modules, "tvm", tvm)
+    monkeypatch.setitem(sys.modules, "tilelang", _module("tilelang", tvm=tvm))
     assert patch_mhc_backend.apply_to_module(module) is True
     assert module.HAS_TILELANG_MHC is expected
     assert module._vllm_hcu_original_has_tilelang_mhc is True

--- a/tests/runtime_patch/test_gfx936_indexer.py
+++ b/tests/runtime_patch/test_gfx936_indexer.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+
+"""gfx936 indexer numerical, multi-token and CUDA Graph regression tests."""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+import torch
+import torch.nn.functional as F
+import pytest
+
+def test_gfx936_indexer_reference(monkeypatch):
+    import ast
+    import sys
+    from types import SimpleNamespace, ModuleType
+    from pathlib import Path
+    import torch
+    import torch.nn.functional as F
+    source = (Path(__file__).resolve().parents[2] / 'vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py').read_text()
+    tree = ast.parse(source)
+    names = {'fp8_paged_mqa_logits_torch', 'fp8_mqa_logits_torch'}
+    selected = ast.Module(body=[n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name in names], type_ignores=[])
+    namespace = dict(torch=torch, F=F, current_platform=SimpleNamespace(fp8_dtype=lambda : torch.float8_e4m3fn))
+    stub = ModuleType('vllm.utils.math_utils')
+    stub.cdiv = lambda a, b: (a + b - 1) // b
+    monkeypatch.setitem(sys.modules, 'vllm.utils.math_utils', stub)
+    exec(compile(selected, '<reference>', 'exec'), namespace)
+    torch.manual_seed(7)
+    (b, d, h) = (4, 8, 3)
+    values = torch.randint(-4, 5, (3, b, d)).to(torch.float8_e4m3fn)
+    scales = torch.tensor([[0.5, 1, 2, 4], [2, 1, 0.5, 4], [1, 2, 4, 0.5]], dtype=torch.float32)
+    packed = torch.cat([values.view(torch.uint8).reshape(3, -1), scales.view(torch.uint8).reshape(3, -1)], dim=1).view(3, b, 1, d + 4)
+    q = torch.randn(1, 1, h, d)
+    w = torch.rand(1, h)
+    table = torch.tensor([[2, 0]], dtype=torch.int32)
+    for length in [1, 4, 7]:
+        actual = namespace['fp8_paged_mqa_logits_torch'](q, packed, w, torch.tensor([length]), table, 8)
+        k = values.float()[table[0].long()].reshape(-1, d)[:length]
+        scale = scales[table[0].long()].reshape(-1)[:length]
+        expected = ((q[0, 0] @ k.T).relu() * w[0, :, None]).sum(0) * scale
+        torch.testing.assert_close(actual[0, :length], expected)
+        assert torch.isneginf(actual[0, length:]).all()
+    for (m, n) in [(9, 2), (2, 9), (3, 3)]:
+        q = torch.randint(-3, 4, (m, 3, 8)).to(torch.float8_e4m3fn)
+        k = torch.randint(-3, 4, (n, 8)).to(torch.float8_e4m3fn)
+        scales = torch.arange(1, n + 1, dtype=torch.float32).reshape(n, 1) / 2
+        weights = torch.rand(m, 3)
+        lo = torch.zeros(m, dtype=torch.int32)
+        hi = torch.full((m,), n, dtype=torch.int32)
+        hi[0] = 1
+        actual = namespace['fp8_mqa_logits_torch'](q, (k, scales), weights, lo, hi)
+        expected = torch.empty(m, n)
+        for row in range(m):
+            for col in range(n):
+                expected[row, col] = sum((max(float(torch.dot(q[row, head].float(), k[col].float())), 0) * float(weights[row, head]) * float(scales[col, 0]) for head in range(3))) if col < int(hi[row]) else -torch.inf
+        torch.testing.assert_close(actual, expected)
+
+def test_decode_graph_replay():
+    if not torch.cuda.is_available():
+        import pytest
+        pytest.skip('GPU graph test requires a visible GPU')
+    source = (Path(__file__).resolve().parents[2] / 'vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py').read_text()
+    node = next((n for n in ast.parse(source).body if isinstance(n, ast.FunctionDef) and n.name == 'fp8_paged_mqa_logits_torch'))
+    node.body = [n for n in node.body if not isinstance(n, ast.ImportFrom)]
+    ns = dict(torch=torch, F=F, current_platform=SimpleNamespace(fp8_dtype=lambda : torch.float8_e4m3fn))
+    exec(compile(ast.Module(body=[node], type_ignores=[]), '<decode>', 'exec'), ns)
+    fn = ns['fp8_paged_mqa_logits_torch']
+    torch.manual_seed(17)
+    for batch in (1, 8):
+        (block, dim, heads, limit) = (256, 128, 8, 513)
+        values = torch.randint(-3, 4, (5, block, dim), device='cuda').to(torch.float8_e4m3fn)
+        scales = torch.rand(5, block, device='cuda') + 0.25
+        cache = torch.cat((values.view(torch.uint8).reshape(5, -1), scales.view(torch.uint8).reshape(5, -1)), 1).view(5, block, 1, dim + 4)
+        q = torch.randn(batch, 1, heads, dim, device='cuda').to(torch.float8_e4m3fn)
+        weights = torch.rand(batch, heads, device='cuda')
+        lengths = torch.full((batch,), 1, device='cuda', dtype=torch.int32)
+        tables = torch.tensor([[2, 0, 4]] * batch, device='cuda', dtype=torch.int32)
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(3):
+                fn(q, cache, weights, lengths, tables, limit)
+        torch.cuda.current_stream().wait_stream(stream)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            output = fn(q, cache, weights, lengths, tables, limit)
+        for step in range(3):
+            lens = [[0, 255, 513][(i + step) % 3] for i in range(batch)]
+            lengths.copy_(torch.tensor(lens, device='cuda', dtype=torch.int32))
+            tables.copy_(torch.tensor([[4, 2, 1] if step % 2 else [1, 0, 3]] * batch, device='cuda', dtype=torch.int32))
+            q.copy_(torch.randn_like(q.float()).to(q.dtype))
+            weights.mul_(0.9)
+            graph.replay()
+            expected = torch.full((batch, limit), -torch.inf, device='cuda')
+            for (i, length) in enumerate(lens):
+                ids = tables[i].long()
+                k = values.float()[ids].reshape(-1, dim)[:length]
+                scale = scales[ids].reshape(-1)[:length]
+                expected[i, :length] = ((q[i, 0].float() @ k.T).relu() * weights[i, :, None]).sum(0) * scale
+            torch.testing.assert_close(output, expected, atol=0.002, rtol=0.0002)
+
+def test_prefill_gather_graph_replay():
+    if not torch.cuda.is_available():
+        import pytest
+        pytest.skip('GPU graph test requires a visible GPU')
+    source = (Path(__file__).resolve().parents[2] / 'vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py').read_text()
+    branch = next((n for n in ast.walk(ast.parse(source)) if isinstance(n, ast.If) and isinstance(n.test, ast.Name) and (n.test.id == 'v4_fp8_fallback') and any((isinstance(x, ast.Assign) and any((isinstance(t, ast.Name) and t.id == 'page_size' for t in x.targets)) for x in n.body))))
+    code = compile(ast.Module(body=branch.body, type_ignores=[]), '<gather>', 'exec')
+    (block, dim, count) = (4, 8, 7)
+    values = torch.arange(3 * block * dim, device='cuda').reshape(3, block, dim).remainder(7).to(torch.float8_e4m3fn)
+    scales = torch.arange(12, device='cuda', dtype=torch.float32).reshape(3, 4) + 1
+    cache = torch.cat((values.view(torch.uint8).reshape(3, -1), scales.view(torch.uint8).reshape(3, -1)), 1).view(3, block, dim + 4)
+    chunk = SimpleNamespace(total_seq_lens=count, cu_seq_lens=torch.tensor([0, 3, 7], device='cuda', dtype=torch.int32), block_table=torch.tensor([[2, 1], [0, 2]], device='cuda', dtype=torch.int32))
+    out = torch.empty(count, dim, device='cuda', dtype=torch.float8_e4m3fn)
+    out_scale = torch.empty(count, 4, device='cuda', dtype=torch.uint8)
+    ns = dict(torch=torch, chunk=chunk, kv_cache=cache, head_dim=dim, fp8_dtype=torch.float8_e4m3fn, k_fp8=out, k_scale=out_scale)
+
+    def gather():
+        exec(code, ns)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            gather()
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        gather()
+    for boundary in (0, 2, 5):
+        chunk.cu_seq_lens.copy_(torch.tensor([0, boundary, count], device='cuda', dtype=torch.int32))
+        graph.replay()
+        expected = []
+        expected_scales = []
+        for (seq, (start, end)) in enumerate(((0, boundary), (boundary, count))):
+            for j in range(end - start):
+                page = int(chunk.block_table[seq, j // block].item())
+                expected.append(values[page, j % block].float())
+                expected_scales.append(scales[page, j % block])
+        torch.testing.assert_close(out.float(), torch.stack(expected))
+        torch.testing.assert_close(out_scale.view(torch.float32).flatten(), torch.stack(expected_scales))
+
+def _load_decode_fn():
+    path = Path(__file__).resolve().parents[2] / 'vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py'
+    node = next((n for n in ast.parse(path.read_text()).body if isinstance(n, ast.FunctionDef) and n.name == 'fp8_paged_mqa_logits_torch'))
+    ns = dict(torch=torch, current_platform=SimpleNamespace(fp8_dtype=lambda : torch.float8_e4m3fn))
+    exec(compile(ast.Module(body=[node], type_ignores=[]), str(path), 'exec'), ns)
+    return ns[node.name]
+
+@pytest.mark.parametrize('next_n', [1, 2, 6])
+@pytest.mark.parametrize('per_query', [False, True])
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_multitoken(next_n, per_query, device):
+    if device == 'cuda' and (not torch.cuda.is_available()):
+        pytest.skip('GPU required')
+    fn = _load_decode_fn()
+    torch.manual_seed(9)
+    (batch, block, dim, heads, limit) = (2, 4, 8, 3, 11)
+    values = torch.randint(-3, 4, (5, block, dim), device=device).to(torch.float8_e4m3fn)
+    scales = torch.rand(5, block, device=device) + 0.25
+    cache = torch.cat([values.view(torch.uint8).reshape(5, -1), scales.view(torch.uint8).reshape(5, -1)], 1).view(5, block, 1, dim + 4)
+    q = torch.randn(batch, next_n, heads, dim, device=device).to(torch.float8_e4m3fn)
+    weights = torch.rand(batch * next_n, heads, device=device)
+    table = torch.tensor([[4, 1, 0], [2, 3, 1]], device=device, dtype=torch.int32)
+    lengths = torch.full((batch, next_n) if per_query else (batch,), 7, device=device, dtype=torch.int32)
+    graph = None
+    if device == 'cuda':
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(3):
+                fn(q, cache, weights, lengths, table, limit)
+        torch.cuda.current_stream().wait_stream(stream)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            out = fn(q, cache, weights, lengths, table, limit)
+    for step in (0, 1, 2):
+        if per_query:
+            data = [[min(11, max(0, step * 3 + j - 1)) for j in range(next_n)], [0] * next_n]
+        else:
+            data = [11 - step * 4, step * 4]
+        lengths.copy_(torch.tensor(data, device=device, dtype=torch.int32))
+        table.copy_(torch.tensor([[step, 4, 1], [4, step, 0]], device=device, dtype=torch.int32))
+        q.copy_(torch.randn_like(q.float()).to(q.dtype))
+        if graph:
+            graph.replay()
+        else:
+            out = fn(q, cache, weights, lengths, table, limit)
+        expected = torch.full((batch, next_n, limit), -torch.inf, device=device)
+        for b in range(batch):
+            keys = values.float()[table[b].long()].reshape(-1, dim)
+            scale = scales[table[b].long()].reshape(-1)
+            for j in range(next_n):
+                end = data[b][j] if per_query else max(0, data[b] - next_n + j + 1)
+                expected[b, j, :end] = ((q[b, j].float() @ keys[:end].T).relu() * weights[b * next_n + j, :, None]).sum(0) * scale[:end]
+        torch.testing.assert_close(out, expected.reshape(batch * next_n, limit), atol=0.0002, rtol=0.0002)

--- a/tests/runtime_patch/test_sparse_indexer_torch_fallback.py
+++ b/tests/runtime_patch/test_sparse_indexer_torch_fallback.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
 
-"""gfx936 indexer numerical, multi-token and CUDA Graph regression tests."""
+"""Sparse indexer PyTorch fallback numerical and GPU Graph regression tests."""
 
 import ast
 from pathlib import Path
@@ -10,7 +10,7 @@ import torch
 import torch.nn.functional as F
 import pytest
 
-def test_gfx936_indexer_reference(monkeypatch):
+def test_sparse_indexer_torch_reference(monkeypatch):
     import ast
     import sys
     from types import SimpleNamespace, ModuleType
@@ -194,3 +194,161 @@ def test_multitoken(next_n, per_query, device):
                 end = data[b][j] if per_query else max(0, data[b] - next_n + j + 1)
                 expected[b, j, :end] = ((q[b, j].float() @ keys[:end].T).relu() * weights[b * next_n + j, :, None]).sum(0) * scale[:end]
         torch.testing.assert_close(out, expected.reshape(batch * next_n, limit), atol=0.0002, rtol=0.0002)
+
+
+def test_long_context_bounds_decode_workspace(monkeypatch):
+    """A large configured limit must not expand all requests' KV at once."""
+    fn = _load_decode_fn()
+    batch, block, dim, heads, limit = 9, 256, 128, 8, 32769
+    values = torch.ones(1, block, dim).to(torch.float8_e4m3fn)
+    scales = torch.ones(1, block)
+    cache = torch.cat((values.view(torch.uint8).reshape(1, -1),
+                       scales.view(torch.uint8).reshape(1, -1)), 1)
+    cache = cache.view(1, block, 1, dim + 4)
+    table = torch.full((batch, (limit + block - 1) // block), -999, dtype=torch.int32)
+    table[:, 0] = 0
+    q = torch.ones(batch, 1, heads, dim)
+    weights = torch.ones(batch, heads)
+    lengths = torch.arange(batch, dtype=torch.int32)
+    original_bmm = torch.bmm
+    workspaces = []
+
+    def bounded_bmm(a, b):
+        workspaces.append((b.numel() + a.shape[0] * a.shape[1] * b.shape[2]) * 4)
+        return original_bmm(a, b)
+
+    monkeypatch.setattr(torch, 'bmm', bounded_bmm)
+    out = fn(q, cache, weights, lengths, table, limit)
+    assert len(workspaces) > 2
+    assert max(workspaces) <= 8 * 1024 * 1024
+    for row in range(batch):
+        torch.testing.assert_close(out[row, :row], torch.full((row,), float(heads * dim)))
+        assert torch.isneginf(out[row, row:]).all()
+
+
+def test_fallback_packs_weights_with_variable_decode_lengths():
+    """Exercise the dispatch branch with a short decode beside a full decode."""
+    path = Path(__file__).resolve().parents[2] / 'vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py'
+    branch = next(
+        n for n in ast.walk(ast.parse(path.read_text()))
+        if isinstance(n, ast.If) and isinstance(n.test, ast.Name)
+        and n.test.id == 'v4_fp8_fallback'
+        and any(isinstance(c, ast.Call) and isinstance(c.func, ast.Name)
+                and c.func.id == 'fp8_paged_mqa_logits_torch' for c in ast.walk(n))
+    )
+    block, dim, heads = 4, 8, 3
+    values = torch.ones(1, block, dim).to(torch.float8_e4m3fn)
+    scales = torch.ones(1, block)
+    cache = torch.cat((values.view(torch.uint8).reshape(1, -1),
+                       scales.view(torch.uint8).reshape(1, -1)), 1).view(1, block, 1, dim + 4)
+    weights = torch.arange(1, 5).float()[:, None].expand(-1, heads)
+    calls = []
+
+    def pack(tensor, lengths):
+        calls.append(tensor.clone())
+        out = torch.zeros(2, 3, heads)
+        out[0, 0] = tensor[0]
+        out[1] = tensor[1:4]
+        return out
+
+    namespace = dict(
+        fp8_paged_mqa_logits_torch=_load_decode_fn(), pack_seq_triton=pack,
+        padded_q_fp8_decode_tokens=torch.ones(2, 3, heads, dim),
+        kv_cache=cache, weights=weights, num_decode_tokens=4, num_padded_tokens=6,
+        seq_lens=torch.tensor([[1, 0, 0], [1, 2, 3]]),
+        decode_lens=torch.tensor([1, 3]), max_model_len=4,
+        decode_metadata=SimpleNamespace(requires_padding=True,
+                                        block_table=torch.zeros(2, 1, dtype=torch.int32)),
+    )
+    exec(compile(ast.Module(body=branch.body, type_ignores=[]), str(path), 'exec'), namespace)
+    assert len(calls) == 1
+    out = namespace['logits']
+    for row, length, weight in [(0, 1, 1), (3, 1, 2), (4, 2, 3), (5, 3, 4)]:
+        torch.testing.assert_close(out[row, :length], torch.full((length,), float(heads * dim * weight)))
+        assert torch.isneginf(out[row, length:]).all()
+
+
+def _load_prefill_fn():
+    path = Path(__file__).resolve().parents[2] / 'vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py'
+    node = next(n for n in ast.parse(path.read_text()).body
+                if isinstance(n, ast.FunctionDef) and n.name == 'fp8_mqa_logits_torch')
+    namespace = dict(torch=torch)
+    exec(compile(ast.Module(body=[node], type_ignores=[]), str(path), 'exec'), namespace)
+    return namespace[node.name]
+
+
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_prefill_bounds_workspace_and_preserves_masks(monkeypatch, device):
+    if device == 'cuda' and not torch.cuda.is_available():
+        pytest.skip('GPU required')
+    fn = _load_prefill_fn()
+    # Cross both query and key chunk boundaries with the V4 head count.
+    m, n, h, d = 65, 1025, 64, 8
+    torch.manual_seed(81)
+    q = torch.randint(-3, 4, (m, h, d), device=device).to(torch.float8_e4m3fn)
+    k = torch.randint(-3, 4, (n, d), device=device).to(torch.float8_e4m3fn)
+    scales = torch.rand(n, 1, device=device) + 0.25
+    weights = torch.randn(m, h, device=device)
+    lo = torch.arange(m, device=device, dtype=torch.int32) * 7
+    hi = torch.clamp(lo + 300, max=n)
+    lo[0], hi[0] = 0, n
+    hi[1] = lo[1]  # Empty interval must stay entirely masked.
+    calls = []
+    original_einsum = torch.einsum
+
+    def measured_einsum(equation, a, b):
+        result = original_einsum(equation, a, b)
+        calls.append((a.shape[0], b.shape[0], result.numel() * 6))
+        return result
+
+    monkeypatch.setattr(torch, 'einsum', measured_einsum)
+    actual = fn(q, (k, scales), weights, lo, hi)
+    assert len(calls) > 1
+    assert max(size for _, _, size in calls) <= 8 * 1024 * 1024
+    # Independent head-by-head reference keeps test memory small.
+    expected = torch.zeros(m, n, device=device)
+    for head in range(h):
+        score = (q[:, head].float() @ k.float().T) * scales.flatten()[None, :]
+        expected += score.relu() * weights[:, head, None]
+    offsets = torch.arange(n, device=device)
+    expected.masked_fill_((offsets[None, :] < lo[:, None]) |
+                          (offsets[None, :] >= hi[:, None]), -torch.inf)
+    torch.testing.assert_close(actual, expected, atol=0.001, rtol=0.0002)
+    torch.testing.assert_close(fn(q, (k, scales.flatten()), weights, lo, hi), actual)
+
+
+def test_prefill_logits_graph_replay():
+    if not torch.cuda.is_available():
+        pytest.skip('GPU graph test requires a visible GPU')
+    fn = _load_prefill_fn()
+    m, n, h, d = 65, 1025, 64, 8
+    q = torch.ones(m, h, d, device='cuda').to(torch.float8_e4m3fn)
+    k = torch.ones(n, d, device='cuda').to(torch.float8_e4m3fn)
+    scales = torch.ones(n, 1, device='cuda')
+    weights = torch.ones(m, h, device='cuda')
+    lo = torch.zeros(m, dtype=torch.int32, device='cuda')
+    hi = torch.full_like(lo, n)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            fn(q, (k, scales), weights, lo, hi)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        out = fn(q, (k, scales), weights, lo, hi)
+    for step in range(3):
+        q.copy_(torch.full_like(q.float(), step + 1).to(q.dtype))
+        k.copy_(torch.full_like(k.float(), 3 - step).to(k.dtype))
+        scales.fill_(0.5 * (step + 1))
+        weights.fill_(0.25 * (step + 1))
+        lo.fill_(step * 300)
+        hi.fill_(n - step * 100)
+        hi[1] = lo[1]
+        graph.replay()
+        value = h * d * (step + 1) * (3 - step) * 0.5 * (step + 1) * 0.25 * (step + 1)
+        expected = torch.full((m, n), value, device='cuda')
+        offsets = torch.arange(n, device='cuda')
+        expected.masked_fill_((offsets[None, :] < lo[:, None]) |
+                              (offsets[None, :] >= hi[:, None]), -torch.inf)
+        torch.testing.assert_close(out, expected)

--- a/tests/runtime_patch/test_sparse_indexer_torch_fallback.py
+++ b/tests/runtime_patch/test_sparse_indexer_torch_fallback.py
@@ -100,45 +100,62 @@ def test_decode_graph_replay():
                 expected[i, :length] = ((q[i, 0].float() @ k.T).relu() * weights[i, :, None]).sum(0) * scale
             torch.testing.assert_close(output, expected, atol=0.002, rtol=0.0002)
 
-def test_prefill_gather_graph_replay():
-    if not torch.cuda.is_available():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_prefill_gather_graph_replay(device):
+    if device == "cuda" and not torch.cuda.is_available():
         import pytest
         pytest.skip('GPU graph test requires a visible GPU')
     source = (Path(__file__).resolve().parents[2] / 'vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py').read_text()
     branch = next((n for n in ast.walk(ast.parse(source)) if isinstance(n, ast.If) and isinstance(n.test, ast.Name) and (n.test.id == 'v4_fp8_fallback') and any((isinstance(x, ast.Assign) and any((isinstance(t, ast.Name) and t.id == 'page_size' for t in x.targets)) for x in n.body))))
     code = compile(ast.Module(body=branch.body, type_ignores=[]), '<gather>', 'exec')
     (block, dim, count) = (4, 8, 7)
-    values = torch.arange(3 * block * dim, device='cuda').reshape(3, block, dim).remainder(7).to(torch.float8_e4m3fn)
-    scales = torch.arange(12, device='cuda', dtype=torch.float32).reshape(3, 4) + 1
+    values = torch.arange(3 * block * dim, device=device).reshape(3, block, dim).remainder(7).to(torch.float8_e4m3fn)
+    scales = torch.arange(12, device=device, dtype=torch.float32).reshape(3, 4) + 1
     cache = torch.cat((values.view(torch.uint8).reshape(3, -1), scales.view(torch.uint8).reshape(3, -1)), 1).view(3, block, dim + 4)
-    chunk = SimpleNamespace(total_seq_lens=count, cu_seq_lens=torch.tensor([0, 3, 7], device='cuda', dtype=torch.int32), block_table=torch.tensor([[2, 1], [0, 2]], device='cuda', dtype=torch.int32))
-    out = torch.empty(count, dim, device='cuda', dtype=torch.float8_e4m3fn)
-    out_scale = torch.empty(count, 4, device='cuda', dtype=torch.uint8)
+    chunk = SimpleNamespace(total_seq_lens=count, cu_seq_lens=torch.tensor([0, 3, 7], device=device, dtype=torch.int32), block_table=torch.tensor([[2, 1], [0, 2]], device=device, dtype=torch.int32))
+    out = torch.empty(count, dim, device=device, dtype=torch.float8_e4m3fn)
+    out_scale = torch.empty(count, 4, device=device, dtype=torch.uint8)
     ns = dict(torch=torch, chunk=chunk, kv_cache=cache, head_dim=dim, fp8_dtype=torch.float8_e4m3fn, k_fp8=out, k_scale=out_scale)
 
     def gather():
         exec(code, ns)
-    stream = torch.cuda.Stream()
-    stream.wait_stream(torch.cuda.current_stream())
-    with torch.cuda.stream(stream):
-        for _ in range(3):
+    graph = None
+    if device == "cuda":
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(3):
+                gather()
+        torch.cuda.current_stream().wait_stream(stream)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
             gather()
-    torch.cuda.current_stream().wait_stream(stream)
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph):
-        gather()
-    for boundary in (0, 2, 5):
-        chunk.cu_seq_lens.copy_(torch.tensor([0, boundary, count], device='cuda', dtype=torch.int32))
-        graph.replay()
+    # Shrink the exact total, including zero and empty requests, then regrow.
+    # Allocation shapes and graph remain unchanged throughout.
+    for boundary, total in ((0, 7), (2, 4), (0, 0), (3, 3), (0, 2), (5, 7)):
+        chunk.cu_seq_lens.copy_(torch.tensor([0, boundary, total], device=device, dtype=torch.int32))
+        tables = [[2, 1], [0, 2]]
+        if boundary == 0:
+            tables[0] = [-999, -999]
+        if boundary == total:
+            tables[1] = [-999, -999]
+        chunk.block_table.copy_(torch.tensor(tables, device=device, dtype=torch.int32))
+        if graph is not None:
+            graph.replay()
+        else:
+            gather()
         expected = []
         expected_scales = []
-        for (seq, (start, end)) in enumerate(((0, boundary), (boundary, count))):
+        for (seq, (start, end)) in enumerate(((0, boundary), (boundary, total))):
             for j in range(end - start):
                 page = int(chunk.block_table[seq, j // block].item())
                 expected.append(values[page, j % block].float())
                 expected_scales.append(scales[page, j % block])
-        torch.testing.assert_close(out.float(), torch.stack(expected))
-        torch.testing.assert_close(out_scale.view(torch.float32).flatten(), torch.stack(expected_scales))
+        if total:
+            torch.testing.assert_close(out[:total].float(), torch.stack(expected))
+            torch.testing.assert_close(out_scale.view(torch.float32).flatten()[:total], torch.stack(expected_scales))
+        assert torch.count_nonzero(out.view(torch.uint8)[total:]) == 0
+        assert torch.count_nonzero(out_scale[total:]) == 0
 
 def _load_decode_fn():
     path = Path(__file__).resolve().parents[2] / 'vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py'

--- a/vllm_hcu/patch/worker/core_fix/patch_mhc_backend.py
+++ b/vllm_hcu/patch/worker/core_fix/patch_mhc_backend.py
@@ -40,7 +40,11 @@ def apply_to_module(module: ModuleType) -> bool:
     # importable TileLang package need not contain the HIP code generator.
     tilelang_usable = has_tilelang_mhc
     if has_tilelang_mhc and mhc.current_platform.is_rocm():
-        import tvm
+        # TileLang initializes its bundled TVM search path and registers
+        # code generators when loading its shared library. Probe afterwards.
+        import tilelang
+
+        tvm = tilelang.tvm
 
         tilelang_usable = tvm.ffi.get_global_func(
             "target.build.tilelang_hip", allow_missing=True

--- a/vllm_hcu/patch/worker/core_fix/patch_mhc_backend.py
+++ b/vllm_hcu/patch/worker/core_fix/patch_mhc_backend.py
@@ -28,7 +28,25 @@ def apply_to_module(module: ModuleType) -> bool:
             f"required HCU patch target {TARGET_MODULE}.HAS_AITER_MHC is missing"
         )
 
+    has_tilelang_mhc = getattr(mhc, "HAS_TILELANG_MHC", None)
+    if not isinstance(has_tilelang_mhc, bool):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGET_MODULE}.HAS_TILELANG_MHC is missing"
+        )
+
     import vllm_hcu.platforms.envs as henvs
+
+    # This callback runs before importers capture HAS_TILELANG_MHC. An
+    # importable TileLang package need not contain the HIP code generator.
+    tilelang_usable = has_tilelang_mhc
+    if has_tilelang_mhc and mhc.current_platform.is_rocm():
+        import tvm
+
+        tilelang_usable = tvm.ffi.get_global_func(
+            "target.build.tilelang_hip", allow_missing=True
+        ) is not None
+    mhc._vllm_hcu_original_has_tilelang_mhc = has_tilelang_mhc
+    mhc.HAS_TILELANG_MHC = tilelang_usable
 
     # The target implementation otherwise always prefers AITER whenever it is
     # installed, making the plugin's documented switch ineffective.  Preserve

--- a/vllm_hcu/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm_hcu/v1/attention/backends/mla/sparse_swa.py
@@ -574,6 +574,7 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         }
         if (
             num_decode_tokens == 0
+            or current_platform.is_rocm()
             or current_platform.is_xpu()
             or current_platform.is_device_capability_family(120)
         ):

--- a/vllm_hcu/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm_hcu/v1/attention/backends/mla/sparse_swa.py
@@ -7,6 +7,8 @@ from typing import ClassVar, cast
 
 import torch
 
+import vllm_hcu.platforms.envs as henvs
+
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.platforms import current_platform
@@ -564,8 +566,9 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         call of each type. Subsequent same-type calls reuse the plan because
         the tensors (and ``have_initialized``) are populated on the struct.
 
-        Returns all-``None`` when there are no decode tokens this step, so
-        ``_forward_decode`` sees a clean sentinel.
+        Returns all-``None`` for paths that do not consume FlashMLA tile
+        metadata, including native ROCm/AITER and the explicit HCU decode
+        fallback, or when there are no decode tokens this step.
         """
         out: dict[str, FlashMLASchedMeta | None] = {
             _LAYER_TYPE_SWAONLY: None,
@@ -574,11 +577,24 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         }
         if (
             num_decode_tokens == 0
-            or current_platform.is_rocm()
             or current_platform.is_xpu()
             or current_platform.is_device_capability_family(120)
         ):
             return out
+        if current_platform.is_rocm():
+            # The native ROCm/AITER builder serves a decode implementation
+            # that never consumes FlashMLA tile metadata. The generic builder
+            # still needs it unless its explicit decode fallback is enabled.
+            # Import lazily: the native builder inherits this class.
+            from vllm.models.deepseek_v4.amd.rocm import (
+                DeepseekV4ROCMAiterSparseSWAMetadataBuilder,
+            )
+
+            if (
+                isinstance(self, DeepseekV4ROCMAiterSparseSWAMetadataBuilder)
+                or henvs.VLLM_HCU_DEEPSEEK_V4_ROCM_DECODE_FALLBACK
+            ):
+                return out
         for layer_type in self._layer_types:
             # get_mla_metadata() is the official FlashMLA entry point that
             # returns a fresh empty FlashMLASchedMeta; using it keeps this

--- a/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -627,30 +627,60 @@ def fp8_paged_mqa_logits_torch(
     else:
         # Compressed indexer metadata supplies exact per-query cache lengths.
         ends = context_lens[:batch_size, :next_n]
-    lengths = ends.amax(dim=1)
-    page_offsets = torch.arange(num_pages, device=q.device)
-    valid_pages = page_offsets[None, :] * block_size < lengths[:, None]
-    page_ids = torch.where(
-        valid_pages, block_tables[:batch_size, :num_pages], 0
-    ).long()
-    flat_cache = kv_cache.reshape(-1, block_size * (dim + 4))
-    pages = flat_cache.index_select(0, page_ids.reshape(-1))
-    values = pages[:, :block_size * dim].contiguous().view(fp8_dtype)
-    values = values.reshape(batch_size, num_pages * block_size, dim).float()
-    scales = pages[:, block_size * dim:].contiguous().view(torch.float32)
-    scales = scales.reshape(batch_size, num_pages * block_size)
-    scores = torch.bmm(q.float().reshape(batch_size, next_n * heads, dim), values.transpose(1, 2))
-    scores = scores.reshape(batch_size, next_n, heads, -1)
-    scores = (scores.relu() * weights.reshape(batch_size, next_n, heads, 1)).sum(dim=2)
-    scores = scores * scales[:, None, :]
-    offsets = torch.arange(num_pages * block_size, device=q.device)
-    scores = scores.masked_fill(offsets[None, None, :] >= ends[:, :, None], float("-inf"))
     logits = torch.full(
         (batch_size, next_n, max_model_len), float("-inf"),
         dtype=torch.float32, device=q.device,
     )
-    count = min(max_model_len, num_pages * block_size)
-    logits[:, :, :count].copy_(scores[:, :, :count])
+    flat_cache = kv_cache.reshape(-1, block_size * (dim + 4))
+    # Bound temporary KV/score storage independently of the context limit.
+    # Loop bounds use tensor shapes only, so replay may change lengths/pages.
+    # The final logits allocation remains part of the existing top-k ABI.
+    for batch_start in range(0, batch_size, 8):
+        batch_end = min(batch_start + 8, batch_size)
+        batch_count = batch_end - batch_start
+        chunk_ends = ends[batch_start:batch_end]
+        lengths = chunk_ends.amax(dim=1)
+        query = q[batch_start:batch_end].float().reshape(
+            batch_count, next_n * heads, dim
+        )
+        query_weights = weights.reshape(batch_size, next_n, heads, 1)[
+            batch_start:batch_end
+        ]
+        bytes_per_page = batch_count * block_size * (
+            dim * 6 + next_n * heads * 4 + next_n * 4 + 8
+        )
+        pages_per_chunk = max(1, (8 * 1024 * 1024) // bytes_per_page)
+        for page_start in range(0, num_pages, pages_per_chunk):
+            page_end = min(page_start + pages_per_chunk, num_pages)
+            page_count = page_end - page_start
+            page_offsets = torch.arange(page_start, page_end, device=q.device)
+            valid_pages = page_offsets[None, :] * block_size < lengths[:, None]
+            page_ids = torch.where(
+                valid_pages,
+                block_tables[batch_start:batch_end, page_start:page_end],
+                0,
+            ).long()
+            pages = flat_cache.index_select(0, page_ids.reshape(-1))
+            values = pages[:, :block_size * dim].contiguous().view(fp8_dtype)
+            values = values.reshape(batch_count, page_count * block_size, dim).float()
+            scales = pages[:, block_size * dim:].contiguous().view(torch.float32)
+            scales = scales.reshape(batch_count, page_count * block_size)
+            scores = torch.bmm(query, values.transpose(1, 2)).reshape(
+                batch_count, next_n, heads, page_count * block_size
+            )
+            scores.relu_().mul_(query_weights)
+            scores = scores.sum(dim=2).mul_(scales[:, None, :])
+            token_start = page_start * block_size
+            token_end = min(page_end * block_size, max_model_len)
+            offsets = torch.arange(
+                token_start, page_end * block_size, device=q.device
+            )
+            scores.masked_fill_(
+                offsets[None, None, :] >= chunk_ends[:, :, None], float("-inf")
+            )
+            logits[batch_start:batch_end, :, token_start:token_end].copy_(
+                scores[:, :, :token_end - token_start]
+            )
     return logits.reshape(batch_size * next_n, max_model_len)
 
 
@@ -801,22 +831,41 @@ def fp8_mqa_logits_torch(
         Logits tensor of shape [M, N], dtype `torch.float32`.
     """
     k_fp8, scale = kv
-    seq_len_kv = k_fp8.shape[0]
-    k = k_fp8.to(torch.bfloat16)
-    q = q.to(torch.bfloat16)
-
-    mask_lo = (
-        torch.arange(0, seq_len_kv, device=q.device)[None, :] >= cu_seqlen_ks[:, None]
+    num_queries, heads, dim = q.shape
+    num_keys = k_fp8.shape[0]
+    scale = scale.reshape(-1)
+    logits = torch.empty(
+        (num_queries, num_keys), dtype=torch.float32, device=q.device
     )
-    mask_hi = (
-        torch.arange(0, seq_len_kv, device=q.device)[None, :] < cu_seqlen_ke[:, None]
-    )
-    mask = mask_lo & mask_hi
-
-    score = torch.einsum("mhd,nd->hmn", q, k).float() * scale.reshape(1, 1, -1)
-    logits = (score.relu() * weights.unsqueeze(-1).transpose(0, 1)).sum(dim=0)
-    logits = logits.masked_fill(~mask, float("-inf"))
-
+    # The caller budgets the final M*N logits, not an H*M*N score tensor.
+    # Tile Q and K while keeping the full head reduction and BF16 dot-product
+    # semantics. Shape-only loop bounds also allow CUDA/HIP Graph replay.
+    for query_start in range(0, num_queries, 64):
+        query_end = min(query_start + 64, num_queries)
+        query_count = query_end - query_start
+        query = q[query_start:query_end].to(torch.bfloat16)
+        query_weights = weights[query_start:query_end].T.unsqueeze(-1)
+        # Account for BF16 + FP32 scores, converted K, masks and reduced
+        # logits. The final output and backend GEMM workspace are separate.
+        bytes_per_key = heads * query_count * 6 + dim * 2 + query_count * 8
+        keys_per_chunk = max(1, min(1024, (8 * 1024 * 1024) // bytes_per_key))
+        for key_start in range(0, num_keys, keys_per_chunk):
+            key_end = min(key_start + keys_per_chunk, num_keys)
+            keys = k_fp8[key_start:key_end].to(torch.bfloat16)
+            scores = torch.einsum("mhd,nd->hmn", query, keys).float()
+            scores.mul_(scale[None, None, key_start:key_end])
+            scores.relu_().mul_(query_weights)
+            reduced = scores.sum(dim=0)
+            offsets = torch.arange(key_start, key_end, device=q.device)
+            invalid = (
+                offsets[None, :] < cu_seqlen_ks[query_start:query_end, None]
+            ) | (
+                offsets[None, :] >= cu_seqlen_ke[query_start:query_end, None]
+            )
+            reduced.masked_fill_(invalid, float("-inf"))
+            logits[query_start:query_end, key_start:key_end].copy_(reduced)
+            # Do not retain the previous tile during the next GEMM allocation.
+            del scores, reduced, keys, invalid
     return logits
 
 
@@ -1154,7 +1203,9 @@ def rocm_aiter_sparse_attn_indexer_native(
     # careful! this will be None in dummy run
     attn_metadata = get_forward_context().attn_metadata
     # V4 writes packed FP8+scale pages in its compressor and passes k=None.
-    # gfx936's V3.2 BF16 cache kernels cannot consume those pages.
+    # All non-gfx938 HCU devices otherwise select the V3.2 BF16 path,
+    # which cannot consume these pages. Keep this compatibility fallback
+    # scoped to packed V4 caches, rather than changing V3.2 dispatch.
     v4_fp8_fallback = (
         current_platform.is_rocm() and not on_gfx938()
         and skip_k_cache_insert and kv_cache.dtype == torch.uint8
@@ -1339,9 +1390,15 @@ def rocm_aiter_sparse_attn_indexer_native(
         )
 
         if v4_fp8_fallback:
+            # Q was packed above; apply the identical layout to head weights.
+            decode_weights = weights[:num_padded_tokens]
+            if decode_metadata.requires_padding:
+                decode_weights = pack_seq_triton(
+                    weights[:num_decode_tokens], decode_lens
+                ).reshape(num_padded_tokens, -1)
             logits = fp8_paged_mqa_logits_torch(
                 padded_q_fp8_decode_tokens, kv_cache,
-                weights[:num_padded_tokens], seq_lens,
+                decode_weights, seq_lens,
                 decode_metadata.block_table, max_model_len,
             )
         else:

--- a/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -1298,13 +1298,26 @@ def rocm_aiter_sparse_attn_indexer_native(
                 pages = kv_cache.view(kv_cache.shape[0], -1)
                 offsets = torch.arange(chunk.total_seq_lens, device=kv_cache.device)
                 seq = torch.searchsorted(chunk.cu_seq_lens[1:].contiguous(), offsets, right=True)
-                local = offsets - chunk.cu_seq_lens[seq]
-                page_ids = chunk.block_table[seq, local // page_size].long()
+                # The CPU allocation length is an upper bound during async
+                # speculation. Mask before indexing the exact device tables:
+                # searchsorted returns num_reqs for the inactive tail.
+                active = offsets < chunk.cu_seq_lens[-1]
+                seq = torch.where(active, seq, 0)
+                local = torch.where(active, offsets - chunk.cu_seq_lens[seq], 0)
+                page_ids = torch.where(
+                    active, chunk.block_table[seq, local // page_size], 0
+                ).long()
                 values = pages[:, :page_size * head_dim].reshape(-1, page_size, head_dim)
                 scales = pages[:, page_size * head_dim:].reshape(-1, page_size, 4)
                 # Gather bytes before viewing FP8 for HIP indexing compatibility.
-                k_fp8.copy_(values[page_ids, local % page_size].contiguous().view(fp8_dtype))
-                k_scale.copy_(scales[page_ids, local % page_size])
+                value_bytes = values[page_ids, local % page_size]
+                scale_bytes = scales[page_ids, local % page_size]
+                # Zero inactive output bytes as well: page 0 may contain stale
+                # data, including NaNs. Mask uint8 before interpreting FP8.
+                value_bytes.masked_fill_(~active[:, None], 0)
+                scale_bytes.masked_fill_(~active[:, None], 0)
+                k_fp8.copy_(value_bytes.contiguous().view(fp8_dtype))
+                k_scale.copy_(scale_bytes)
             elif not current_platform.is_rocm() or on_gfx938():
                 ops.cp_gather_indexer_k_quant_cache(
                     kv_cache,

--- a/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -612,98 +612,46 @@ def fp8_paged_mqa_logits_torch(
     block_tables: torch.Tensor,
     max_model_len: int,
 ):
-    from vllm.utils.math_utils import cdiv
-
     fp8_dtype = current_platform.fp8_dtype()
-    batch_size, next_n, _, dim = q.size()
-    if next_n == 1:
-        block_size = kv_cache.shape[1]
-        logits = torch.full(
-            [batch_size, max_model_len],
-            float("-inf"),
-            device=q.device,
-            dtype=torch.float32,
-        )
-        if context_lens.dim() > 1:
-            context_lens = context_lens.squeeze(-1)
-        kv_cache_flat = kv_cache.view(-1, block_size * (dim + 4))
-        for i in range(batch_size):
-            q_i = q[i, 0].to(torch.float32)
-            q_scale = weights[i]
-            seq_len = int(context_lens[i].item())
-            assert seq_len <= max_model_len
-            num_pages = cdiv(seq_len, block_size)
-            padded_seq_len = num_pages * block_size
-            pages = block_tables[i, :num_pages]
-            cache = kv_cache_flat[pages]
-            scale_offset = block_size * dim
-            cache_value = (
-                cache[..., :scale_offset].view(dtype=fp8_dtype).to(torch.float32)
-            )
-            cache_scale = (
-                cache[..., scale_offset:].view(dtype=torch.float32).contiguous()
-            )
-            cache_value = cache_value.view(padded_seq_len, dim)
-            cache_scale = cache_scale.view(padded_seq_len)
-            score = F.linear(cache_value, q_i)
-            score = F.relu(score)
-            score *= q_scale[None, :]
-            score = score.sum(dim=1)
-            score *= cache_scale
-            logits[i, :seq_len] = score[:seq_len]
-        return logits
-
-    kv_cache, scale = kv_cache[..., :dim], kv_cache[..., dim:]
-    scale = scale.contiguous().view(torch.float)
-    q = q.float()
-    kv_cache = kv_cache.view(fp8_dtype).float() * scale
-    num_block, block_size, _, dim = kv_cache.size()
+    batch_size, next_n, heads, dim = q.size()
+    block_size = kv_cache.shape[1]
+    # Shapes depend only on the capture bucket, never on GPU scalar values.
+    # Read complete logical pages, masking unused table entries before gather.
+    num_pages = (max_model_len + block_size - 1) // block_size
+    if block_tables.shape[1] < num_pages:
+        # Metadata may allocate only enough columns for this bucket.
+        num_pages = block_tables.shape[1]
+    if context_lens.ndim == 1:
+        # One final context length per request: each query has its own causal end.
+        ends = context_lens[:batch_size, None] - next_n + 1 + torch.arange(next_n, device=q.device)[None, :]
+    else:
+        # Compressed indexer metadata supplies exact per-query cache lengths.
+        ends = context_lens[:batch_size, :next_n]
+    lengths = ends.amax(dim=1)
+    page_offsets = torch.arange(num_pages, device=q.device)
+    valid_pages = page_offsets[None, :] * block_size < lengths[:, None]
+    page_ids = torch.where(
+        valid_pages, block_tables[:batch_size, :num_pages], 0
+    ).long()
+    flat_cache = kv_cache.reshape(-1, block_size * (dim + 4))
+    pages = flat_cache.index_select(0, page_ids.reshape(-1))
+    values = pages[:, :block_size * dim].contiguous().view(fp8_dtype)
+    values = values.reshape(batch_size, num_pages * block_size, dim).float()
+    scales = pages[:, block_size * dim:].contiguous().view(torch.float32)
+    scales = scales.reshape(batch_size, num_pages * block_size)
+    scores = torch.bmm(q.float().reshape(batch_size, next_n * heads, dim), values.transpose(1, 2))
+    scores = scores.reshape(batch_size, next_n, heads, -1)
+    scores = (scores.relu() * weights.reshape(batch_size, next_n, heads, 1)).sum(dim=2)
+    scores = scores * scales[:, None, :]
+    offsets = torch.arange(num_pages * block_size, device=q.device)
+    scores = scores.masked_fill(offsets[None, None, :] >= ends[:, :, None], float("-inf"))
     logits = torch.full(
-        [batch_size * next_n, max_model_len],
-        float("-inf"),
-        device=q.device,
-        dtype=torch.float32,
+        (batch_size, next_n, max_model_len), float("-inf"),
+        dtype=torch.float32, device=q.device,
     )
-    for i in range(batch_size):
-        context_len = context_lens[i]
-        if context_len.ndim == 0:
-            context_len_i = int(context_len.item())
-            q_offsets = torch.arange(
-                context_len_i - next_n, context_len_i, device=q.device
-            )
-            context_limit = torch.full(
-                (next_n,), context_len_i, dtype=torch.int32, device=q.device
-            )
-        else:
-            context_limit = context_len.to(device=q.device, dtype=torch.int32)
-            q_offsets = context_limit - 1
-        weight_slice = (
-            weights[i * next_n : (i + 1) * next_n, :].transpose(0, 1).contiguous()
-        )
-        max_context_len = int(context_limit.max().item())
-        for block_rk in range(cdiv(max_context_len, block_size)):
-            block_idx = block_tables[i][block_rk]
-            qx, kx = q[i], kv_cache[block_idx]
-            k_offsets = torch.arange(
-                block_rk * block_size, (block_rk + 1) * block_size, device=q.device
-            )
-            mask = (k_offsets[None, :] < context_limit[:, None]) & (
-                k_offsets[None, :] <= q_offsets[:, None]
-            )
-            s = torch.where(
-                mask[None, :, :],
-                (qx.transpose(0, 1) @ kx.transpose(0, 1).transpose(1, 2)).to(
-                    logits.dtype
-                ),
-                float("-inf"),
-            )
-            s = torch.relu(s) * weight_slice[..., None]
-            s = s.sum(dim=0)
-            logits[
-                i * next_n : (i + 1) * next_n,
-                block_rk * block_size : (block_rk + 1) * block_size,
-            ] = torch.where(k_offsets[None, :] <= q_offsets[:, None], s, float("-inf"))
-    return logits
+    count = min(max_model_len, num_pages * block_size)
+    logits[:, :, :count].copy_(scores[:, :, :count])
+    return logits.reshape(batch_size * next_n, max_model_len)
 
 
 @functools.lru_cache
@@ -858,14 +806,14 @@ def fp8_mqa_logits_torch(
     q = q.to(torch.bfloat16)
 
     mask_lo = (
-        torch.arange(0, seq_len_kv, device="cuda")[None, :] >= cu_seqlen_ks[:, None]
+        torch.arange(0, seq_len_kv, device=q.device)[None, :] >= cu_seqlen_ks[:, None]
     )
     mask_hi = (
-        torch.arange(0, seq_len_kv, device="cuda")[None, :] < cu_seqlen_ke[:, None]
+        torch.arange(0, seq_len_kv, device=q.device)[None, :] < cu_seqlen_ke[:, None]
     )
     mask = mask_lo & mask_hi
 
-    score = torch.einsum("mhd,nd->hmn", q, k).float() * scale
+    score = torch.einsum("mhd,nd->hmn", q, k).float() * scale.reshape(1, 1, -1)
     logits = (score.relu() * weights.unsqueeze(-1).transpose(0, 1)).sum(dim=0)
     logits = logits.masked_fill(~mask, float("-inf"))
 
@@ -1205,7 +1153,17 @@ def rocm_aiter_sparse_attn_indexer_native(
 ) -> torch.Tensor:
     # careful! this will be None in dummy run
     attn_metadata = get_forward_context().attn_metadata
-    fp8_dtype = current_platform.fp8_dtype() if not current_platform.is_rocm() or on_gfx938() else k.dtype
+    # V4 writes packed FP8+scale pages in its compressor and passes k=None.
+    # gfx936's V3.2 BF16 cache kernels cannot consume those pages.
+    v4_fp8_fallback = (
+        current_platform.is_rocm() and not on_gfx938()
+        and skip_k_cache_insert and kv_cache.dtype == torch.uint8
+    )
+    fp8_dtype = (
+        current_platform.fp8_dtype()
+        if not current_platform.is_rocm() or on_gfx938() or v4_fp8_fallback
+        else (k.dtype if k is not None else hidden_states.dtype)
+    )
     from vllm import _custom_ops as ops
     from vllm.utils.torch_utils import _resolve_layer_name
 
@@ -1283,7 +1241,20 @@ def rocm_aiter_sparse_attn_indexer_native(
                 device=device,
                 dtype=torch.uint8,
             )
-            if not current_platform.is_rocm() or on_gfx938():
+            if v4_fp8_fallback:
+                # Fixed-size GPU gather; sequence boundaries remain device data.
+                page_size = kv_cache.shape[1]
+                pages = kv_cache.view(kv_cache.shape[0], -1)
+                offsets = torch.arange(chunk.total_seq_lens, device=kv_cache.device)
+                seq = torch.searchsorted(chunk.cu_seq_lens[1:].contiguous(), offsets, right=True)
+                local = offsets - chunk.cu_seq_lens[seq]
+                page_ids = chunk.block_table[seq, local // page_size].long()
+                values = pages[:, :page_size * head_dim].reshape(-1, page_size, head_dim)
+                scales = pages[:, page_size * head_dim:].reshape(-1, page_size, 4)
+                # Gather bytes before viewing FP8 for HIP indexing compatibility.
+                k_fp8.copy_(values[page_ids, local % page_size].contiguous().view(fp8_dtype))
+                k_scale.copy_(scales[page_ids, local % page_size])
+            elif not current_platform.is_rocm() or on_gfx938():
                 ops.cp_gather_indexer_k_quant_cache(
                     kv_cache,
                     k_fp8,
@@ -1307,7 +1278,8 @@ def rocm_aiter_sparse_attn_indexer_native(
                 #     token_to_seq=chunk.token_to_seq,
                 # )
 
-            logits = rocm_fp8_mqa_logits(
+            logits_fn = fp8_mqa_logits_torch if v4_fp8_fallback else rocm_fp8_mqa_logits
+            logits = logits_fn(
                 q_fp8[chunk.token_start : chunk.token_end],
                 (k_fp8, k_scale.view(torch.float32)),
                 weights[chunk.token_start : chunk.token_end],
@@ -1366,15 +1338,22 @@ def rocm_aiter_sparse_attn_indexer_native(
             else decode_metadata.seq_lens
         )
 
-        logits = rocm_fp8_paged_mqa_logits(
-            padded_q_fp8_decode_tokens,
-            kv_cache,
-            weights[:num_padded_tokens],
-            seq_lens,
-            decode_metadata.block_table,
-            decode_metadata.schedule_metadata,
-            max_model_len=max_model_len,
-        )
+        if v4_fp8_fallback:
+            logits = fp8_paged_mqa_logits_torch(
+                padded_q_fp8_decode_tokens, kv_cache,
+                weights[:num_padded_tokens], seq_lens,
+                decode_metadata.block_table, max_model_len,
+            )
+        else:
+            logits = rocm_fp8_paged_mqa_logits(
+                padded_q_fp8_decode_tokens,
+                kv_cache,
+                weights[:num_padded_tokens],
+                seq_lens,
+                decode_metadata.block_table,
+                decode_metadata.schedule_metadata,
+                max_model_len=max_model_len,
+            )
 
         # A padded decode batch has more kernel rows than actual decode
         # tokens.  Do not point those extra rows at the shared output buffer:


### PR DESCRIPTION

## 问题
DeepSeek V4 的 compressor 已经写入 packed FP8 indexer 缓存，因此调用 indexer 时可以传入 `k=None`。此前非 gfx938 的 ROCm 分支直接访问 `k.dtype`，并沿用 V3.2 的 BF16 缓存处理路径，无法正确处理这一调用方式和缓存格式。多 token decode 的 PyTorch 实现还存在页面解包方式不一致的问题。

本 MR 增加兼容 V4 packed FP8 缓存的 PyTorch fallback，修正 prefill/decode 计算和不等长批次的权重排列，并通过分块控制临时显存。同时修正 TileLang HIP codegen 探测顺序，以及 ROCm 的 sparse SWA 调度元数据创建路径。

适配目标是 gfx936 上的 DeepSeek-V4-INT8-w8a8模型推理，模型权重为 INT8 W8A8，indexer 缓存为 FP8，两者相互独立。

## 代码修改与解决的问题

### 1. V4 packed FP8 缓存读取与平台路由

文件：`vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py`  
函数：`rocm_aiter_sparse_attn_indexer_native()`

对以下条件启用 V4 FP8 fallback：

```python
current_platform.is_rocm() and not on_gfx938() \
    and skip_k_cache_insert and kv_cache.dtype == torch.uint8
```

- 正确处理 `k=None`，避免访问空对象的 `dtype`。
- 使用平台 FP8 dtype 解释缓存，避免将 packed FP8 页面交给 BF16 路径。
- prefill 根据请求边界和 block table 定位物理页面，先 gather 字节，再恢复 FP8 数据和 FP32 scale。
- prefill/decode 分别调用兼容该格式的 PyTorch logits 实现。

缓存按整页组织为：

```text
[整页 FP8 数据字节] + [整页 FP32 scale 字节]
```

该条件覆盖gfx936以及其他非 gfx938 ROCm 平台上的此类 V4 缓存；gfx938 正常执行不会通过此条件进入新增 fallback。

### 2. decode 缓存解包、因果边界和 padding

文件：`vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py`  
函数：`fp8_paged_mqa_logits_torch()`、`rocm_aiter_sparse_attn_indexer_native()`

原实现的单 token 分支按整页读取数据和 scale，多 token 分支却按**最后一维**切分，不能正确解释上述 packed page。本 MR 统一两者的解包方式，并支持一维最终 context 长度和二维逐 query 长度。无效页表项在 gather 前替换为安全页号，超出有效长度的 logits 最终设为 `-inf`。

不等长 decode 中，Q 已按 `decode_lens` 做 padding，但 weights 原先仍保持扁平排列。例如长度 `[1, 3]` 的两个请求，Q 排列为 `[A0, pad, pad]`、`[B0, B1, B2]`，weights 也必须采用相同布局。现在 fallback 在 `requires_padding=True` 时，对 weights 同样调用 `pack_seq_triton`，避免请求之间的权重错位或 reshape 失败。

### 3. prefill scale 广播与设备一致性

文件：`vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py`  
函数：`fp8_mqa_logits_torch()`

多头 score 形状为 `[heads, queries, keys]`，scale 可能是 `[keys]` 或 `[keys, 1]`。本 MR 将 scale 展平并明确沿 key 维应用，避免广播到 query 维或产生形状错误。

创建 mask 等辅助张量时使用 `q.device`，保证与输入设备一致，也支持 CPU 数值测试。

### 4. 分块控制 prefill/decode 临时显存

文件：`vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py`

整批向量化虽然消除了 `.item()` 驱动的 Python 循环，但会完整展开缓存及多头 score。上层按最终 logits 估算的内存预算不足以覆盖这些中间张量。

例如 prefill 的 `heads=64、queries=512、keys=8192` 时，最终 FP32 logits 为 16 MiB，而单个 FP32 score 为 1 GiB，尚未计入类型转换及其他操作的临时分配。

prefill/decode 两条路径使用约 8 MiB 的临时计算预算决定块大小，并逐块写入最终 logits。prefill 使用原位操作并及时释放块内引用，减少中间结果同时存活的数量。


## 测试

gfx936 和 gfx938 平台的精度测试

```bash
vllm serve ./models/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8 \
  --host 0.0.0.0 \
  --port 8002 \
  --served-model-name deepseek-v4-flash-0731 \
  --dtype bfloat16 \
  --kv-cache-dtype fp8 \
  --tensor-parallel-size 8 \
  --max-model-len 4096 \
  --max-num-batched-tokens 512 \
  --max-num-seqs 8 \
  --gpu-memory-utilization 0.80 \
  --block-size 256 \
  --trust-remote-code \
  --tokenizer-mode deepseek_v4 \
  --distributed-executor-backend mp \
  --speculative-config '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic"}'
```

```bash
evalscope eval \
    --model deepseek-v4-flash-0731 \
    --api-url http://127.0.0.1:8002/v1 \
    --api-key EMPTY \
    --datasets gsm8k \
    --generation-config '{"temperature":0.0,"max_tokens":512,"timeout":1800}' \
    --eval-batch-size 10 \
    --limit 10
```