### PR TITLE
feat(hy4): enable MTP with PP2 + PCP4

### DIFF
--- a/docs/hy4_channel_fp8_mtp_aiter_validation.md
+++ b/docs/hy4_channel_fp8_mtp_aiter_validation.md
@@ -596,3 +596,51 @@ python -m evalscope.cli.cli eval \
 The run completed all 32 requests in 266.43 seconds with no API or runtime
 errors. EvalScope reported `Accuracy=1.0` and `Pass@1=1.0` (32/32 correct),
 with mean per-request latency 98.273 seconds and mean output length 135 tokens.
+
+### PP2 + PCP4 MTP validation
+
+The same topology supports built-in MTP with one or two speculative tokens.
+Append one of these options to the service command and update
+`--served-model-name` accordingly:
+
+```bash
+# MTP1
+--speculative-config '{"method":"mtp","num_speculative_tokens":1}'
+
+# MTP2
+--speculative-config '{"method":"mtp","num_speculative_tokens":2}'
+```
+
+Both MTP1 and MTP2 loaded the `HYV4MTPModel` on the final PP stage while
+retaining DeepEP HT, DeepGEMM HT, and FP8 E4M3 KV cache. MTP1 returned HTTP
+200 with exact assistant content `OK`; its log reported one drafted and one
+accepted token. MTP2 also returned exact `OK` for the short request and logged
+nonzero speculative work. During HumanEval, its 10-second acceptance windows
+were typically 89% to 97%.
+
+The 3,049-token MTP2 prefill request returned HTTP 200 and content
+`OK</think:opensource>OK`. This differs from the target-only exact `OK` response
+and is recorded as a deterministic generation-trajectory difference rather
+than hidden by the accuracy aggregate.
+
+HumanEval-32 used the same dataset, batch size, seed, temperature, and output
+limit as target-only, changing only the served model and work directory to the
+MTP2 values:
+
+```bash
+--model hy4-pp2-pcp4-mtp2
+--model-id Hy4-preview-Channel-FP8-w8a8-v2-deepgemm-pp2-pcp4-ep4-mtp2-fp8kv-no_think
+--work-dir /models/evalscope_hy4_pp2_pcp4_deepgemm_mtp2_humaneval32_20260911
+```
+
+| Mode | Predictions/reviews | Correct | Accuracy | Pass@1 | Wall time | Mean latency | Mean output |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Target-only | 32/32 | 32/32 | 100% | 100% | 266.43 s | 98.273 s | 135 tokens |
+| MTP2 | 32/32 | 32/32 | 100% | 100% | 115.65 s | 41.543 s | 135 tokens |
+
+The two runs produced byte-identical assistant text for 24 of 32 tasks. Eight
+tasks followed different valid generation trajectories, but there were no
+pass/fail flips and no API or runtime errors. The timing comparison is an
+observation from consecutive runs on the same host, not an isolated throughput
+benchmark. MTP3 remains fail-closed because the PCP contract validates only
+one or two speculative tokens.

--- a/docs/superpowers/plans/2026-09-11-hy4-pp2-pcp4.md
+++ b/docs/superpowers/plans/2026-09-11-hy4-pp2-pcp4.md
@@ -12,7 +12,8 @@
 
 ## Global Constraints
 
-- Only `HYV4ForCausalLM` with PP2, TP1, PCP4, DP1, DCP1, EP enabled, eager execution, and no speculative configuration is newly accepted.
+- Only `HYV4ForCausalLM` with PP2, TP1, PCP4, DP1, DCP1, EP enabled, eager
+  execution, and either target-only or built-in MTP1/MTP2 is newly accepted.
 - GLM-5.2, GQA, and other PP+PCP topologies remain fail-closed.
 - Existing PCP=1 and PP=1 behavior is unchanged.
 - Live validation uses DeepEP high-throughput, DeepGEMM, and FP8 E4M3 KV cache.
