### PR TITLE
feat(hy4): support PP2 + PCP4 + MTP with stage-local EP4

### DIFF
--- a/docs/hy4_channel_fp8_mtp_aiter_validation.md
+++ b/docs/hy4_channel_fp8_mtp_aiter_validation.md
@@ -522,3 +522,77 @@ a PCP configuration or Hy4 model-registration failure.
 
 The fail-closed configuration and sparse-backend capability changes are in
 commits `5682574` and `d1a47b6`, respectively.
+
+## PP2 + PCP4 + EP4 DeepEP/DeepGEMM validation (2026-09-11)
+
+The exact eight-HCU topology `PP=2, TP=1, PCP=4, EP=4` was validated in eager
+mode with DeepEP high-throughput, DeepGEMM, and FP8 E4M3 KV cache. Hy4 shares
+indexer state across layer groups, so the pipeline must be split at the full
+indexer boundary `41,37`; the default `39,39` split is intentionally rejected.
+
+```bash
+export PLUGIN_ROOT=/path/to/vllm-plugin-das
+export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export VLLM_USE_V2_MODEL_RUNNER=1
+export VLLM_KV_CACHE_LAYOUT=NHD
+export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=300
+export VLLM_ENGINE_ITERATION_TIMEOUT_S=300
+export VLLM_PP_LAYER_PARTITION=41,37
+export PYTHONPATH="${PLUGIN_ROOT}"
+unset VLLM_USE_DEEP_GEMM
+unset VLLM_PLUGINS
+
+vllm serve /models/Hy4-preview-Channel-FP8-w8a8-v2 \
+  --served-model-name hy4-pp2-pcp4 \
+  --tensor-parallel-size 1 \
+  --pipeline-parallel-size 2 \
+  --prefill-context-parallel-size 4 \
+  --enable-expert-parallel \
+  --all2all-backend deepep_high_throughput \
+  --moe-backend deep_gemm \
+  --kv-cache-dtype fp8_e4m3 \
+  --enforce-eager \
+  --gpu-memory-utilization 0.95 \
+  --max-model-len 4096 \
+  --max-num-seqs 16 \
+  --max-num-batched-tokens 4096 \
+  --default-chat-template-kwargs '{"reasoning_effort":"no_think"}' \
+  --reasoning-parser hy_v4 \
+  --enable-auto-tool-choice \
+  --tool-call-parser hy_v4 \
+  --port 8000
+```
+
+All eight workers initialized as PP0/PP1 times PCP0-3/EP0-3. Runtime logs
+confirmed `DeepEPHTAll2AllManager`, `DeepEPHTPrepareAndFinalize`, and
+`DeepEPDeepGemmContiguousExperts with DeepGEMM HT path`. A short request and a
+3,049-token long-prefill request both returned HTTP 200 with assistant content
+`OK`.
+
+HumanEval used the first 32 ModelScope samples, request batch size 16,
+temperature zero, seed 42, and a 1,024-token output limit:
+
+```bash
+env -u ALL_PROXY -u HTTP_PROXY -u HTTPS_PROXY \
+    -u all_proxy -u http_proxy -u https_proxy \
+    NO_PROXY=127.0.0.1,localhost \
+    no_proxy=127.0.0.1,localhost \
+python -m evalscope.cli.cli eval \
+  --model hy4-pp2-pcp4 \
+  --model-id Hy4-preview-Channel-FP8-w8a8-v2-deepgemm-pp2-pcp4-ep4-fp8kv-no_think \
+  --api-url http://127.0.0.1:8000/v1 \
+  --api-key EMPTY \
+  --eval-type openai_api \
+  --datasets humaneval \
+  --dataset-hub modelscope \
+  --limit 32 \
+  --eval-batch-size 16 \
+  --generation-config '{"batch_size":16,"max_tokens":1024,"temperature":0.0,"top_p":1.0,"seed":42,"timeout":1800.0,"extra_body":{"chat_template_kwargs":{"reasoning_effort":"no_think"}}}' \
+  --seed 42 \
+  --work-dir /models/evalscope_hy4_pp2_pcp4_deepgemm_humaneval32_20260911 \
+  --no-timestamp
+```
+
+The run completed all 32 requests in 266.43 seconds with no API or runtime
+errors. EvalScope reported `Accuracy=1.0` and `Pass@1=1.0` (32/32 correct),
+with mean per-request latency 98.273 seconds and mean output length 135 tokens.

