### PR TITLE
fix: preserve padded MLA decode fast path

### DIFF
--- a/tests/runtime_patch/test_mla_target_ownership.py
+++ b/tests/runtime_patch/test_mla_target_ownership.py
@@ -468,6 +468,49 @@ def test_mla_feature_off_delegates_exact_v0251_forward_on_rocm():
     assert module.split_calls[-1] == (warmup, 3, True, True)
 
 
+def test_mla_split_preserves_decode_fast_path_for_padded_full_graph():
+    adapter = _adapter()
+    module = _fake_mla_module(adapter, [])
+
+    def split_decodes_and_prefills(
+        common_attn_metadata,
+        decode_threshold=1,
+        require_uniform=False,
+        treat_short_extends_as_decodes=True,
+    ):
+        del require_uniform
+        query_lens = (
+            common_attn_metadata.query_start_loc_cpu[1:]
+            - common_attn_metadata.query_start_loc_cpu[:-1]
+        )
+        if (
+            common_attn_metadata.max_query_len <= decode_threshold
+            and treat_short_extends_as_decodes
+        ):
+            return (
+                common_attn_metadata.num_reqs,
+                0,
+                common_attn_metadata.num_actual_tokens,
+                0,
+            )
+        is_prefill = query_lens > decode_threshold
+        if not treat_short_extends_as_decodes:
+            is_prefill |= common_attn_metadata.is_prefilling
+        return (0, 0, 0, int(is_prefill.sum().item()))
+
+    module.split_decodes_and_prefills = split_decodes_and_prefills
+    assert adapter.apply_to_module(module) is True
+    common = SimpleNamespace(
+        query_start_loc_cpu=torch.arange(9, dtype=torch.int32),
+        is_prefilling=torch.zeros(7, dtype=torch.bool),
+        max_query_len=1,
+        num_reqs=8,
+        num_actual_tokens=8,
+    )
+
+    assert module.split_decodes_and_prefills(common) == (8, 0, 8, 0)
+
+
 def test_mla_pcp_disables_rank_local_sparse_mha_prefill():
     adapter = _adapter()
     module = _fake_mla_module(adapter, [])

--- a/vllm_hcu/patch/worker/op_opt/patch_mla_attention.py
+++ b/vllm_hcu/patch/worker/op_opt/patch_mla_attention.py
@@ -289,9 +289,18 @@ def apply_to_module(module: ModuleType) -> bool:
         # Preserve the target vLLM decode classification in that case, while
         # retaining HCU's prefix-hit short-extend policy for real requests.
         del treat_short_extends_as_decodes
-        hcu_treat_short_extends_as_decodes = (
-            getattr(common_attn_metadata, "is_prefilling", None) is None
+        is_prefilling = getattr(common_attn_metadata, "is_prefilling", None)
+        # Official MRV2 builds this mask from a NumPy array on CPU.  FULL
+        # graphs can pad query rows, but are dispatched only for uniform
+        # decode batches (has_prefill=False); mixed batches use unpadded
+        # PIECEWISE metadata.  Inspect the zero-copy NumPy view so the decode
+        # hot path neither allocates a torch scalar nor synchronizes HCU.
+        has_prefill = (
+            False
+            if is_prefilling is None
+            else bool(is_prefilling.numpy().any())
         )
+        hcu_treat_short_extends_as_decodes = not has_prefill
         return split_batch(
             common_attn_metadata,
             decode_threshold,


### PR DESCRIPTION
## Summary
- preserve official pure-decode fast path for padded MRV2 FULL graphs
- retain HCU short-extend classification when the active CPU prefill mask contains a real prefill
- inspect the official CPU mask through a zero-copy NumPy view to avoid Torch scalar allocation and HCU synchronization
- add a regression reproducing the 8-row/7-mask shape mismatch

## Validation
- `pytest -q tests/runtime_patch/test_mla_target_ownership.py tests/runtime_patch/test_attention_utils_draft_metadata.py`: 23 passed
- DeepSeek-R1-Channel-FP8-w8a8, TP8, FLASHMLA, AITER FP8 MoE, default FULL_AND_PIECEWISE graph, HumanEval batch 8: 8/8
- GLM-5-W8A8, TP8, FLASHMLA_SPARSE, AITER Int8 MoE, MTP3, default FULL_AND_PIECEWISE graph, HumanEval batch 8: 8/8

## GLM-5 command note
`use_local_argmax_reduction` is intentionally omitted because this model draft class does not implement `get_top_tokens()`. No PIECEWISE override or custom graph environment variable is required.