@@ -141,3 +142,34 @@ Pass@1. Treat infrastructure errors separately from incorrect generations.
 Target branch `feat/hy-v4-mtp-blockwise-v0251`. Include the launch command,
 test counts, runtime evidence, limitations, and HumanEval-32 result in the MR
 description.
+
+### Task 4: Validate built-in MTP with PP2 + PCP4
+
+**Files:**
+- Modify: `tests/runtime_patch/test_glm52_pcp_config.py`
+- Modify: `vllm_hcu/patch/platform/core_fix/patch_vllm_config.py`
+- Modify: `docs/hy4_channel_fp8_mtp_aiter_validation.md`
+
+**Interfaces:**
+- Consumes: existing replicated PCP MTP sampling and PP draft-token sync
+- Produces: fail-closed MTP1/MTP2 configuration support for exact Hy4 PP2+PCP4
+
+- [x] **Step 1: Add RED tests for MTP1, MTP2, and MTP3**
+
+Require MTP1/MTP2 acceptance and MTP3 rejection on the exact topology. The
+tests fail against the old blanket PP+PCP speculative rejection.
+
+- [x] **Step 2: Reuse the existing MTP method/depth validation**
+
+Remove only the blanket Hy4 PP+PCP rejection. Keep the existing built-in MTP
+method check and the one-or-two-token allowlist.
+
+- [x] **Step 3: Validate MTP1 and MTP2 live**
+
+Require both depths to start and report nonzero drafted/accepted tokens. Run
+short and long-prefill smoke requests with MTP2 and a short smoke with MTP1.
+
+- [x] **Step 4: Run HumanEval-32 with MTP2**
+
+Require 32 predictions, 32 reviews, no API/runtime errors, and Pass@1 no lower
+than the target-only result.

--- a/docs/superpowers/specs/2026-09-11-hy4-pp2-pcp4-design.md
+++ b/docs/superpowers/specs/2026-09-11-hy4-pp2-pcp4-design.md
@@ -10,7 +10,8 @@ with DeepEP high-throughput, DeepGEMM, and FP8 E4M3 KV cache.
 
 - Permit pipeline parallelism with PCP only for the exact Hy4 topology above.
 - Keep GLM-5.2, GQA, and every other PP+PCP topology fail-closed.
-- Keep PP+PCP speculative decoding disabled; MTP is a separate validation.
+- Permit built-in MTP with one or two speculative tokens on the exact Hy4
+  PP2+PCP4 topology; keep MTP3 and other speculative methods fail-closed.
 - Preserve the existing PCP=1, PP=1, and DeepEP communicator behavior.
 - Do not introduce a PP-boundary all-gather. Each PP stage keeps the same
   PCP-local virtual batch during model execution.
@@ -47,7 +48,7 @@ accepted only when all of these values match:
 - decode context parallel size: `1`
 - expert parallelism: enabled
 - eager execution: enabled
-- speculative configuration: absent
+- speculative configuration: absent, or built-in MTP with one or two tokens
 
 Hy4 shares indexer results across groups of layers. The default 39/39 split
 starts PP stage 1 on shared indexer layer 39, so the launch must set
@@ -60,11 +61,11 @@ P/D disaggregation, lightly-CP, and HCU multi-layer MTP.
 
 ## Validation
 
-CPU regression tests must prove that the exact Hy4 topology is accepted, that
-nearby Hy4 topologies and Hy4 PP+PCP+MTP are rejected, and that GLM/GQA PP+PCP
-remain rejected. A runner regression test must model a non-final PP rank with
-`hidden_states=None`, prove there is no PCP hidden-state gather, restore the
-global batch, and delegate to upstream sampling.
+CPU regression tests must prove that the exact Hy4 topology is accepted with
+target-only, MTP1, and MTP2, that nearby Hy4 topologies and MTP3 are rejected,
+and that GLM/GQA PP+PCP remain rejected. A runner regression test must model a
+non-final PP rank with `hidden_states=None`, prove there is no PCP hidden-state
+gather, restore the global batch, and delegate to upstream sampling.
 
 Live validation uses `/models/Hy4-preview-Channel-FP8-w8a8-v2` with:
 