--- a/docs/superpowers/plans/2026-09-11-hy4-pp2-pcp4.md
+++ b/docs/superpowers/plans/2026-09-11-hy4-pp2-pcp4.md
@@ -1,0 +1,140 @@
+# Hy4 PP2 + PCP4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable and validate Hy4 PP2+PCP4+EP4 serving on eight HCUs.
+
+**Architecture:** Keep intermediate tensors PCP-local across matching pipeline ranks. Restore only the saved global `InputBatch` on non-final PP stages, and restore both PCP-gathered hidden states and the global batch on the final stage.
+
+**Tech Stack:** Python, pytest, PyTorch distributed, vLLM Model Runner V2, HCU PCP, DeepEP, DeepGEMM.
+
+**Spec:** `docs/superpowers/specs/2026-09-11-hy4-pp2-pcp4-design.md`
+
+## Global Constraints
+
+- Only `HYV4ForCausalLM` with PP2, TP1, PCP4, DP1, DCP1, EP enabled, eager execution, and no speculative configuration is newly accepted.
+- GLM-5.2, GQA, and other PP+PCP topologies remain fail-closed.
+- Existing PCP=1 and PP=1 behavior is unchanged.
+- Live validation uses DeepEP high-throughput, DeepGEMM, and FP8 E4M3 KV cache.
+
+---
+
+### Task 1: Fail-closed configuration exception
+
+**Files:**
+- Modify: `tests/runtime_patch/test_glm52_pcp_config.py`
+- Modify: `vllm_hcu/patch/platform/core_fix/patch_vllm_config.py`
+
+**Interfaces:**
+- Consumes: `_validate_hcu_pcp_scope(vllm_config: object) -> bool`
+- Produces: `_is_supported_hy4_pp_pcp_topology(...) -> bool`
+
+- [ ] **Step 1: Add failing acceptance and rejection tests**
+
+Add an acceptance test for architecture `HYV4ForCausalLM`, `pp=2`, `tp=1`,
+`pcp=4`, EP and eager enabled. Add parameterized rejections for PP3, TP2,
+PCP2, and speculative MTP. Preserve the GLM PP2 rejection test.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+python -m pytest -q tests/runtime_patch/test_glm52_pcp_config.py
+```
+
+Expected: the exact Hy4 PP2+PCP4 acceptance test fails with the existing
+`HCU PCP does not support pipeline parallelism` error.
+
+- [ ] **Step 3: Implement the narrow exception**
+
+Classify the exact Hy4 PP+PCP topology before the generic pipeline rejection.
+Reject unsupported Hy4 PP+PCP values with an error listing PP2/TP1/PCP4, and
+reject speculative decoding when the accepted PP+PCP topology is selected.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run the command from Step 2 and require zero failures.
+
+### Task 2: Restore the PP sampling batch without a hidden-state collective
+
+**Files:**
+- Modify: `tests/runtime_patch/test_glm52_pcp_runner.py`
+- Modify: `vllm_hcu/v1/pcp_manager.py`
+- Modify: `vllm_hcu/v1/hcu_model_runner_v2.py`
+
+**Interfaces:**
+- Produces: `HcuPCPManager.restore_batch_for_sampling() -> InputBatch`
+- Consumes: `execute_model_state.hidden_states`, which is `None` on non-final PP ranks
+
+- [ ] **Step 1: Add a failing non-final PP runner test**
+
+Construct an execute state with a PCP-local batch and `hidden_states=None`.
+The fake manager's hidden restore must fail if called; its batch-only method
+returns the global batch. Assert upstream sampling receives `None` and the
+global batch.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+python -m pytest -q tests/runtime_patch/test_glm52_pcp_runner.py -k non_final
+```
+
+Expected: failure because `restore_for_sampling(None)` is called.
+
+- [ ] **Step 3: Add checked batch-only restoration**
+
+Implement `restore_batch_for_sampling()` with an assertion that
+`_global_batch` exists. In `sample_tokens`, call it only when hidden states are
+`None`; otherwise keep `restore_for_sampling`. Enable replicated MTP handling
+only when real final-stage hidden states exist.
+
+- [ ] **Step 4: Run the runner tests and verify GREEN**
+
+Run:
+
+```bash
+python -m pytest -q tests/runtime_patch/test_glm52_pcp_runner.py
+```
+
+Expected: zero failures.
+
+### Task 3: Regression suite and live validation
+
+**Files:**
+- Modify after successful runtime evidence: `docs/hy4_channel_fp8_mtp_aiter_validation.md`
+
+**Interfaces:**
+- Consumes: exact configuration and runner contracts from Tasks 1 and 2
+- Produces: reproducible launch command and validation evidence
+
+- [ ] **Step 1: Run all affected CPU tests**
+
+```bash
+python -m pytest -q \
+  tests/runtime_patch/test_glm52_pcp_config.py \
+  tests/runtime_patch/test_glm52_pcp_runner.py \
+  tests/runtime_patch/test_patch_base_communicator_pcp.py
+```
+
+- [ ] **Step 2: Start the exact eight-HCU service**
+
+Use PP2, TP1, PCP4, EP, eager, `deepep_high_throughput`, `deep_gemm`, and
+`fp8_e4m3`. Require logs for all PP/PCP/EP ranks and the selected MoE paths.
+
+- [ ] **Step 3: Run service smoke and long-prefill requests**
+
+Require HTTP 200 and non-empty generated text for both requests.
+
+- [ ] **Step 4: Run HumanEval-32**
+
+Record dataset size, completed requests, correct count, failed count, and
+Pass@1. Treat infrastructure errors separately from incorrect generations.
+
+- [ ] **Step 5: Document evidence, commit, push, and open the stacked MR**
+
+Target branch `feat/hy-v4-mtp-blockwise-v0251`. Include the launch command,
+test counts, runtime evidence, limitations, and HumanEval-32 result in the MR
+description.

