### PR TITLE
test: align v0.28.1 runtime contracts

### DIFF
--- a/tests/patch/test_lightop_api_boundary.py
+++ b/tests/patch/test_lightop_api_boundary.py
@@ -37,6 +37,19 @@ ALLOWED_TOP_LEVEL = {
     (CLAMP_OWNER, "fuse_silu_mul_clamp_quant"),
     (CLAMP_OWNER, "fuse_silu_mul_clamp_quant_ep"),
 }
+AUDITED_NON_PUBLIC_IMPORTS = {
+    (
+        "vllm_hcu/model_executor/layers/quantization/"
+        "lightop_marlin_moe_compat.py",
+        "lightop",
+        "envs",
+    ),
+    (
+        "vllm_hcu/v1/attention/ops/lightop_kpool_topk_transform.py",
+        "lightop.fuse_topk_transform",
+        "fast_kpool_topk_transform_fused",
+    ),
+}
 
 
 def _attribute_parts(node: ast.Attribute) -> tuple[ast.expr, list[str]]:
@@ -62,9 +75,25 @@ class _LightOpVisitor(ast.NodeVisitor):
         self.category_aliases: dict[str, str] = {}
         self.used: set[tuple[str, str]] = set()
         self.allowed_calls: list[tuple[str, str, int]] = []
+        self.audited_non_public_imports: set[tuple[str, str, str]] = set()
         self.violations: list[str] = []
         self._violation_keys: set[tuple[int, str]] = set()
         self._functions: list[str] = []
+
+    def _is_audited_non_public_import(
+        self,
+        module: str,
+        symbol: str,
+    ) -> bool:
+        key = (
+            self.relative_path,
+            module,
+            symbol,
+        )
+        if key not in AUDITED_NON_PUBLIC_IMPORTS:
+            return False
+        self.audited_non_public_imports.add(key)
+        return True
 
     def _violate(self, node: ast.AST, detail: str) -> None:
         line = getattr(node, "lineno", 1)
@@ -148,7 +177,10 @@ class _LightOpVisitor(ast.NodeVisitor):
             for alias in node.names:
                 if alias.name in PUBLIC_CATEGORIES:
                     self.category_aliases[alias.asname or alias.name] = alias.name
-                else:
+                elif not self._is_audited_non_public_import(
+                    module,
+                    alias.name,
+                ):
                     self._violate(
                         node,
                         f"moved top-level LightOp import {alias.name!r}",
@@ -158,7 +190,15 @@ class _LightOpVisitor(ast.NodeVisitor):
             if suffix in {"op", "gemmopt"}:
                 self._violate(node, f"obsolete LightOp namespace {module!r}")
             elif suffix not in PUBLIC_CATEGORIES:
-                self._violate(node, f"non-public LightOp module {module!r}")
+                for alias in node.names:
+                    if not self._is_audited_non_public_import(
+                        module,
+                        alias.name,
+                    ):
+                        self._violate(
+                            node,
+                            f"non-public LightOp module {module!r}",
+                        )
             else:
                 for alias in node.names:
                     if alias.name == "*":
@@ -459,9 +499,16 @@ def _activation_resolver_is_exact(tree: ast.Module) -> bool:
     )
 
 
-def _scan(root: Path) -> tuple[list[str], set[tuple[str, str]]]:
+def _scan(
+    root: Path,
+) -> tuple[
+    list[str],
+    set[tuple[str, str]],
+    set[tuple[str, str, str]],
+]:
     violations: list[str] = []
     used: set[tuple[str, str]] = set()
+    audited_non_public_imports: set[tuple[str, str, str]] = set()
     allowed_calls: list[tuple[str, str, int]] = []
     owner_tree: ast.Module | None = None
     repository = root.parent
@@ -473,6 +520,9 @@ def _scan(root: Path) -> tuple[list[str], set[tuple[str, str]]]:
         visitor.visit(tree)
         violations.extend(visitor.violations)
         used.update(visitor.used)
+        audited_non_public_imports.update(
+            visitor.audited_non_public_imports
+        )
         allowed_calls.extend(visitor.allowed_calls)
         if relative_path == CLAMP_OWNER:
             owner_tree = tree
@@ -496,7 +546,7 @@ def _scan(root: Path) -> tuple[list[str], set[tuple[str, str]]]:
             "categorized lookup"
         )
 
-    return sorted(violations), used
+    return sorted(violations), used, audited_non_public_imports
 
 
 def scan_lightop_imports(root: Path) -> list[str]:
