### PR TITLE
fix(hcu): restore hybrid KV cache block alignment

### DIFF
--- a/vllm_hcu/platforms/hcu.py
+++ b/vllm_hcu/platforms/hcu.py
@@ -660,9 +660,11 @@ class HCUPlatform(Platform):
 
     @classmethod
     def update_block_size_for_backend(cls, vllm_config: "VllmConfig") -> None:
-        # TODO: ROCm still sets block_size in check_and_update_config.
-        # Move that logic here so block_size is chosen by the backend.
-        pass
+        # Preserve the backend-specific block size selected in
+        # check_and_update_config, then let vLLM align hybrid attention/Mamba
+        # cache pages. Skipping the shared alignment grossly overestimates the
+        # Mamba cache for long-context hybrid models.
+        super().update_block_size_for_backend(vllm_config)
 
 
     @classmethod


### PR DESCRIPTION
## Summary

- delegate backend block-size post-processing to vLLM's shared platform implementation
- restore Attention/Mamba cache-page alignment for hybrid models while preserving the HCU-selected block size

## Problem

`HCUPlatform.update_block_size_for_backend()` was a no-op, which skipped vLLM's hybrid cache-page alignment.

For Qwen3.5-27B with TP=2 and `max_model_len=262144`, this caused the KV cache requirement to be overestimated at approximately 391 GiB, preventing large-context startup.

After restoring the shared alignment logic, the attention block size is adjusted to 784 tokens with 0.13% Mamba-page padding. The resulting KV cache capacity is 807,957 tokens, supporting 3.08 concurrent 262,144-token requests.

## Validation

- `python -m py_compile vllm_hcu/platforms/hcu.py`
- `git diff --check`
- verified startup on BW1000/HCU with `max_model_len=262144`
- verified `/health` returns HTTP 200