--- a/docs/superpowers/plans/2026-09-11-hy4-pp2-pcp4.md
+++ b/docs/superpowers/plans/2026-09-11-hy4-pp2-pcp4.md
@@ -29,15 +29,15 @@
 
 **Interfaces:**
 - Consumes: `_validate_hcu_pcp_scope(vllm_config: object) -> bool`
-- Produces: `_is_supported_hy4_pp_pcp_topology(...) -> bool`
+- Produces: an inline, exact-match `hy4_pp_pcp` topology classification
 
-- [ ] **Step 1: Add failing acceptance and rejection tests**
+- [x] **Step 1: Add failing acceptance and rejection tests**
 
 Add an acceptance test for architecture `HYV4ForCausalLM`, `pp=2`, `tp=1`,
 `pcp=4`, EP and eager enabled. Add parameterized rejections for PP3, TP2,
 PCP2, and speculative MTP. Preserve the GLM PP2 rejection test.
 
-- [ ] **Step 2: Run the focused tests and verify RED**
+- [x] **Step 2: Run the focused tests and verify RED**
 
 Run:
 
@@ -48,13 +48,13 @@ python -m pytest -q tests/runtime_patch/test_glm52_pcp_config.py
 Expected: the exact Hy4 PP2+PCP4 acceptance test fails with the existing
 `HCU PCP does not support pipeline parallelism` error.
 
-- [ ] **Step 3: Implement the narrow exception**
+- [x] **Step 3: Implement the narrow exception**
 
 Classify the exact Hy4 PP+PCP topology before the generic pipeline rejection.
 Reject unsupported Hy4 PP+PCP values with an error listing PP2/TP1/PCP4, and
 reject speculative decoding when the accepted PP+PCP topology is selected.
 
-- [ ] **Step 4: Run the focused tests and verify GREEN**
+- [x] **Step 4: Run the focused tests and verify GREEN**
 
 Run the command from Step 2 and require zero failures.
 
@@ -69,14 +69,14 @@ Run the command from Step 2 and require zero failures.
 - Produces: `HcuPCPManager.restore_batch_for_sampling() -> InputBatch`
 - Consumes: `execute_model_state.hidden_states`, which is `None` on non-final PP ranks
 
-- [ ] **Step 1: Add a failing non-final PP runner test**
+- [x] **Step 1: Add a failing non-final PP runner test**
 
 Construct an execute state with a PCP-local batch and `hidden_states=None`.
 The fake manager's hidden restore must fail if called; its batch-only method
 returns the global batch. Assert upstream sampling receives `None` and the
 global batch.
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 Run:
 
@@ -86,14 +86,14 @@ python -m pytest -q tests/runtime_patch/test_glm52_pcp_runner.py -k non_final
 
 Expected: failure because `restore_for_sampling(None)` is called.
 
-- [ ] **Step 3: Add checked batch-only restoration**
+- [x] **Step 3: Add checked batch-only restoration**
 
 Implement `restore_batch_for_sampling()` with an assertion that
 `_global_batch` exists. In `sample_tokens`, call it only when hidden states are
 `None`; otherwise keep `restore_for_sampling`. Enable replicated MTP handling
 only when real final-stage hidden states exist.
 
-- [ ] **Step 4: Run the runner tests and verify GREEN**
+- [x] **Step 4: Run the runner tests and verify GREEN**
 
 Run:
 
@@ -112,7 +112,7 @@ Expected: zero failures.
 - Consumes: exact configuration and runner contracts from Tasks 1 and 2
 - Produces: reproducible launch command and validation evidence
 
-- [ ] **Step 1: Run all affected CPU tests**
+- [x] **Step 1: Run all affected CPU tests**
 
 ```bash
 python -m pytest -q \
@@ -121,22 +121,22 @@ python -m pytest -q \
   tests/runtime_patch/test_patch_base_communicator_pcp.py
 ```
 
-- [ ] **Step 2: Start the exact eight-HCU service**
+- [x] **Step 2: Start the exact eight-HCU service**
 
 Set `VLLM_PP_LAYER_PARTITION=41,37`, then use PP2, TP1, PCP4, EP, eager,
 `deepep_high_throughput`, `deep_gemm`, and `fp8_e4m3`. Require logs for all
 PP/PCP/EP ranks and the selected MoE paths.
 
-- [ ] **Step 3: Run service smoke and long-prefill requests**
+- [x] **Step 3: Run service smoke and long-prefill requests**
 
 Require HTTP 200 and non-empty generated text for both requests.
 
-- [ ] **Step 4: Run HumanEval-32**
+- [x] **Step 4: Run HumanEval-32**
 
 Record dataset size, completed requests, correct count, failed count, and
 Pass@1. Treat infrastructure errors separately from incorrect generations.
 
-- [ ] **Step 5: Document evidence, commit, push, and open the stacked MR**
+- [x] **Step 5: Document evidence, commit, push, and open the stacked MR**
 
 Target branch `feat/hy-v4-mtp-blockwise-v0251`. Include the launch command,
 test counts, runtime evidence, limitations, and HumanEval-32 result in the MR