@@ -79,8 +80,11 @@ export VLLM_PP_LAYER_PARTITION=41,37
 --moe-backend deep_gemm
 --kv-cache-dtype fp8_e4m3
 --enforce-eager
+# Optional validated MTP1/MTP2:
+--speculative-config '{"method":"mtp","num_speculative_tokens":2}'
 ```
 
 Acceptance requires all eight workers to initialize, logs to show two PP
 stages with four PCP/EP ranks per stage, a successful short request and long
-prefill request, and exact HumanEval-32 correctness counts.
+prefill request, and exact HumanEval-32 correctness counts. MTP validation must
+also show nonzero drafted and accepted token metrics.

--- a/tests/runtime_patch/test_glm52_pcp_config.py
+++ b/tests/runtime_patch/test_glm52_pcp_config.py
@@ -420,10 +420,13 @@ def test_hy4_pp_pcp_rejects_unvalidated_topologies(
         )
 
 
-def test_hy4_pp_pcp_rejects_speculative_decoding(make_pcp_config) -> None:
-    """MTP has no validated combined PP+PCP execution contract."""
+@pytest.mark.parametrize("num_speculative_tokens", [1, 2])
+def test_hy4_pp_pcp_allows_validated_mtp_depths(
+    make_pcp_config, num_speculative_tokens: int
+) -> None:
+    """The exact Hy4 PP+PCP topology supports existing replicated PCP MTP."""
 
-    with pytest.raises(ValueError, match="does not support speculative"):
+    assert (
         patch_vllm_config._validate_hcu_pcp_scope(
             make_pcp_config(
                 architecture="HYV4ForCausalLM",
@@ -431,6 +434,50 @@ def test_hy4_pp_pcp_rejects_speculative_decoding(make_pcp_config) -> None:
                 tp=1,
                 pcp=4,
                 speculative=True,
+                speculative_method="mtp",
+                num_speculative_tokens=num_speculative_tokens,
+            )
+        )
+        is True
+    )
+
+
+def test_hy4_pp_pcp_rejects_unvalidated_mtp3(make_pcp_config) -> None:
+    """MTP3 stays fail-closed because PCP validates only one or two drafts."""
+
+    with pytest.raises(ValueError, match="one or two speculative tokens"):
+        patch_vllm_config._validate_hcu_pcp_scope(
+            make_pcp_config(
+                architecture="HYV4ForCausalLM",
+                pp=2,
+                tp=1,
+                pcp=4,
+                speculative=True,
+                speculative_method="mtp",
+                num_speculative_tokens=3,
+            )
+        )
+
+
+@pytest.mark.parametrize("speculative", [False, True])
+def test_hy4_pp_pcp_rejects_pd_cross_product(
+    make_pcp_config, speculative: bool
+) -> None:
+    """Mooncake PCP producer support does not include PP2+PCP4."""
+
+    with pytest.raises(ValueError, match=r"PP\+PCP does not support P/D"):
+        patch_vllm_config._validate_hcu_pcp_scope(
+            make_pcp_config(
+                architecture="HYV4ForCausalLM",
+                pp=2,
+                tp=1,
+                pcp=4,
+                speculative=speculative,
+                speculative_method="mtp",
+                num_speculative_tokens=2,
+                kv_transfer=True,
+                kv_connector="MooncakeConnector",
+                kv_role="kv_producer",
             )
         )
 

--- a/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
+++ b/vllm_hcu/patch/platform/core_fix/patch_vllm_config.py
@@ -161,10 +161,6 @@ def _require_mrv2_pcp_contract(vllm_config: object) -> None:
         vllm_config, "speculative_config", "VllmConfig"
     )
     if speculative_config is not None:
-        if hy4_pp_pcp:
-            raise ValueError(
-                "Hy4 PP+PCP does not support speculative decoding or MTP."
-            )
         if not use_mla:
             raise ValueError(
                 "FlashAttention PCP does not support speculative decoding or MTP."
@@ -202,6 +198,10 @@ def _require_mrv2_pcp_contract(vllm_config: object) -> None:
             kv_transfer_config, "kv_connector", "KVTransferConfig"
         )
         if connector is not None:
+            if hy4_pp_pcp:
+                raise ValueError(
+                    "Hy4 PP+PCP does not support P/D disaggregation."
+                )
             # Replica-dedup send path exists only on MooncakeConnector.
             if connector != "MooncakeConnector":
                 raise ValueError(


### PR DESCRIPTION
## Summary

- enable built-in MTP speculative decoding for the validated Hy4 `PP2 + PCP4 + stage-local EP4` topology
- allow `num_speculative_tokens=1` and `2`; keep `3+` fail-closed through the existing MLA validation
- keep P/D disaggregation fail-closed for exact Hy4 PP+PCP, for both target-only and MTP paths
- document the launch command and target-only/MTP validation results

## Service command (MTP2)

```bash
export PLUGIN_ROOT=/models/.worktrees/vllm-plugin-das-hy4-mtp-v0251
export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export VLLM_USE_V2_MODEL_RUNNER=1
export VLLM_KV_CACHE_LAYOUT=NHD
export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=300
export VLLM_ENGINE_ITERATION_TIMEOUT_S=300
export VLLM_PP_LAYER_PARTITION=41,37
export PYTHONPATH="${PLUGIN_ROOT}"
unset VLLM_USE_DEEP_GEMM
unset VLLM_PLUGINS

