### PR TITLE
fix: restore HIPC indexer cache page view

### DIFF
--- a/tests/runtime_patch/test_indexer_cache_backing_view.py
+++ b/tests/runtime_patch/test_indexer_cache_backing_view.py
@@ -21,6 +21,7 @@ def test_collapsed_indexer_cache_restores_physical_page_axis():
     assert restored.shape == (3, 64, 132)
     assert restored.stride() == (64 * 132, 132, 1)
     assert restored.data_ptr() == collapsed.data_ptr()
+    assert collapsed.shape == (3, 1, 132)
 
 
 def test_regular_indexer_cache_is_not_reinterpreted():

--- a/tests/runtime_patch/test_indexer_cache_backing_view.py
+++ b/tests/runtime_patch/test_indexer_cache_backing_view.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+"""CPU contracts for sparse-indexer KV-cache backing views."""
+
+import torch
+
+from vllm_hcu.v1.attention.ops.rocm_aiter_mla_sparse import (
+    _indexer_cache_as_hipc_view,
+)
+
+
+def test_collapsed_indexer_cache_restores_physical_page_axis():
+    backing = torch.empty(3, 64, 132, dtype=torch.uint8)
+    collapsed = backing.as_strided(
+        size=(3, 1, 132),
+        stride=(64 * 132, 132, 1),
+    )
+
+    restored = _indexer_cache_as_hipc_view(collapsed)
+
+    assert restored.shape == (3, 64, 132)
+    assert restored.stride() == (64 * 132, 132, 1)
+    assert restored.data_ptr() == collapsed.data_ptr()
+
+
+def test_regular_indexer_cache_is_not_reinterpreted():
+    cache = torch.empty(3, 64, 132, dtype=torch.uint8)
+
+    assert _indexer_cache_as_hipc_view(cache) is cache
+
+
+def test_noncollapsed_padded_indexer_cache_is_not_reinterpreted():
+    backing = torch.empty(3, 33, 132, dtype=torch.uint8)
+    padded = backing.as_strided(
+        size=(3, 32, 132),
+        stride=(33 * 132, 132, 1),
+    )
+
+    assert _indexer_cache_as_hipc_view(padded) is padded