@@ -540,8 +590,64 @@ def installed_public_exports(
 
 
 def test_production_uses_public_lightop_categories_only() -> None:
-    violations = scan_lightop_imports(REPOSITORY / "vllm_hcu")
+    violations, _, audited_non_public_imports = _scan(
+        REPOSITORY / "vllm_hcu"
+    )
     assert violations == []
+    assert audited_non_public_imports == AUDITED_NON_PUBLIC_IMPORTS
+
+
+def test_scanner_limits_non_public_imports_to_audited_owner_and_symbol(
+    tmp_path: Path,
+) -> None:
+    root = _write_mutation_owner(tmp_path)
+    audited = {
+        path: (module, symbol)
+        for path, module, symbol in AUDITED_NON_PUBLIC_IMPORTS
+    }
+    for relative_path, (module, symbol) in audited.items():
+        owner = tmp_path / relative_path
+        owner.parent.mkdir(parents=True, exist_ok=True)
+        owner.write_text(f"from {module} import {symbol}\n", encoding="utf-8")
+
+    assert scan_lightop_imports(root) == []
+
+    mutation = root / "non_public_mutation.py"
+    mutation.write_text(
+        "from lightop import envs\n"
+        "from lightop.fuse_topk_transform import "
+        "fast_kpool_topk_transform_fused\n",
+        encoding="utf-8",
+    )
+
+    violations = scan_lightop_imports(root)
+
+    assert any(
+        "moved top-level LightOp import 'envs'" in item
+        for item in violations
+    )
+    assert any(
+        "non-public LightOp module 'lightop.fuse_topk_transform'" in item
+        for item in violations
+    )
+
+    for relative_path, (module, _symbol) in audited.items():
+        owner = tmp_path / relative_path
+        owner.write_text(
+            f"from {module} import wrong_symbol\n",
+            encoding="utf-8",
+        )
+
+    violations = scan_lightop_imports(root)
+
+    assert any(
+        "moved top-level LightOp import 'wrong_symbol'" in item
+        for item in violations
+    )
+    assert any(
+        "non-public LightOp module 'lightop.fuse_topk_transform'" in item
+        for item in violations
+    )
 
 
 def _write_mutation_owner(

--- a/tests/runtime_patch/test_deep_gemm_utils.py
+++ b/tests/runtime_patch/test_deep_gemm_utils.py
@@ -34,6 +34,21 @@ def _install_categorized_lightop(
     monkeypatch.setitem(sys.modules, "lightop.gemm_ops", gemm_ops)
 
 
+def _install_deepgemm_i8(
+    monkeypatch,
+    *,
+    contiguous_kernel=None,
+    masked_kernel=None,
+) -> None:
+    deepgemm = ModuleType("deepgemm")
+    deepgemm.__path__ = []
+    if contiguous_kernel is not None:
+        deepgemm.m_grouped_i8_gemm_nt_contiguous = contiguous_kernel
+    if masked_kernel is not None:
+        deepgemm.m_grouped_i8_gemm_nt_masked = masked_kernel
+    monkeypatch.setitem(sys.modules, "deepgemm", deepgemm)
+
+
 def _load_permute_function():
     source_path = (
         Path(__file__).parents[2]
@@ -200,8 +215,11 @@ def test_w8a8_apply_skips_alignment_scope_only_on_rocm(monkeypatch):
             torch.ones((tensor.shape[0], 1)),
         ),
         gemm_name="m_grouped_w8a8_gemm_nt_contig_asm",
-        gemm_kernel=lambda *_args: None,
+        gemm_kernel=lambda *_args: pytest.fail(
+            "LightOp INT8 GEMM routing regressed"
+        ),
     )
+    _install_deepgemm_i8(monkeypatch, contiguous_kernel=lambda *_args: None)
 
     hcu = _load_deep_gemm_apply()
     hcu["current_platform"] = SimpleNamespace(is_rocm=lambda: True)
@@ -229,26 +247,34 @@ def test_w8a8_apply_skips_alignment_scope_only_on_rocm(monkeypatch):
     assert events == [("scope", 256), "enter", "exit"]
 
 
-def test_w8a8_apply_uses_categorized_lightop_contiguous_api(
+def test_w8a8_apply_pairs_deepgemm_contiguous_gemm_with_lightop_activation(
     monkeypatch,
 ):
-    calls: list[tuple[object, ...]] = []
+    events: list[str] = []
+
+    def quantize(tensor, **kwargs):
+        events.append("activation")
+        return kwargs["output"], torch.ones((tensor.shape[0], 1))
+
+    def gemm(*_args):
+        events.append("gemm")
+
     _install_categorized_lightop(
         monkeypatch,
         activation_name="fuse_silu_mul_quant",
-        activation_kernel=lambda tensor, **kwargs: (
-            kwargs["output"],
-            torch.ones((tensor.shape[0], 1)),
-        ),
+        activation_kernel=quantize,
         gemm_name="m_grouped_w8a8_gemm_nt_contig_asm",
-        gemm_kernel=lambda *args: calls.append(args),
+        gemm_kernel=lambda *_args: pytest.fail(
+            "LightOp INT8 contiguous GEMM routing regressed"
+        ),
     )
+    _install_deepgemm_i8(monkeypatch, contiguous_kernel=gemm)
     hcu = _load_deep_gemm_apply()
     hcu["current_platform"] = SimpleNamespace(is_rocm=lambda: True)
 
     _run_w8a8_apply(hcu, packed_weights=True)
 
-    assert len(calls) == 2
+    assert events == ["gemm", "activation", "gemm"]
 
 
 def _load_batched_deep_gemm_apply():
@@ -291,20 +317,28 @@ def _load_batched_deep_gemm_apply():
     return namespace
 
 
-def test_w8a8_batched_apply_uses_categorized_lightop_masked_api(
+def test_w8a8_batched_apply_pairs_deepgemm_masked_gemm_with_lightop_activation(
     monkeypatch,
 ):
-    calls: list[tuple[object, ...]] = []
+    events: list[str] = []
+
+    def quantize(tensor, _counts):
+        events.append("activation")
+        return tensor, torch.ones((*tensor.shape[:-1], 1))
+
+    def gemm(*_args):
+        events.append("gemm")
+
     _install_categorized_lightop(
         monkeypatch,
         activation_name="fuse_silu_mul_quant_ep",
-        activation_kernel=lambda tensor, _counts: (
-            tensor,
-            torch.ones((*tensor.shape[:-1], 1)),
-        ),
+        activation_kernel=quantize,
         gemm_name="m_grouped_w8a8_gemm_nt_masked",
-        gemm_kernel=lambda *args: calls.append(args),
+        gemm_kernel=lambda *_args: pytest.fail(
+            "LightOp INT8 masked GEMM routing regressed"
+        ),
     )
+    _install_deepgemm_i8(monkeypatch, masked_kernel=gemm)
     hcu = _load_batched_deep_gemm_apply()
     hcu["current_platform"] = SimpleNamespace(is_rocm=lambda: True)
     experts = SimpleNamespace(
@@ -339,7 +373,7 @@ def test_w8a8_batched_apply_uses_categorized_lightop_masked_api(
         apply_router_weight_on_input=False,
     )
 
-    assert len(calls) == 2
+    assert events == ["gemm", "activation", "gemm"]
 
 
 def _make_w4a8_expert_layer() -> torch.nn.Module:

--- a/tests/runtime_patch/test_qwen4_exp_mtp_metadata.py
+++ b/tests/runtime_patch/test_qwen4_exp_mtp_metadata.py
@@ -182,6 +182,9 @@ def test_scheduler_leaves_qwen35_groups_and_block_size_to_upstream():
         ):
             del self, draft_token_ids, scheduler_output
 
+        def _update_after_schedule(self, scheduler_output):
+            del self, scheduler_output
+
         def __init__(
             self,
             vllm_config,


### PR DESCRIPTION
## Summary

- Align the LightOp boundary audit with two already-merged non-public imports using exact owner/module/symbol exceptions, while requiring the exception inventory to match production and rejecting use elsewhere.
- Update CPU-only DeepGEMM tests to fake the current DeepGEMM INT8 entry points, assert the DeepGEMM → LightOp activation → DeepGEMM sequence, and fail if routing regresses to the former LightOp GEMM APIs.
- Bring the local Scheduler test double in line with the pinned vLLM 0.28.1 `_update_after_schedule` interface.
- Change tests only; no `vllm_hcu/` runtime or development functionality is modified.

## Validation

- Baseline affected set: `5 failed, 24 passed`.
- Updated affected set: `30 passed`.
- Full portable contract against frozen vLLM SHA `58ad1f3b8973b23943107b51230d594050b42ec3`: `1569 passed, 145 deselected`.
- Inventory suite: `81 passed`.
- Patch coverage audit: clean (`110` adapters, no missing or untested modules).
- Production boundary audit: clean (`275` Python files).
- `compileall`, `git diff --check`, test-only diff check, and credential scan: clean.

## Scope

The two LightOp imports are grandfathered only at their current exact locations. This MR does not claim that those APIs are public or change their runtime behavior.