--- a/docs/superpowers/plans/2026-09-11-hy4-pp2-pcp4.md
+++ b/docs/superpowers/plans/2026-09-11-hy4-pp2-pcp4.md
@@ -16,6 +16,8 @@
 - GLM-5.2, GQA, and other PP+PCP topologies remain fail-closed.
 - Existing PCP=1 and PP=1 behavior is unchanged.
 - Live validation uses DeepEP high-throughput, DeepGEMM, and FP8 E4M3 KV cache.
+- Live validation sets `VLLM_PP_LAYER_PARTITION=41,37` so PP stage 1 starts on
+  Hy4 full indexer layer 41 rather than shared layer 39.
 
 ---
 
@@ -121,8 +123,9 @@ python -m pytest -q \
 
 - [ ] **Step 2: Start the exact eight-HCU service**
 
-Use PP2, TP1, PCP4, EP, eager, `deepep_high_throughput`, `deep_gemm`, and
-`fp8_e4m3`. Require logs for all PP/PCP/EP ranks and the selected MoE paths.
+Set `VLLM_PP_LAYER_PARTITION=41,37`, then use PP2, TP1, PCP4, EP, eager,
+`deepep_high_throughput`, `deep_gemm`, and `fp8_e4m3`. Require logs for all
+PP/PCP/EP ranks and the selected MoE paths.
 
 - [ ] **Step 3: Run service smoke and long-prefill requests**
 

--- a/docs/superpowers/specs/2026-09-11-hy4-pp2-pcp4-design.md
+++ b/docs/superpowers/specs/2026-09-11-hy4-pp2-pcp4-design.md
@@ -1,0 +1,78 @@
+# Hy4 PP2 + PCP4 Design
+
+## Goal
+
+Enable the eight-HCU `HYV4ForCausalLM` topology `PP=2, TP=1, PCP=4,
+DP=1, DCP=1, EP=4` in Model Runner V2 eager mode. Validate the target path
+with DeepEP high-throughput, DeepGEMM, and FP8 E4M3 KV cache.
+
+## Scope
+
+- Permit pipeline parallelism with PCP only for the exact Hy4 topology above.
+- Keep GLM-5.2, GQA, and every other PP+PCP topology fail-closed.
+- Keep PP+PCP speculative decoding disabled; MTP is a separate validation.
+- Preserve the existing PCP=1, PP=1, and DeepEP communicator behavior.
+- Do not introduce a PP-boundary all-gather. Each PP stage keeps the same
+  PCP-local virtual batch during model execution.
+
+## Runtime ownership
+
+vLLM constructs PP groups between equal PCP ranks, while each PP stage owns a
+separate PCP group. Consequently, the first stage sends PCP-local intermediate
+tensors to the matching PCP rank in the second stage. Only the final PP stage
+has final hidden states and gathers those states across its PCP group before
+sampling.
+
+All PP ranks still enter `sample_tokens`. A non-final PP stage has
+`execute_model_state.hidden_states is None`, but upstream PP receive/broadcast
+uses the request layout passed in `InputBatch`. It must therefore restore the
+saved global batch without attempting a hidden-state collective. The final
+stage restores both hidden states and the same global batch.
+
+`HcuPCPManager` will expose a checked accessor for the saved global sampling
+batch. `HcuGPUModelRunnerV2.sample_tokens` will select batch-only restoration
+when hidden states are absent and the existing hidden-state restoration when
+they are present.
+
+## Configuration contract
+
+The existing generic PP rejection becomes a model-aware exception. PP+PCP is
+accepted only when all of these values match:
+
+- architecture: `HYV4ForCausalLM`
+- pipeline parallel size: `2`
+- tensor parallel size: `1`
+- prefill context parallel size: `4`
+- data parallel size: `1`
+- decode context parallel size: `1`
+- expert parallelism: enabled
+- eager execution: enabled
+- speculative configuration: absent
+
+Existing checks continue to reject LoRA, multimodal execution, KV offload,
+P/D disaggregation, lightly-CP, and HCU multi-layer MTP.
+
+## Validation
+
+CPU regression tests must prove that the exact Hy4 topology is accepted, that
+nearby Hy4 topologies and Hy4 PP+PCP+MTP are rejected, and that GLM/GQA PP+PCP
+remain rejected. A runner regression test must model a non-final PP rank with
+`hidden_states=None`, prove there is no PCP hidden-state gather, restore the
+global batch, and delegate to upstream sampling.
+
+Live validation uses `/models/Hy4-preview-Channel-FP8-w8a8-v2` with:
+
+```bash
+--pipeline-parallel-size 2
+--tensor-parallel-size 1
+--prefill-context-parallel-size 4
+--enable-expert-parallel
+--all2all-backend deepep_high_throughput
+--moe-backend deep_gemm
+--kv-cache-dtype fp8_e4m3
+--enforce-eager
+```
+
+Acceptance requires all eight workers to initialize, logs to show two PP
+stages with four PCP/EP ranks per stage, a successful short request and long
+prefill request, and exact HumanEval-32 correctness counts.

--- a/docs/superpowers/specs/2026-09-11-hy4-pp2-pcp4-design.md
+++ b/docs/superpowers/specs/2026-09-11-hy4-pp2-pcp4-design.md
@@ -49,6 +49,12 @@ accepted only when all of these values match:
 - eager execution: enabled
 - speculative configuration: absent
 