vllm serve /models/Hy4-preview-Channel-FP8-w8a8-v2 \
  --served-model-name hy4-pp2-pcp4-mtp2 \
  --tensor-parallel-size 1 \
  --pipeline-parallel-size 2 \
  --prefill-context-parallel-size 4 \
  --enable-expert-parallel \
  --all2all-backend deepep_high_throughput \
  --moe-backend deep_gemm \
  --kv-cache-dtype fp8_e4m3 \
  --enforce-eager \
  --gpu-memory-utilization 0.95 \
  --max-model-len 4096 \
  --max-num-seqs 16 \
  --max-num-batched-tokens 4096 \
  --default-chat-template-kwargs '{"reasoning_effort":"no_think"}' \
  --reasoning-parser hy_v4 \
  --enable-auto-tool-choice \
  --tool-call-parser hy_v4 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":2}' \
  --port 8000
```

Use `num_speculative_tokens: 1` for MTP1. Omit `--speculative-config` for target-only.

## Validation

- MTP2 service started on all 8 cards with `HYV4MTPModel`, PP0/PP1 × PCP0-3, DeepEP high-throughput, DeepGEMM and FP8 E4M3 KV cache
- short request: HTTP 200, exact `OK`
- 3049-token prefill: HTTP 200; output trajectory differed from target-only (`OK</think:opensource>OK` vs exact `OK`), so this is recorded rather than treated as byte-for-byte equivalence
- MTP1 separately started and returned HTTP 200, exact `OK`
- HumanEval-32 with MTP2: 32 predictions / 32 reviews, Accuracy 1.0, Pass@1 1.0, zero API/runtime errors
- target-only reference: Accuracy 1.0, Pass@1 1.0; MTP2 had no pass/fail flips and 24/32 byte-identical outputs
- observed same-host sequential timing: MTP2 wall 115.65 s vs target-only 266.43 s; informational only, not an isolated benchmark
- focused tests on the clean backport branch: `119 passed, 14 warnings`
- full contract suite on the identical change: `1352 passed, 71 deselected, 15 warnings`
- full inventory suite: `86 passed, 1 warning`
- patch coverage, production boundary, compileall and `git diff --check`: passed

## Review

Code review found no remaining Critical, Important, or Minor issues after adding explicit PP+PCP+P/D cross-product coverage. Existing PP1 PCP Mooncake producer behavior remains reachable.