--- a/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -1294,7 +1294,9 @@ def rocm_aiter_sparse_attn_indexer_native(
     has_prefill = layer_attn_metadata.num_prefills > 0
     num_decode_tokens = layer_attn_metadata.num_decode_tokens
     device = hidden_states.device if k is None else k.device
-    kv_cache = _indexer_cache_as_hipc_view(kv_cache)
+    # HIPC cache writer/gather require the physical page axis. Keep the
+    # official view unchanged for the LightOp paged-MQA decode contract.
+    hipc_kv_cache = _indexer_cache_as_hipc_view(kv_cache)
 
     # during speculative decoding, k may be padded to the CUDA graph batch
     # size while slot_mapping only covers actual tokens.
@@ -1308,7 +1310,7 @@ def rocm_aiter_sparse_attn_indexer_native(
         if not current_platform.is_rocm() or on_gfx938():
             ops.indexer_k_quant_and_cache(
                 k,
-                kv_cache,
+                hipc_kv_cache,
                 slot_mapping,
                 quant_block_size,
                 scale_fmt,
@@ -1344,7 +1346,7 @@ def rocm_aiter_sparse_attn_indexer_native(
             )
             if not current_platform.is_rocm() or on_gfx938():
                 ops.cp_gather_indexer_k_quant_cache(
-                    kv_cache,
+                    hipc_kv_cache,
                     k_fp8,
                     k_scale,
                     chunk.block_table,

--- a/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm_hcu/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -1216,6 +1216,31 @@ def rocm_aiter_sparse_attn_indexer_fake(
     return topk_indices_buffer
 
 
+def _indexer_cache_as_hipc_view(kv_cache: torch.Tensor) -> torch.Tensor:
+    """Restore the physical page axis expected by the HIPC indexer kernels.
+
+    vLLM may expose the official KV-cache backing as a collapsed
+    ``[num_blocks, 1, packed_dim]`` view while retaining a full physical page
+    in the block stride. HIPC derives its page size from ``size(1)``, so recover
+    that axis without copying. Do not reinterpret regular or padded views.
+    """
+    if kv_cache.ndim < 3 or kv_cache.size(1) != 1:
+        return kv_cache
+
+    block_stride = kv_cache.stride(0)
+    token_stride = kv_cache.stride(1)
+    if token_stride <= 0 or block_stride <= token_stride:
+        return kv_cache
+    if block_stride % token_stride != 0:
+        return kv_cache
+
+    block_size = block_stride // token_stride
+    return kv_cache.as_strided(
+        size=(kv_cache.size(0), block_size, *kv_cache.shape[2:]),
+        stride=(block_stride, token_stride, *kv_cache.stride()[2:]),
+    )
+
+
 def rocm_aiter_sparse_attn_indexer_native(
     hidden_states: torch.Tensor,
     k_cache_prefix: LayerNameType,
@@ -1269,6 +1294,7 @@ def rocm_aiter_sparse_attn_indexer_native(
     has_prefill = layer_attn_metadata.num_prefills > 0
     num_decode_tokens = layer_attn_metadata.num_decode_tokens
     device = hidden_states.device if k is None else k.device
+    kv_cache = _indexer_cache_as_hipc_view(kv_cache)
 
     # during speculative decoding, k may be padded to the CUDA graph batch
     # size while slot_mapping only covers actual tokens.


### PR DESCRIPTION
## Summary

- Restore the physical HIPC page view when official vLLM exposes a collapsed DSA indexer cache tensor.
- Keep official allocation and the original cache view for LightOp paged-MQA decode.
- Use the zero-copy physical-page view only for the HIPC cache writer and HIPC prefill gather.
- Add CPU contracts for collapsed, regular, and padded non-collapsed layouts.

## Code review correction

The initial implementation replaced `kv_cache` globally. Full Graph capture exposed that LightOp decode requires the original official view and failed in `paged_mqa_logits.hip` with `num_heads == num_heads_ and num_heads_kv == 1`. Commit `aaabc24` limits the restored view to HIPC writer/gather call sites and preserves the original view for decode.

## Validation

Installed wheel:

`/models/wheels/pr108-aaabc24/vllm_hcu-0.28.1rc1.dev491+das.aaabc24.dtk2604-cp310-cp310-linux_x86_64.whl`

Focused test:

`pytest -q tests/runtime_patch/test_indexer_cache_backing_view.py` -> `3 passed`

All model runs used the installed wheel, an isolated per-model `VLLM_CACHE_ROOT`, default `FULL_AND_PIECEWISE` Graph, `--attention-backend FLASHMLA_SPARSE`, `--moe-backend aiter`, MTP3, and prefix caching. No explicit PIECEWISE override or eager mode was used.

| Model | Graph/startup | MoE evidence | HumanEval/0-7 |
|---|---|---|---|
| `/models/GLM-5___1-Channel-FP8-w8a8` | PASS | AITER FP8 config `E=256,N=256` | 8/8 with `enable_thinking=false` |
| `/models/GLM-5.3-Flash-Channel-FP8-w8a8` | PASS | AITER channel-FP8 config `E=288,N=256` | 8/8 with `reasoning_effort=low` |
| `/models/GLM-5-W8A8` | PASS | AITER INT8 config `E=256,N=256` | 8/8 with `enable_thinking=false` |

The GLM-5___1 long-prefix replay produced 14,912 hits for 15,008 queried tokens on the second request (99.36%).

## Serve command template

```bash
env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY \
  -u ALL_PROXY -u all_proxy \
  VLLM_CACHE_ROOT=/models/vllm-cache/<unique-model-run> \
  HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
  vllm serve <model-path> \
  --served-model-name <name> \
  --trust-remote-code \
  --tensor-parallel-size 8 \
  --attention-backend FLASHMLA_SPARSE \
  --moe-backend aiter \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
  --enable-prefix-caching \
  --max-model-len 32768 \
  --max-num-batched-tokens 16384 \
  --max-num-seqs 8 \
  --port 8000
```