### PR TITLE
fix: align hybrid Mamba prefix-cache block size

### DIFF
--- a/tests/runtime_patch/test_glm53_channel_fp8.py
+++ b/tests/runtime_patch/test_glm53_channel_fp8.py
@@ -156,21 +156,66 @@ def test_hcu_glm5next_kpool_cache_keeps_compression_without_deepgemm_page() -> N
     assert spec.num_states == 16
 
 
-def test_glm5next_graph_auto_enables_breakable_cudagraph(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    "architecture",
+    [
+        "Glm5NextForConditionalGeneration",
+        "Qwen3_5ForCausalLM",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MTP",
+        "Qwen3_5MoeForCausalLM",
+        "Qwen3_5MoeForConditionalGeneration",
+        "Qwen3_5MoeMTP",
+    ],
+)
+def test_hcu_recurrent_graph_auto_enables_breakable_cudagraph(
+    monkeypatch, architecture: str
+) -> None:
     from vllm.config.compilation import CUDAGraphMode
 
     monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
     config = SimpleNamespace(
         model_config=SimpleNamespace(
-            architectures=["Glm5NextForConditionalGeneration"],
+            architectures=[architecture],
             enforce_eager=False,
         ),
         compilation_config=SimpleNamespace(cudagraph_mode=CUDAGraphMode.PIECEWISE),
     )
 
-    patch_vllm_config._normalize_glm5next_breakable_cudagraph(config)
+    patch_vllm_config._normalize_hcu_breakable_cudagraph(config)
 
     assert __import__("os").environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] == "1"
