### PR TITLE
fix: relax v0.28.1 runtime compatibility gate

### DIFF
--- a/tests/patch/test_compatibility_gate.py
+++ b/tests/patch/test_compatibility_gate.py
@@ -67,13 +67,38 @@ def test_frozen_opendas_vllm_wheel_is_accepted(
 @pytest.mark.parametrize(
     "value",
     (
+        "0.28.1",
+        "0.28.1+das.vendor.dtk2604",
+        "0.28.1rc1.dev491+g58ad1f3b",
+        "0.28.1rc1.dev999+gdeadbee.das.vendor.dtk2604",
+        "0.28.1rc2",
+        "0.28.1.post1",
+    ),
+)
+def test_v0281_release_line_accepts_rolling_vendor_builds(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    value: str,
+) -> None:
+    _install_version(monkeypatch, tmp_path, value)
+
+    result = compatibility.ensure_vllm_compatible()
+
+    assert result.compatible
+    assert result.actual_version == value
+    assert result.reason == (
+        "installed vLLM build matches supported release line 0.28.1"
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
         "0.20.2",
         "0.22.0",
         "0.25.1+das.local",
         "0.28.0",
         "0.28.9",
-        "0.28.1rc1.dev491+g58ad1f3b",
-        "0.28.1rc1.dev491+g462fdb097.das.other.dtk2604",
         "1!0.28.1rc1.dev491+g462fdb097.das.462fdb0.dtk2604",
         "not a version",
     ),

--- a/vllm_hcu/compatibility.py
+++ b/vllm_hcu/compatibility.py
@@ -2,9 +2,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
 """Dependency-light vLLM distribution compatibility checks.
 
-The runtime integration is audited against the vLLM release series encoded by
-``vllm_hcu.version.__version_tuple__``.  Check the installed distribution
-metadata before any process-local patch registration so a mismatched wheel
+The runtime integration is audited against the vLLM release line encoded by
+``vllm_hcu.version.__vllm_target_version__``. Check the installed distribution
+metadata before any process-local patch registration so a mismatched release
 cannot leave a partially armed registry behind.
 """
 
@@ -120,21 +120,20 @@ def inspect_vllm_compatibility() -> VllmCompatibility:
             reason=f"invalid vLLM distribution version: {exc}",
         )
 
-    # Accept the frozen development artifact and vendor builds of the final
-    # release it became.  Local build metadata (DTK, Torch, timestamp, SHA)
-    # does not change the public vLLM release, but other prerelease or release
-    # versions must still fail closed.
-    compatible = parsed == expected or (
-        parsed.epoch == expected.epoch
-        and parsed.release == expected.release
-        and parsed.pre is None
-        and parsed.post is None
-        and parsed.dev is None
+    # A rolling vendor branch is compatible at the major.minor.patch release
+    # line. Pre/dev/post and local build metadata retain provenance without
+    # pinning the plugin to one OpenDAS wheel build.
+    release_line = ".".join(str(component) for component in expected.release)
+    compatible = (
+        parsed.epoch == expected.epoch and parsed.release == expected.release
     )
     if compatible:
-        reason = "installed vLLM build matches the frozen OpenDAS artifact"
+        reason = f"installed vLLM build matches supported release line {release_line}"
     else:
-        reason = "installed vLLM build does not match the frozen OpenDAS artifact"
+        reason = (
+            "installed vLLM build does not match supported release line "
+            f"{release_line}"
+        )
     return VllmCompatibility(
         expected_version=__vllm_target_version__,
         upstream_sha=__vllm_upstream_sha__,


### PR DESCRIPTION
## Summary

- match installed vLLM by PEP 440 epoch and `major.minor.patch` release tuple
- accept rolling `0.28.1` rc/dev/post/local vendor builds without pinning one OpenDAS SHA
- retain the recommended wheel version and source SHAs in compatibility diagnostics
- keep `0.28.0`, `0.28.9`, `0.29.0`, nonzero epochs, and invalid metadata rejected

## Verification

- `pytest -q tests/patch/test_compatibility_gate.py tests/patch/test_setup_packaging.py`: 22 passed
- installed vLLM: `0.28.1rc1.dev491+g462fdb097.das.462fdb0.dtk2604`
- installed plugin: `0.28.1rc1.dev491+das.ae2173a.dtk2604`
- simulated rolling build `0.28.1rc9.dev999+gdeadbee.das.vendor.dtk9999`: accepted as release line `0.28.1`

## Prefix-cache validation

Both models used FLASH_ATTN, AITER MoE, MTP3, prefix caching, `mamba_cache_mode=align`, `prefix_match_unit=64`, official fine-grained Mamba checkpoints, and default FULL_AND_PIECEWISE graphs.

- `/models/Qwen3.5-35B-A3B`, TP4: cold `0/23989`; reuse B `23040/23989` (96.04%); reuse C `23872/23989` (99.51%); 0 request errors
- `/models/Qwen3.5-35B-A3B-W8A8`, TP1: cold `0/23989`; reuse B `22848/23989` (95.24%); reuse C `23872/23989` (99.51%); 0 request errors
- BF16 manager block: 576; W8A8 manager block: 1088; FLASH_ATTN kernel block: 64
- all server processes stopped and all eight HCU devices returned to 0% memory use
