### PR TITLE
fix: pair DeepGEMM INT8 packing and kernels

### DIFF
--- a/tests/patch/test_module_exchange.py
+++ b/tests/patch/test_module_exchange.py
@@ -232,8 +232,10 @@ def test_deep_gemm_replacements_keep_target_features_and_scoped_hcu_deltas():
     }
     assert "use_nn_moe" not in experts_source
     assert "use_nn_moe" not in batched_source
-    assert "m_grouped_w8a8_gemm_nt_contig_asm" in experts_source
-    assert "m_grouped_w8a8_gemm_nt_masked" in batched_source
+    assert "m_grouped_i8_gemm_nt_contiguous" in experts_source
+    assert "m_grouped_i8_gemm_nt_masked" in batched_source
+    assert "m_grouped_w8a8_gemm_nt_contig_asm" not in experts_source
+    assert "m_grouped_w8a8_gemm_nt_masked" not in batched_source
     assert "m_grouped_w8a8_gemm_nt_masked_ll" not in batched_source
     assert "VLLM_HCU_USE_LIGHTOP_EP_SCATTER" in utils_source
     assert "_HCU_TOKEN_ALIGNMENT = 256" in utils_source

--- a/tests/runtime_patch/test_hcu_model_runner_v2_api.py
+++ b/tests/runtime_patch/test_hcu_model_runner_v2_api.py
@@ -1,0 +1,12 @@
+from inspect import signature
+
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm_hcu.v1.hcu_model_runner_v2 import HcuGPUModelRunnerV2
+
+
+def test_prepare_dummy_attn_matches_vllm_parameter_contract() -> None:
+    upstream = signature(GPUModelRunner.prepare_dummy_attn).parameters
+    hcu = signature(HcuGPUModelRunnerV2.prepare_dummy_attn).parameters
+
+    assert tuple(hcu) == tuple(upstream)
+    assert hcu["valid_state_slots"].default is False

--- a/tests/runtime_patch/test_lightop_ops_api.py
+++ b/tests/runtime_patch/test_lightop_ops_api.py
@@ -706,11 +706,10 @@ def _run_deep_int8_apply(apply, output: torch.Tensor) -> None:
     )
 
 
