### PR TITLE
fix: accept vLLM 0.28.1 vendor builds

### DIFF
--- a/vllm_hcu/compatibility.py
+++ b/vllm_hcu/compatibility.py
@@ -120,7 +120,17 @@ def inspect_vllm_compatibility() -> VllmCompatibility:
             reason=f"invalid vLLM distribution version: {exc}",
         )
 
-    compatible = parsed == expected
+    # Accept the frozen development artifact and vendor builds of the final
+    # release it became.  Local build metadata (DTK, Torch, timestamp, SHA)
+    # does not change the public vLLM release, but other prerelease or release
+    # versions must still fail closed.
+    compatible = parsed == expected or (
+        parsed.epoch == expected.epoch
+        and parsed.release == expected.release
+        and parsed.pre is None
+        and parsed.post is None
+        and parsed.dev is None
+    )
     if compatible:
         reason = "installed vLLM build matches the frozen OpenDAS artifact"
     else:


### PR DESCRIPTION
## Summary

- Keep the exact frozen OpenDAS development artifact accepted.
- Also accept final vLLM `0.28.1` vendor wheels whose local metadata records DTK, Torch, build timestamp, or commit SHA.
- Continue to reject other releases, non-matching prerelease builds, post releases, and non-zero epochs.
- Limit the change to `vllm_hcu/compatibility.py` only.

## Validation

- Reproduced the reported failure before the change with `0.28.1+dtk2604.torch2110.2609111625.ge8fe1b`.
- Verified the original `import vllm` platform-plugin path activates `HCUPlatform` with that metadata (exit 0).
- Compatibility and doctor tests: `20 passed`.
- Version matrix: 2 supported versions accepted and 7 unsupported variants rejected.
- Patch coverage audit: clean.
- Production boundary audit: clean.
- `compileall` and `git diff --check`: clean.
- Full portable contract run: `1563 passed, 5 failed, 145 deselected`; the 5 failures are existing target-branch LightOp/DeepGEMM/scheduler failures and are intentionally out of scope for this single-file change.