+Hy4 shares indexer results across groups of layers. The default 39/39 split
+starts PP stage 1 on shared indexer layer 39, so the launch must set
+`VLLM_PP_LAYER_PARTITION=41,37`. Layer 41 is the closest balanced `full`
+indexer boundary and does not require transferring indexer top-k state across
+the PP boundary.
+
 Existing checks continue to reject LoRA, multimodal execution, KV offload,
 P/D disaggregation, lightly-CP, and HCU multi-layer MTP.
 
@@ -63,6 +69,8 @@ global batch, and delegate to upstream sampling.
 Live validation uses `/models/Hy4-preview-Channel-FP8-w8a8-v2` with:
 
 ```bash
+export VLLM_PP_LAYER_PARTITION=41,37
+
 --pipeline-parallel-size 2
 --tensor-parallel-size 1
 --prefill-context-parallel-size 4

--- a/tests/runtime_patch/test_glm52_pcp_config.py
+++ b/tests/runtime_patch/test_glm52_pcp_config.py
@@ -118,6 +118,22 @@ def test_hy4_mrv2_mla_pcp2_eager_is_allowed(make_pcp_config) -> None:
     assert patch_vllm_config._validate_hcu_pcp_scope(config) is True
 
 
+def test_hy4_mrv2_pp2_pcp4_eager_is_allowed(make_pcp_config) -> None:
+    """The validated eight-rank Hy4 pipeline topology must start."""
+
+    config = make_pcp_config(
+        architecture="HYV4ForCausalLM",
+        use_mla=True,
+        pp=2,
+        tp=1,
+        pcp=4,
+        enable_expert_parallel=True,
+        enforce_eager=True,
+    )
+
+    assert patch_vllm_config._validate_hcu_pcp_scope(config) is True
+
+
 def test_gqa_mrv2_flash_pcp_is_allowed(make_pcp_config) -> None:
     """GQA PCP must not remain trapped behind the former MLA-only gate."""
 
@@ -309,7 +325,6 @@ def test_glm52_pcp_scope_rejects_unsupported_combinations(
     [
         ({"enable_expert_parallel": False}, "expert parallel"),
         ({"enforce_eager": False}, "eager"),
-        ({"pp": 2}, "pipeline parallel"),
         ({"dcp": 2}, "decode context parallel"),
         ({"dp": 2}, "data parallel"),
         (
@@ -333,6 +348,43 @@ def test_hy4_pcp_rejects_unsupported_combinations(
                 architecture="HYV4ForCausalLM",
                 pcp=2,
                 **override,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"pp": 3, "tp": 1, "pcp": 4},
+        {"pp": 2, "tp": 2, "pcp": 4},
+        {"pp": 2, "tp": 1, "pcp": 2},
+    ],
+)
+def test_hy4_pp_pcp_rejects_unvalidated_topologies(
+    make_pcp_config, override
+) -> None:
+    """PP+PCP must remain fail-closed outside PP2/TP1/PCP4."""
+
+    with pytest.raises(ValueError, match="PP=2, TP=1, and PCP=4"):
+        patch_vllm_config._validate_hcu_pcp_scope(
+            make_pcp_config(
+                architecture="HYV4ForCausalLM",
+                **override,
+            )
+        )
+
+
+def test_hy4_pp_pcp_rejects_speculative_decoding(make_pcp_config) -> None:
+    """MTP has no validated combined PP+PCP execution contract."""
+
+    with pytest.raises(ValueError, match="does not support speculative"):
+        patch_vllm_config._validate_hcu_pcp_scope(
+            make_pcp_config(
+                architecture="HYV4ForCausalLM",
+                pp=2,
+                tp=1,
+                pcp=4,
+                speculative=True,
             )
         )
 

--- a/tests/runtime_patch/test_glm52_pcp_manager.py
+++ b/tests/runtime_patch/test_glm52_pcp_manager.py
@@ -775,6 +775,7 @@ def test_restore_returns_global_token_and_request_order() -> None:
         sampled_hidden, sampled_batch = manager.restore_for_sampling(local)
         assert sampled_hidden[:, 0].tolist() == expected.tolist()
         assert sampled_batch is global_batch
+        assert manager.restore_batch_for_sampling() is global_batch
 
 
 def test_dummy_slots_are_invalid_without_touching_real_block_tables() -> None:

--- a/tests/runtime_patch/test_glm52_pcp_runner.py
+++ b/tests/runtime_patch/test_glm52_pcp_runner.py
@@ -296,6 +296,47 @@ def test_pcp_runner_replaces_immutable_execute_model_state(
     assert runner.execute_model_state.hidden_states is global_hidden
 
 
+def test_pcp_non_final_pp_rank_restores_only_global_sampling_batch(
+    pcp_runner_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-final PP rank has no hidden states to gather across PCP."""
+
+    runner_module, events = pcp_runner_module
+    global_batch = object()
+    local_batch = object()
+
+    class Manager:
+        def restore_for_sampling(self, hidden_states):
+            pytest.fail(
+                "non-final PP rank attempted a PCP hidden-state collective"
+            )
+
+        def restore_batch_for_sampling(self):
+            events.append("restore_batch_for_sampling")
+            return global_batch
+
+    monkeypatch.setattr(
+        runner_module,
+        "synchronize_pp_spec_draft_tokens",
+        lambda *args: False,
+    )
+    runner = runner_module.HcuGPUModelRunnerV2(_config(2), "hcu:0")
+    runner.pcp_manager = Manager()
+    runner.execute_model_state = _ExecuteModelState(local_batch, None)
+    runner.expected_hidden = None
+    runner.expected_batch = global_batch
+    events.clear()
+
+    assert runner.sample_tokens("grammar") == "sampled"
+    assert runner.execute_model_state.hidden_states is None
+    assert runner.execute_model_state.input_batch is global_batch
+    assert events == [
+        "restore_batch_for_sampling",
+        "super.sample_tokens",
+    ]
+
+
 def test_pcp_mtp_rebuilds_global_drafter_attention_state(
     pcp_runner_module,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/runtime_patch/test_sparse_indexer_loading.py
+++ b/tests/runtime_patch/test_sparse_indexer_loading.py
@@ -459,6 +459,85 @@ def test_hy_v4_lightop_qk_fusion_writes_cache_before_topk(
     assert events[1][-1]["indexer_cache_layout"] == "NORMAL"
 
 
+def test_hy_v4_lightop_pcp_preserves_expanded_slots_for_gather(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PCP must not truncate rank-ordered slots to the local K width."""
+
+    events: list[tuple[object, ...]] = []
+    fp8_dtype = torch.float8_e4m3fn
+    expanded_slots = torch.arange(8, dtype=torch.int64)
+    metadata = SimpleNamespace(
+        slot_mapping=expanded_slots,
+        num_kv_actual_tokens=2,
+        pcp_world_size=4,
+        num_decode_tokens=0,
+    )
+    local_k = torch.ones((2, 128), dtype=torch.bfloat16)
+    gathered_k = torch.ones((8, 128), dtype=torch.bfloat16)
+    fused_q = torch.ones((2, 3, 128), dtype=fp8_dtype)
+    fused_weights = torch.ones((2, 3), dtype=torch.float32)
+
+    def gather(k, slots, actual_metadata):
+        events.append(("gather", k, slots, actual_metadata))
+        torch.testing.assert_close(k, local_k)
+        assert slots is expanded_slots
+        assert actual_metadata is metadata
+        return gathered_k, expanded_slots
+
+    def quant_and_store(q, k, _cache, slots, _weights, **_kwargs):
+        events.append(("fuse", q, k, slots))
+        return fused_q, fused_weights
+
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(
+        "vllm_hcu.v1.attention.ops.rocm_aiter_mla_sparse."
+        "rocm_aiter_sparse_attn_indexer_native",
+        lambda *args, **_kwargs: args[3],
+    )
+    forward_hip = _load_sparse_indexer_contract(
+        torch=torch,
+        current_platform=SimpleNamespace(fp8_dtype=lambda: fp8_dtype),
+        get_forward_context=lambda: SimpleNamespace(
+            attn_metadata={"indexer": metadata}
+        ),
+        effective_pcp_world_size=lambda value: value,
+        maybe_gather_indexer_k=gather,
+        lightop_indexer_qk_quant_and_store=quant_and_store,
+        rocm_aiter_ops=SimpleNamespace(is_enabled=lambda: True),
+        _encode_layer_name=lambda value: value,
+    )
+    indexer = SimpleNamespace(
+        use_fp4_cache=False,
+        use_lightop_hy_v4_indexer=True,
+        skip_k_cache_insert=False,
+        pcp_world_size=4,
+        dcp_world_size=1,
+        k_cache=SimpleNamespace(
+            prefix="indexer",
+            kv_cache=torch.zeros((1, 8, 132), dtype=torch.uint8),
+        ),
+        quant_block_size=128,
+        scale_fmt="ue8m0",
+        topk_tokens=64,
+        head_dim=128,
+        max_model_len=4096,
+        max_total_seq_len=4096,
+        topk_indices_buffer=torch.empty((2, 64), dtype=torch.int32),
+    )
+
+    assert forward_hip(
+        indexer,
+        torch.empty((2, 1)),
+        torch.ones((2, 3, 128), dtype=torch.bfloat16),
+        local_k,
+        torch.ones((2, 3), dtype=torch.bfloat16),
+    ) is fused_q
+    assert [event[0] for event in events] == ["gather", "fuse"]
+    torch.testing.assert_close(events[1][2], gathered_k)
+    torch.testing.assert_close(events[1][3], expanded_slots)
+
+
 def test_hy_v4_lightop_filters_negative_slots_on_idle_dp_rank(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/vllm_hcu/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm_hcu/model_executor/layers/sparse_attn_indexer.py
@@ -972,11 +972,10 @@ class SparseAttnIndexer(CustomOp):
             attn_metadata = get_forward_context().attn_metadata
             if isinstance(attn_metadata, dict):
                 layer_metadata = attn_metadata[self.k_cache.prefix]
-                slot_mapping = layer_metadata.slot_mapping[
-                    : layer_metadata.num_kv_actual_tokens
-                ]
-                cache_k = k[: slot_mapping.shape[0]]
                 pcp_world_size = effective_pcp_world_size(self.pcp_world_size)
+                num_kv_actual_tokens = layer_metadata.num_kv_actual_tokens
+                cache_k = k[:num_kv_actual_tokens]
+                slot_mapping = layer_metadata.slot_mapping
                 if pcp_world_size > 1:
                     metadata_world_size = int(
                         getattr(layer_metadata, "pcp_world_size", 1)
@@ -992,6 +991,8 @@ class SparseAttnIndexer(CustomOp):
                         slot_mapping,
                         layer_metadata,
                     )
+                else:
+                    slot_mapping = slot_mapping[:num_kv_actual_tokens]
                 # Boolean compaction (``cache_k[slot_mapping >= 0]``) creates a
                 # dynamic-shaped tensor and is forbidden during HIP graph
                 # capture. Keep the captured launch fixed-shape and let the HCU

--- a/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
@@ -100,9 +100,35 @@ def _require_mrv2_pcp_contract(vllm_config: object) -> None:
         raise ValueError(
             "FlashAttention PCP does not support hybrid KV cache groups."
         )
-    if _require_hcu_pcp_attribute(
-        parallel_config, "pipeline_parallel_size", "ParallelConfig"
-    ) != 1:
+    pp_size = int(
+        _require_hcu_pcp_attribute(
+            parallel_config, "pipeline_parallel_size", "ParallelConfig"
+        )
+    )
+    tp_size = int(
+        _require_hcu_pcp_attribute(
+            parallel_config, "tensor_parallel_size", "ParallelConfig"
+        )
+    )
+    pcp_size = int(
+        _require_hcu_pcp_attribute(
+            parallel_config,
+            "prefill_context_parallel_size",
+            "ParallelConfig",
+        )
+    )
+    hy4_pp_pcp = (
+        architecture == "HYV4ForCausalLM"
+        and pp_size == 2
+        and tp_size == 1
+        and pcp_size == 4
+    )
+    if pp_size != 1 and not hy4_pp_pcp:
+        if architecture == "HYV4ForCausalLM":
+            raise ValueError(
+                "Hy4 PP+PCP only supports PP=2, TP=1, and PCP=4; "
+                f"got PP={pp_size}, TP={tp_size}, and PCP={pcp_size}."
+            )
         raise ValueError("HCU PCP does not support pipeline parallelism.")
     dcp_size = int(
         _require_hcu_pcp_attribute(
@@ -135,6 +161,10 @@ def _require_mrv2_pcp_contract(vllm_config: object) -> None:
         vllm_config, "speculative_config", "VllmConfig"
     )
     if speculative_config is not None:
+        if hy4_pp_pcp:
+            raise ValueError(
+                "Hy4 PP+PCP does not support speculative decoding or MTP."
+            )
         if not use_mla:
             raise ValueError(
                 "FlashAttention PCP does not support speculative decoding or MTP."

--- a/vllm_hcu/v1/hcu_model_runner_v2.py
+++ b/vllm_hcu/v1/hcu_model_runner_v2.py
@@ -173,17 +173,26 @@ class HcuGPUModelRunnerV2(GPUModelRunner):
         execute_model_state = self.execute_model_state
         use_replicated_mtp_batch = False
         if self.pcp_manager is not None and execute_model_state is not None:
-            (
-                restored_hidden_states,
-                restored_input_batch,
-            ) = self.pcp_manager.restore_for_sampling(
-                execute_model_state.hidden_states
-            )
+            if execute_model_state.hidden_states is None:
+                restored_hidden_states = None
+                restored_input_batch = (
+                    self.pcp_manager.restore_batch_for_sampling()
+                )
+            else:
+                (
+                    restored_hidden_states,
+                    restored_input_batch,
+                ) = self.pcp_manager.restore_for_sampling(
+                    execute_model_state.hidden_states
+                )
             execute_model_state = execute_model_state._replace(
                 hidden_states=restored_hidden_states,
                 input_batch=restored_input_batch,
             )
-            use_replicated_mtp_batch = getattr(self, "speculator", None) is not None
+            use_replicated_mtp_batch = (
+                restored_hidden_states is not None
+                and getattr(self, "speculator", None) is not None
+            )
             self.execute_model_state = execute_model_state
         input_batch = (
             None

--- a/vllm_hcu/v1/pcp_manager.py
+++ b/vllm_hcu/v1/pcp_manager.py
@@ -830,6 +830,12 @@ class HcuPCPManager:
         gathered = self._pcp_group.all_gather(hidden_states, dim=0)
         return gathered[self._hidden_restore_idx]
 
+    def restore_batch_for_sampling(self) -> InputBatch:
+        """Return the global batch required by PP sampling collectives."""
+
+        assert self._global_batch is not None
+        return self._global_batch
+
     def build_plan(self) -> PCPPlan | None:
         """Build the GQA attention plan for a sharded PCP+DCP prefill."""
 
@@ -942,8 +948,10 @@ class HcuPCPManager:
     ) -> tuple[torch.Tensor, InputBatch]:
         """Restore final hidden states and the exact saved global InputBatch."""
 
-        assert self._global_batch is not None
-        return self.restore_hidden_states(hidden_states), self._global_batch
+        return (
+            self.restore_hidden_states(hidden_states),
+            self.restore_batch_for_sampling(),
+        )
 
 
 def maybe_build_pcp_manager(


### PR DESCRIPTION
## Summary

- allow the exact Hy4 `PP=2, TP=1, PCP=4, DP=1, DCP=1, EP=4` eager topology
- support target-only and built-in MTP with one or two speculative tokens; keep MTP3 and other speculative methods fail-closed
- restore the global sampling batch without a PCP hidden-state collective on non-final PP stages
- preserve full rank-ordered PCP slot mappings in the default LightOp Hy4 indexer path
- retain PP draft-token synchronization and rebuild global PCP attention metadata only on the final MTP stage
- keep GLM/GQA, other PP+PCP topologies, and the unvalidated PP2+PCP4+P/D cross-product fail-closed

## Tests

```text
Affected regression suite: 257 passed, 14 warnings
Repository contract suite: 1352 passed, 71 deselected, 15 warnings
Patch inventory suite: 86 passed, 1 warning
Patch coverage: ok=true, 0 untested modules
Production boundary: clean (286 Python files)
compileall and git diff --check: passed
```

The MTP configuration tests followed RED/GREEN: MTP1/MTP2 and MTP3 initially failed on the old blanket rejection; after the minimal change MTP1/MTP2 pass and MTP3 reaches the existing one-or-two-token rejection. A review-discovered P/D cross-product was also reproduced RED for target-only and MTP2, then closed with dedicated regression coverage.

## Validated service command

Hy4 shares indexer results across layer groups. The default 39/39 PP split starts stage 1 on shared layer 39, so PP2 must use the nearest balanced full-indexer boundary, 41/37.

```bash
export PLUGIN_ROOT=/path/to/vllm-plugin-das
export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export VLLM_USE_V2_MODEL_RUNNER=1
export VLLM_KV_CACHE_LAYOUT=NHD
export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=300
export VLLM_ENGINE_ITERATION_TIMEOUT_S=300
export VLLM_PP_LAYER_PARTITION=41,37
export PYTHONPATH="${PLUGIN_ROOT}"
unset VLLM_USE_DEEP_GEMM
unset VLLM_PLUGINS

