### PR TITLE
fix: align Mamba cache with official checkpoints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if "MAX_JOBS" not in os.environ:
 # 基础路径
 # =========================================================
 ROOT = Path(__file__).parent.resolve()
-BASE_VERSION = "0.28.1rc1.dev490"
+BASE_VERSION = "0.28.1rc1.dev491"
 
 ADD_GIT_VERSION = os.environ.get("ADD_GIT_VERSION", "1") == "1"
 

--- a/tests/patch/test_compatibility_gate.py
+++ b/tests/patch/test_compatibility_gate.py
@@ -53,7 +53,7 @@ def test_frozen_opendas_vllm_wheel_is_accepted(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    value = "0.28.1rc1.dev490+g7d5e12c72.das.7d5e12c.dtk2604"
+    value = "0.28.1rc1.dev491+g462fdb097.das.462fdb0.dtk2604"
     _install_version(monkeypatch, tmp_path, value)
 
     result = compatibility.ensure_vllm_compatible()
@@ -72,9 +72,9 @@ def test_frozen_opendas_vllm_wheel_is_accepted(
         "0.25.1+das.local",
         "0.28.0",
         "0.28.9",
-        "0.28.1rc1.dev490+g58ad1f3b",
-        "0.28.1rc1.dev490+g7d5e12c72.das.other.dtk2604",
-        "1!0.28.1rc1.dev490+g7d5e12c72.das.7d5e12c.dtk2604",
+        "0.28.1rc1.dev491+g58ad1f3b",
+        "0.28.1rc1.dev491+g462fdb097.das.other.dtk2604",
+        "1!0.28.1rc1.dev491+g462fdb097.das.462fdb0.dtk2604",
         "not a version",
     ),
 )
