### PR TITLE
fix(ci): relax torch 2.11.0 environment lock

### DIFF
--- a/.github/workflows/configs/hcu-runner-environment.json
+++ b/.github/workflows/configs/hcu-runner-environment.json
@@ -13,7 +13,7 @@
   "distributions": {
     "torch": {
       "match": "prefix",
-      "version": "2.11.0+das.opt1.dtk2604."
+      "version": "2.11.0"
     },
     "vllm": {
       "match": "prefix",

--- a/tests/patch/test_hcu_ci_selector.py
+++ b/tests/patch/test_hcu_ci_selector.py
@@ -437,6 +437,30 @@ def test_environment_lock_allows_compatible_hip_prefix(
         )
 
 
+def test_default_environment_lock_accepts_any_torch_2_11_0_build(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = tmp_path / "dtk"
+    version_file = runtime_root / ".info" / "rocm_version"
+    version_file.parent.mkdir(parents=True)
+    version_file.write_text("26.04\n", encoding="utf-8")
+    monkeypatch.setenv("ROCM_PATH", str(runtime_root))
+    monkeypatch.setattr("hcu_ci_preflight.platform.python_version", lambda: "3.10.12")
+
+    _check_environment_lock(
+        REPOSITORY / ".github/workflows/configs/hcu-runner-environment.json",
+        versions={
+            "torch": "2.11.0+custom.build",
+            "vllm": "0.25.1+das.test",
+            "vllm-hcu": "0.25.1+test",
+            "aiter": "0.1.5",
+            "pytest": "9.1.1",
+        },
+        torch_hip="6.3.26093",
+    )
+
+
 def test_evalscope_is_required_only_by_evalscope_jobs() -> None:
     config = _config()
     evalscope_jobs = {

--- a/tests/patch/test_hcu_ci_selector.py
+++ b/tests/patch/test_hcu_ci_selector.py
@@ -437,30 +437,6 @@ def test_environment_lock_allows_compatible_hip_prefix(
         )
 
 
-def test_default_environment_lock_accepts_any_torch_2_11_0_build(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    runtime_root = tmp_path / "dtk"
-    version_file = runtime_root / ".info" / "rocm_version"
-    version_file.parent.mkdir(parents=True)
-    version_file.write_text("26.04\n", encoding="utf-8")
-    monkeypatch.setenv("ROCM_PATH", str(runtime_root))
-    monkeypatch.setattr("hcu_ci_preflight.platform.python_version", lambda: "3.10.12")
-
-    _check_environment_lock(
-        REPOSITORY / ".github/workflows/configs/hcu-runner-environment.json",
-        versions={
-            "torch": "2.11.0+custom.build",
-            "vllm": "0.25.1+das.test",
-            "vllm-hcu": "0.25.1+test",
-            "aiter": "0.1.5",
-            "pytest": "9.1.1",
-        },
-        torch_hip="6.3.26093",
-    )
-
-
 def test_evalscope_is_required_only_by_evalscope_jobs() -> None:
     config = _config()
     evalscope_jobs = {


### PR DESCRIPTION
## Summary

- accept any installed PyTorch package whose version starts with `2.11.0`
- retain the existing Torch HIP, DTK/ROCm, and other distribution locks

## Testing

- `python3 -m pytest -q tests/patch/test_hcu_ci_selector.py` (60 passed)
- `python3 -m json.tool .github/workflows/configs/hcu-runner-environment.json`
- `git diff --check origin/v0.25.1...HEAD`

The full portable contract command was also attempted locally, but collection is blocked by the installed vLLM lacking `_reshape_attention_kv_cache`, `TQFullAttentionSpec`, and `HybridKVCacheCoordinator`, which this change does not touch.