vllm serve /models/Hy4-preview-Channel-FP8-w8a8-v2 \
  --served-model-name hy4-pp2-pcp4-mtp2 \
  --tensor-parallel-size 1 \
  --pipeline-parallel-size 2 \
  --prefill-context-parallel-size 4 \
  --enable-expert-parallel \
  --all2all-backend deepep_high_throughput \
  --moe-backend deep_gemm \
  --kv-cache-dtype fp8_e4m3 \
  --enforce-eager \
  --gpu-memory-utilization 0.95 \
  --max-model-len 4096 \
  --max-num-seqs 16 \
  --max-num-batched-tokens 4096 \
  --default-chat-template-kwargs '{"reasoning_effort":"no_think"}' \
  --reasoning-parser hy_v4 \
  --enable-auto-tool-choice \
  --tool-call-parser hy_v4 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":2}' \
  --port 8000
```

Use `num_speculative_tokens=1` and a matching served name for MTP1. Omit `--speculative-config` for target-only.

## Live validation

- all eight workers loaded as PP0/PP1 x PCP0-3/EP0-3
- logs confirmed FP8 E4M3 KV cache, `DeepEPHTAll2AllManager`, `DeepEPHTPrepareAndFinalize`, and `DeepEPDeepGemmContiguousExperts with DeepGEMM HT path`
- MTP1: `HYV4MTPModel` loaded; short request HTTP 200 with exact `OK`; drafted=1, accepted=1
- MTP2: `HYV4MTPModel` loaded; short request HTTP 200 with exact `OK`; nonzero drafted/accepted tokens throughout HumanEval, typical 10-second acceptance windows 89%-97%
- MTP2 long prefill: HTTP 200 with 3,049 prompt tokens; generated `OK</think:opensource>OK`, recorded as a trajectory difference from target-only exact `OK`

| Mode | Predictions/reviews | Correct | Accuracy | Pass@1 | Wall time | Mean latency | Mean output |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Target-only | 32/32 | 32/32 | 100% | 100% | 266.43 s | 98.273 s | 135 tokens |
| MTP2 | 32/32 | 32/32 | 100% | 100% | 115.65 s | 41.543 s | 135 tokens |

MTP2 and target-only produced byte-identical text for 24/32 HumanEval tasks. Eight tasks followed different valid trajectories, with no pass/fail flips and zero API/runtime errors. Timing is observational from consecutive runs on the same host, not an isolated throughput benchmark.

Full commands and evidence are recorded in `docs/hy4_channel_fp8_mtp_aiter_validation.md`.

## Review

Final read-only review found no remaining Critical, Important, or Minor findings. The review-discovered PP+PCP+MTP+P/D cross-product was closed before push, while the target branch's validated PP1 PCP Mooncake producer support remains unchanged.