### PR TITLE
perf(deepep): skip cleanup for fixed low latency

### DIFF
--- a/tests/runtime_patch/test_moe_deepep.py
+++ b/tests/runtime_patch/test_moe_deepep.py
@@ -282,6 +282,7 @@ def test_all2all_auto_builds_ht_and_ll_around_one_manager_handle():
         "physical_to_global": "physical-to-global",
         "local_expert_global_ids": "local-ids",
     }
+    assert result.ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer is True
     int8_result = module.maybe_make_prepare_finalize(
         moe,
         SimpleNamespace(quant_dtype=torch.int8),
@@ -296,6 +297,7 @@ def test_all2all_auto_builds_ht_and_ll_around_one_manager_handle():
         "physical_to_global": "physical-to-global",
         "local_expert_global_ids": "local-ids",
     }
+    assert int8_result.ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer is True
     assert module.maybe_roundup_layer_hidden_size(
         10, torch.float16, moe.moe_parallel_config
     ) == 13
@@ -4603,8 +4605,17 @@ def test_deepep_ll_non_hcu_dispatch_signatures_delegate_to_upstream(
     )
 
 
-def test_deepep_ll_fp8_auto_detects_hcu_buffer_dispatch_abi(
+@pytest.mark.parametrize(
+    ("shared_with_high_throughput", "expected_clean_calls"),
+    [
+        (False, []),
+        (True, [(8, 2048, 1, 128), (8, 2048, 1, 128)]),
+    ],
+)
+def test_deepep_ll_fp8_cleans_only_when_buffer_is_shared_with_high_throughput(
     monkeypatch: pytest.MonkeyPatch,
+    shared_with_high_throughput: bool,
+    expected_clean_calls: list[tuple[int, int, int, int]],
 ):
     module = _fake_deepep_ll_module()
     module.torch = torch
@@ -4674,6 +4685,7 @@ def test_deepep_ll_fp8_auto_detects_hcu_buffer_dispatch_abi(
             return expert_x, torch.ones(1, dtype=torch.int32), "handle", None, lambda: None
 
     instance = cls(Buffer(), 8, 1, use_fp8_dispatch=True)
+    instance._vllm_hcu_clean_low_latency_buffer = shared_with_high_throughput
     instance.handles = [None]
     instance.use_int8_dispatch = False
     instance.use_ue8m0_dispatch = False
@@ -4718,14 +4730,13 @@ def test_deepep_ll_fp8_auto_detects_hcu_buffer_dispatch_abi(
     assert calls["topk_weight"] is topk_weights
     assert calls["quant_type"] == 2
     assert calls["quant_group_size"] == 128
-    assert calls["clean"] == [
-        (8, 2048, 1, 128),
-        (8, 2048, 1, 128),
-    ]
+    assert calls.get("clean", []) == expected_clean_calls
 
 
+@pytest.mark.parametrize("shared_with_high_throughput", [False, True])
 def test_deepep_ll_hcu_int8_dispatch_contract(
     monkeypatch: pytest.MonkeyPatch,
+    shared_with_high_throughput: bool,
 ):
     module = _fake_deepep_ll_module()
 
@@ -4769,6 +4780,7 @@ def test_deepep_ll_hcu_int8_dispatch_contract(
             return expert_x, expert_counts, "handle", None, lambda: None
 
     instance = cls(Buffer(), 8, 1, use_int8_dispatch=True)
+    instance._vllm_hcu_clean_low_latency_buffer = shared_with_high_throughput
     instance.handles = [None, None]
     instance.use_ue8m0_dispatch = False
     quant_config = SimpleNamespace(
@@ -4817,12 +4829,16 @@ def test_deepep_ll_hcu_int8_dispatch_contract(
         False,
         quant_config,
     )
-    assert calls["order"] == [
-        ("clean", (8, 2048, 1, 0)),
-        ("dispatch", 1),
-        ("clean", (8, 2048, 1, 0)),
-        ("dispatch", 1),
-    ]
+    expected_dispatches = [("dispatch", 1), ("dispatch", 1)]
+    if shared_with_high_throughput:
+        assert calls["order"] == [
+            ("clean", (8, 2048, 1, 0)),
+            expected_dispatches[0],
+            ("clean", (8, 2048, 1, 0)),
+            expected_dispatches[1],
+        ]
+    else:
+        assert calls["order"] == expected_dispatches
 
     fp8_instance = cls(None, 8, 1, use_fp8_dispatch=True)
     fp8_instance.use_int8_dispatch = False

--- a/vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py
+++ b/vllm_hcu/model_executor/layers/fused_moe/deepep_runtime.py
@@ -411,6 +411,7 @@ def ll_init(
         local_expert_global_ids,
     )
     self.use_int8_dispatch = bool(use_int8_dispatch)
+    self._vllm_hcu_clean_low_latency_buffer = False
     self._hcu_low_latency_dispatch_abi = _has_hcu_low_latency_dispatch_abi(buffer)
 
 
@@ -596,17 +597,18 @@ def ll_prepare_async(
             if block_k is None and quant_config.per_act_token_quant
             else module.DEEPEP_QUANT_BLOCK_SIZE
         )
-    cleanup = getattr(self.buffer, "clean_low_latency_buffer", None)
-    if not callable(cleanup):
-        raise RuntimeError(
-            "HCU DeepEP LL buffer does not expose clean_low_latency_buffer"
+    if getattr(self, "_vllm_hcu_clean_low_latency_buffer", False):
+        cleanup = getattr(self.buffer, "clean_low_latency_buffer", None)
+        if not callable(cleanup):
+            raise RuntimeError(
+                "HCU DeepEP LL buffer does not expose clean_low_latency_buffer"
+            )
+        cleanup(
+            self.max_tokens_per_rank,
+            hidden_size,
+            num_experts,
+            quant_group_size,
         )
-    cleanup(
-        self.max_tokens_per_rank,
-        hidden_size,
-        num_experts,
-        quant_group_size,
-    )
     try:
         if use_hcu_api:
             result = self.buffer.low_latency_dispatch(

--- a/vllm_hcu/patch/worker/op_opt/moe/patch_all2all_utils.py
+++ b/vllm_hcu/patch/worker/op_opt/moe/patch_all2all_utils.py
@@ -131,6 +131,7 @@ def apply_to_module(module: ModuleType) -> bool:
                 physical_to_global=physical_to_global,
                 local_expert_global_ids=local_expert_global_ids,
             )
+            ll_prepare_finalize._vllm_hcu_clean_low_latency_buffer = True
             from vllm_hcu.model_executor.layers.fused_moe.prepare_finalize import (
                 deepep_auto,
             )


### PR DESCRIPTION
## Summary

- port the intent of PR #62 commit `1f613ca` to the current `v0.28.1-dev` DeepEP runtime
- skip `clean_low_latency_buffer` for standalone fixed low-latency prepare/finalize instances
- retain cleanup when DeepEP auto shares one manager handle between HT and LL
- cover shared and standalone HCU FP8/INT8 dispatch paths

## Validation

- `pytest -q tests/runtime_patch/test_moe_deepep.py`: 92 passed, 14 TorchScript deprecation warnings
- `/models/GLM-5-W8A8`: DP8 + EP8 + `deepep_low_latency` + `deep_gemm` + `FLASHMLA_SPARSE` + MTP3
- default CUDA Graph policy: all 8 ranks completed graph capture; no `--enforce-eager` and no explicit PIECEWISE config
- strict HumanEval completion A/B: candidate 6/8; unchanged-base runs 6/8 and 6/8, with different failed task IDs between runs. This shows no aggregate regression but also exposes existing DP8+MTP3 temperature-0 nondeterminism; no 8/8 claim is made.

## Launch command

```bash
PYTHONPATH=/path/to/this/branch \
HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
VLLM_LOGGING_LEVEL=INFO \
vllm serve /models/GLM-5-W8A8 \
  --served-model-name GLM-5-W8A8 \
  --trust-remote-code \
  --tensor-parallel-size 1 \
  --data-parallel-size 8 \
  --enable-expert-parallel \
  --all2all-backend deepep_low_latency \
  --attention-backend FLASHMLA_SPARSE \
  --moe-backend deep_gemm \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
  --max-model-len 4096 \
  --kv-cache-memory 1073741824 \
  --host 127.0.0.1 --port 8000
```