@@ -90,12 +90,12 @@ def test_unsupported_or_invalid_vllm_metadata_has_actionable_error(
 
     message = str(raised.value)
     assert (
-        "expected=0.28.1rc1.dev490+g7d5e12c72.das.7d5e12c.dtk2604"
+        "expected=0.28.1rc1.dev491+g462fdb097.das.462fdb0.dtk2604"
         in message
     )
     assert f"actual={value!r}" in message
     assert "upstream_sha=58ad1f3b8973b23943107b51230d594050b42ec3" in message
-    assert "opendas_sha=7d5e12c72491b4067ed03db1a789060efd84e1ee" in message
+    assert "opendas_sha=462fdb097c66b487ef4826e8009431c10fe88fb8" in message
     assert "vllm_hcu=" in message
     assert "vllm_location=" in message
     assert "vllm_hcu_location=" in message
@@ -122,11 +122,11 @@ def test_runtime_hcu_version_prefers_metadata_with_source_fallback(
     monkeypatch.setattr(
         hcu_version.importlib_metadata,
         "version",
-        lambda name: "0.28.1rc1.dev490+das.abcdef0.dtk2604",
+        lambda name: "0.28.1rc1.dev491+das.abcdef0.dtk2604",
     )
     assert (
         hcu_version.get_hcu_version()
-        == "0.28.1rc1.dev490+das.abcdef0.dtk2604"
+        == "0.28.1rc1.dev491+das.abcdef0.dtk2604"
     )
 
     def missing(name: str):

--- a/tests/patch/test_setup_packaging.py
+++ b/tests/patch/test_setup_packaging.py
@@ -99,7 +99,7 @@ def test_setup_version_query_keeps_provenance_without_rewriting_source(
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert f"0.28.1rc1.dev490+das.{sha}.dtk2604" in result.stdout
+    assert f"0.28.1rc1.dev491+das.{sha}.dtk2604" in result.stdout
     assert hashlib.sha256(version_file.read_bytes()).hexdigest() == before
 
 

--- a/tests/runtime_patch/test_mtp_kv_cache_coordinator.py
+++ b/tests/runtime_patch/test_mtp_kv_cache_coordinator.py
@@ -12,14 +12,6 @@ from vllm_hcu.patch.worker.framework_opt import patch_mamba_hybrid_model_state
 
 
 def _coordinator_module() -> ModuleType:
-    class MambaManager:
-        def cache_blocks(self, request, num_tokens, retention_interval=None):
-            self.original_cache_call = (
-                request,
-                num_tokens,
-                retention_interval,
-            )
-
     class KVCacheCoordinator:
         def __init__(
             self,
@@ -60,7 +52,6 @@ def _coordinator_module() -> ModuleType:
 
     module = ModuleType(patch_kv_cache_coordinator.TARGET_MODULE)
     module.KVCacheCoordinator = KVCacheCoordinator
-    module.MambaManager = MambaManager
     return module
 
 
@@ -108,43 +99,6 @@ def test_mtp_indexer_group_skips_only_unmarked_all_group_eagle_fallback():
         (["model.layers.0.self_attn.indexer", "model.layers.61.nextn"], True)
     )
     assert _construct(module, explicit).eagle_group_ids == {0}
-
-
-def test_mamba_sparse_cache_retains_materialized_eagle_replay_boundary():
-    module = _coordinator_module()
-    assert patch_kv_cache_coordinator.apply_to_module(module) is True
-
-    null_block = SimpleNamespace(is_null=True, block_hash=None)
-    replay_block = SimpleNamespace(
-        is_null=False,
-        block_hash=None,
-        block_hash_num_tokens=None,
-    )
-
-    class BlockPool:
-        def cache_full_blocks(self, **kwargs):
-            assert kwargs["num_cached_blocks"] == 6
-            assert kwargs["num_full_blocks"] == 7
-            assert kwargs["block_size"] == 576
-            kwargs["blocks"][6].block_hash = "group-0-replay"
-            kwargs["blocks"][6].block_hash_num_tokens = 4032
-
-    manager = module.MambaManager()
-    manager.drop_eagle_checkpoint_block = True
-    manager.mamba_cache_mode = "align"
-    manager.cache_hit_alignment_tokens = 576
-    manager.block_size = 576
-    manager.kv_cache_group_id = 0
-    manager.block_pool = BlockPool()
-    manager.cached_blocks_this_step = set()
-    manager.req_to_blocks = {"request": [null_block] * 6 + [replay_block]}
-    request = SimpleNamespace(request_id="request", num_prompt_tokens=5050)
-
-    manager.cache_blocks(request, 4032, retention_interval=0)
-
-    assert manager.original_cache_call == (request, 4032, 0)
-    assert replay_block.block_hash_num_tokens == 4032
-    assert manager.cached_blocks_this_step == {"group-0-replay"}
 
 
 def test_mamba_resume_seed_uses_hybrid_manager_block_size():

--- a/vllm_hcu/patch/platform/framework_opt/patch_kv_cache_coordinator.py
+++ b/vllm_hcu/patch/platform/framework_opt/patch_kv_cache_coordinator.py
@@ -20,11 +20,9 @@ TARGET_MODULE = "vllm.v1.core.kv_cache_coordinator"
 PATCH_ID = "platform.framework_opt.mtp_indexer_kv_cache_coordinator"
 TARGETS = (
     f"{TARGET_MODULE}.KVCacheCoordinator.__init__",
-    f"{TARGET_MODULE}.MambaManager.cache_blocks",
 )
 _MARKER = "_vllm_hcu_mtp_indexer_coordinator_applied"
 _WRAPPER = "_vllm_hcu_mtp_indexer_coordinator_wrapper"
-_MAMBA_WRAPPER = "_vllm_hcu_mamba_eagle_replay_wrapper"
 
 _PARAMETERS = (
     "self",
@@ -67,14 +65,10 @@ def apply_to_module(module: ModuleType) -> bool:
     coordinator_cls = require_class(
         coordinator, "KVCacheCoordinator", f"{TARGET_MODULE}.KVCacheCoordinator"
     )
-    mamba_cls = require_class(coordinator, "MambaManager", TARGETS[1])
     if already_applied(
         coordinator,
         _MARKER,
-        (
-            (coordinator_cls, "__init__", _WRAPPER),
-            (mamba_cls, "cache_blocks", _MAMBA_WRAPPER),
-        ),
+        ((coordinator_cls, "__init__", _WRAPPER),),
     ):
         return False
 
@@ -93,10 +87,6 @@ def apply_to_module(module: ModuleType) -> bool:
             f"required HCU patch target {TARGETS[0]} has incompatible "
             f"signature {signature}"
         )
-
-    original_mamba_cache_blocks = require_callable(
-        mamba_cls, "cache_blocks", TARGETS[1]
-    )
 
     @functools.wraps(original)
     def hcu_init(
@@ -138,64 +128,8 @@ def apply_to_module(module: ModuleType) -> bool:
         )
 
     setattr(hcu_init, _WRAPPER, True)
-    @functools.wraps(original_mamba_cache_blocks)
-    def cache_mamba_eagle_replay_boundary(
-        self, request, num_tokens, retention_interval=None
-    ):
-        result = original_mamba_cache_blocks(
-            self,
-            request,
-            num_tokens,
-            retention_interval=retention_interval,
-        )
-        if (
-            not self.drop_eagle_checkpoint_block
-            or retention_interval is None
-            or self.mamba_cache_mode != "align"
-        ):
-            return result
-
-        alignment = self.cache_hit_alignment_tokens
-        if not isinstance(alignment, int) or alignment <= 0:
-            return result
-        replay_boundary = (
-            (request.num_prompt_tokens - 1) // alignment * alignment
-        ) - alignment
-        if replay_boundary <= 0 or num_tokens < replay_boundary:
-            return result
-
-        block_idx = replay_boundary // self.block_size - 1
-        blocks = self.req_to_blocks.get(request.request_id, ())
-        if block_idx < 0 or block_idx >= len(blocks):
-            return result
-        block = blocks[block_idx]
-        if block.is_null or block.block_hash is not None:
-            return result
-
-        # The scheduler has materialized this exact recurrent state, but
-        # upstream retention=0 masks the pre-Eagle replay boundary. Register
-        # only that existing state; do not make Mamba caching dense.
-        self.block_pool.cache_full_blocks(
-            request=request,
-            blocks=blocks,
-            num_cached_blocks=block_idx,
-            num_full_blocks=block_idx + 1,
-            block_size=self.block_size,
-            kv_cache_group_id=self.kv_cache_group_id,
-        )
-        if block.block_hash is not None:
-            self.cached_blocks_this_step.add(block.block_hash)
-        return result
-
-    setattr(cache_mamba_eagle_replay_boundary, _MAMBA_WRAPPER, True)
     setattr(coordinator_cls, "_vllm_hcu_original_init", original)
-    setattr(
-        mamba_cls,
-        "_vllm_hcu_original_cache_blocks",
-        original_mamba_cache_blocks,
-    )
     setattr(coordinator_cls, "__init__", hcu_init)
-    setattr(mamba_cls, "cache_blocks", cache_mamba_eagle_replay_boundary)
     setattr(coordinator, _MARKER, True)
     return True
 

--- a/vllm_hcu/version.py
+++ b/vllm_hcu/version.py
@@ -12,13 +12,13 @@ import importlib.metadata as importlib_metadata
 # This source constant defines the vLLM release series audited by this branch.
 # ``setup.py`` computes build provenance for wheel metadata without rewriting
 # this tracked file.
-__version__ = "0.28.1rc1.dev490"
+__version__ = "0.28.1rc1.dev491"
 __version_tuple__ = (0, 28, 1)
 __vllm_target_version__ = (
-    "0.28.1rc1.dev490+g7d5e12c72.das.7d5e12c.dtk2604"
+    "0.28.1rc1.dev491+g462fdb097.das.462fdb0.dtk2604"
 )
 __vllm_upstream_sha__ = "58ad1f3b8973b23943107b51230d594050b42ec3"
-__vllm_opendas_sha__ = "7d5e12c72491b4067ed03db1a789060efd84e1ee"
+__vllm_opendas_sha__ = "462fdb097c66b487ef4826e8009431c10fe88fb8"
 
 
 def get_hcu_version() -> str:


### PR DESCRIPTION
## Summary

- Base this change directly on the latest `v0.28.1-dev`.
- Remove the plugin-owned `MambaManager.cache_blocks` replay-boundary wrapper now that OpenDAS vLLM MR !58 backports the official vLLM #53945 `replay_boundary` checkpoint policy.
- Keep only the HCU-specific MTP/indexer KV-group classification at the coordinator extension boundary.
- Update plugin build provenance to the validated OpenDAS wheel `0.28.1rc1.dev491+g462fdb097.das.462fdb0.dtk2604`.
- Preserve the vendor-build compatibility behavior merged by #101.

Core dependency: https://developer.sourcefind.cn/codes/OpenDAS/vllm/-/merge_requests/58

## Validation

- `pytest -q tests/patch/test_compatibility_gate.py tests/patch/test_setup_packaging.py tests/runtime_patch/test_mtp_kv_cache_coordinator.py`: 20 passed.
- The same runtime delta was validated with `/models/Qwen3.5-35B-A3B`, TP4, FLASH_ATTN, AITER MoE selection, MTP3, prefix caching, fine-grained Mamba PC, and default FULL_AND_PIECEWISE graph.
- HumanEval smoke: 8/8.
- MTP acceptance: 705/762 (92.52%).
- Three-suffix prefix-cache hits: 0, 25,920, and 26,496 tokens out of 26,614-token prompts.
- No server traceback or runtime error was observed.

## Serve command

```bash
env -u VLLM_PLUGINS \
  -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
  -u http_proxy -u https_proxy -u all_proxy \
  NO_PROXY=127.0.0.1,localhost \
  no_proxy=127.0.0.1,localhost \
  HIP_VISIBLE_DEVICES=4,5,6,7 \
  vllm serve /models/Qwen3.5-35B-A3B \
    --served-model-name hygon/Qwen3.5-35B-A3B \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --attention-backend FLASH_ATTN \
    --moe-backend aiter \
    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
    --enable-prefix-caching \
    --mamba-cache-mode align \
    --prefix-match-unit 64 \
    --enable-mamba-fine-grained-prefix-cache \
    --max-model-len 32768 \
    --max-num-batched-tokens 16384 \
    --max-num-seqs 8
```

## Merge order

Merge and publish the core wheel from MR !58 before merging or deploying this plugin change.