+
+
+def test_hcu_breakable_normalization_wraps_official_enable_hook(monkeypatch) -> None:
+    from vllm.config.compilation import CompilationMode
+
+    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            architectures=["Qwen3_5ForConditionalGeneration"],
+            enforce_eager=False,
+        ),
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=None,
+            mode=CompilationMode.VLLM_COMPILE,
+        ),
+    )
+
+    def official_maybe_enable(self) -> bool:
+        enabled = (
+            __import__("os").environ.get("VLLM_USE_BREAKABLE_CUDAGRAPH") == "1"
+        )
+        if enabled:
+            self.compilation_config.mode = CompilationMode.NONE
+        return enabled
+
+    wrapped = patch_vllm_config._wrap_maybe_enable_breakable_cudagraph(
+        official_maybe_enable
+    )
+
+    assert wrapped(config) is True
+    assert config.compilation_config.mode == CompilationMode.NONE
 
 
 def test_rocm_sparse_builder_disables_missing_aiter_metadata_api(

--- a/tests/runtime_patch/test_mtp_kv_cache_coordinator.py
+++ b/tests/runtime_patch/test_mtp_kv_cache_coordinator.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 from types import ModuleType, SimpleNamespace
 
+import torch
+
 from vllm_hcu.patch.platform.framework_opt import patch_kv_cache_coordinator
+from vllm_hcu.patch.worker.framework_opt import patch_mamba_hybrid_model_state
 
 
 def _coordinator_module() -> ModuleType:
@@ -142,3 +145,58 @@ def test_mamba_sparse_cache_retains_materialized_eagle_replay_boundary():
     assert manager.original_cache_call == (request, 4032, 0)
     assert replay_block.block_hash_num_tokens == 4032
     assert manager.cached_blocks_this_step == {"group-0-replay"}
+
+
+def test_mamba_resume_seed_uses_hybrid_manager_block_size():
+    class MambaHybridModelState:
+        def __init__(self):
+            self._align_mode = True
+            self.cache_config = SimpleNamespace(block_size=64)
+            self._mamba_spec = None
+            self._mamba_state_idx_gpu = torch.full((4,), -99, dtype=torch.int32)
+            self.state_idx_seen = None
+
+        def add_request(self, req_index, new_req_data):
+            self._mamba_state_idx_gpu[req_index].fill_(
+                (new_req_data.num_computed_tokens - 1)
+                // self.cache_config.block_size
+            )
+
+        def _get_mamba_group_info(self, kv_cache_config):
+            del kv_cache_config
+            self._mamba_spec = SimpleNamespace(block_size=832)
+            return [0], self._mamba_spec
+
+        def preprocess_state(
+            self,
+            input_batch,
+            block_tables,
+            kv_cache_config,
+            num_computed_tokens,
+        ):
+            del input_batch, block_tables, kv_cache_config, num_computed_tokens
+            self.state_idx_seen = self._mamba_state_idx_gpu.clone()
+
+    module = ModuleType(patch_mamba_hybrid_model_state.TARGET_MODULE)
+    module.MambaHybridModelState = MambaHybridModelState
+    assert patch_mamba_hybrid_model_state.apply_to_module(module) is True
+    assert patch_mamba_hybrid_model_state.apply_to_module(module) is False
+
+    state = module.MambaHybridModelState()
+    resumed = SimpleNamespace(num_computed_tokens=4992)
+    earlier = SimpleNamespace(num_computed_tokens=1664)
+    state.add_request(1, earlier)
+    state.add_request(2, resumed)
+    assert state._mamba_state_idx_gpu[2].item() == 77
+
+    state.preprocess_state(None, (), object(), torch.tensor([4992]))
+    assert state.state_idx_seen[1].item() == 1
+    assert state.state_idx_seen[2].item() == 5
+
+    state.add_request(3, resumed)
+    assert state._mamba_state_idx_gpu[3].item() == 5
+
+    non_aligned = module.MambaHybridModelState()
+    non_aligned._align_mode = False
+    non_aligned.add_request(0, resumed)
+    assert non_aligned._mamba_state_idx_gpu[0].item() == 77

--- a/tests/runtime_patch/test_platform_framework_opt.py
+++ b/tests/runtime_patch/test_platform_framework_opt.py
@@ -162,6 +162,8 @@ def _fake_scheduler_module():
             type(self).observed_eagle_groups = [
                 group.is_eagle_group for group in kv_cache_config.kv_cache_groups
             ]
+            self.block_size = block_size
+            self.cache_config = SimpleNamespace(block_size=64)
 
         def schedule(self, throttle_prefills=False):
             return "official"
@@ -175,12 +177,14 @@ def _fake_scheduler_module():
         def _update_after_schedule(self, scheduler_output):
             return None
 
+        def _mamba_block_aligned_split(self, request, num_new_tokens, *args, **kwargs):
+            return None
+
     for name in (
         "_select_waiting_queue_for_scheduling",
         "_is_blocked_waiting_status",
         "_try_promote_blocked_waiting_request",
         "_try_schedule_encoder_inputs",
-        "_mamba_block_aligned_split",
         "_build_kv_connector_meta",
         "_inflight_prefill_reserved_blocks",
         "_make_cached_request_data",

--- a/tests/runtime_patch/test_platform_framework_opt.py
+++ b/tests/runtime_patch/test_platform_framework_opt.py
@@ -145,6 +145,9 @@ def test_kv_factory_passes_dp_rank_only_to_supporting_connector(monkeypatch):
 
 
 def _fake_scheduler_module():
+    class MambaSpec:
+        pass
+
     class Scheduler:
         observed_eagle_groups = None
 
@@ -191,7 +194,11 @@ def _fake_scheduler_module():
         "_preempt_request",
     ):
         setattr(Scheduler, name, lambda self, *args, **kwargs: None)
-    return _module(patch_scheduler.TARGET_MODULE, Scheduler=Scheduler)
+    return _module(
+        patch_scheduler.TARGET_MODULE,
+        Scheduler=Scheduler,
+        MambaSpec=MambaSpec,
+    )
 
 
 

--- a/tests/runtime_patch/test_qwen4_exp_mtp_metadata.py
+++ b/tests/runtime_patch/test_qwen4_exp_mtp_metadata.py
@@ -63,7 +63,13 @@ def test_qsa_draft_metadata_refresh_reuses_official_builder_in_place():
 
 @pytest.mark.parametrize(
     "model_type",
-    ["qwen4_exp", "qwen3_5_moe", "qwen3_5_moe_text"],
+    [
+        "qwen4_exp",
+        "qwen3_5",
+        "qwen3_5_text",
+        "qwen3_5_moe",
+        "qwen3_5_moe_text",
+    ],
 )
 def test_qwen_mtp_groups_are_annotated_without_target_mamba_groups(model_type):
     module = ModuleType(kv_groups_patch.TARGET_MODULE)
@@ -170,8 +176,14 @@ def test_qwen4_exp_mtp_groups_are_annotated_after_upstream_early_return():
 
 
 def test_scheduler_uses_hybrid_block_size_only_inside_upstream_mamba_split():
+    from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
+
     module = ModuleType(scheduler_patch.TARGET_MODULE)
     observed_block_sizes = []
+
+    class MambaSpec:
+        def __init__(self, block_size):
+            self.block_size = block_size
 
     class Scheduler:
         def update_draft_token_ids(self, draft_token_ids):
@@ -202,10 +214,11 @@ def test_scheduler_uses_hybrid_block_size_only_inside_upstream_mamba_split():
             del self, scheduler_output
 
     module.Scheduler = Scheduler
+    module.MambaSpec = MambaSpec
     original_init = Scheduler.__init__
     assert scheduler_patch.apply_to_module(module) is True
     assert scheduler_patch.apply_to_module(module) is False
-    assert Scheduler.__init__ is original_init
+    assert Scheduler.__init__ is not original_init
 
     config = SimpleNamespace(
         speculative_config=SimpleNamespace(use_eagle_block_drop=lambda: True),
@@ -215,22 +228,33 @@ def test_scheduler_uses_hybrid_block_size_only_inside_upstream_mamba_split():
     )
     groups = [
         SimpleNamespace(
-            layer_names=["model.layers.0.linear_attn"], is_eagle_group=False
+            layer_names=["model.layers.0.linear_attn"],
+            kv_cache_spec=SimpleNamespace(block_size=64),
+            is_eagle_group=False,
         ),
         SimpleNamespace(
-            layer_names=["mtp.layers.0.self_attn"], is_eagle_group=False
+            layer_names=["mtp.layers.0.self_attn"],
+            kv_cache_spec=UniformTypeKVCacheSpecs(
+                block_size=832,
+                kv_cache_specs={
+                    "mtp.layers.0.self_attn": MambaSpec(block_size=832),
+                    "mtp.layers.1.self_attn": MambaSpec(block_size=832),
+                },
+            ),
+            is_eagle_group=False,
         ),
     ]
     scheduler = module.Scheduler(
         config,
         SimpleNamespace(kv_cache_groups=groups),
         None,
-        576,
+        1664,
     )
 
     assert [group.is_eagle_group for group in groups] == [False, False]
     assert scheduler._mamba_block_aligned_split(object(), 128) == 127
-    assert observed_block_sizes == [576]
+    assert scheduler.block_size == 1664
+    assert observed_block_sizes == [832]
     assert scheduler.cache_config.block_size == 64
 
     no_mtp_config = SimpleNamespace(
@@ -243,9 +267,9 @@ def test_scheduler_uses_hybrid_block_size_only_inside_upstream_mamba_split():
         no_mtp_config,
         SimpleNamespace(kv_cache_groups=groups),
         None,
-        576,
+        1664,
     )
 
     assert no_mtp_scheduler._mamba_block_aligned_split(object(), 128) == 127
-    assert observed_block_sizes == [576, 576]
+    assert observed_block_sizes == [832, 832]
     assert no_mtp_scheduler.cache_config.block_size == 64

--- a/tests/runtime_patch/test_qwen4_exp_mtp_metadata.py
+++ b/tests/runtime_patch/test_qwen4_exp_mtp_metadata.py
@@ -169,7 +169,7 @@ def test_qwen4_exp_mtp_groups_are_annotated_after_upstream_early_return():
     assert [group.is_eagle_group for group in groups] == [False, True]
 
 
-def test_scheduler_leaves_qwen35_groups_and_block_size_to_upstream():
+def test_scheduler_uses_hybrid_block_size_only_inside_upstream_mamba_split():
     module = ModuleType(scheduler_patch.TARGET_MODULE)
     observed_block_sizes = []
 
@@ -197,6 +197,9 @@ def test_scheduler_leaves_qwen35_groups_and_block_size_to_upstream():
             del request
             observed_block_sizes.append(self.cache_config.block_size)
             return num_new_tokens - 1
+
+        def _update_after_schedule(self, scheduler_output):
+            del self, scheduler_output
 
     module.Scheduler = Scheduler
     original_init = Scheduler.__init__
@@ -227,7 +230,7 @@ def test_scheduler_leaves_qwen35_groups_and_block_size_to_upstream():
 
     assert [group.is_eagle_group for group in groups] == [False, False]
     assert scheduler._mamba_block_aligned_split(object(), 128) == 127
-    assert observed_block_sizes == [64]
+    assert observed_block_sizes == [576]
     assert scheduler.cache_config.block_size == 64
 
     no_mtp_config = SimpleNamespace(
@@ -244,5 +247,5 @@ def test_scheduler_leaves_qwen35_groups_and_block_size_to_upstream():
     )
 
     assert no_mtp_scheduler._mamba_block_aligned_split(object(), 128) == 127
-    assert observed_block_sizes == [64, 64]
+    assert observed_block_sizes == [576, 576]
     assert no_mtp_scheduler.cache_config.block_size == 64

--- a/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
@@ -25,14 +25,21 @@ TARGETS = (
     f"{TARGET_MODULE}.VllmConfig._validate_v2_model_runner",
     "vllm.config.model.ModelConfig.get_model_arch_config",
     "vllm_hcu.platforms.hcu.HCUPlatform.check_and_update_config",
+    f"{TARGET_MODULE}.VllmConfig._maybe_enable_breakable_cudagraph",
 )
 _MARKER = "_vllm_hcu_feature_config_patch_applied"
 _GLM_DSA_ARCHITECTURE = "GlmMoeDsaForCausalLM"
-_GLM5NEXT_BREAKABLE_CUDAGRAPH_ARCHITECTURES = frozenset(
+_HCU_BREAKABLE_CUDAGRAPH_ARCHITECTURES = frozenset(
     {
         "Glm5NextForCausalLM",
         "Glm5NextForConditionalGeneration",
         "Glm5NextMTPModel",
+        "Qwen3_5ForCausalLM",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MTP",
+        "Qwen3_5MoeForCausalLM",
+        "Qwen3_5MoeForConditionalGeneration",
+        "Qwen3_5MoeMTP",
     }
 )
 _REQUEST_CAPTURE_SIZES = (
@@ -53,23 +60,29 @@ def _normalize_hcu_model_runner(model_config: object) -> None:
         os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"
 
 
-def _normalize_glm5next_breakable_cudagraph(vllm_config: object) -> None:
-    """Restore upstream's architecture opt-in for GLM5Next on HCU."""
+def _normalize_hcu_breakable_cudagraph(vllm_config: object) -> None:
+    """Restore upstream's graph-safe recurrent-model opt-ins on HCU."""
 
     if "VLLM_USE_BREAKABLE_CUDAGRAPH" in os.environ:
         return
     model_config = getattr(vllm_config, "model_config", None)
     architectures = set(getattr(model_config, "architectures", ()) or ())
-    if not architectures & _GLM5NEXT_BREAKABLE_CUDAGRAPH_ARCHITECTURES:
+    if not architectures & _HCU_BREAKABLE_CUDAGRAPH_ARCHITECTURES:
         return
     if bool(getattr(model_config, "enforce_eager", False)):
         return
-    compilation_config = getattr(vllm_config, "compilation_config", None)
-    cudagraph_mode = getattr(compilation_config, "cudagraph_mode", None)
-    none_mode = getattr(type(cudagraph_mode), "NONE", None)
-    if cudagraph_mode is None or cudagraph_mode == none_mode:
-        return
     os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
+
+
+def _wrap_maybe_enable_breakable_cudagraph(maybe_enable: Any) -> Any:
+    """Opt HCU recurrent models into upstream breakable CUDA graphs."""
+
+    @functools.wraps(maybe_enable)
+    def hcu_maybe_enable(self) -> Any:
+        _normalize_hcu_breakable_cudagraph(self)
+        return maybe_enable(self)
+
+    return hcu_maybe_enable
 
 
 def _require_hcu_pcp_attribute(owner: object, name: str, owner_name: str) -> Any:
@@ -249,7 +262,6 @@ def validate_and_update_hcu_config(vllm_config: object) -> HcuFeatureConfig:
     """Validate cross-config invariants and bind the compilation adapter."""
 
     _normalize_hcu_model_runner(vllm_config.model_config)
-    _normalize_glm5next_breakable_cudagraph(vllm_config)
 
     _validate_hcu_pcp_scope(vllm_config)
     _validate_dspark_pd_scope(vllm_config)
@@ -444,6 +456,9 @@ def apply_to_module(module: ModuleType) -> bool:
     if getattr(vllm_config, _MARKER, False):
         return False
 
+    maybe_enable_breakable = vars(vllm_config).get(
+        "_maybe_enable_breakable_cudagraph"
+    )
     with_hf_config = vars(vllm_config).get("with_hf_config")
     set_cudagraph_sizes = vars(vllm_config).get("_set_cudagraph_sizes")
     get_v2_unsupported_features = vars(vllm_config).get(
@@ -452,7 +467,8 @@ def apply_to_module(module: ModuleType) -> bool:
     validate_v2_model_runner = vars(vllm_config).get("_validate_v2_model_runner")
     get_model_arch_config = vars(model_config_class).get("get_model_arch_config")
     if (
-        not callable(with_hf_config)
+        not callable(maybe_enable_breakable)
+        or not callable(with_hf_config)
         or not callable(set_cudagraph_sizes)
         or not callable(get_v2_unsupported_features)
         or not callable(validate_v2_model_runner)
@@ -460,6 +476,12 @@ def apply_to_module(module: ModuleType) -> bool:
     ):
         raise PatchCompatibilityError(
             "required HCU VllmConfig compatibility methods are missing"
+        )
+    maybe_enable_signature = inspect.signature(maybe_enable_breakable)
+    if tuple(maybe_enable_signature.parameters) != ("self",):
+        raise PatchCompatibilityError(
+            f"required HCU patch target {TARGETS[6]} has incompatible "
+            f"signature {maybe_enable_signature}"
         )
     model_arch_signature = inspect.signature(get_model_arch_config)
     if tuple(model_arch_signature.parameters) != ("self",):
@@ -602,6 +624,16 @@ def apply_to_module(module: ModuleType) -> bool:
                 return validate_v2_model_runner(self)
         return validate_v2_model_runner(self)
 
+    setattr(
+        vllm_config,
+        "_vllm_hcu_original_maybe_enable_breakable_cudagraph",
+        maybe_enable_breakable,
+    )
+    setattr(
+        vllm_config,
+        "_maybe_enable_breakable_cudagraph",
+        _wrap_maybe_enable_breakable_cudagraph(maybe_enable_breakable),
+    )
     setattr(vllm_config, "_vllm_hcu_original_with_hf_config", with_hf_config)
     setattr(vllm_config, "with_hf_config", hcu_with_hf_config)
     setattr(

--- a/vllm_hcu/patch/platform/framework_opt/patch_qwen4_exp_mtp_kv_cache_groups.py
+++ b/vllm_hcu/patch/platform/framework_opt/patch_qwen4_exp_mtp_kv_cache_groups.py
@@ -29,6 +29,8 @@ _GROUPS_WRAPPER = "_vllm_hcu_qwen4_exp_mtp_get_kv_groups_wrapper"
 logger = logging.getLogger(__name__)
 _SUPPORTED_MODEL_TYPES = frozenset(
     {
+        "qwen3_5",
+        "qwen3_5_text",
         "qwen3_5_moe",
         "qwen3_5_moe_text",
         "qwen4_exp",

--- a/vllm_hcu/patch/platform/framework_opt/patch_scheduler.py
+++ b/vllm_hcu/patch/platform/framework_opt/patch_scheduler.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import functools
+import importlib
 from types import ModuleType
 
 from ._common import (
@@ -23,8 +24,11 @@ TARGETS = (
     f"{TARGET_MODULE}.Scheduler.__init__",
     f"{TARGET_MODULE}.Scheduler._update_after_schedule",
     f"{TARGET_MODULE}.Scheduler._mamba_block_aligned_split",
+    f"{TARGET_MODULE}.MambaSpec",
+    "vllm.v1.kv_cache_interface.iter_layer_specs",
 )
 _MARKER = "_vllm_hcu_scheduler_contract_validated"
+_MAMBA_BLOCK_SIZE = "_vllm_hcu_mamba_block_size"
 
 
 def _install_pp_spec_decode_cadence(scheduler: type) -> None:
@@ -50,38 +54,80 @@ def _install_pp_spec_decode_cadence(scheduler: type) -> None:
     scheduler._update_after_schedule = _update_after_schedule
 
 
-def _install_hybrid_mamba_split_block_size(scheduler: type) -> None:
-    """Run the official Mamba split with the hybrid scheduler block size.
+def _install_hybrid_mamba_split_block_size(
+    scheduler: type, mamba_spec_type: type, iter_layer_specs
+) -> None:
+    """Run the official Mamba split with the actual Mamba block size.
 
     HCU attention keeps ``cache_config.block_size`` at the 64-token vendor
-    kernel page, while official hybrid cache grouping may select a larger
-    scheduler block. The upstream split currently reads the former even though
-    ``Scheduler.block_size`` already contains the latter. Scope the correction
-    to the upstream call and restore the kernel page immediately afterwards.
+    kernel page. ``Scheduler.block_size`` is the LCM of all effective group
+    sizes and can exceed the Mamba page under DCP, so retain the concrete
+    ``MambaSpec.block_size`` from the official KV groups. Scope the correction
+    to the upstream split and restore the kernel page immediately afterwards.
     """
 
+    original_init = scheduler.__init__
     original = scheduler._mamba_block_aligned_split
+
+    @functools.wraps(original_init)
+    def __init__(
+        self,
+        vllm_config,
+        kv_cache_config,
+        structured_output_manager,
+        block_size,
+        *args,
+        **kwargs,
+    ):
+        original_init(
+            self,
+            vllm_config,
+            kv_cache_config,
+            structured_output_manager,
+            block_size,
+            *args,
+            **kwargs,
+        )
+        mamba_spec = next(
+            (
+                spec
+                for group in kv_cache_config.kv_cache_groups
+                for spec in iter_layer_specs(
+                    getattr(group, "kv_cache_spec", None)
+                )
+                if isinstance(spec, mamba_spec_type)
+            ),
+            None,
+        )
+        if mamba_spec is not None:
+            setattr(self, _MAMBA_BLOCK_SIZE, mamba_spec.block_size)
 
     @functools.wraps(original)
     def _mamba_block_aligned_split(self, request, num_new_tokens, *args, **kwargs):
         cache_config = self.cache_config
         kernel_block_size = cache_config.block_size
-        scheduler_block_size = self.block_size
-        if kernel_block_size == scheduler_block_size:
+        mamba_block_size = getattr(self, _MAMBA_BLOCK_SIZE, kernel_block_size)
+        if kernel_block_size == mamba_block_size:
             return original(self, request, num_new_tokens, *args, **kwargs)
 
-        cache_config.block_size = scheduler_block_size
+        cache_config.block_size = mamba_block_size
         try:
             return original(self, request, num_new_tokens, *args, **kwargs)
         finally:
             cache_config.block_size = kernel_block_size
 
+    scheduler.__init__ = __init__
     scheduler._mamba_block_aligned_split = _mamba_block_aligned_split
 
 
 def apply_to_module(module: ModuleType) -> bool:
     target = load_exact_module(TARGET_MODULE, module)
     scheduler = require_class(target, "Scheduler", TARGETS[0])
+    mamba_spec_type = require_class(target, "MambaSpec", TARGETS[6])
+    kv_cache_interface = importlib.import_module("vllm.v1.kv_cache_interface")
+    iter_layer_specs = require_callable(
+        kv_cache_interface, "iter_layer_specs", TARGETS[7]
+    )
     if getattr(target, _MARKER, False):
         return False
 
@@ -120,8 +166,15 @@ def apply_to_module(module: ModuleType) -> bool:
         TARGETS[5],
         ("self", "request", "num_new_tokens"),
     )
+    require_signature_prefix(
+        iter_layer_specs,
+        TARGETS[7],
+        ("kv_cache_spec",),
+    )
     _install_pp_spec_decode_cadence(scheduler)
-    _install_hybrid_mamba_split_block_size(scheduler)
+    _install_hybrid_mamba_split_block_size(
+        scheduler, mamba_spec_type, iter_layer_specs
+    )
     setattr(target, _MARKER, True)
     return True
 

--- a/vllm_hcu/patch/platform/framework_opt/patch_scheduler.py
+++ b/vllm_hcu/patch/platform/framework_opt/patch_scheduler.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
-"""Validate the upstream scheduler interfaces consumed by HCU patches."""
+"""Validate and adapt upstream scheduler interfaces consumed by HCU patches."""
 
 from __future__ import annotations
 
@@ -22,6 +22,7 @@ TARGETS = (
     f"{TARGET_MODULE}.Scheduler.update_draft_token_ids_in_output",
     f"{TARGET_MODULE}.Scheduler.__init__",
     f"{TARGET_MODULE}.Scheduler._update_after_schedule",
+    f"{TARGET_MODULE}.Scheduler._mamba_block_aligned_split",
 )
 _MARKER = "_vllm_hcu_scheduler_contract_validated"
 
@@ -47,6 +48,35 @@ def _install_pp_spec_decode_cadence(scheduler: type) -> None:
                 request.next_decode_eligible_step = next_step
 
     scheduler._update_after_schedule = _update_after_schedule
+
+
+def _install_hybrid_mamba_split_block_size(scheduler: type) -> None:
+    """Run the official Mamba split with the hybrid scheduler block size.
+
+    HCU attention keeps ``cache_config.block_size`` at the 64-token vendor
+    kernel page, while official hybrid cache grouping may select a larger
+    scheduler block. The upstream split currently reads the former even though
+    ``Scheduler.block_size`` already contains the latter. Scope the correction
+    to the upstream call and restore the kernel page immediately afterwards.
+    """
+
+    original = scheduler._mamba_block_aligned_split
+
+    @functools.wraps(original)
+    def _mamba_block_aligned_split(self, request, num_new_tokens, *args, **kwargs):
+        cache_config = self.cache_config
+        kernel_block_size = cache_config.block_size
+        scheduler_block_size = self.block_size
+        if kernel_block_size == scheduler_block_size:
+            return original(self, request, num_new_tokens, *args, **kwargs)
+
+        cache_config.block_size = scheduler_block_size
+        try:
+            return original(self, request, num_new_tokens, *args, **kwargs)
+        finally:
+            cache_config.block_size = kernel_block_size
+
+    scheduler._mamba_block_aligned_split = _mamba_block_aligned_split
 
 
 def apply_to_module(module: ModuleType) -> bool:
@@ -85,7 +115,13 @@ def apply_to_module(module: ModuleType) -> bool:
         TARGETS[4],
         ("self", "scheduler_output"),
     )
+    require_signature_prefix(
+        require_callable(scheduler, "_mamba_block_aligned_split", TARGETS[5]),
+        TARGETS[5],
+        ("self", "request", "num_new_tokens"),
+    )
     _install_pp_spec_decode_cadence(scheduler)
+    _install_hybrid_mamba_split_block_size(scheduler)
     setattr(target, _MARKER, True)
     return True
 

--- a/vllm_hcu/patch/worker/__init__.py
+++ b/vllm_hcu/patch/worker/__init__.py
@@ -324,6 +324,9 @@ _FRAMEWORK_CALLBACKS: tuple[_CallbackSpec, ...] = (
         _adapter("framework_opt", "patch_pcp_model_state"),
     ),
     _CallbackSpec(
+        _adapter("framework_opt", "patch_mamba_hybrid_model_state"),
+    ),
+    _CallbackSpec(
         _adapter("framework_opt", "patch_dp_utils"),
         feature="deepep_low_latency",
     ),

--- a/vllm_hcu/patch/worker/framework_opt/patch_mamba_hybrid_model_state.py
+++ b/vllm_hcu/patch/worker/framework_opt/patch_mamba_hybrid_model_state.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""Align resumed Mamba state indices with the hybrid manager block size."""
+
+from __future__ import annotations
+
+import functools
+from types import ModuleType
+
+from ._common import (
+    already_applied,
+    load_exact_module,
+    require_callable,
+    require_class,
+    require_exact_signature,
+)
+
+TARGET_MODULE = "vllm.v1.worker.gpu.model_states.mamba_hybrid"
+PATCH_ID = "worker.framework_opt.mamba.hybrid_resume_state_index"
+TARGETS = (
+    f"{TARGET_MODULE}.MambaHybridModelState.add_request",
+    f"{TARGET_MODULE}.MambaHybridModelState.preprocess_state",
+)
+_MARKER = "_vllm_hcu_mamba_hybrid_state_index_applied"
+_ADD_WRAPPER = "_vllm_hcu_mamba_hybrid_add_request_wrapper"
+_PREPROCESS_WRAPPER = "_vllm_hcu_mamba_hybrid_preprocess_wrapper"
+_PENDING_SEEDS = "_vllm_hcu_pending_mamba_state_seeds"
+
+
+def _seed_state_index(
+    self, req_index: int, num_computed_tokens: int, block_size: int
+) -> None:
+    self._mamba_state_idx_gpu[req_index].fill_(
+        (num_computed_tokens - 1) // block_size
+    )
+
+
+def apply_to_module(module: ModuleType) -> bool:
+    target = load_exact_module(TARGET_MODULE, module)
+    model_state = require_class(
+        target,
+        "MambaHybridModelState",
+        f"{TARGET_MODULE}.MambaHybridModelState",
+    )
+    if already_applied(
+        target,
+        _MARKER,
+        (
+            (model_state, "add_request", TARGETS[0], _ADD_WRAPPER),
+            (
+                model_state,
+                "preprocess_state",
+                TARGETS[1],
+                _PREPROCESS_WRAPPER,
+            ),
+        ),
+    ):
+        return False
+
+    original_add_request = require_callable(model_state, "add_request", TARGETS[0])
+    require_exact_signature(
+        original_add_request,
+        TARGETS[0],
+        positional=("self", "req_index", "new_req_data"),
+    )
+    original_preprocess_state = require_callable(
+        model_state, "preprocess_state", TARGETS[1]
+    )
+    require_exact_signature(
+        original_preprocess_state,
+        TARGETS[1],
+        positional=(
+            "self",
+            "input_batch",
+            "block_tables",
+            "kv_cache_config",
+            "num_computed_tokens",
+        ),
+    )
+
+    @functools.wraps(original_add_request)
+    def add_request(self, req_index, new_req_data):
+        result = original_add_request(self, req_index, new_req_data)
+        if not self._align_mode:
+            return result
+
+        num_computed_tokens = new_req_data.num_computed_tokens
+        mamba_spec = self._mamba_spec
+        if mamba_spec is None:
+            pending = getattr(self, _PENDING_SEEDS, None)
+            if pending is None:
+                pending = {}
+                setattr(self, _PENDING_SEEDS, pending)
+            pending[req_index] = num_computed_tokens
+        elif self.cache_config.block_size != mamba_spec.block_size:
+            _seed_state_index(
+                self,
+                req_index,
+                num_computed_tokens,
+                mamba_spec.block_size,
+            )
+        return result
+
+    @functools.wraps(original_preprocess_state)
+    def preprocess_state(
+        self,
+        input_batch,
+        block_tables,
+        kv_cache_config,
+        num_computed_tokens,
+    ):
+        pending = getattr(self, _PENDING_SEEDS, None)
+        if self._align_mode and pending:
+            _, mamba_spec = self._get_mamba_group_info(kv_cache_config)
+            if self.cache_config.block_size != mamba_spec.block_size:
+                for req_index, seed_tokens in pending.items():
+                    _seed_state_index(
+                        self,
+                        req_index,
+                        seed_tokens,
+                        mamba_spec.block_size,
+                    )
+            pending.clear()
+        return original_preprocess_state(
+            self,
+            input_batch,
+            block_tables,
+            kv_cache_config,
+            num_computed_tokens,
+        )
+
+    setattr(add_request, _ADD_WRAPPER, True)
+    setattr(preprocess_state, _PREPROCESS_WRAPPER, True)
+    setattr(model_state, "_vllm_hcu_original_add_request", original_add_request)
+    setattr(
+        model_state,
+        "_vllm_hcu_original_preprocess_state",
+        original_preprocess_state,
+    )
+    setattr(model_state, "add_request", add_request)
+    setattr(model_state, "preprocess_state", preprocess_state)
+    setattr(target, _MARKER, True)
+    return True
+
+
+def apply(module: ModuleType | None = None) -> bool:
+    return apply_to_module(load_exact_module(TARGET_MODULE, module))
+
+
+__all__ = ["PATCH_ID", "TARGET_MODULE", "TARGETS", "apply", "apply_to_module"]


### PR DESCRIPTION
## Summary

- Keep HCU FLASH_ATTN, FLASHMLA, and FLASHMLA_SPARSE KV-cache/kernel block size at 64.
- Run the official Mamba aligned split with the official hybrid Scheduler.block_size only for the duration of that call.
- Restore cache_config.block_size in finally; do not replace upstream scheduling or add a model-specific override.
- Add scheduler contract and regression tests.

## Root cause

For Qwen3.8 Flash-Next, HCU attention uses a 64-token vendor kernel page while official hybrid grouping selected a larger scheduler block (800 with MTP3). The upstream split read cache_config.block_size, so FullAttention reused prefixes while Mamba cacheable boundaries were placed on the wrong physical block.

## Validation

- Focused plugin suite: 31 passed.
- Qwen3.8-Flash-Next-FP8-Channelwise, TP4, FLASH_ATTN, --moe-backend aiter, MTP3, prefix caching, default CUDA Graph: started successfully.
- Duplicate 2501-token prompt: 1600 prefix-cache hits with MTP3.
- HumanEval8: 8/8.
- No vLLM source changes.

## Runtime command

```bash
env -u VLLM_PLUGINS \
  -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
  -u http_proxy -u https_proxy -u all_proxy \
  NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
  PYTHONPATH=/models/.worktrees/vllm-plugin-das-pcp-ep-mtp3-v0281 \
  HIP_VISIBLE_DEVICES=4,5,6,7 \
  vllm serve /models/Qwen3.8-Flash-Next-FP8-Channelwise \
    --trust-remote-code --host 127.0.0.1 --port 8000 \
    --served-model-name Qwen3.8-Flash-Next-FP8-Channelwise \
    --tensor-parallel-size 4 \
    --attention-backend FLASH_ATTN \
    --moe-backend aiter \
    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
    --enable-prefix-caching \
    --max-model-len 32768 --max-num-batched-tokens 16384 --max-num-seqs 8 \
    --default-chat-template-kwargs '{"reasoning_effort":"low"}'
```

No --enforce-eager, custom FA, manual PIECEWISE mode, or VLLM_HCU_USE_FLASH_ATTN_UNIFIED is used.