### PR TITLE
perf: copy MTP sampling inputs asynchronously

### DIFF
--- a/tests/runtime_patch/test_worker_framework_opt.py
+++ b/tests/runtime_patch/test_worker_framework_opt.py
@@ -26,6 +26,7 @@ from vllm_hcu.patch.worker.framework_opt import (
     patch_base_device_communicator,
     patch_cuda_communicator,
     patch_dp_utils,
+    patch_draft_speculator_inputs,
     patch_eagle_utils,
     patch_forward_context,
     patch_gpu_ubatch_wrapper,
@@ -1165,6 +1166,51 @@ def test_dp_coordination_deepep_low_latency_and_feature_off_delegation():
     assert calls == [(4, normal)]
 
 
+def test_draft_speculator_sampling_inputs_copy_async_and_preserve_padding():
+    class _Buffer:
+        def copy_(self, other, *, non_blocking=False):
+            self.copied = (other, non_blocking)
+
+    class _IdxMapping:
+        def __getitem__(self, key):
+            return self
+
+        def copy_(self, other):
+            self.copied = other
+
+        def fill_(self, value):
+            self.filled = value
+
+    class DraftModelSpeculator:
+        def __init__(self):
+            self.temperature = _Buffer()
+            self.seeds = _Buffer()
+            self.idx_mapping = _IdxMapping()
+
+        def _copy_request_inputs(self, num_reqs, idx_mapping, temperature, seeds):
+            raise AssertionError("original should be wrapped")
+
+    module = _module(patch_draft_speculator_inputs.TARGET_MODULE)
+    module.DraftModelSpeculator = DraftModelSpeculator
+    assert patch_draft_speculator_inputs.apply_to_module(module) is True
+    assert patch_draft_speculator_inputs.apply_to_module(module) is False
+
+    obj = DraftModelSpeculator()
+    temperature = object()
+    seeds = object()
+    idx_mapping = object()
+    temperature_buffer = obj.temperature
+    seeds_buffer = obj.seeds
+    obj._copy_request_inputs(2, idx_mapping, temperature, seeds)
+
+    assert obj.temperature is temperature_buffer
+    assert obj.seeds is seeds_buffer
+    assert obj.temperature.copied == (temperature, True)
+    assert obj.seeds.copied == (seeds, True)
+    assert obj.idx_mapping.copied is idx_mapping
+    assert obj.idx_mapping.filled == -1
+
+
 class _Buffer:
     def __init__(self, size, **kwargs):
         self.size = size
@@ -1877,13 +1923,15 @@ assert target_file.is_relative_to(target_root), (
 print('VLLM_SOURCE', vllm.__file__)
 from vllm_hcu.patch.worker.framework_opt import (
     patch_all2all, patch_base_device_communicator, patch_cuda_communicator,
-    patch_dp_utils, patch_eagle_utils, patch_forward_context,
+    patch_dp_utils, patch_draft_speculator_inputs, patch_eagle_utils,
+    patch_forward_context,
     patch_gpu_ubatch_wrapper, patch_llm_base_proposer, patch_pynccl,
     patch_pynccl_wrapper, patch_ubatch_utils,
 )
 adapters = (
     patch_all2all, patch_base_device_communicator, patch_forward_context,
-    patch_llm_base_proposer, patch_dp_utils, patch_eagle_utils,
+    patch_llm_base_proposer, patch_dp_utils, patch_draft_speculator_inputs,
+    patch_eagle_utils,
     patch_gpu_ubatch_wrapper, patch_ubatch_utils,
 )
 for adapter in adapters:

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -356,6 +356,9 @@ _FRAMEWORK_CALLBACKS: tuple[_CallbackSpec, ...] = (
         _adapter("framework_opt", "patch_eagle_utils"),
         feature="multi_layers_mtp",
     ),
+    _CallbackSpec(
+        _adapter("framework_opt", "patch_draft_speculator_inputs"),
+    ),
     _CallbackSpec(_adapter("framework_opt", "patch_gpu_ubatch_wrapper")),
     _CallbackSpec(_adapter("framework_opt", "patch_ubatch_utils")),
     _CallbackSpec(

--- a/vllm_hcu/patch/worker/framework_opt/patch_draft_speculator_inputs.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_draft_speculator_inputs.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Keep per-step MTP request-buffer copies asynchronous."""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+from ._common import (
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_exact_signature,
+)
+
+TARGET_MODULE = "vllm.v1.worker.gpu.spec_decode.speculator"
+PATCH_ID = "worker.framework_opt.spec_decode.draft_input_async_copy"
+TARGETS = (f"{TARGET_MODULE}.DraftModelSpeculator._copy_request_inputs",)
+_MARKER = "_vllm_hcu_draft_input_async_copy_applied"
+_WRAPPER = "_vllm_hcu_draft_input_async_copy_wrapper"
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    spec = load_exact_module(TARGET_MODULE, module)
+    cls = require_class(
+        spec, "DraftModelSpeculator", f"{TARGET_MODULE}.DraftModelSpeculator"
+    )
+    wrapped = ((cls, "_copy_request_inputs", TARGETS[0], _WRAPPER),)
+    if already_applied(spec, _MARKER, wrapped):
+        return False
+    original = require_callable(cls, "_copy_request_inputs", TARGETS[0])
+    require_exact_signature(
+        original,
+        TARGETS[0],
+        positional=("self", "num_reqs", "idx_mapping", "temperature", "seeds"),
+    )
+
+    @functools.wraps(original)
+    def hcu_copy_request_inputs(self, num_reqs, idx_mapping, temperature, seeds):
+        # Preserve the graph-owned destination addresses. Rebinding these
+        # buffers to caller tensors makes captured speculator graphs read stale
+        # storage. Copies on the current stream retain ordering without forcing
+        # synchronous H2D transfers when the source memory supports async copy.
+        self.temperature.copy_(temperature, non_blocking=True)
+        self.seeds.copy_(seeds, non_blocking=True)
+        self.idx_mapping[:num_reqs].copy_(idx_mapping)
+        # Keep current upstream semantics: every graph-padded request must map
+        # to -1 so stale slots cannot update draft logits.
+        self.idx_mapping[num_reqs:].fill_(-1)
+
+    setattr(hcu_copy_request_inputs, _WRAPPER, True)
+    setattr(cls, "_vllm_hcu_original_copy_request_inputs", original)
+    setattr(cls, "_copy_request_inputs", hcu_copy_request_inputs)
+    setattr(spec, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]


### PR DESCRIPTION
## Summary

Adapt the safe MTP sampling-input optimization from #71 to the current v0.28.1-dev worker/speculator APIs.

- Keep DraftModelSpeculator-owned temperature and seeds buffer addresses stable for CUDA Graph replay.
- Copy temperature and seeds with non_blocking=True on the current stream.
- Preserve the current upstream idx_mapping valid-region copy and unconditional padded-slot fill(-1).
- Register the patch lazily through the worker callback dispatcher with strict signature and idempotency checks.

The patch_gpu_dp_utils bypass from #71 is intentionally not included. The current sync_cudagraph_and_dp_padding API also coordinates empty ranks, graph modes, microbatching, uniform decode, LoRA counts, and DP sync state; bypassing it as in the older branch is no longer safe.

## Validation

- Targeted tests: 63 passed.
- Pre-commit and post-commit code review: no blocking findings.
- Model: /models/GLM-5-W8A8.
- Runtime: DP8 + EP8 + deepep_low_latency + FLASHMLA_SPARSE + deep_gemm + MTP3.
- No enforce-eager and no explicit compilation-config; all 8 ranks completed default CUDA Graph capture.
- HumanEval-8: 8/8, mean_acc=1.0, pass@1=1.0.
- MTP: 972 draft tokens, 926 accepted tokens.
- Runtime error lines: 0.
- Localhost evaluation explicitly bypassed proxy settings.

A direct caller-buffer alias was also A/B tested and rejected before this branch was created: it reduced HumanEval-8 from 8/8 to 6/8 because current speculator graphs require stable owned-buffer addresses. That failed implementation is not present in this branch.