-def test_contiguous_deep_gemm_prefers_categorized_kernels_and_consumes_activation(
+def test_contiguous_deep_gemm_pairs_deepgemm_gemm_with_lightop_activation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     activation = ModuleType("lightop.activation")
-    gemm_ops = ModuleType("lightop.gemm_ops")
     calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
 
     def gemm(*args, **kwargs) -> None:
@@ -723,8 +722,8 @@ def test_contiguous_deep_gemm_prefers_categorized_kernels_and_consumes_activatio
         return torch.full((1, 2), 6, dtype=torch.int8), torch.ones((1, 1))
 
     activation.fuse_silu_mul_quant = quant
-    gemm_ops.m_grouped_w8a8_gemm_nt_contig_asm = gemm
-    _install_lightop(monkeypatch, activation=activation, gemm_ops=gemm_ops)
+    _install_deepgemm_i8(monkeypatch, contiguous=gemm)
+    _install_lightop(monkeypatch, activation=activation)
     apply = _method(
         "vllm_hcu/model_executor/layers/fused_moe/experts/deep_gemm_moe.py",
         "DeepGemmExperts",
@@ -765,11 +764,10 @@ def test_contiguous_deep_gemm_rejects_top_level_activation_and_grouped_gemm(
     assert legacy_calls == []
 
 
-def test_masked_deep_gemm_prefers_categorized_kernels_and_consumes_activation(
+def test_masked_deep_gemm_pairs_deepgemm_gemm_with_lightop_activation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     activation = ModuleType("lightop.activation")
-    gemm_ops = ModuleType("lightop.gemm_ops")
     calls: list[tuple[str, tuple[object, ...]]] = []
 
     def gemm(*args) -> None:
@@ -782,8 +780,8 @@ def test_masked_deep_gemm_prefers_categorized_kernels_and_consumes_activation(
         return torch.full((1, 1, 2), 7, dtype=torch.int8), torch.ones((1, 1, 1))
 
     activation.fuse_silu_mul_quant_ep = quant
-    gemm_ops.m_grouped_w8a8_gemm_nt_masked = gemm
-    _install_lightop(monkeypatch, activation=activation, gemm_ops=gemm_ops)
+    _install_deepgemm_i8(monkeypatch, masked=gemm)
+    _install_lightop(monkeypatch, activation=activation)
     namespace = {
         "torch": torch,
         "MoEActivation": SimpleNamespace(SILU="silu"),

--- a/tests/runtime_patch/test_sparse_indexer_loading.py
+++ b/tests/runtime_patch/test_sparse_indexer_loading.py
@@ -214,7 +214,7 @@ def test_v32_pcp_gathers_k_and_slots_before_hcu_cache_insertion():
 
     def hcu_op(*args):
         events.append(("hcu_op", *args))
-        return "topk"
+        return None
 
     fake_torch = SimpleNamespace(
         Tensor=torch.Tensor,
@@ -253,7 +253,10 @@ def test_v32_pcp_gathers_k_and_slots_before_hcu_cache_insertion():
         topk_indices_buffer=object(),
     )
 
-    assert forward_hip(indexer, hidden_states, q_quant, local_k, weights) == "topk"
+    assert (
+        forward_hip(indexer, hidden_states, q_quant, local_k, weights)
+        is indexer.topk_indices_buffer
+    )
 
     assert [event[0] for event in events] == ["gather", "cache", "hcu_op"]
     assert events[0][1] is local_k
@@ -278,7 +281,7 @@ def test_v32_replicated_mtp_batch_bypasses_static_pcp_indexer_state():
 
     def hcu_op(*args):
         calls.append(args)
-        return "topk"
+        return None
 
     fake_torch = SimpleNamespace(
         Tensor=torch.Tensor,
@@ -321,7 +324,10 @@ def test_v32_replicated_mtp_batch_bypasses_static_pcp_indexer_state():
         topk_indices_buffer=object(),
     )
 
-    assert forward_hip(indexer, object(), q_quant, local_k, object()) == "topk"
+    assert (
+        forward_hip(indexer, object(), q_quant, local_k, object())
+        is indexer.topk_indices_buffer
+    )
     assert len(calls) == 1
     assert calls[0][4] is local_k
     assert calls[0][-1] is False
@@ -592,7 +598,7 @@ def test_v32_pcp_one_preserves_existing_hcu_custom_op_ownership():
 
     def hcu_op(*args):
         calls.append(args)
-        return "topk"
+        return None
 
     fake_torch = SimpleNamespace(
         Tensor=torch.Tensor,
@@ -620,6 +626,7 @@ def test_v32_pcp_one_preserves_existing_hcu_custom_op_ownership():
     )
     local_k = torch.ones(1, 2)
     q_quant = torch.ones(1, 2)
+    topk_indices_buffer = object()
     indexer = SimpleNamespace(
         use_fp4_cache=False,
         use_pcp=False,
@@ -632,10 +639,20 @@ def test_v32_pcp_one_preserves_existing_hcu_custom_op_ownership():
         head_dim=128,
         max_model_len=65536,
         max_total_seq_len=65536,
-        topk_indices_buffer=object(),
+        topk_indices_buffer=topk_indices_buffer,
     )
 
-    assert forward_hip(indexer, object(), q_quant, local_k, object()) == "topk"
+    assert (
+        forward_hip(indexer, object(), q_quant, local_k, object())
+        is topk_indices_buffer
+    )
     assert len(calls) == 1
     assert calls[0][4] is local_k
     assert calls[0][-1] is False
+
+
+def test_hcu_sparse_indexer_custom_op_has_no_tensor_return() -> None:
+    importlib.import_module("vllm_hcu.model_executor.layers.sparse_attn_indexer")
+
+    schema = torch.ops.vllm.hcu_sparse_attn_indexer.default._schema
+    assert len(schema.returns) == 0

--- a/vllm_hcu/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py
@@ -506,10 +506,10 @@ class BatchedDeepGemmExperts(mk.FusedMoEExpertsModular):
                 raise ValueError(
                     "HCU Channel INT8 batched DeepGEMM supports only SiLU activation"
                 )
+            from deepgemm import m_grouped_i8_gemm_nt_masked
             from lightop.activation import fuse_silu_mul_quant_ep
-            from lightop.gemm_ops import m_grouped_w8a8_gemm_nt_masked
 
-            m_grouped_w8a8_gemm_nt_masked(
+            m_grouped_i8_gemm_nt_masked(
                 (a1q, a1q_scale),
                 (w1, self.w1_scale),
                 workspace1,
@@ -520,7 +520,7 @@ class BatchedDeepGemmExperts(mk.FusedMoEExpertsModular):
                 workspace1,
                 expert_num_tokens,
             )
-            m_grouped_w8a8_gemm_nt_masked(
+            m_grouped_i8_gemm_nt_masked(
                 (a2q, a2q_scale),
                 (w2, self.w2_scale),
                 output,

--- a/vllm_hcu/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
@@ -430,10 +430,10 @@ class DeepGemmExperts(mk.FusedMoEExpertsModular):
                     raise ValueError(
                         "HCU Channel INT8 DeepGEMM supports only SiLU activation"
                     )
+                from deepgemm import m_grouped_i8_gemm_nt_contiguous
                 from lightop.activation import fuse_silu_mul_quant
-                from lightop.gemm_ops import m_grouped_w8a8_gemm_nt_contig_asm
 
-                m_grouped_w8a8_gemm_nt_contig_asm(
+                m_grouped_i8_gemm_nt_contiguous(
                     (a1q, a1q_scale),
                     (w1, self.w1_scale),
                     mm1_out,
@@ -450,7 +450,7 @@ class DeepGemmExperts(mk.FusedMoEExpertsModular):
                     expert_ids=expert_ids,
                 )
                 mm2_out = _resize_cache(workspace2, (M_sum, K))
-                m_grouped_w8a8_gemm_nt_contig_asm(
+                m_grouped_i8_gemm_nt_contiguous(
                     (a2q, a2q_scale),
                     (w2, self.w2_scale),
                     mm2_out,

--- a/vllm_hcu/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm_hcu/model_executor/layers/sparse_attn_indexer.py
@@ -731,8 +731,8 @@ if current_platform.is_rocm():
         total_seq_lens: int,
         topk_indices_buffer: torch.Tensor,
         skip_k_cache_insert: bool,
-    ) -> torch.Tensor:
-        return rocm_aiter_sparse_attn_indexer_native(
+    ) -> None:
+        rocm_aiter_sparse_attn_indexer_native(
             hidden_states,
             k_cache_prefix,
             kv_cache,
@@ -764,9 +764,9 @@ if current_platform.is_rocm():
         total_seq_lens: int,
         topk_indices_buffer: torch.Tensor,
         skip_k_cache_insert: bool,
-    ) -> torch.Tensor:
+    ) -> None:
         del skip_k_cache_insert
-        return rocm_aiter_sparse_attn_indexer_fake(
+        rocm_aiter_sparse_attn_indexer_fake(
             hidden_states,
             k_cache_prefix,
             kv_cache,
@@ -1031,7 +1031,7 @@ class V32SparseAttnIndexer(SparseAttnIndexer):
                 # The complete cache write is explicit above.  Keep the
                 # existing HCU custom op for local Q/top-k work only.
                 skip_k_cache_insert = True
-        return torch.ops.vllm.hcu_sparse_attn_indexer(
+        torch.ops.vllm.hcu_sparse_attn_indexer(
             hidden_states,
             _encode_layer_name(self.k_cache.prefix),
             self.k_cache.kv_cache,
@@ -1047,3 +1047,4 @@ class V32SparseAttnIndexer(SparseAttnIndexer):
             self.topk_indices_buffer,
             skip_k_cache_insert,
         )
+        return self.topk_indices_buffer

--- a/vllm_hcu/v1/hcu_model_runner_v2.py
+++ b/vllm_hcu/v1/hcu_model_runner_v2.py
@@ -174,12 +174,21 @@ class HcuGPUModelRunnerV2(GPUModelRunner):
             return super().prepare_attn(input_batch)
         return self.pcp_manager.prepare_attn(input_batch)
 
-    def prepare_dummy_attn(self, input_batch):
+    def prepare_dummy_attn(self, input_batch, valid_state_slots=False):
         if self.pcp_manager is None:
-            return super().prepare_dummy_attn(input_batch)
+            return super().prepare_dummy_attn(input_batch, valid_state_slots)
         block_tables = self.block_tables.get_dummy_block_tables(
             input_batch.num_reqs
         )
+        if valid_state_slots:
+            state_slots = torch.arange(
+                1,
+                input_batch.num_reqs + 1,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            for block_table in block_tables:
+                block_table[:, 0].copy_(state_slots)
         slot_mappings = self.pcp_manager.get_dummy_slot_mappings(
             input_batch.num_tokens
         )


### PR DESCRIPTION
## Summary

- Pair DeepGEMM Marlin INT8 packed weights with the matching DeepGEMM grouped INT8 GEMMs for both layouts.
- Keep LightOp only for fused activation/activation quantization.
- Align HCU MRV2 prepare_dummy_attn with the official valid_state_slots contract, carrying the relevant PR #71 behavior onto v0.28.1-dev.
- Add API/path regression coverage.

## Root cause

The plugin packed Channel-INT8 MoE weights with deepgemm.marlin_i8_* but executed them through legacy lightop.gemm_ops.m_grouped_w8a8_*. The binary layouts are not compatible. Real GLM-5 shapes produced mostly incorrect values/NaNs; the high-throughput contiguous path could later trigger a device VM fault.

## Verification

- Targeted tests: 47 passed
- DeepGEMM numeric checks at real model shapes passed for contiguous and masked layouts.
- /models/GLM-5-W8A8, DP8 + EP8, FLASHMLA_SPARSE, deep_gemm
- deepep_low_latency, default graph + MTP3: HumanEval-8 8/8, pass@1 1.0
- deepep_high_throughput, eager isolation: HumanEval-8 8/8, pass@1 1.0
- deepep_high_throughput + MTP3: deterministic 80-token output passed; 58/66 draft tokens accepted, with accepted tokens at draft positions 0/1/2.
- Localhost evaluation bypassed HTTP proxies.

## Launch: low latency, graph + MTP3

~~~bash
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
  NO_PROXY=127.0.0.1,localhost \
  HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
  vllm serve /models/GLM-5-W8A8 \
  --served-model-name GLM-5-W8A8 \
  --trust-remote-code \
  --tensor-parallel-size 1 \
  --data-parallel-size 8 \
  --enable-expert-parallel \
  --all2all-backend deepep_low_latency \
  --attention-backend FLASHMLA_SPARSE \
  --moe-backend deep_gemm \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
  --max-model-len 4096 \
  --gpu-memory-utilization 0.90
~~~

No explicit PIECEWISE compilation config is required.

## Launch: high throughput + MTP3

~~~bash
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
  NO_PROXY=127.0.0.1,localhost \
  HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
  vllm serve /models/GLM-5-W8A8 \
  --served-model-name GLM-5-W8A8 \
  --trust-remote-code \
  --tensor-parallel-size 1 \
  --data-parallel-size 8 \
  --enable-expert-parallel \
  --all2all-backend deepep_high_throughput \
  --attention-backend FLASHMLA_SPARSE \
  --moe-backend deep_gemm \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
  --max-model-len 4096 \
  --kv-cache-memory 1073741824
~~~

Official vLLM disables CUDA Graph for deepep_high_throughput; graph coverage therefore uses deepep_low_latency. The explicit 1 GiB KV cache avoids the MTP + compile profiling memory limit and still provides 10,560 cache tokens per card.